### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Official binaries for the Blazium editor and the export templates can be found
 
 ### Compiling from source
 
-[See the official docs](https://docs.blazium.app/contributing/development/compiling)
+[See the official docs](https://docs.blazium.app/contributing/development/compiling/)
 for compilation instructions for every supported platform.
 
 ## Community and contributing


### PR DESCRIPTION
Not including the trailing / at the end of the URL caused the link to route to a local instance that included :8080 appended to the domain.

This caused an error message.  With the trailing /, the link redirects as expected

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
