### PR TITLE
Default UI font: enable Inter features

### DIFF
--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -152,8 +152,8 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	const int default_font_size = int(EDITOR_GET("interface/editor/main_font_size")) * EDSCALE;
 	const float embolden_strength = 0.6;
 
-	Ref<Font> default_font = load_internal_font(_font_Inter_Regular, _font_Inter_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, false);
-	Ref<Font> default_font_msdf = load_internal_font(_font_Inter_Regular, _font_Inter_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, true);
+	Ref<FontFile> default_font = load_internal_font(_font_Inter_Regular, _font_Inter_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, false);
+	Ref<FontFile> default_font_msdf = load_internal_font(_font_Inter_Regular, _font_Inter_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, true);
 
 	TypedArray<Font> fallbacks;
 	Ref<FontFile> arabic_font = load_internal_font(_font_NotoNaskhArabicUI_Regular, _font_NotoNaskhArabicUI_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, false, &fallbacks);
@@ -205,6 +205,17 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 
 	default_font_bold->set_fallbacks(fallbacks_bold);
 	default_font_bold_msdf->set_fallbacks(fallbacks_bold);
+
+	// Enable Inter OpenType features.
+	Dictionary ot_features;
+	ot_features["ss01"] = true; // Alternate digits (flat-top 3, open 4, 6 and 9)
+	ot_features["ss02"] = true; // Disambiguation (Upper-case I with serif, lower-case L with tail, slashed zero)
+
+	default_font->set_opentype_feature_overrides(ot_features);
+	default_font_msdf->set_opentype_feature_overrides(ot_features);
+
+	default_font_bold->set_opentype_feature_overrides(ot_features);
+	default_font_bold_msdf->set_opentype_feature_overrides(ot_features);
 
 	Ref<FontFile> default_font_mono = load_internal_font(_font_JetBrainsMono_Regular, _font_JetBrainsMono_Regular_size, font_mono_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
 	default_font_mono->set_fallbacks(fallbacks);


### PR DESCRIPTION
Enables a few OpenType features from the Inter font (implemented as default through #102).

Alternate digits give the number 3 a flat top, and opens numbers 4, 6 and 9. Disambiguation makes upper-case i serifed, gives lower-case L a tail, and slashes the 0.

Screenshot from Inter's official site:
![image](https://github.com/user-attachments/assets/c8557869-361e-4bbb-b3e4-287a41d1e55e)

I also thought about enabling tabular numbers, but there were a few problems so I left it out.

This should only affect the default main font and not affect custom ones.