### PR TITLE
Support Codium as a standalone C# editor

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/ExternalEditorId.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/ExternalEditorId.cs
@@ -7,6 +7,7 @@ namespace GodotTools
         VisualStudioForMac, // Mac-only
         MonoDevelop,
         VsCode,
+        Codium,
         Rider,
         CustomEditor
     }


### PR DESCRIPTION
While Godot has an open PR to add Codium support, it lumps it under VSCode and checks for it last. I have both editors installed on one of my systems, so it will never use Codium that way. I explicitly want to use Codium with Godot/Blazium, so I added a separate selection option for it.