### PR TITLE
Many ColorPicker fixes.

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -53,6 +53,26 @@
 				Returns the list of colors in the recent presets of the color picker.
 			</description>
 		</method>
+		<method name="is_displaying_old_color" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns if the old color is being displayed.
+			</description>
+		</method>
+		<method name="set_display_old_color">
+			<return type="void" />
+			<param index="0" name="display" type="bool" />
+			<description>
+				Toggles displaying old color.
+			</description>
+		</method>
+		<method name="set_old_color">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Sets the old color value.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="can_add_swatches" type="bool" setter="set_can_add_swatches" getter="are_swatches_enabled" default="true">

--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -45,8 +45,7 @@ String ColorModeRGB::get_slider_label(int idx) const {
 
 float ColorModeRGB::get_slider_max(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider max value.");
-	Color color = color_picker->get_pick_color();
-	return next_power_of_2(MAX(255, color.components[idx] * 255.0)) - 1;
+	return slider_max[idx];
 }
 
 float ColorModeRGB::get_slider_value(int idx) const {
@@ -252,30 +251,27 @@ void ColorModeRAW::slider_draw(int p_which) {
 		left_color.a = 0;
 		right_color = color;
 		right_color.a = 1;
-
-		col.set(0, left_color);
-		col.set(1, right_color);
-		col.set(2, right_color);
-		col.set(3, left_color);
-		pos.set(0, Vector2(0, 0));
-		pos.set(1, Vector2(size.x, 0));
-		pos.set(2, Vector2(size.x, margin));
-		pos.set(3, Vector2(0, margin));
-
-		slider->draw_polygon(pos, col);
-	}
-}
-
-bool ColorModeRAW::apply_theme() const {
-	for (int i = 0; i < 4; i++) {
-		HSlider *slider = color_picker->get_slider(i);
-		slider->remove_theme_icon_override("grabber");
-		slider->remove_theme_icon_override("grabber_highlight");
-		slider->remove_theme_style_override("slider");
-		slider->remove_theme_constant_override("grabber_offset");
+	} else {
+		left_color = Color(
+				p_which == 0 ? 0 : color.r,
+				p_which == 1 ? 0 : color.g,
+				p_which == 2 ? 0 : color.b);
+		right_color = Color(
+				p_which == 0 ? 1 : color.r,
+				p_which == 1 ? 1 : color.g,
+				p_which == 2 ? 1 : color.b);
 	}
 
-	return true;
+	col.set(0, left_color);
+	col.set(1, right_color);
+	col.set(2, right_color);
+	col.set(3, left_color);
+	pos.set(0, Vector2(0, 0));
+	pos.set(1, Vector2(size.x, 0));
+	pos.set(2, Vector2(size.x, margin));
+	pos.set(3, Vector2(0, margin));
+
+	slider->draw_polygon(pos, col);
 }
 
 void ColorModeOKHSL::_value_changed() {

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -46,6 +46,7 @@ public:
 	virtual float get_spinbox_arrow_step() const { return get_slider_step(); };
 	virtual String get_slider_label(int idx) const = 0;
 	virtual float get_slider_max(int idx) const = 0;
+	virtual bool can_allow_greater() const { return false; };
 	virtual float get_slider_value(int idx) const = 0;
 
 	virtual Color get_color() const = 0;
@@ -87,12 +88,14 @@ public:
 class ColorModeRGB : public ColorMode {
 public:
 	String labels[3] = { "R", "G", "B" };
+	float slider_max[4] = { 255, 255, 255, 255 };
 
 	virtual String get_name() const override { return "RGB"; }
 
 	virtual float get_slider_step() const override { return 1; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual bool can_allow_greater() const override { return true; };
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
@@ -106,20 +109,19 @@ public:
 class ColorModeRAW : public ColorMode {
 public:
 	String labels[3] = { "R", "G", "B" };
-	float slider_max[4] = { 100, 100, 100, 1 };
+	float slider_max[4] = { 1, 1, 1, 1 };
 
 	virtual String get_name() const override { return "RAW"; }
 
-	virtual float get_slider_step() const override { return 0.001; }
-	virtual float get_spinbox_arrow_step() const override { return 0.01; }
+	virtual float get_slider_step() const override { return 1.0 / 255.0; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual bool can_allow_greater() const override { return true; };
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
 
 	virtual void slider_draw(int p_which) override;
-	virtual bool apply_theme() const override;
 
 	ColorModeRAW(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker){};
@@ -144,7 +146,6 @@ public:
 	virtual void _value_changed() override;
 
 	virtual void slider_draw(int p_which) override;
-	virtual ColorPicker::PickerShapeType get_shape_override() const override { return ColorPicker::SHAPE_OKHSL_CIRCLE; }
 
 	ColorModeOKHSL(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker){};

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -631,6 +631,7 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 		float spinbox_arrow_step = modes[current_mode]->get_spinbox_arrow_step();
 		for (int i = 0; i < current_slider_count; i++) {
 			sliders[i]->set_max(modes[current_mode]->get_slider_max(i));
+			sliders[i]->set_allow_greater(modes[current_mode]->can_allow_greater());
 			sliders[i]->set_step(step);
 			values[i]->set_custom_arrow_step(spinbox_arrow_step);
 			sliders[i]->set_value(modes[current_mode]->get_slider_value(i));
@@ -1072,6 +1073,9 @@ void ColorPicker::_update_text_value() {
 }
 
 void ColorPicker::_sample_input(const Ref<InputEvent> &p_event) {
+	if (!display_old_color) {
+		return;
+	}
 	const Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		const Rect2 rect_old = Rect2(Point2(), Size2(sample->get_size().width * 0.5, sample->get_size().height * 0.95));
@@ -1124,7 +1128,7 @@ void ColorPicker::_sample_draw() {
 
 	if (color.r > 1 || color.g > 1 || color.b > 1) {
 		// Draw an indicator to denote that the new color is "overbright" and can't be displayed accurately in the preview.
-		sample->draw_texture(theme_cache.overbright_indicator, Point2(uv_edit->get_size().width * 0.5, 0));
+		sample->draw_texture(theme_cache.overbright_indicator, Point2(display_old_color ? sample->get_size().width * 0.5 : 0, 0));
 	}
 }
 
@@ -1135,70 +1139,43 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 
 	PickerShapeType actual_shape = _get_actual_shape();
 	if (p_which == 0) {
-		Vector<Point2> points;
-		Vector<Color> colors;
-		Vector<Color> colors2;
 		Color col = color;
 		Vector2 center = c->get_size() / 2.0;
 
-		switch (actual_shape) {
-			case SHAPE_HSV_WHEEL: {
-				points.resize(4);
-				colors.resize(4);
-				colors2.resize(4);
+		if (current_shape == SHAPE_HSV_RECTANGLE || current_shape == SHAPE_HSV_WHEEL) {
+			Vector<Point2> points;
+			Vector<Color> colors;
+			Vector<Color> colors2;
+			if (current_shape == SHAPE_HSV_RECTANGLE) {
+				points.append(Vector2());
+				points.append(Vector2(c->get_size().x, 0));
+				points.append(c->get_size());
+				points.append(Vector2(0, c->get_size().y));
+			} else {
 				real_t ring_radius_x = Math_SQRT12 * c->get_size().width * 0.42;
 				real_t ring_radius_y = Math_SQRT12 * c->get_size().height * 0.42;
 
-				points.set(0, center - Vector2(ring_radius_x, ring_radius_y));
-				points.set(1, center + Vector2(ring_radius_x, -ring_radius_y));
-				points.set(2, center + Vector2(ring_radius_x, ring_radius_y));
-				points.set(3, center + Vector2(-ring_radius_x, ring_radius_y));
-				colors.set(0, Color(1, 1, 1, 1));
-				colors.set(1, Color(1, 1, 1, 1));
-				colors.set(2, Color(0, 0, 0, 1));
-				colors.set(3, Color(0, 0, 0, 1));
-				c->draw_polygon(points, colors);
+				points.append(center - Vector2(ring_radius_x, ring_radius_y));
+				points.append(center + Vector2(ring_radius_x, -ring_radius_y));
+				points.append(center + Vector2(ring_radius_x, ring_radius_y));
+				points.append(center + Vector2(-ring_radius_x, ring_radius_y));
+			}
+			colors.append(Color(1, 1, 1, 1));
+			colors.append(Color(1, 1, 1, 1));
+			colors.append(Color(0, 0, 0, 1));
+			colors.append(Color(0, 0, 0, 1));
+			c->draw_polygon(points, colors);
 
-				col.set_hsv(h, 1, 1);
-				col.a = 0;
-				colors2.set(0, col);
-				col.a = 1;
-				colors2.set(1, col);
-				col.set_hsv(h, 1, 0);
-				colors2.set(2, col);
-				col.a = 0;
-				colors2.set(3, col);
-				c->draw_polygon(points, colors2);
-				break;
-			}
-			case SHAPE_HSV_RECTANGLE: {
-				points.resize(4);
-				colors.resize(4);
-				colors2.resize(4);
-				points.set(0, Vector2());
-				points.set(1, Vector2(c->get_size().x, 0));
-				points.set(2, c->get_size());
-				points.set(3, Vector2(0, c->get_size().y));
-				colors.set(0, Color(1, 1, 1, 1));
-				colors.set(1, Color(1, 1, 1, 1));
-				colors.set(2, Color(0, 0, 0, 1));
-				colors.set(3, Color(0, 0, 0, 1));
-				c->draw_polygon(points, colors);
-				col = color;
-				col.set_hsv(h, 1, 1);
-				col.a = 0;
-				colors2.set(0, col);
-				col.a = 1;
-				colors2.set(1, col);
-				col.set_hsv(h, 1, 0);
-				colors2.set(2, col);
-				col.a = 0;
-				colors2.set(3, col);
-				c->draw_polygon(points, colors2);
-				break;
-			}
-			default: {
-			}
+			col.set_hsv(h, 1, 1);
+			col.a = 0;
+			colors2.append(col);
+			col.a = 1;
+			colors2.append(col);
+			col.set_hsv(h, 1, 0);
+			colors2.append(col);
+			col.a = 0;
+			colors2.append(col);
+			c->draw_polygon(points, colors2);
 		}
 
 		int x;
@@ -1218,14 +1195,9 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 
 		col.set_hsv(h, 1, 1);
 		if (actual_shape == SHAPE_HSV_WHEEL) {
-			points.resize(4);
-			double h1 = h - (0.5 / 360);
-			double h2 = h + (0.5 / 360);
-			points.set(0, Point2(center.x + (center.x * Math::cos(h1 * Math_TAU)), center.y + (center.y * Math::sin(h1 * Math_TAU))));
-			points.set(1, Point2(center.x + (center.x * Math::cos(h1 * Math_TAU) * 0.84), center.y + (center.y * Math::sin(h1 * Math_TAU) * 0.84)));
-			points.set(2, Point2(center.x + (center.x * Math::cos(h2 * Math_TAU)), center.y + (center.y * Math::sin(h2 * Math_TAU))));
-			points.set(3, Point2(center.x + (center.x * Math::cos(h2 * Math_TAU) * 0.84), center.y + (center.y * Math::sin(h2 * Math_TAU) * 0.84)));
-			c->draw_multiline(points, col.inverted());
+			Point2 from = Point2(center.x + (center.x * Math::cos(h * Math_TAU)), center.y + (center.y * Math::sin(h * Math_TAU)));
+			Point2 to = Point2(center.x + (center.x * Math::cos(h * Math_TAU) * 0.84), center.y + (center.y * Math::sin(h * Math_TAU) * 0.84));
+			c->draw_line(from, to, col.inverted());
 		}
 
 	} else if (p_which == 1) {
@@ -1540,7 +1512,6 @@ void ColorPicker::_pick_finished() {
 	}
 	is_picking_color = false;
 	set_process_internal(false);
-	picker_window->hide();
 }
 
 void ColorPicker::_pick_button_pressed_legacy() {
@@ -1736,6 +1707,9 @@ bool ColorPicker::is_hex_visible() const {
 void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pick_color", "color"), &ColorPicker::set_pick_color);
 	ClassDB::bind_method(D_METHOD("get_pick_color"), &ColorPicker::get_pick_color);
+	ClassDB::bind_method(D_METHOD("set_old_color", "color"), &ColorPicker::set_old_color);
+	ClassDB::bind_method(D_METHOD("set_display_old_color", "display"), &ColorPicker::set_display_old_color);
+	ClassDB::bind_method(D_METHOD("is_displaying_old_color"), &ColorPicker::is_displaying_old_color);
 	ClassDB::bind_method(D_METHOD("set_deferred_mode", "mode"), &ColorPicker::set_deferred_mode);
 	ClassDB::bind_method(D_METHOD("is_deferred_mode"), &ColorPicker::is_deferred_mode);
 	ClassDB::bind_method(D_METHOD("set_color_mode", "color_mode"), &ColorPicker::set_color_mode);
@@ -1909,17 +1883,10 @@ ColorPicker::ColorPicker() {
 	mode_popup->set_item_checked(current_mode, true);
 	mode_popup->set_item_checked(MODE_MAX + 1, true);
 	mode_popup->connect(SceneStringName(id_pressed), callable_mp(this, &ColorPicker::_set_mode_popup_value));
-	VBoxContainer *vbl = memnew(VBoxContainer);
-	real_vbox->add_child(vbl);
-
-	VBoxContainer *vbr = memnew(VBoxContainer);
-
-	real_vbox->add_child(vbr);
-	vbr->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	slider_gc = memnew(GridContainer);
 
-	vbr->add_child(slider_gc);
+	real_vbox->add_child(slider_gc);
 	slider_gc->set_h_size_flags(SIZE_EXPAND_FILL);
 	slider_gc->set_columns(3);
 
@@ -1931,7 +1898,7 @@ ColorPicker::ColorPicker() {
 
 	hex_hbc = memnew(HBoxContainer);
 	hex_hbc->set_alignment(ALIGNMENT_BEGIN);
-	vbr->add_child(hex_hbc);
+	real_vbox->add_child(hex_hbc);
 
 	hex_hbc->add_child(memnew(Label("Hex")));
 


### PR DESCRIPTION
Changes:
1. Makes RAW sliders colored same as RGB mode.
2. Fix RAW mode maximum values, from 100 to 1.0.
3. Allow RGB and RAW modes to have greater values for over bright.
4. Changes RAW step value to 1.0 / 255.0, to match the RGB mode values when changed.
5. Fix pressing the sample left side changes the color to black when old color is not displayed.
6. Remove an empty `VBoxContainer` called vbl.
7. Remove an extra `VBoxContainer` used as child of `real_vbox`, and adding it's children to the `real_vbox` directly.
8. Prevent OKHSL mode from changing the picker shape. The color mode is for sliders only, no need to override the shape.
9. Fix over bright indicator position.
10. Fix conversion between RAW and RGB modes when color is over bright.
11. Fix pressing the ColorPicker's sample left half side changes the color to black when old color is not displayed.
12. Fix switching to RAW mode and then to RGB will change slider max value.
13. Expose `is_displaying_old_color()`, `set_display_old_color()` and `set_old_color()` to gdscript.