### PR TITLE
Add descriptions to RDTextureFormat's methods Co-authored-by: @DevPoo…

### DIFF
--- a/doc/classes/RDTextureFormat.xml
+++ b/doc/classes/RDTextureFormat.xml
@@ -13,12 +13,14 @@
 			<return type="void" />
 			<param index="0" name="format" type="int" enum="RenderingDevice.DataFormat" />
 			<description>
+				Adds [param format] as a valid format for the corresponding [RDTextureView]'s [member RDTextureView.format_override] property. If any format is added as shareable, then the main [member format] must also be added.
 			</description>
 		</method>
 		<method name="remove_shareable_format">
 			<return type="void" />
 			<param index="0" name="format" type="int" enum="RenderingDevice.DataFormat" />
 			<description>
+				Removes [param format] from the list of valid formats that the corresponding [RDTextureView]'s [member RDTextureView.format_override] property can be set to.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDTextureView.xml
+++ b/doc/classes/RDTextureView.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="format_override" type="int" setter="set_format_override" getter="get_format_override" enum="RenderingDevice.DataFormat" default="218">
-			Optional override for the data format to return sampled values in. The default value of [constant RenderingDevice.DATA_FORMAT_MAX] does not override the format.
+			Optional override for the data format to return sampled values in. The corresponding [RDTextureFormat] must have had this added as a shareable format. The default value of [constant RenderingDevice.DATA_FORMAT_MAX] does not override the format.
 		</member>
 		<member name="swizzle_a" type="int" setter="set_swizzle_a" getter="get_swizzle_a" enum="RenderingDevice.TextureSwizzle" default="6">
 			The channel to sample when sampling the alpha channel.


### PR DESCRIPTION
@DevPoodle added descriptions for RDTextureFormat's add_shareable_format and remove_shareable_format methods. In testing these functions to make sure I properly understood them, he also realized that the description of RDTextureView's format_override property should be updated as well.
