### PR TITLE
antonWetzel's fix external material for invalid material

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1478,6 +1478,11 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					if (mat.is_valid()) {
 						String mat_id = mat->get_meta("import_id", mat->get_name());
 
+						if (mat_id.is_empty() && mat->has_meta("unique_id")) {
+							mat_id = mat->get_meta("unique_id");
+							mat->remove_meta("unique_id");
+						}
+
 						if (!mat_id.is_empty() && p_material_data.has(mat_id)) {
 							Dictionary matdata = p_material_data[mat_id];
 							{

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -206,6 +206,8 @@ void SceneImportSettingsDialog::_fill_material(Tree *p_tree, const Ref<Material>
 		has_import_id = true;
 	} else if (unnamed_material_name_map.has(p_material)) {
 		import_id = unnamed_material_name_map[p_material];
+	} else if (p_material->has_meta("unique_id")) {
+		import_id = p_material->get_meta("unique_id");
 	} else {
 		import_id = "@MATERIAL:" + itos(material_map.size());
 		unnamed_material_name_map[p_material] = import_id;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3269,6 +3269,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				} else {
 					Ref<StandardMaterial3D> mat3d;
 					mat3d.instantiate();
+					mat3d->set_meta("unique_id", vformat("%s@%s", import_mesh->get_name(), itos(j)));
 					if (has_vertex_color) {
 						mat3d->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 					}


### PR DESCRIPTION
This makes the "use external" import option work with GLTF placeholder materials.
See https://github.com/godotengine/godot/pull/64903