### PR TITLE
Separate Blazium and Godot versioning

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -190,6 +190,10 @@ def version_info_builder(target, source, env):
 #define VERSION_WEBSITE "{website}"
 #define VERSION_DOCS_BRANCH "{docs_branch}"
 #define VERSION_DOCS_URL "https://docs.blazium.app"
+#define EXTERNAL_VERSION_MAJOR {external_major}
+#define EXTERNAL_VERSION_MINOR {external_minor}
+#define EXTERNAL_VERSION_PATCH {external_patch}
+#define EXTERNAL_VERSION_STATUS "{external_status}"
 """.format(**env.version_info)
         )
 

--- a/core/version.h
+++ b/core/version.h
@@ -57,6 +57,8 @@
 #define VERSION_NUMBER VERSION_BRANCH
 #endif // VERSION_PATCH
 
+#define EXTERNAL_VERSION_NUMBER _MKSTR(EXTERNAL_VERSION_MAJOR) "." _MKSTR(EXTERNAL_VERSION_MINOR) "." _MKSTR(EXTERNAL_VERSION_PATCH) "." EXTERNAL_VERSION_STATUS
+
 // Version number encoded as hexadecimal int with one byte for each number,
 // for easy comparison from code.
 // Example: 3.1.4 will be 0x030104, making comparison easy from script.
@@ -67,14 +69,18 @@
 // Example: "3.1.4.stable.mono"
 #define VERSION_FULL_CONFIG VERSION_NUMBER "." VERSION_STATUS VERSION_MODULE_CONFIG
 
+#define EXTERNAL_VERSION_FULL_CONFIG EXTERNAL_VERSION_NUMBER VERSION_MODULE_CONFIG
+
 // Similar to VERSION_FULL_CONFIG, but also includes the (potentially custom) VERSION_BUILD
 // description (e.g. official, custom_build, etc.).
 // Example: "3.1.4.stable.mono.official"
 #define VERSION_FULL_BUILD VERSION_FULL_CONFIG "." VERSION_BUILD
 
+#define EXTERNAL_VERSION_FULL_BUILD EXTERNAL_VERSION_NUMBER "(" VERSION_FULL_BUILD ")"
+
 // Same as above, but prepended with Godot's name and a cosmetic "v" for "version".
 // Example: "Godot v3.1.4.stable.official.mono"
-#define VERSION_FULL_NAME VERSION_NAME " v" VERSION_FULL_BUILD
+#define VERSION_FULL_NAME VERSION_NAME " v" EXTERNAL_VERSION_NUMBER " (base v" VERSION_FULL_BUILD ")"
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
 extern const char *const VERSION_HASH;

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -205,7 +205,7 @@ EditorAbout::EditorAbout() {
 	}
 	version_btn->set_text(VERSION_FULL_NAME + hash);
 	// Set the text to copy in metadata as it slightly differs from the button's text.
-	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
+	version_btn->set_meta(META_TEXT_TO_COPY, "v" EXTERNAL_VERSION_FULL_BUILD + hash);
 	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	String build_date;
 	if (VERSION_TIMESTAMP > 0) {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -552,7 +552,7 @@ EditorLog::EditorLog() {
 	vb_right->add_child(editor_filter->toggle_button);
 	type_filter_map.insert(MSG_TYPE_EDITOR, editor_filter);
 
-	add_message(VERSION_FULL_NAME " (c) 2007-present Juan Linietsky, Ariel Manzur & Godot Contributors & Blazium Contributors.");
+	add_message(VERSION_FULL_NAME " (c) 2007-present Juan Linietsky, Ariel Manzur, Godot Contributors & Blazium Contributors.");
 
 	eh.errfunc = _error_handler;
 	eh.userdata = this;

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -330,7 +330,7 @@ Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 }
 
 String EditorExportPlatform::find_export_template(const String &template_file_name, String *err) const {
-	String current_version = VERSION_FULL_CONFIG;
+	String current_version = EXTERNAL_VERSION_FULL_CONFIG;
 	String template_path = EditorPaths::get_singleton()->get_export_templates_dir().path_join(current_version).path_join(template_file_name);
 
 	if (FileAccess::exists(template_path)) {

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -69,7 +69,7 @@ void ExportTemplateManager::_update_template_status() {
 	da->list_dir_end();
 
 	// Update the state of the current version.
-	String current_version = VERSION_FULL_CONFIG;
+	String current_version = EXTERNAL_VERSION_FULL_CONFIG;
 	current_value->set_text(current_version);
 
 	if (templates.has(current_version)) {
@@ -237,7 +237,7 @@ void ExportTemplateManager::_refresh_mirrors() {
 	}
 	is_refreshing_mirrors = true;
 
-	String current_version = VERSION_FULL_CONFIG;
+	String current_version = EXTERNAL_VERSION_FULL_CONFIG;
 	const String mirrors_metadata_url = "https://blazium.app/mirrorlist/" + current_version + ".json";
 	request_mirrors->request(mirrors_metadata_url);
 }
@@ -678,7 +678,7 @@ String ExportTemplateManager::get_android_source_zip(const Ref<EditorExportPrese
 		}
 	}
 
-	const String templates_dir = EditorPaths::get_singleton()->get_export_templates_dir().path_join(VERSION_FULL_CONFIG);
+	const String templates_dir = EditorPaths::get_singleton()->get_export_templates_dir().path_join(EXTERNAL_VERSION_FULL_CONFIG);
 	return templates_dir.path_join("android_source.zip");
 }
 
@@ -931,14 +931,14 @@ ExportTemplateManager::ExportTemplateManager() {
 	current_open_button->set_text(TTR("Open Folder"));
 	current_open_button->set_tooltip_text(TTR("Open the folder containing installed templates for the current version."));
 	current_installed_hb->add_child(current_open_button);
-	current_open_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_open_template_folder).bind(VERSION_FULL_CONFIG));
+	current_open_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_open_template_folder).bind(EXTERNAL_VERSION_FULL_CONFIG));
 #endif
 
 	current_uninstall_button = memnew(Button);
 	current_uninstall_button->set_text(TTR("Uninstall"));
 	current_uninstall_button->set_tooltip_text(TTR("Uninstall templates for the current version."));
 	current_installed_hb->add_child(current_uninstall_button);
-	current_uninstall_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_uninstall_template).bind(VERSION_FULL_CONFIG));
+	current_uninstall_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_uninstall_template).bind(EXTERNAL_VERSION_FULL_CONFIG));
 
 	main_vb->add_child(memnew(HSeparator));
 

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -331,13 +331,13 @@ EditorBottomPanel::EditorBottomPanel() {
 	bottom_hbox->add_child(editor_toaster);
 
 	version_btn = memnew(LinkButton);
-	version_btn->set_text(VERSION_FULL_CONFIG);
+	version_btn->set_text(EXTERNAL_VERSION_FULL_CONFIG);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0) {
 		hash = " " + vformat("[%s]", hash.left(9));
 	}
 	// Set the text to copy in metadata as it slightly differs from the button's text.
-	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
+	version_btn->set_meta(META_TEXT_TO_COPY, "v" EXTERNAL_VERSION_FULL_BUILD + hash);
 	// Fade out the version label to be less prominent, but still readable.
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
 	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1422,7 +1422,7 @@ ProjectManager::ProjectManager() {
 		if (hash.length() != 0) {
 			hash = " " + vformat("[%s]", hash.left(9));
 		}
-		version_btn->set_text("v" VERSION_FULL_BUILD + hash);
+		version_btn->set_text("v" EXTERNAL_VERSION_FULL_BUILD + hash);
 		// Fade the version label to be less prominent, but still readable.
 		version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
 		version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);

--- a/methods.py
+++ b/methods.py
@@ -214,6 +214,10 @@ def get_version_info(module_version_string="", silent=False):
         "module_config": str(version.module_config) + module_version_string,
         "website": str(version.website),
         "docs_branch": str(version.docs),
+        "external_major": int(os.getenv("EXTERNAL_MAJOR", version.external_major)),
+        "external_minor": int(os.getenv("EXTERNAL_MINOR", version.external_minor)),
+        "external_patch": int(os.getenv("EXTERNAL_PATCH", version.external_patch)),
+        "external_status": os.getenv("EXTERNAL_STATUS", version.external_status)
     }
 
     # For dev snapshots (alpha, beta, RC, etc.) we do not commit status change to Git,

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -285,6 +285,8 @@ def generate_sdk_package_versions():
             version_status = version_status[:pos] + "." + version_status[pos:]
         version_str += "-" + version_status
 
+    external_version_str = "{external_major}.{external_minor}.{external_patch}-{external_status}".format(**version_info)
+
     import version
 
     version_defines = (
@@ -306,7 +308,7 @@ def generate_sdk_package_versions():
     <GodotVersionConstants>{1}</GodotVersionConstants>
   </PropertyGroup>
 </Project>
-""".format(version_str, ";".join(version_defines))
+""".format(external_version_str, ";".join(version_defines))
 
     # We write in ../SdkPackageVersions.props.
     with open(os.path.join(dirname(script_path), "SdkPackageVersions.props"), "w", encoding="utf-8", newline="\n") as f:

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -103,7 +103,7 @@ bool godot_icall_EditorProgress_Step(const godot_string *p_task, const godot_str
 }
 
 void godot_icall_Internal_FullExportTemplatesDir(godot_string *r_dest) {
-	String full_templates_dir = EditorPaths::get_singleton()->get_export_templates_dir().path_join(VERSION_FULL_CONFIG);
+	String full_templates_dir = EditorPaths::get_singleton()->get_export_templates_dir().path_join(EXTERNAL_VERSION_FULL_CONFIG);
 	memnew_placement(r_dest, String(full_templates_dir));
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5725,7 +5725,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			PROPVARIANT val;
 			String appname;
 			if (Engine::get_singleton()->is_editor_hint()) {
-				appname = "Blazium.GodotEditor." + String(VERSION_FULL_CONFIG);
+				appname = "Blazium.GodotEditor." + String(EXTERNAL_VERSION_FULL_CONFIG);
 			} else {
 				String name = GLOBAL_GET("application/config/name");
 				String version = GLOBAL_GET("application/config/version");
@@ -6247,7 +6247,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	String appname;
 	if (Engine::get_singleton()->is_editor_hint()) {
-		appname = "Blazium.GodotEditor." + String(VERSION_FULL_CONFIG);
+		appname = "Blazium.GodotEditor." + String(EXTERNAL_VERSION_FULL_CONFIG);
 	} else {
 		String name = GLOBAL_GET("application/config/name");
 		String version = GLOBAL_GET("application/config/version");

--- a/platform/windows/godot_res.rc
+++ b/platform/windows/godot_res.rc
@@ -22,9 +22,9 @@ BEGIN
             VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME
             VALUE "Licence",                "MIT"
-            VALUE "LegalCopyright",         "(c) 2024-present Blazium Engine & 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
+            VALUE "LegalCopyright",         "(c) 2024-present Blazium Engine contributors, 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
             VALUE "Info",                   "https://blazium.app"
-            VALUE "ProductVersion",         VERSION_FULL_BUILD
+            VALUE "ProductVersion",         EXTERNAL_VERSION_FULL_BUILD
         END
     END
     BLOCK "VarFileInfo"

--- a/platform/windows/godot_res_wrap.rc
+++ b/platform/windows/godot_res_wrap.rc
@@ -17,9 +17,9 @@ BEGIN
             VALUE "FileVersion",            VERSION_NUMBER
             VALUE "ProductName",            VERSION_NAME " (Console)"
             VALUE "Licence",                "MIT"
-            VALUE "LegalCopyright",         "(c) 2024-present Blazium Engine & 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
+            VALUE "LegalCopyright",         "(c) 2024-present Blazium Engine contributors, 2007-present Juan Linietsky, Ariel Manzur and Godot Engine contributors"
             VALUE "Info",                   "https://blazium.app"
-            VALUE "ProductVersion",         VERSION_FULL_BUILD
+            VALUE "ProductVersion",         EXTERNAL_VERSION_FULL_BUILD
         END
     END
     BLOCK "VarFileInfo"

--- a/version.py
+++ b/version.py
@@ -7,3 +7,7 @@ status = "stable"
 module_config = ""
 website = "https://blazium.app"
 docs = "4.3"
+external_major = 0
+external_minor = 1
+external_patch = 0
+external_status = "nightly"


### PR DESCRIPTION
Godot versioning is retained for compatibility and informational use. Blazium versioning is set to 0.1.0-nightly.