### PR TITLE
Add blazium sdk module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,6 +144,7 @@ repos:
             platform/(?!android|ios|linuxbsd|macos|web|windows)\w+/.*|
             platform/android/java/editor/src/main/java/com/android/.*|
             platform/android/java/lib/src/com/.*|
+            modules/blazium_sdk/.*|
             platform/android/java/lib/src/org/godotengine/godot/gl/GLSurfaceView\.java$|
             platform/android/java/lib/src/org/godotengine/godot/gl/EGLLogWrapper\.java$|
             platform/android/java/lib/src/org/godotengine/godot/utils/ProcessPhoenix\.java$

--- a/modules/blazium_sdk/SCsub
+++ b/modules/blazium_sdk/SCsub
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_blazium_sdk = env_modules.Clone()
+env_blazium_sdk.add_source_files(env.modules_sources, "lobby/*.cpp")
+env_blazium_sdk.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/blazium_sdk/blazium_client.h
+++ b/modules/blazium_sdk/blazium_client.h
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  blazium_client.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                            BLAZIUM ENGINE                              */
+/*                        https://blazium.app                             */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/* Copyright (c) 2024 Dragos Daian, Randolph William Aarseth II.          */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef BLAZIUM_CLIENT_H
+#define BLAZIUM_CLIENT_H
+
+#include "scene/main/node.h"
+
+class BlaziumClient : public Node {
+	GDCLASS(BlaziumClient, Node);
+
+protected:
+	static void _bind_methods() {}
+};
+
+#endif // BLAZIUM_CLIENT_H

--- a/modules/blazium_sdk/config.py
+++ b/modules/blazium_sdk/config.py
@@ -1,0 +1,27 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "LobbyClient",
+        "BlaziumClient",
+        "LobbyInfo",
+        "LobbyPeer",
+        "CreateLobbyResponse",
+        "CreateLobbyResult",
+        "LobbyResponse",
+        "LobbyResult",
+        "ListLobbyResponse",
+        "ListLobbyResult",
+        "ViewLobbyResponse",
+        "ViewLobbyResult",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/blazium_sdk/doc_classes/BlaziumClient.xml
+++ b/modules/blazium_sdk/doc_classes/BlaziumClient.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="BlaziumClient" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		An abstract base node used to connect to a blazium services.
+	</brief_description>
+	<description>
+		An abstract base node used to connect to a blazium services. See implementations of it:
+		- [LobbyClient]
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/blazium_sdk/doc_classes/CreateLobbyResponse.xml
+++ b/modules/blazium_sdk/doc_classes/CreateLobbyResponse.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CreateLobbyResponse" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Response from a create lobby request.
+	</brief_description>
+	<description>
+		Response from a create lobby request. Await on finished to get the [CreateLobbyResult].
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="finished">
+			<param index="0" name="result" type="CreateLobbyResult" />
+			<description>
+				Signal emitted when the request is finished.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/blazium_sdk/doc_classes/CreateLobbyResult.xml
+++ b/modules/blazium_sdk/doc_classes/CreateLobbyResult.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CreateLobbyResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A result from a [CreateLobbyResponse].
+	</brief_description>
+	<description>
+		A result from a [CreateLobbyResponse]. Contains either result or error.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="has_error" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if there is an error.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="error" type="String" setter="" getter="get_error" default="&quot;&quot;">
+			Gets the error message.
+		</member>
+		<member name="lobby_name" type="String" setter="" getter="get_lobby_name" default="&quot;&quot;">
+			Gets the lobby name.
+		</member>
+	</members>
+</class>

--- a/modules/blazium_sdk/doc_classes/ListLobbyResponse.xml
+++ b/modules/blazium_sdk/doc_classes/ListLobbyResponse.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ListLobbyResponse" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Response from a list lobby request.
+	</brief_description>
+	<description>
+		Response from a list lobby request. Await on finished to get the [ListLobbyResult].
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="finished">
+			<param index="0" name="result" type="ListLobbyResult" />
+			<description>
+				Signal emitted when the request is finished.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/blazium_sdk/doc_classes/ListLobbyResult.xml
+++ b/modules/blazium_sdk/doc_classes/ListLobbyResult.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ListLobbyResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A result from a [ListLobbyResponse].
+	</brief_description>
+	<description>
+		A result from a [ListLobbyResponse]. Contains either result or error.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="has_error" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if there is an error.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="error" type="String" setter="" getter="get_error" default="&quot;&quot;">
+			Gets the error message.
+		</member>
+		<member name="lobbies" type="String[]" setter="" getter="get_lobbies" default="[]">
+			Gets the lobbies.
+		</member>
+	</members>
+</class>

--- a/modules/blazium_sdk/doc_classes/LobbyClient.xml
+++ b/modules/blazium_sdk/doc_classes/LobbyClient.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LobbyClient" inherits="BlaziumClient" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A node used to connect to a blazium lobby websocket server.
+	</brief_description>
+	<description>
+		A node used to connect to a lobby server. It can be used to do matchmaking. You care do operations such as create lobbys, join lobbys, etc.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="connect_to_lobby">
+			<return type="bool" />
+			<param index="0" name="game_id" type="String" />
+			<description>
+				Connect to a Blazium Lobby Server using a game id.
+			</description>
+		</method>
+		<method name="create_lobby">
+			<return type="CreateLobbyResponse" />
+			<param index="0" name="max_players" type="int" default="4" />
+			<param index="1" name="password" type="String" default="&quot;&quot;" />
+			<description>
+				Create a lobby and become host. If you are already in a lobby, you cannot create one. You need to leave first.
+				Will generate either error signal or lobby_created.
+			</description>
+		</method>
+		<method name="join_lobby">
+			<return type="LobbyResponse" />
+			<param index="0" name="lobby_name" type="String" />
+			<param index="1" name="password" type="String" default="&quot;&quot;" />
+			<description>
+				Joint a lobby. If you are already in a lobby, you cannot join another one. You need to leave first.
+				Will generate either error signal or lobby_joined.
+			</description>
+		</method>
+		<method name="kick_peer">
+			<return type="LobbyResponse" />
+			<param index="0" name="peer_id" type="String" />
+			<description>
+				Kick a peer. You need to be host to do so.
+			</description>
+		</method>
+		<method name="leave_lobby">
+			<return type="LobbyResponse" />
+			<description>
+				Leave a lobby. You need to be in a lobby to leave one.
+				Will generate either error signal or lobby_left.
+			</description>
+		</method>
+		<method name="list_lobby">
+			<return type="ListLobbyResponse" />
+			<param index="0" name="start" type="int" default="0" />
+			<param index="1" name="count" type="int" default="10" />
+			<description>
+				Lists all lobbies.
+				Will generate either error signal or lobby_list.
+			</description>
+		</method>
+		<method name="lobby_data">
+			<return type="LobbyResponse" />
+			<param index="0" name="data" type="String" />
+			<description>
+				Send data either to the host, or if you are host send data to all peers.
+				Generates received_data signal.
+			</description>
+		</method>
+		<method name="lobby_data_to">
+			<return type="LobbyResponse" />
+			<param index="0" name="data" type="String" />
+			<param index="1" name="target_peer" type="String" />
+			<description>
+				Send data either to a peer, works only if you are host.
+				Generates received_data_to signal.
+			</description>
+		</method>
+		<method name="lobby_ready">
+			<return type="LobbyResponse" />
+			<description>
+				Ready up in the lobby. You need to be in a lobby and unready to run this.
+				Will generate either error signal or peer_ready.
+			</description>
+		</method>
+		<method name="lobby_unready">
+			<return type="LobbyResponse" />
+			<description>
+				Ready up in the lobby. You need to be in a lobby and ready to run this.
+				Will generate either error signal or peer_unready.
+			</description>
+		</method>
+		<method name="seal_lobby">
+			<return type="LobbyResponse" />
+			<description>
+				Seals the lobby. You need to be the host to do this and the lobby needs to be unsealed.
+				Will generate either error signal or lobby_sealed.
+			</description>
+		</method>
+		<method name="unseal_lobby">
+			<return type="LobbyResponse" />
+			<description>
+				Unseals the lobby. You need to be the host to do this and the lobby needs to be sealed.
+				Will generate either error signal or lobby_unsealed.
+			</description>
+		</method>
+		<method name="view_lobby">
+			<return type="ViewLobbyResponse" />
+			<param index="0" name="lobby_name" type="String" />
+			<param index="1" name="password" type="String" default="&quot;&quot;" />
+			<description>
+				View data from a lobby. Returns lobby settings and peers.
+				Will generate either error signal or lobby_view.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="server_url" type="String" setter="set_server_url" getter="get_server_url" default="&quot;wss://lobby.blazium.app/connect&quot;">
+			Set to what url this lobby should connect to.
+		</member>
+	</members>
+	<signals>
+		<signal name="append_log">
+			<param index="0" name="action" type="String" />
+			<param index="1" name="info" type="String" />
+			<param index="2" name="logs" type="String" />
+			<description>
+				Signals a log from a command.
+			</description>
+		</signal>
+		<signal name="lobby_created">
+			<param index="0" name="lobby" type="String" />
+			<description>
+				Signal generated after a lobby is created.
+			</description>
+		</signal>
+		<signal name="lobby_joined">
+			<param index="0" name="lobby" type="String" />
+			<description>
+				Signal generated after you joint a lobby.
+			</description>
+		</signal>
+		<signal name="lobby_left">
+			<description>
+				Signal generated after you leave a lobby.
+			</description>
+		</signal>
+		<signal name="lobby_sealed">
+			<description>
+				Signal generated after the host seals the lobby.
+			</description>
+		</signal>
+		<signal name="lobby_unsealed">
+			<description>
+				Signal generated after the host unseals the lobby.
+			</description>
+		</signal>
+		<signal name="peer_joined">
+			<param index="0" name="peer" type="String" />
+			<description>
+				Signal generated after a peer joins the lobby.
+			</description>
+		</signal>
+		<signal name="peer_left">
+			<param index="0" name="peer" type="String" />
+			<param index="1" name="kicked" type="bool" />
+			<description>
+				Signal generated after a peer leaves the lobby.
+			</description>
+		</signal>
+		<signal name="peer_named">
+			<param index="0" name="peer" type="String" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Signal generated after a peer names himself.
+			</description>
+		</signal>
+		<signal name="peer_ready">
+			<param index="0" name="peer" type="String" />
+			<description>
+				Signal generated after a peer is ready.
+			</description>
+		</signal>
+		<signal name="peer_unready">
+			<param index="0" name="peer" type="String" />
+			<description>
+				Signal generated after a peer is unready.
+			</description>
+		</signal>
+		<signal name="received_data">
+			<param index="0" name="data" type="String" />
+			<description>
+				Signal generated after a lobby_data call.
+			</description>
+		</signal>
+		<signal name="received_data_to">
+			<param index="0" name="data" type="String" />
+			<description>
+				Signal generated after a data_to call.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/blazium_sdk/doc_classes/LobbyInfo.xml
+++ b/modules/blazium_sdk/doc_classes/LobbyInfo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LobbyInfo" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Lobby information returned after a view lobby request.
+	</brief_description>
+	<description>
+		Lobby information returned after a view lobby request.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="host" type="String" setter="" getter="get_host" default="&quot;&quot;">
+			The host id of the lobby.
+		</member>
+		<member name="max_players" type="int" setter="" getter="get_max_players" default="0">
+			The maximum number of players allowed in the lobby.
+		</member>
+		<member name="sealed" type="bool" setter="" getter="is_sealed" default="false">
+			Whether the lobby is sealed.
+		</member>
+	</members>
+</class>

--- a/modules/blazium_sdk/doc_classes/LobbyPeer.xml
+++ b/modules/blazium_sdk/doc_classes/LobbyPeer.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LobbyPeer" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Lobby peers information returned after a view lobby request.
+	</brief_description>
+	<description>
+		Lobby peers information returned after a view lobby request.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="id" type="String" setter="" getter="get_id" default="&quot;&quot;">
+			Identifier of the peer.
+		</member>
+		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			Name of the peer.
+		</member>
+		<member name="ready" type="bool" setter="" getter="is_ready" default="false">
+			Whether the peer is ready.
+		</member>
+	</members>
+</class>

--- a/modules/blazium_sdk/doc_classes/LobbyResponse.xml
+++ b/modules/blazium_sdk/doc_classes/LobbyResponse.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LobbyResponse" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Generic response from a lobby request.
+	</brief_description>
+	<description>
+		Generic response from a lobby request. Await on finished to get the result.
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="finished">
+			<param index="0" name="result" type="LobbyResult" />
+			<description>
+				Signal emitted when the request is finished.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/blazium_sdk/doc_classes/LobbyResult.xml
+++ b/modules/blazium_sdk/doc_classes/LobbyResult.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LobbyResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A result from a [LobbyResponse].
+	</brief_description>
+	<description>
+		A result from a [LobbyResponse]. Contains either nothing or error.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="has_error" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if there is an error.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="error" type="String" setter="" getter="get_error" default="&quot;&quot;">
+			Gets the error message.
+		</member>
+	</members>
+</class>

--- a/modules/blazium_sdk/doc_classes/ViewLobbyResponse.xml
+++ b/modules/blazium_sdk/doc_classes/ViewLobbyResponse.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ViewLobbyResponse" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		View response from a lobby request.
+	</brief_description>
+	<description>
+		View response from a lobby request. Await on finished to get the result.
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="finished">
+			<param index="0" name="result" type="ViewLobbyResult" />
+			<description>
+				Signal emitted when the request is finished.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/blazium_sdk/doc_classes/ViewLobbyResult.xml
+++ b/modules/blazium_sdk/doc_classes/ViewLobbyResult.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ViewLobbyResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A result from a [ViewLobbyResponse].
+	</brief_description>
+	<description>
+		A result from a [ViewLobbyResponse]. Contains either result or error.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_lobby_info" qualifiers="const">
+			<return type="LobbyInfo" />
+			<description>
+				Gets the lobby info.
+			</description>
+		</method>
+		<method name="has_error" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if there is an error.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="error" type="String" setter="" getter="get_error" default="&quot;&quot;">
+			Gets the error message.
+		</member>
+		<member name="peers" type="LobbyPeer[]" setter="" getter="get_peers" default="[]">
+			Gets the peers.
+		</member>
+	</members>
+</class>

--- a/modules/blazium_sdk/icons/BlaziumClient.svg
+++ b/modules/blazium_sdk/icons/BlaziumClient.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="5" fill="none" stroke="#F079F2" stroke-width="2"/></svg>

--- a/modules/blazium_sdk/icons/LobbyClient.svg
+++ b/modules/blazium_sdk/icons/LobbyClient.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#f079f2" d="m 5,5 v 2 h 6 V 5 Z M 3,1 C 2,1 1,2 1,3 v 10.034483 c 0,1.104569 0.8954305,2 2,2 h 10 c 1.104569,0 2,-0.929914 2,-2.034483 V 3 C 15,2 14,1 13,1 Z M 3,2 H 4 V 3 H 3 Z M 6,2 H 7 V 3 H 6 Z m 3,0 h 1 V 3 H 9 Z m 3,0 h 1 V 3 H 12 Z M 3,4 h 10 v 9 H 3 Z m 2,6 v 2 h 6 v -2 z"/></svg>

--- a/modules/blazium_sdk/lobby/lobby_client.cpp
+++ b/modules/blazium_sdk/lobby/lobby_client.cpp
@@ -1,0 +1,613 @@
+/**************************************************************************/
+/*  lobby_client.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                            BLAZIUM ENGINE                              */
+/*                        https://blazium.app                             */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/* Copyright (c) 2024 Dragos Daian, Randolph William Aarseth II.          */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "./lobby_client.h"
+#include "scene/main/node.h"
+LobbyClient::LobbyClient() {
+	_socket = Ref<WebSocketPeer>(WebSocketPeer::create());
+}
+
+LobbyClient::~LobbyClient() {
+	_socket->close(1000, "Disconnected");
+	set_process_internal(false);
+}
+
+void LobbyClient::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_server_url", "server_url"), &LobbyClient::set_server_url);
+	ClassDB::bind_method(D_METHOD("get_server_url"), &LobbyClient::get_server_url);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "server_url", PROPERTY_HINT_NONE, ""), "set_server_url", "get_server_url");
+	// Register methods
+	ClassDB::bind_method(D_METHOD("connect_to_lobby", "game_id"), &LobbyClient::connect_to_lobby);
+	ClassDB::bind_method(D_METHOD("create_lobby", "max_players", "password"), &LobbyClient::create_lobby, DEFVAL(4), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("join_lobby", "lobby_name", "password"), &LobbyClient::join_lobby, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("leave_lobby"), &LobbyClient::leave_lobby);
+	ClassDB::bind_method(D_METHOD("list_lobby", "start", "count"), &LobbyClient::list_lobby, DEFVAL(0), DEFVAL(10));
+	ClassDB::bind_method(D_METHOD("view_lobby", "lobby_name", "password"), &LobbyClient::view_lobby, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("kick_peer", "peer_id"), &LobbyClient::kick_peer);
+	ClassDB::bind_method(D_METHOD("lobby_ready"), &LobbyClient::lobby_ready);
+	ClassDB::bind_method(D_METHOD("lobby_unready"), &LobbyClient::lobby_unready);
+	ClassDB::bind_method(D_METHOD("seal_lobby"), &LobbyClient::seal_lobby);
+	ClassDB::bind_method(D_METHOD("unseal_lobby"), &LobbyClient::unseal_lobby);
+	ClassDB::bind_method(D_METHOD("lobby_data", "data"), &LobbyClient::lobby_data);
+	ClassDB::bind_method(D_METHOD("lobby_data_to", "data", "target_peer"), &LobbyClient::lobby_data_to);
+
+	// Register signals
+	ADD_SIGNAL(MethodInfo("peer_named", PropertyInfo(Variant::STRING, "peer"), PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("received_data", PropertyInfo(Variant::STRING, "data")));
+	ADD_SIGNAL(MethodInfo("received_data_to", PropertyInfo(Variant::STRING, "data")));
+	ADD_SIGNAL(MethodInfo("lobby_created", PropertyInfo(Variant::STRING, "lobby")));
+	ADD_SIGNAL(MethodInfo("lobby_joined", PropertyInfo(Variant::STRING, "lobby")));
+	ADD_SIGNAL(MethodInfo("lobby_left"));
+	ADD_SIGNAL(MethodInfo("lobby_sealed"));
+	ADD_SIGNAL(MethodInfo("lobby_unsealed"));
+	ADD_SIGNAL(MethodInfo("peer_joined", PropertyInfo(Variant::STRING, "peer")));
+	ADD_SIGNAL(MethodInfo("peer_left", PropertyInfo(Variant::STRING, "peer"), PropertyInfo(Variant::BOOL, "kicked")));
+	ADD_SIGNAL(MethodInfo("peer_ready", PropertyInfo(Variant::STRING, "peer")));
+	ADD_SIGNAL(MethodInfo("peer_unready", PropertyInfo(Variant::STRING, "peer")));
+	ADD_SIGNAL(MethodInfo("append_log", PropertyInfo(Variant::STRING, "action"), PropertyInfo(Variant::STRING, "info"), PropertyInfo(Variant::STRING, "logs")));
+}
+
+bool LobbyClient::connect_to_lobby(const String &game_id) {
+	String lobby_url = get_server_url();
+	String url = lobby_url + "?gameID=" + game_id;
+	Error err = _socket->connect_to_url(url);
+	if (err != OK) {
+		emit_signal("append_log", "error", "Unable to connect to lobby server at: " + url);
+		return false;
+	}
+	set_process_internal(true);
+	emit_signal("append_log", "connect_to_lobby", "Connected to: " + url);
+	return true;
+}
+
+String LobbyClient::_increment_counter() {
+	return String::num(_counter++);
+}
+
+Ref<LobbyClient::CreateLobbyResponse> LobbyClient::create_lobby(int max_players, const String &password) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "create_lobby";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["max_players"] = max_players;
+	data_dict["password"] = password;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<CreateLobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(CREATE_LOBBY);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::join_lobby(const String &lobby_name, const String &password) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "join_lobby";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["lobby_name"] = lobby_name;
+	data_dict["password"] = password;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::leave_lobby() {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "leave_lobby";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::ListLobbyResponse> LobbyClient::list_lobby(int start, int count) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "list_lobby";
+	Dictionary data_dict;
+	data_dict["id"] = id;
+	data_dict["start"] = start;
+	data_dict["count"] = count;
+	command["data"] = data_dict;
+	Array command_array;
+	Ref<ListLobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(LOBBY_LIST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::ViewLobbyResponse> LobbyClient::view_lobby(const String &lobby_name, const String &password) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "view_lobby";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["lobby_name"] = lobby_name;
+	data_dict["password"] = password;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<ViewLobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(LOBBY_VIEW);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::kick_peer(const String &peer_id) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "kick_peer";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["peer_id"] = peer_id;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::lobby_ready() {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "lobby_ready";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::lobby_unready() {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "lobby_unready";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::set_peer_name(const String &peer_name) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "set_name";
+	Dictionary data_dict;
+	data_dict["peer_name"] = peer_name;
+	data_dict["id"] = id;
+	command["data"] = data_dict;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::seal_lobby() {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "seal_lobby";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::unseal_lobby() {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "unseal_lobby";
+	Dictionary data_dict;
+	command["data"] = data_dict;
+	data_dict["id"] = id;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::lobby_data(const String &peer_data) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "lobby_data";
+	Dictionary data_dict;
+	data_dict["peer_data"] = peer_data;
+	data_dict["id"] = id;
+	command["data"] = data_dict;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+Ref<LobbyClient::LobbyResponse> LobbyClient::lobby_data_to(const String &peer_data, const String &target_peer) {
+	String id = _increment_counter();
+	Dictionary command;
+	command["action"] = "data_to";
+	Dictionary data_dict;
+	data_dict["peer_data"] = peer_data;
+	data_dict["target_peer"] = target_peer;
+	data_dict["id"] = id;
+	command["data"] = data_dict;
+	Array command_array;
+	Ref<LobbyResponse> response;
+	response.instantiate();
+	command_array.push_back(SIMPLE_REQUEST);
+	command_array.push_back(response);
+	_commands[id] = command_array;
+	_send_data(command);
+	return response;
+}
+
+void LobbyClient::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			_socket->poll();
+
+			WebSocketPeer::State state = _socket->get_ready_state();
+			if (state == WebSocketPeer::STATE_OPEN) {
+				while (_socket->get_available_packet_count() > 0) {
+					Vector<uint8_t> packet_buffer;
+					Error err = _socket->get_packet_buffer(packet_buffer);
+					if (err != OK) {
+						emit_signal("append_log", "error", "Unable to get packet.");
+						return;
+					}
+					String packet_string = String::utf8((const char *)packet_buffer.ptr(), packet_buffer.size());
+					_receive_data(JSON::parse_string(packet_string));
+				}
+			} else if (state == WebSocketPeer::STATE_CLOSED) {
+				emit_signal("append_log", "error", "WebSocket closed unexpectedly.");
+			}
+		} break;
+	}
+}
+
+void LobbyClient::_send_data(const Dictionary &data_dict) {
+	if (_socket->get_ready_state() != WebSocketPeer::STATE_OPEN) {
+		emit_signal("append_log", "error", "Socket is not ready.");
+		return;
+	}
+	_socket->send_text(JSON::stringify(data_dict));
+}
+
+void LobbyClient::_receive_data(const Dictionary &dict) {
+	String command = dict.get("action", "error");
+	String message = dict.get("message", command);
+	Dictionary data_dict = dict.get("data", Dictionary());
+	String message_id = data_dict.get("id", "");
+	Array command_array = _commands.get(message_id, Array());
+	_commands.erase(message_id);
+	emit_signal("append_log", command, message);
+	if (command == "lobby_created") {
+		String lobby_name = data_dict.get("lobby_name", "");
+		if (command_array.size() == 2) {
+			Ref<CreateLobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<CreateLobbyResponse::CreateLobbyResult> result;
+				result.instantiate();
+				result->set_lobby_name(lobby_name);
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("lobby_created", lobby_name);
+	} else if (command == "joined_lobby") {
+		String lobby_name = data_dict.get("lobby_name", "");
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("lobby_joined", lobby_name);
+	} else if (command == "lobby_left") {
+		// Either if you leave a lobby, or if you get kicked
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("lobby_left");
+	} else if (command == "lobby_sealed") {
+		// Either if you seal a lobby, or if host seals
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("lobby_sealed");
+	} else if (command == "lobby_unsealed") {
+		// Either if you unseal a lobby, or if host unseals
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("lobby_unsealed");
+	} else if (command == "lobby_list") {
+		Array arr = data_dict.get("lobbies", Array());
+		TypedArray<String> lobbies = arr;
+		if (command_array.size() == 2) {
+			Ref<ListLobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<ListLobbyResponse::ListLobbyResult> result;
+				result.instantiate();
+				result->set_lobbies(lobbies);
+				response->emit_signal("finished", result);
+			}
+		}
+	} else if (command == "lobby_view") {
+		Dictionary lobby_dict = data_dict.get("lobby", Dictionary());
+		String host = lobby_dict.get("host", "");
+		bool sealed = lobby_dict.get("sealed", false);
+		int max_players = lobby_dict.get("max_players", 0);
+
+		// Iterate through peers and populate arrays
+		Array arr = data_dict["peers"];
+		TypedArray<LobbyPeer> peers;
+		for (int i = 0; i < arr.size(); ++i) {
+			Ref<LobbyPeer> peer;
+			peer.instantiate();
+			String peer_id = arr[i].get("id");
+			String peer_name = arr[i].get("name");
+			bool peer_ready = arr[i].get("ready");
+			peer->set_id(peer_id);
+			peer->set_name(peer_name);
+			peer->set_ready(peer_ready);
+			peers.push_back(peer);
+		}
+		Ref<LobbyInfo> lobby_info;
+		lobby_info.instantiate();
+		lobby_info->set_host(host);
+		lobby_info->set_sealed(sealed);
+		lobby_info->set_max_players(max_players);
+		if (command_array.size() == 2) {
+			Ref<ViewLobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<ViewLobbyResponse::ViewLobbyResult> result;
+				result.instantiate();
+				result->set_peers(peers);
+				result->set_lobby_info(lobby_info);
+				response->emit_signal("finished", result);
+			}
+		}
+	} else if (command == "peer_name") {
+		// Either if you ready a lobby, or if someone else readies
+		String peer_id = data_dict.get("peer_id", "");
+		String peer_name = data_dict.get("name", "");
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("peer_named", peer_id, peer_name);
+	} else if (command == "peer_ready") {
+		// Either if you ready a lobby, or if someone else readies
+		String peer_id = data_dict.get("peer_id", "");
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("peer_ready", peer_id);
+	} else if (command == "peer_unready") {
+		// Either if you unready a lobby, or if someone else unreadies
+		String peer_id = data_dict.get("peer_id", "");
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("peer_unready", peer_id);
+	} else if (command == "peer_joined") {
+		String peer_id = data_dict.get("peer_id", "");
+		String peer_name = data_dict.get("peer_name", "");
+		emit_signal("peer_joined", peer_id, peer_name);
+	} else if (command == "peer_left") {
+		// Either if you kick a peer, or a peer leaves
+		String peer_id = data_dict.get("peer_id", "");
+		bool kicked = data_dict.get("kicked", false);
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("peer_left", peer_id, kicked);
+	} else if (command == "lobby_data") {
+		String peer_data = data_dict.get("peer_data", "");
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("received_data", peer_data);
+	} else if (command == "data_to") {
+		String peer_data = data_dict.get("peer_data", "");
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+		emit_signal("received_data_to", peer_data);
+	} else if (command == "lobby_data_sent") {
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+	} else if (command == "data_to_sent") {
+		if (command_array.size() == 2) {
+			Ref<LobbyResponse> response = command_array[1];
+			if (response.is_valid()) {
+				Ref<LobbyResponse::LobbyResult> result;
+				result.instantiate();
+				response->emit_signal("finished", result);
+			}
+		}
+	} else if (command == "error") {
+		if (command_array.size() == 2) {
+			int command_type = command_array[0];
+			switch (command_type) {
+				case SIMPLE_REQUEST: {
+					Ref<LobbyResponse> lobby_response = command_array[1];
+					if (lobby_response.is_valid()) {
+						Ref<LobbyResponse::LobbyResult> result;
+						result.instantiate();
+						result->set_error(message);
+						lobby_response->emit_signal("finished", result);
+					}
+				} break;
+				case LOBBY_LIST: {
+					Ref<ListLobbyResponse> list_response = command_array[1];
+					if (list_response.is_valid()) {
+						Ref<ListLobbyResponse::ListLobbyResult> result;
+						result.instantiate();
+						result->set_error(message);
+						list_response->emit_signal("finished", result);
+					}
+				} break;
+				case CREATE_LOBBY: {
+					Ref<CreateLobbyResponse> create_response = command_array[1];
+					if (create_response.is_valid()) {
+						Ref<CreateLobbyResponse::CreateLobbyResult> result;
+						result.instantiate();
+						result->set_error(message);
+						create_response->emit_signal("finished", result);
+					}
+				} break;
+				case LOBBY_VIEW: {
+					Ref<ViewLobbyResponse> view_response = command_array[1];
+					if (view_response.is_valid()) {
+						Ref<ViewLobbyResponse::ViewLobbyResult> result;
+						result.instantiate();
+						result->set_error(message);
+						view_response->emit_signal("finished", result);
+					}
+				} break;
+				default: {
+					emit_signal("append_log", "error", dict["message"]);
+				} break;
+			}
+		}
+	} else {
+		emit_signal("append_log", "error", "Unknown command received.");
+	}
+}

--- a/modules/blazium_sdk/lobby/lobby_client.h
+++ b/modules/blazium_sdk/lobby/lobby_client.h
@@ -1,0 +1,294 @@
+/**************************************************************************/
+/*  lobby_client.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                            BLAZIUM ENGINE                              */
+/*                        https://blazium.app                             */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/* Copyright (c) 2024 Dragos Daian, Randolph William Aarseth II.          */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef LOBBY_CLIENT_H
+#define LOBBY_CLIENT_H
+
+#include "../blazium_client.h"
+#include "core/io/json.h"
+#include "modules/websocket/websocket_peer.h"
+
+class LobbyClient : public BlaziumClient {
+	GDCLASS(LobbyClient, BlaziumClient);
+	enum CommandType {
+		CREATE_LOBBY = 0,
+		SIMPLE_REQUEST,
+		LOBBY_VIEW,
+		LOBBY_LIST
+	};
+	String server_url = "wss://lobby.blazium.app/connect";
+
+public:
+	class CreateLobbyResponse : public RefCounted {
+		GDCLASS(CreateLobbyResponse, RefCounted);
+
+	protected:
+		static void _bind_methods() {
+			ADD_SIGNAL(MethodInfo("finished", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_RESOURCE_TYPE, "CreateLobbyResult")));
+		}
+
+	public:
+		class CreateLobbyResult : public RefCounted {
+			GDCLASS(CreateLobbyResult, RefCounted);
+			String error;
+			String lobby_name;
+
+		protected:
+			static void _bind_methods() {
+				ClassDB::bind_method(D_METHOD("has_error"), &CreateLobbyResult::has_error);
+				ClassDB::bind_method(D_METHOD("get_error"), &CreateLobbyResult::get_error);
+				ClassDB::bind_method(D_METHOD("get_lobby_name"), &CreateLobbyResult::get_lobby_name);
+				ADD_PROPERTY(PropertyInfo(Variant::STRING, "error"), "", "get_error");
+				ADD_PROPERTY(PropertyInfo(Variant::STRING, "lobby_name"), "", "get_lobby_name");
+			}
+
+		public:
+			void set_error(String p_error) { this->error = p_error; }
+			void set_lobby_name(String p_lobby_name) { this->lobby_name = p_lobby_name; }
+
+			bool has_error() const { return !error.is_empty(); }
+			String get_error() const { return error; }
+			String get_lobby_name() const { return lobby_name; }
+			CreateLobbyResult(const CreateLobbyResult &other) :
+					error(other.error), lobby_name(other.lobby_name) {}
+			CreateLobbyResult() {}
+		};
+		CreateLobbyResponse(const CreateLobbyResponse &other) {}
+		CreateLobbyResponse() {}
+	};
+	class LobbyResponse : public RefCounted {
+		GDCLASS(LobbyResponse, RefCounted);
+
+	protected:
+		static void _bind_methods() {
+			ADD_SIGNAL(MethodInfo("finished", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_RESOURCE_TYPE, "LobbyResult")));
+		}
+
+	public:
+		class LobbyResult : public RefCounted {
+			GDCLASS(LobbyResult, RefCounted);
+
+			String error;
+
+		protected:
+			static void _bind_methods() {
+				ClassDB::bind_method(D_METHOD("has_error"), &LobbyResult::has_error);
+				ClassDB::bind_method(D_METHOD("get_error"), &LobbyResult::get_error);
+				ADD_PROPERTY(PropertyInfo(Variant::STRING, "error"), "", "get_error");
+			}
+
+		public:
+			void set_error(String p_error) { this->error = p_error; }
+
+			bool has_error() const { return !error.is_empty(); }
+			String get_error() const { return error; }
+			LobbyResult(const LobbyResult &other) :
+					error(other.error) {}
+			LobbyResult() {}
+		};
+		LobbyResponse(const LobbyResponse &other) {}
+		LobbyResponse() {}
+	};
+	class ListLobbyResponse : public RefCounted {
+		GDCLASS(ListLobbyResponse, RefCounted);
+
+	protected:
+		static void _bind_methods() {
+			ADD_SIGNAL(MethodInfo("finished", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_RESOURCE_TYPE, "ListLobbyResult")));
+		}
+
+	public:
+		class ListLobbyResult : public RefCounted {
+			GDCLASS(ListLobbyResult, RefCounted);
+
+			String error;
+			TypedArray<String> lobbies;
+
+		protected:
+			static void _bind_methods() {
+				ClassDB::bind_method(D_METHOD("has_error"), &ListLobbyResult::has_error);
+				ClassDB::bind_method(D_METHOD("get_error"), &ListLobbyResult::get_error);
+				ClassDB::bind_method(D_METHOD("get_lobbies"), &ListLobbyResult::get_lobbies);
+				ADD_PROPERTY(PropertyInfo(Variant::STRING, "error"), "", "get_error");
+				ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "lobbies"), "", "get_lobbies");
+			}
+
+		public:
+			void set_error(String p_error) { this->error = p_error; }
+			void set_lobbies(TypedArray<String> p_lobbies) { this->lobbies = p_lobbies; }
+
+			bool has_error() const { return !error.is_empty(); }
+			String get_error() const { return error; }
+			TypedArray<String> get_lobbies() const { return lobbies; }
+			ListLobbyResult(const ListLobbyResult &other) :
+					error(other.error), lobbies(other.lobbies) {}
+			ListLobbyResult() {}
+		};
+		ListLobbyResponse(const ListLobbyResponse &other) {}
+		ListLobbyResponse() {}
+	};
+	class LobbyInfo : public RefCounted {
+		GDCLASS(LobbyInfo, RefCounted);
+		String host;
+		int max_players = 0;
+		bool sealed = false;
+
+	protected:
+		static void _bind_methods() {
+			ClassDB::bind_method(D_METHOD("get_host"), &LobbyInfo::get_host);
+			ClassDB::bind_method(D_METHOD("get_max_players"), &LobbyInfo::get_max_players);
+			ClassDB::bind_method(D_METHOD("is_sealed"), &LobbyInfo::is_sealed);
+			ADD_PROPERTY(PropertyInfo(Variant::STRING, "host"), "", "get_host");
+			ADD_PROPERTY(PropertyInfo(Variant::INT, "max_players"), "", "get_max_players");
+			ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sealed"), "", "is_sealed");
+		}
+
+	public:
+		void set_host(String p_host) { this->host = p_host; }
+		void set_max_players(int p_max_players) { this->max_players = p_max_players; }
+		void set_sealed(bool p_sealed) { this->sealed = p_sealed; }
+
+		String get_host() const { return host; }
+		int get_max_players() const { return max_players; }
+		bool is_sealed() const { return sealed; }
+		LobbyInfo(const LobbyInfo &other) :
+				host(other.host), max_players(other.max_players), sealed(other.sealed) {}
+		LobbyInfo() {}
+	};
+	class LobbyPeer : public RefCounted {
+		GDCLASS(LobbyPeer, RefCounted);
+		String id;
+		String name;
+		bool ready = false;
+
+	protected:
+		static void _bind_methods() {
+			ClassDB::bind_method(D_METHOD("get_id"), &LobbyPeer::get_id);
+			ClassDB::bind_method(D_METHOD("get_name"), &LobbyPeer::get_name);
+			ClassDB::bind_method(D_METHOD("is_ready"), &LobbyPeer::is_ready);
+			ADD_PROPERTY(PropertyInfo(Variant::STRING, "id"), "", "get_id");
+			ADD_PROPERTY(PropertyInfo(Variant::STRING, "name"), "", "get_name");
+			ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ready"), "", "is_ready");
+		}
+
+	public:
+		void set_id(String p_id) { this->id = p_id; }
+		void set_name(String p_name) { this->name = p_name; }
+		void set_ready(bool p_ready) { this->ready = p_ready; }
+
+		String get_id() const { return id; }
+		String get_name() const { return name; }
+		bool is_ready() const { return ready; }
+		LobbyPeer(const LobbyPeer &other) :
+				id(other.id), name(other.name), ready(other.ready) {}
+		LobbyPeer() {}
+	};
+	class ViewLobbyResponse : public RefCounted {
+		GDCLASS(ViewLobbyResponse, RefCounted);
+
+	protected:
+		static void _bind_methods() {
+			ADD_SIGNAL(MethodInfo("finished", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_RESOURCE_TYPE, "ViewLobbyResult")));
+		}
+
+	public:
+		class ViewLobbyResult : public RefCounted {
+			GDCLASS(ViewLobbyResult, RefCounted);
+			String error;
+			TypedArray<LobbyPeer> peers;
+			Ref<LobbyInfo> lobby_info;
+
+		protected:
+			static void _bind_methods() {
+				ClassDB::bind_method(D_METHOD("has_error"), &ViewLobbyResult::has_error);
+				ClassDB::bind_method(D_METHOD("get_error"), &ViewLobbyResult::get_error);
+				ClassDB::bind_method(D_METHOD("get_peers"), &ViewLobbyResult::get_peers);
+				ClassDB::bind_method(D_METHOD("get_lobby_info"), &ViewLobbyResult::get_lobby_info);
+				ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "peers"), "", "get_peers");
+				ADD_PROPERTY(PropertyInfo(Variant::STRING, "error"), "", "get_error");
+			}
+
+		public:
+			void set_error(String p_error) { this->error = p_error; }
+			void set_peers(TypedArray<LobbyPeer> p_peers) { this->peers = p_peers; }
+			void set_lobby_info(Ref<LobbyInfo> p_lobby_info) { this->lobby_info = p_lobby_info; }
+
+			bool has_error() const { return !error.is_empty(); }
+			String get_error() const { return error; }
+			TypedArray<LobbyPeer> get_peers() const { return peers; }
+			Ref<LobbyInfo> get_lobby_info() const { return lobby_info; }
+			ViewLobbyResult() {
+				lobby_info.instantiate();
+			}
+			~ViewLobbyResult() {
+			}
+		};
+		ViewLobbyResponse(const ViewLobbyResponse &other) {}
+		ViewLobbyResponse() {}
+	};
+
+private:
+	Ref<WebSocketPeer> _socket;
+	int _counter = 0;
+	Dictionary _commands;
+
+	String _get_data_from_dict(const Dictionary &dict, const String &key);
+	void _receive_data(const Dictionary &data);
+	void _send_data(const Dictionary &data);
+	void _wait_ready();
+	String _increment_counter();
+
+protected:
+	void _notification(int p_notification);
+	static void _bind_methods();
+
+public:
+	bool connect_to_lobby(const String &game_id);
+	void set_server_url(String p_server_url) { this->server_url = p_server_url; }
+	String get_server_url() { return server_url; }
+	Ref<CreateLobbyResponse> create_lobby(int max_players, const String &password);
+	Ref<LobbyResponse> join_lobby(const String &lobby_name, const String &password);
+	Ref<LobbyResponse> leave_lobby();
+	Ref<ListLobbyResponse> list_lobby(int start, int count);
+	Ref<ViewLobbyResponse> view_lobby(const String &lobby_name, const String &password);
+	Ref<LobbyResponse> kick_peer(const String &peer_id);
+	Ref<LobbyResponse> lobby_ready();
+	Ref<LobbyResponse> lobby_unready();
+	Ref<LobbyResponse> set_peer_name(const String &peer_name);
+	Ref<LobbyResponse> seal_lobby();
+	Ref<LobbyResponse> unseal_lobby();
+	Ref<LobbyResponse> lobby_data(const String &peer_data);
+	Ref<LobbyResponse> lobby_data_to(const String &peer_data, const String &target_peer);
+
+	LobbyClient();
+	~LobbyClient();
+};
+
+#endif // LOBBY_CLIENT_H

--- a/modules/blazium_sdk/register_types.cpp
+++ b/modules/blazium_sdk/register_types.cpp
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                            BLAZIUM ENGINE                              */
+/*                        https://blazium.app                             */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/* Copyright (c) 2024 Dragos Daian, Randolph William Aarseth II.          */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+#include "blazium_client.h"
+#include "lobby/lobby_client.h"
+
+void initialize_blazium_sdk_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_ABSTRACT_CLASS(BlaziumClient);
+		GDREGISTER_CLASS(LobbyClient);
+		GDREGISTER_CLASS(LobbyClient::LobbyInfo);
+		GDREGISTER_CLASS(LobbyClient::LobbyPeer);
+		GDREGISTER_CLASS(LobbyClient::CreateLobbyResponse::CreateLobbyResult);
+		GDREGISTER_CLASS(LobbyClient::CreateLobbyResponse);
+		GDREGISTER_CLASS(LobbyClient::LobbyResponse::LobbyResult);
+		GDREGISTER_CLASS(LobbyClient::LobbyResponse);
+		GDREGISTER_CLASS(LobbyClient::ListLobbyResponse::ListLobbyResult);
+		GDREGISTER_CLASS(LobbyClient::ListLobbyResponse);
+		GDREGISTER_CLASS(LobbyClient::ViewLobbyResponse::ViewLobbyResult);
+		GDREGISTER_CLASS(LobbyClient::ViewLobbyResponse);
+	}
+}
+
+void uninitialize_blazium_sdk_module(ModuleInitializationLevel p_level) {
+}

--- a/modules/blazium_sdk/register_types.h
+++ b/modules/blazium_sdk/register_types.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                            BLAZIUM ENGINE                              */
+/*                        https://blazium.app                             */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/* Copyright (c) 2024 Dragos Daian, Randolph William Aarseth II.          */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef BLAZIUM_SDK_REGISTER_TYPES_H
+#define BLAZIUM_SDK_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+void initialize_blazium_sdk_module(ModuleInitializationLevel p_level);
+void uninitialize_blazium_sdk_module(ModuleInitializationLevel p_level);
+
+#endif // BLAZIUM_SDK_REGISTER_TYPES_H


### PR DESCRIPTION
Adds the blazium sdk module. This module communicates with the lobby server.
Adds documentation for some classes. Adds nodes:
**BlaziumClient** - base client node for things that communicate with server
**LobbyClient** - inherits BlaziumClient, right now this is just so it looks nice in the editor, like this:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/6c441d2d-4834-4c45-acc2-b883630c58b7">

The BlaziumClient node has no properties and is abstract such that we can group nodes:
<img width="178" alt="image" src="https://github.com/user-attachments/assets/9ddf3d5c-d81b-4693-b3b1-a8f70346d495">

This PR adds this functionality as a module, so if people don't want this they can remove it. The idea is to have this module add a bunch of networking nodes for clients to services.

The implementation is based on the gdscript implementation I wrote here: https://github.com/blazium-engine/blazium-lobby-sdk/tree/main/godot_demo_sdk/addons/blazium_sdk (for ease of prototype)

The main idea is that functions are awaitable. There is also a demo that can test/run this new module in the previous repo as well, but there is a PR that updates that functionality https://github.com/blazium-engine/blazium-lobby-sdk/pull/6/files