### PR TITLE
Construct `Vector2` & `Vector2i` from a single int/float value.

### DIFF
--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -189,6 +189,21 @@ struct [[nodiscard]] Vector2 {
 		x = p_x;
 		y = p_y;
 	}
+	_FORCE_INLINE_ explicit Vector2(real_t p_v) {
+		x = p_v;
+		y = p_v;
+	}
+	_FORCE_INLINE_ Vector2(const Vector2 &p_v) noexcept {
+		x = p_v.x;
+		y = p_v.y;
+	}
+	_FORCE_INLINE_ Vector2 &operator=(const Vector2 &p_v) {
+		if (this != &p_v) {
+			x = p_v.x;
+			y = p_v.y;
+		}
+		return *this;
+	}
 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -147,6 +147,21 @@ struct [[nodiscard]] Vector2i {
 		x = p_x;
 		y = p_y;
 	}
+	inline explicit Vector2i(int32_t p_v) {
+		x = p_v;
+		y = p_v;
+	}
+	inline Vector2i(const Vector2i &p_v) noexcept {
+		x = p_v.x;
+		y = p_v.y;
+	}
+	inline Vector2i &operator=(const Vector2i &p_v) {
+		if (this != &p_v) {
+			x = p_v.x;
+			y = p_v.y;
+		}
+		return *this;
+	}
 };
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -36,6 +36,7 @@
 #include "core/templates/sort_array.h"
 #include "core/templates/vector.h"
 
+#include <algorithm>
 #include <initializer_list>
 #include <type_traits>
 
@@ -295,9 +296,8 @@ public:
 
 	operator Vector<T>() const {
 		Vector<T> ret;
-		ret.resize(size());
-		T *w = ret.ptrw();
-		memcpy(w, data, sizeof(T) * count);
+		ret.resize(count);
+		std::copy(data, data + count, ret.ptrw());
 		return ret;
 	}
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -234,6 +234,8 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 		} break;
 		case VECTOR2: {
 			static const Type valid[] = {
+				INT,
+				FLOAT,
 				VECTOR2I,
 				NIL,
 			};
@@ -243,6 +245,8 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 		} break;
 		case VECTOR2I: {
 			static const Type valid[] = {
+				INT,
+				FLOAT,
 				VECTOR2,
 				NIL,
 			};
@@ -577,6 +581,8 @@ bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type
 		} break;
 		case VECTOR2: {
 			static const Type valid[] = {
+				INT,
+				FLOAT,
 				VECTOR2I,
 				NIL,
 			};
@@ -586,6 +592,8 @@ bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type
 		} break;
 		case VECTOR2I: {
 			static const Type valid[] = {
+				INT,
+				FLOAT,
 				VECTOR2,
 				NIL,
 			};
@@ -1852,7 +1860,11 @@ String Variant::to_json_string() const {
 }
 
 Variant::operator Vector2() const {
-	if (type == VECTOR2) {
+	if (type == INT) {
+		return Vector2(_data._int, _data._int);
+	} else if (type == FLOAT) {
+		return Vector2(_data._float, _data._float);
+	} else if (type == VECTOR2) {
 		return *reinterpret_cast<const Vector2 *>(_data._mem);
 	} else if (type == VECTOR2I) {
 		return *reinterpret_cast<const Vector2i *>(_data._mem);
@@ -1870,7 +1882,11 @@ Variant::operator Vector2() const {
 }
 
 Variant::operator Vector2i() const {
-	if (type == VECTOR2I) {
+	if (type == INT) {
+		return Vector2(_data._int, _data._int);
+	} else if (type == FLOAT) {
+		return Vector2(_data._float, _data._float);
+	} else if (type == VECTOR2I) {
 		return *reinterpret_cast<const Vector2i *>(_data._mem);
 	} else if (type == VECTOR2) {
 		return *reinterpret_cast<const Vector2 *>(_data._mem);
@@ -2521,12 +2537,12 @@ Variant::Variant(const Vector4i &p_vector4i) :
 
 Variant::Variant(const Vector2 &p_vector2) :
 		type(VECTOR2) {
-	memnew_placement(_data._mem, Vector2(p_vector2));
+	memnew_placement(_data._mem, Vector2(p_vector2.x, p_vector2.y));
 }
 
 Variant::Variant(const Vector2i &p_vector2i) :
 		type(VECTOR2I) {
-	memnew_placement(_data._mem, Vector2i(p_vector2i));
+	memnew_placement(_data._mem, Vector2i(p_vector2i.x, p_vector2i.y));
 }
 
 Variant::Variant(const Rect2 &p_rect2) :

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -84,11 +84,13 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructNoArgs<Vector2>>(sarray());
 	add_constructor<VariantConstructor<Vector2, Vector2>>(sarray("from"));
 	add_constructor<VariantConstructor<Vector2, Vector2i>>(sarray("from"));
+	add_constructor<VariantConstructor<Vector2, double>>(sarray("from"));
 	add_constructor<VariantConstructor<Vector2, double, double>>(sarray("x", "y"));
 
 	add_constructor<VariantConstructNoArgs<Vector2i>>(sarray());
 	add_constructor<VariantConstructor<Vector2i, Vector2i>>(sarray("from"));
 	add_constructor<VariantConstructor<Vector2i, Vector2>>(sarray("from"));
+	add_constructor<VariantConstructor<Vector2i, int64_t>>(sarray("from"));
 	add_constructor<VariantConstructor<Vector2i, int64_t, int64_t>>(sarray("x", "y"));
 
 	add_constructor<VariantConstructNoArgs<Rect2>>(sarray());

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -710,12 +710,16 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return err;
 			}
 
-			if (args.size() != 2) {
-				r_err_str = "Expected 2 arguments for constructor";
+			if (args.size() == 0) {
+				value = Vector2();
+			} else if (args.size() == 1) {
+				value = Vector2(args[0], args[0]);
+			} else if (args.size() == 2) {
+				value = Vector2(args[0], args[1]);
+			} else {
+				r_err_str = "Expected at most 2 arguments for constructor";
 				return ERR_PARSE_ERROR;
 			}
-
-			value = Vector2(args[0], args[1]);
 		} else if (id == "Vector2i") {
 			Vector<int32_t> args;
 			Error err = _parse_construct<int32_t>(p_stream, args, line, r_err_str);
@@ -723,12 +727,16 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return err;
 			}
 
-			if (args.size() != 2) {
-				r_err_str = "Expected 2 arguments for constructor";
+			if (args.size() == 0) {
+				value = Vector2i();
+			} else if (args.size() == 1) {
+				value = Vector2i(args[0], args[0]);
+			} else if (args.size() == 2) {
+				value = Vector2i(args[0], args[1]);
+			} else {
+				r_err_str = "Expected at most 2 arguments for constructor";
 				return ERR_PARSE_ERROR;
 			}
-
-			value = Vector2i(args[0], args[1]);
 		} else if (id == "Rect2") {
 			Vector<real_t> args;
 			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -40,6 +40,13 @@
 		</constructor>
 		<constructor name="Vector2">
 			<return type="Vector2" />
+			<param index="0" name="from" type="float" />
+			<description>
+				Constructs a new [Vector2] from [float].
+			</description>
+		</constructor>
+		<constructor name="Vector2">
+			<return type="Vector2" />
 			<param index="0" name="x" type="float" />
 			<param index="1" name="y" type="float" />
 			<description>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -36,6 +36,13 @@
 		</constructor>
 		<constructor name="Vector2i">
 			<return type="Vector2i" />
+			<param index="0" name="from" type="int" />
+			<description>
+				Constructs a new [Vector2] from [int].
+			</description>
+		</constructor>
+		<constructor name="Vector2i">
+			<return type="Vector2i" />
 			<param index="0" name="x" type="int" />
 			<param index="1" name="y" type="int" />
 			<description>

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -107,9 +107,9 @@ class RasterizerCanvasGLES3 : public RendererCanvasRender {
 		RID texture;
 		struct {
 			bool enabled = false;
-			float z_far;
-			float y_offset;
-			Transform2D directional_xform;
+			float z_far = 0.0f;
+			float y_offset = 0.0f;
+			Transform2D directional_xform = Transform2D();
 		} shadow;
 	};
 

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unsafe_call_argument.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unsafe_call_argument.out
@@ -50,7 +50,7 @@ GDTEST_OK
 >> WARNING
 >> Line: 50
 >> UNSAFE_CALL_ARGUMENT
->> The argument 1 of the constructor "Vector2()" requires the subtype "Vector2" or "Vector2i" but the supertype "Variant" was provided.
+>> The argument 1 of the constructor "Vector2()" requires the subtype "Vector2", "int", "float", or "Vector2i" but the supertype "Variant" was provided.
 >> WARNING
 >> Line: 51
 >> UNSAFE_CALL_ARGUMENT

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -51,6 +51,8 @@
 #include "editor/editor_file_system.h"
 #endif
 
+#include <algorithm>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -446,8 +448,7 @@ godot_packed_array godotsharp_packed_vector2_array_new_mem_copy(const Vector2 *p
 	memnew_placement(&ret, PackedVector2Array);
 	PackedVector2Array *array = reinterpret_cast<PackedVector2Array *>(&ret);
 	array->resize(p_length);
-	Vector2 *dst = array->ptrw();
-	memcpy(dst, p_src, p_length * sizeof(Vector2));
+	std::copy(p_src, p_src + p_length, array->ptrw());
 	return ret;
 }
 

--- a/modules/raycast/lightmap_raycaster_embree.cpp
+++ b/modules/raycast/lightmap_raycaster_embree.cpp
@@ -32,6 +32,8 @@
 
 #include "lightmap_raycaster_embree.h"
 
+#include <algorithm>
+
 #ifdef __SSE2__
 #include <pmmintrin.h>
 #endif
@@ -130,7 +132,7 @@ void LightmapRaycasterEmbree::add_mesh(const Vector<Vector3> &p_vertices, const 
 	memcpy(embree_vertices, p_vertices.ptr(), sizeof(Vector3) * vertex_count);
 
 	Vector2 *embree_light_uvs = (Vector2 *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_VERTEX_ATTRIBUTE, 0, RTC_FORMAT_FLOAT2, sizeof(Vector2), vertex_count);
-	memcpy(embree_light_uvs, p_uv2s.ptr(), sizeof(Vector2) * vertex_count);
+	std::copy(p_uv2s.ptr(), p_uv2s.ptr() + vertex_count, embree_light_uvs);
 
 	uint32_t *embree_triangles = (uint32_t *)rtcSetNewGeometryBuffer(embree_mesh, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, sizeof(uint32_t) * 3, vertex_count / 3);
 	for (int i = 0; i < vertex_count; i++) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -256,9 +256,9 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		RID texture;
 		struct {
 			bool enabled = false;
-			float z_far;
-			float y_offset;
-			Transform2D directional_xform;
+			float z_far = 0.0f;
+			float y_offset = 0.0f;
+			Transform2D directional_xform = Transform2D();
 		} shadow;
 	};
 

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -39,10 +39,18 @@ namespace TestVector2 {
 
 TEST_CASE("[Vector2] Constructor methods") {
 	const Vector2 vector_empty = Vector2();
+	const Vector2 vector_zero_int = Vector2(0);
+	const Vector2 vector_zero_float = Vector2(0.0f);
 	const Vector2 vector_zero = Vector2(0.0, 0.0);
 	CHECK_MESSAGE(
 			vector_empty == vector_zero,
 			"Vector2 Constructor with no inputs should return a zero Vector2.");
+	CHECK_MESSAGE(
+			vector_zero_float == vector_zero,
+			"Vector2 Constructor with single float input should return a zero Vector2.");
+	CHECK_MESSAGE(
+			vector_zero_int == vector_zero,
+			"Vector2 Constructor with single int input should return a zero Vector2.");
 }
 
 TEST_CASE("[Vector2] Angle methods") {
@@ -95,19 +103,19 @@ TEST_CASE("[Vector2] Interpolation methods") {
 			vector1.normalized().slerp(vector2.normalized(), 1.0 / 3.0).is_equal_approx(Vector2(0.508990883827209473, 0.860771894454956055)),
 			"Vector2 slerp should work as expected.");
 	CHECK_MESSAGE(
-			Vector2(5, 0).slerp(Vector2(0, 5), 0.5).is_equal_approx(Vector2(5, 5) * Math_SQRT12),
+			Vector2(5, 0).slerp(Vector2(0, 5), 0.5).is_equal_approx(Vector2(5) * Math_SQRT12),
 			"Vector2 slerp with non-normalized values should work as expected.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).slerp(Vector2(2, 2), 0.5).is_equal_approx(Vector2(1.5, 1.5)),
+			Vector2(1).slerp(Vector2(2), 0.5).is_equal_approx(Vector2(1.5)),
 			"Vector2 slerp with colinear inputs should behave as expected.");
 	CHECK_MESSAGE(
 			Vector2().slerp(Vector2(), 0.5) == Vector2(),
 			"Vector2 slerp with both inputs as zero vectors should return a zero vector.");
 	CHECK_MESSAGE(
-			Vector2().slerp(Vector2(1, 1), 0.5) == Vector2(0.5, 0.5),
+			Vector2().slerp(Vector2(1), 0.5) == Vector2(0.5),
 			"Vector2 slerp with one input as zero should behave like a regular lerp.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).slerp(Vector2(), 0.5) == Vector2(0.5, 0.5),
+			Vector2(1).slerp(Vector2(), 0.5) == Vector2(0.5),
 			"Vector2 slerp with one input as zero should behave like a regular lerp.");
 	CHECK_MESSAGE(
 			Vector2(4, 6).slerp(Vector2(8, 10), 0.5).is_equal_approx(Vector2(5.9076470794008017626, 8.07918879020090480697)),
@@ -130,7 +138,7 @@ TEST_CASE("[Vector2] Interpolation methods") {
 }
 
 TEST_CASE("[Vector2] Length methods") {
-	const Vector2 vector1 = Vector2(10, 10);
+	const Vector2 vector1 = Vector2(10);
 	const Vector2 vector2 = Vector2(20, 30);
 	CHECK_MESSAGE(
 			vector1.length_squared() == 200,
@@ -153,12 +161,12 @@ TEST_CASE("[Vector2] Length methods") {
 }
 
 TEST_CASE("[Vector2] Limiting methods") {
-	const Vector2 vector = Vector2(10, 10);
+	const Vector2 vector = Vector2(10);
 	CHECK_MESSAGE(
-			vector.limit_length().is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
+			vector.limit_length().is_equal_approx(Vector2(Math_SQRT12)),
 			"Vector2 limit_length should work as expected.");
 	CHECK_MESSAGE(
-			vector.limit_length(5).is_equal_approx(5 * Vector2(Math_SQRT12, Math_SQRT12)),
+			vector.limit_length(5).is_equal_approx(5 * Vector2(Math_SQRT12)),
 			"Vector2 limit_length should work as expected.");
 
 	CHECK_MESSAGE(
@@ -174,13 +182,13 @@ TEST_CASE("[Vector2] Normalization methods") {
 			Vector2(1, 0).is_normalized() == true,
 			"Vector2 is_normalized should return true for a normalized vector.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).is_normalized() == false,
+			Vector2(1).is_normalized() == false,
 			"Vector2 is_normalized should return false for a non-normalized vector.");
 	CHECK_MESSAGE(
 			Vector2(1, 0).normalized() == Vector2(1, 0),
 			"Vector2 normalized should return the same vector for a normalized vector.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).normalized().is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
+			Vector2(1).normalized().is_equal_approx(Vector2(Math_SQRT12)),
 			"Vector2 normalized should work as expected.");
 
 	Vector2 vector = Vector2(3.2, -5.4);
@@ -218,7 +226,7 @@ TEST_CASE("[Vector2] Operators") {
 			(power1 - power2) == Vector2(0.25, 1.375),
 			"Vector2 subtraction with powers of two should give exact results.");
 	CHECK_MESSAGE(
-			(int1 - int2) == Vector2(3, 3),
+			(int1 - int2) == Vector2(3),
 			"Vector2 subtraction with integers should give exact results.");
 
 	CHECK_MESSAGE(
@@ -301,7 +309,7 @@ TEST_CASE("[Vector2] Other methods") {
 			vector.direction_to(Vector2()).is_equal_approx(-vector.normalized()),
 			"Vector2 direction_to should work as expected.");
 	CHECK_MESSAGE(
-			Vector2(1, 1).direction_to(Vector2(2, 2)).is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
+			Vector2(1).direction_to(Vector2(2)).is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
 			"Vector2 direction_to should work as expected.");
 
 	CHECK_MESSAGE(
@@ -331,13 +339,13 @@ TEST_CASE("[Vector2] Other methods") {
 			"Vector2 rotated should work as expected.");
 
 	CHECK_MESSAGE(
-			vector.snapped(Vector2(1, 1)) == Vector2(1, 3),
+			vector.snapped(Vector2(1)) == Vector2(1, 3),
 			"Vector2 snapped to integers should be the same as rounding.");
 	CHECK_MESSAGE(
-			Vector2(3.4, 5.6).snapped(Vector2(1, 1)) == Vector2(3, 6),
+			Vector2(3.4, 5.6).snapped(Vector2(1)) == Vector2(3, 6),
 			"Vector2 snapped to integers should be the same as rounding.");
 	CHECK_MESSAGE(
-			vector.snapped(Vector2(0.25, 0.25)) == Vector2(1.25, 3.5),
+			vector.snapped(Vector2(0.25)) == Vector2(1.25, 3.5),
 			"Vector2 snapped to 0.25 should give exact results.");
 
 	CHECK_MESSAGE(
@@ -430,7 +438,7 @@ TEST_CASE("[Vector2] Rounding methods") {
 			"Vector2 round should work as expected.");
 
 	CHECK_MESSAGE(
-			vector1.sign() == Vector2(1, 1),
+			vector1.sign() == Vector2(1),
 			"Vector2 sign should work as expected.");
 	CHECK_MESSAGE(
 			vector2.sign() == Vector2(1, -1),

--- a/tests/core/math/test_vector2i.h
+++ b/tests/core/math/test_vector2i.h
@@ -39,10 +39,18 @@ namespace TestVector2i {
 
 TEST_CASE("[Vector2i] Constructor methods") {
 	const Vector2i vector_empty = Vector2i();
+	const Vector2i vector_zero_int = Vector2i(0);
+	const Vector2i vector_zero_float = Vector2i(0.0f);
 	const Vector2i vector_zero = Vector2i(0, 0);
 	CHECK_MESSAGE(
 			vector_empty == vector_zero,
 			"Vector2i Constructor with no inputs should return a zero Vector2i.");
+	CHECK_MESSAGE(
+			vector_zero_int == vector_zero,
+			"Vector2i Constructor with single int input should return a zero Vector2i.");
+	CHECK_MESSAGE(
+			vector_zero_float == vector_zero,
+			"Vector2i Constructor with single float input should return a zero Vector2i.");
 }
 
 TEST_CASE("[Vector2i] Axis methods") {
@@ -63,7 +71,7 @@ TEST_CASE("[Vector2i] Axis methods") {
 }
 
 TEST_CASE("[Vector2i] Clamp method") {
-	const Vector2i vector = Vector2i(10, 10);
+	const Vector2i vector = Vector2i(10);
 	CHECK_MESSAGE(
 			Vector2i(-5, 15).clamp(Vector2i(), vector) == Vector2i(0, 10),
 			"Vector2i clamp should work as expected.");
@@ -73,7 +81,7 @@ TEST_CASE("[Vector2i] Clamp method") {
 }
 
 TEST_CASE("[Vector2i] Length methods") {
-	const Vector2i vector1 = Vector2i(10, 10);
+	const Vector2i vector1 = Vector2i(10);
 	const Vector2i vector2 = Vector2i(20, 30);
 	CHECK_MESSAGE(
 			vector1.length_squared() == 200,
@@ -160,7 +168,7 @@ TEST_CASE("[Vector2i] Abs and sign methods") {
 			"Vector2i abs should work as expected.");
 
 	CHECK_MESSAGE(
-			vector1.sign() == Vector2i(1, 1),
+			vector1.sign() == Vector2i(1),
 			"Vector2i sign should work as expected.");
 	CHECK_MESSAGE(
 			vector2.sign() == Vector2i(1, -1),

--- a/tests/core/variant/test_variant_utility.h
+++ b/tests/core/variant/test_variant_utility.h
@@ -61,7 +61,7 @@ TEST_CASE("[VariantUtility] Type conversion") {
 
 	converted = VariantUtilityFunctions::type_convert(5, Variant::Type::VECTOR2);
 	CHECK(converted.get_type() == Variant::Type::VECTOR2);
-	CHECK(converted == Variant(Vector2(0, 0)));
+	CHECK(converted == Variant(Vector2(5, 5)));
 
 	converted = VariantUtilityFunctions::type_convert(Vector3(1, 2, 3), Variant::Type::VECTOR2);
 	CHECK(converted.get_type() == Variant::Type::VECTOR2);


### PR DESCRIPTION
GDScript Example:
```gdscript

print(Vector2() == Vector2(0, 0) and Vector2(0) == Vector2(0, 0)) # prints "true"
print(Vector2(12) == Vector2(12.0, 12.0)) # prints "true"

print(Vector2i() == Vector2i(0, 0) and Vector2i(0) == Vector2i(0, 0)) # prints "true"
print(Vector2i(12.5) == Vector2i(12, 12)) # prints "true"
```

C++ Example:
```c++
print_line(Vector2(0) == Vector2(0, 0)); // prints "true"
print_line(Vector2(12) == Vector2(12.0, 12.0)); // prints "true"

print_line(Vector2i(0) == Vector2i(0, 0)); // prints "true"
print_line(Vector2i(12.5) == Vector2i(12, 12)); // prints "true"
```