### PR TITLE
auto starts the web editor directly

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -349,75 +349,6 @@ a:active {
 			</div>
 		</div>
 		<script>
-window.addEventListener('load', () => {
-	preloadZip(document.getElementById('zip-file')).then(function (zip) {
-		startEditor(zip);
-	});
-	function notifyUpdate(sw) {
-		const btn = document.getElementById('btn-tab-update');
-		btn.onclick = function () {
-			if (!window.confirm('Are you sure you want to update?\nClicking "OK" will reload all active instances!')) {
-				return;
-			}
-			sw.postMessage('update');
-			btn.innerHTML = 'Updating...';
-			btn.disabled = true;
-		};
-		btn.style.display = '';
-	}
-	if ('serviceWorker' in navigator) {
-		navigator.serviceWorker.register('service.worker.js').then(function (reg) {
-			if (reg.waiting) {
-				notifyUpdate(reg.waiting);
-			}
-			reg.addEventListener('updatefound', function () {
-				const update = reg.installing;
-				update.addEventListener('statechange', function () {
-					if (update.state === 'installed') {
-						// It's a new install, claim and perform aggressive caching.
-						if (!reg.active) {
-							update.postMessage('claim');
-						} else {
-							notifyUpdate(update);
-						}
-					}
-				});
-			});
-		});
-	}
-
-	const missing = Engine.getMissingFeatures({
-		threads: ___GODOT_THREADS_ENABLED___,
-	});
-	if (missing.length) {
-		// Display error dialog as threading support is required for the editor.
-		document.getElementById('startButton').disabled = 'disabled';
-		document.getElementById('welcome-modal-description').style.display = 'none';
-		document.getElementById('welcome-modal-missing-description').style.display = 'block';
-		document.getElementById('welcome-modal-dismiss').style.display = 'none';
-		const list = document.getElementById('welcome-modal-missing-list');
-		for (let i = 0; i < missing.length; i++) {
-			const node = document.createElement('li');
-			node.innerText = missing[i];
-			list.appendChild(node);
-		}
-	}
-
-	if (missing.length || localStorage.getItem('welcomeModalDismissed') !== 'true') {
-		document.getElementById('welcome-modal').style.display = 'block';
-		document.getElementById('welcome-modal-dismiss').focus();
-	}
-});
-
-function closeWelcomeModal(dontShowAgain) { // eslint-disable-line no-unused-vars
-	document.getElementById('welcome-modal').style.display = 'none';
-	if (dontShowAgain) {
-		localStorage.setItem('welcomeModalDismissed', 'true');
-	}
-}
-		</script>
-		<script src="blazium.editor.js"></script>
-		<script>
 let editor = null;
 let game = null;
 let setStatusMode;
@@ -755,6 +686,79 @@ function preloadZip(target) {
 		}
 	});
 }
+window.addEventListener('load', () => {
+	function notifyUpdate(sw) {
+		const btn = document.getElementById('btn-tab-update');
+		btn.onclick = function () {
+			if (!window.confirm('Are you sure you want to update?\nClicking "OK" will reload all active instances!')) {
+				return;
+			}
+			sw.postMessage('update');
+			btn.innerHTML = 'Updating...';
+			btn.disabled = true;
+		};
+		btn.style.display = '';
+	}
+	if ('serviceWorker' in navigator) {
+		navigator.serviceWorker.register('service.worker.js').then(function (reg) {
+			if (reg.waiting) {
+				notifyUpdate(reg.waiting);
+			}
+			reg.addEventListener('updatefound', function () {
+				const update = reg.installing;
+				update.addEventListener('statechange', function () {
+					if (update.state === 'installed') {
+						// It's a new install, claim and perform aggressive caching.
+						if (!reg.active) {
+							update.postMessage('claim');
+						} else {
+							notifyUpdate(update);
+						}
+					}
+				});
+			});
+		});
+	}
+
+	const missing = Engine.getMissingFeatures({
+		threads: ___GODOT_THREADS_ENABLED___,
+	});
+	if (missing.length) {
+		// Display error dialog as threading support is required for the editor.
+		document.getElementById('startButton').disabled = 'disabled';
+		document.getElementById('welcome-modal-description').style.display = 'none';
+		document.getElementById('welcome-modal-missing-description').style.display = 'block';
+		document.getElementById('welcome-modal-dismiss').style.display = 'none';
+		const list = document.getElementById('welcome-modal-missing-list');
+		for (let i = 0; i < missing.length; i++) {
+			const node = document.createElement('li');
+			node.innerText = missing[i];
+			list.appendChild(node);
+		}
+	}
+
+	if (missing.length || localStorage.getItem('welcomeModalDismissed') !== 'true') {
+		document.getElementById('welcome-modal').style.display = 'block';
+		document.getElementById('welcome-modal-dismiss').focus();
+	}
+
+	setTimeout(() => {
+        preloadZip(document.getElementById('zip-file')).then(function (zip) {
+            startEditor(zip);
+        });
+    }, 100);
+});
+
+function closeWelcomeModal(dontShowAgain) { // eslint-disable-line no-unused-vars
+	document.getElementById('welcome-modal').style.display = 'none';
+	if (dontShowAgain) {
+		localStorage.setItem('welcomeModalDismissed', 'true');
+	}
+}
+		</script>
+		<script src="blazium.editor.js"></script>
+		<script>
+
 
 document.getElementById('startButton').onclick = function () {
 	preloadZip(document.getElementById('zip-file')).then(function (zip) {

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -350,6 +350,9 @@ a:active {
 		</div>
 		<script>
 window.addEventListener('load', () => {
+	preloadZip(document.getElementById('zip-file')).then(function (zip) {
+		startEditor(zip);
+	});
 	function notifyUpdate(sw) {
 		const btn = document.getElementById('btn-tab-update');
 		btn.onclick = function () {


### PR DESCRIPTION
This auto starts the web editor directly, if people want to go back to the main screen of any reason they can lose the "Project Loader" and return to the start page.
Idea came from bitbrain
![image](https://github.com/user-attachments/assets/4380e9c1-eb55-4066-8be7-f7b491bee6ca)

goes directly here 
![Screenshot 2024-11-04 003509](https://github.com/user-attachments/assets/926be025-7fdc-4e05-b3b3-48613813b993)
