### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,33 @@
-# Godot Engine
+# Blazium Engine
 
 <p align="center">
-  <a href="https://godotengine.org">
+  <a href="https://blazium.app">
     <img src="logo_outlined.svg" width="400" alt="Godot Engine logo">
   </a>
 </p>
 
 ## 2D and 3D cross-platform game engine
 
-**[Godot Engine](https://godotengine.org) is a feature-packed, cross-platform
+**[Blazium Engine](https://blazium.app) is a feature-packed, cross-platform
 game engine to create 2D and 3D games from a unified interface.** It provides a
-comprehensive set of [common tools](https://godotengine.org/features), so that
+comprehensive set of [common tools](), so that
 users can focus on making games without having to reinvent the wheel. Games can
 be exported with one click to a number of platforms, including the major desktop
 platforms (Linux, macOS, Windows), mobile platforms (Android, iOS), as well as
-Web-based platforms and [consoles](https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html).
+Web-based platforms and [consoles](https://docs.blazium.app/tutorials/platform/consoles.html).
 
 ## Free, open source and community-driven
 
-Godot is completely free and open source under the very permissive [MIT license](https://godotengine.org/license).
+Blazium is completely free and open source under the very permissive [MIT license](https://mit-license.org).
 No strings attached, no royalties, nothing. The users' games are theirs, down
 to the last line of engine code. Godot's development is fully independent and
 community-driven, empowering users to help shape their engine to match their
-expectations. It is supported by the [Godot Foundation](https://godot.foundation/)
-not-for-profit.
+expectations.
 
 Before being open sourced in [February 2014](https://github.com/godotengine/godot/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac),
 Godot had been developed by [Juan Linietsky](https://github.com/reduz) and
-[Ariel Manzur](https://github.com/punto-) (both still maintaining the project)
-for several years as an in-house engine, used to publish several work-for-hire
-titles.
+[Ariel Manzur](https://github.com/punto-) for several years as an in-house engine, used to publish several work-for-hire
+titles. in October 2024, the project was forked due to community dissatisfaction with project direction and politics being expressed by official Godot accounts.
 
 ![Screenshot of a 3D scene in the Godot Engine editor](https://raw.githubusercontent.com/godotengine/godot-design/master/screenshots/editor_tps_demo_1920x1080.jpg)
 
@@ -37,40 +35,40 @@ titles.
 
 ### Binary downloads
 
-Official binaries for the Godot editor and the export templates can be found
-[on the Godot website](https://godotengine.org/download).
+Official binaries for the Blazium editor and the export templates can be found
+[on the Blazium website]() when available.
 
 ### Compiling from source
 
-[See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
+[See the official docs](https://docs.blazium.app/contributing/development/compiling)
 for compilation instructions for every supported platform.
 
 ## Community and contributing
 
-Godot is not only an engine but an ever-growing community of users and engine
-developers. The main community channels are listed [on the homepage](https://godotengine.org/community).
+Blazium is not only an engine but an ever-growing community of users and engine
+developers. The main community channels are listed [on the homepage]().
 
 The best way to get in touch with the core engine developers is to join the
-[Godot Contributors Chat](https://chat.godotengine.org).
+[Official Discord Server](https://chat.blazium.app).
 
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 This document also includes guidelines for reporting bugs.
 
 ## Documentation and demos
 
-The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).
-It is maintained by the Godot community in its own [GitHub repository](https://github.com/godotengine/godot-docs).
+The official documentation is hosted on [Read the Docs](https://docs.blazium.app).
+It is maintained by the Blazium community in its own [GitHub repository](https://github.com/blazium-engine/blazium-docs).
 
-The [class reference](https://docs.godotengine.org/en/latest/classes/)
-is also accessible from the Godot editor.
+The [class reference](https://docs.blazium.app/classes/index.html)
+is also accessible from the Blazium editor.
 
-We also maintain official demos in their own [GitHub repository](https://github.com/godotengine/godot-demo-projects)
-as well as a list of [awesome Godot community resources](https://github.com/godotengine/awesome-godot).
+We also maintain official demos in their own [GitHub repository]()
+as well as a list of [awesome Blazium community resources]().
 
 There are also a number of other
-[learning resources](https://docs.godotengine.org/en/latest/community/tutorials.html)
+[learning resources](https://docs.blazium.app/community/tutorials.html)
 provided by the community, such as text and video tutorials, demos, etc.
-Consult the [community channels](https://godotengine.org/community)
+Consult the [community channels](https://docs.blazium.app/community/channels.html)
 for more information.
 
 [![Code Triagers Badge](https://www.codetriage.com/blazium-engine/blazium/badges/users.svg)](https://www.codetriage.com/blazium-engine/blazium)


### PR DESCRIPTION
Edited the readme to fit with the rebranding. I changed the links where possible, the couple that couldn't be updated were left blank and will currently redirect to the git page. Someone can just plug the permanent links into those spots when they're ready. All the docs ones are good to go.