### PR TITLE
Fix mono glue generation with .NET 6 (targeting blazium-dev)

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <LangVersion>11</LangVersion>
   </PropertyGroup>
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpAnalyzerVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpAnalyzerVerifier.cs
@@ -43,10 +43,7 @@ public static class CSharpAnalyzerVerifier<TAnalyzer>
     {
         var verifier = new Test();
 
-        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"""
-        is_global = true
-        build_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}
-        """));
+        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"is_global = true\nbuild_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}"));
 
         verifier.TestState.Sources.AddRange(sources.Select(source =>
         {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpCodeFixVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpCodeFixVerifier.cs
@@ -39,10 +39,7 @@ public static class CSharpCodeFixVerifier<TCodeFix, TAnalyzer>
         verifier.TestCode = File.ReadAllText(Path.Combine(Constants.SourceFolderPath, source));
         verifier.FixedCode = File.ReadAllText(Path.Combine(Constants.GeneratedSourceFolderPath, results));
 
-        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"""
-        is_global = true
-        build_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}
-        """));
+        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"is_global = true\nbuild_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}"));
 
         return verifier;
     }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -56,10 +56,7 @@ where TSourceGenerator : ISourceGenerator, new()
     {
         var verifier = new Test();
 
-        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"""
-        is_global = true
-        build_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}
-        """));
+        verifier.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $"is_global = true\nbuild_property.GodotProjectDir = {Constants.ExecutingAssemblyPath}"));
 
         verifier.TestState.Sources.AddRange(sources.Select(source => (
             source,

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <LangVersion>11</LangVersion>
 
     <Nullable>enable</Nullable>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPathAttributeGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPathAttributeGeneratorTests.cs
@@ -14,10 +14,7 @@ public class ScriptPathAttributeGeneratorTests
     {
         return (
             Path.Combine("Godot.SourceGenerators", "Godot.SourceGenerators.ScriptPathAttributeGenerator", "AssemblyScriptTypes.generated.cs"),
-            SourceText.From($$"""
-            [assembly:Godot.AssemblyHasScriptsAttribute(new System.Type[] {{{string.Join(", ", types.Select(type => $"typeof({type})"))}}})]
-
-            """, Encoding.UTF8)
+            SourceText.From($"[assembly:Godot.AssemblyHasScriptsAttribute(new System.Type[] {{{string.Join(", ", types.Select(type => $"typeof({type})"))}}})]\n", Encoding.UTF8)
         );
     }
 

--- a/modules/mono/global.json
+++ b/modules/mono/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "6.0.0",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
EnablePreviewFeatures is utilized in two source generator tests so more invasive changes are not required.
EnablePreviewFeatures should not impact anything outside of the tests.
Raw string literals are not a feature covered by EnablePreviewFeatures, which is why some .cs files required edits.
