### PR TITLE
Unhardcode and expose doppler effect parameters of audio stream player 3D

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -72,6 +72,12 @@
 			The bus on which this audio is playing.
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
+		<member name="doppler_clamp" type="float" setter="set_doppler_clamp" getter="get_doppler_clamp" default="8.0">
+			Clamps pitch change of the doppler effect, e.g. if set to 5 the audio playback speed will be clamped between 5 times slower and 5 times faster then normal.
+		</member>
+		<member name="doppler_strength" type="float" setter="set_doppler_strength" getter="get_doppler_strength" default="1.0">
+			Strength of the doppler effect.
+		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="AudioStreamPlayer3D.DopplerTracking" default="0">
 			Decides in which step the Doppler effect should be calculated.
 		</member>

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -470,7 +470,8 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 				float speed_of_sound = 343.0;
 
 				float doppler_pitch_scale = internal->pitch_scale * speed_of_sound / (speed_of_sound + velocity * approaching);
-				doppler_pitch_scale = CLAMP(doppler_pitch_scale, (1 / 8.0), 8.0); //avoid crazy stuff
+				doppler_pitch_scale = doppler_pitch_scale * doppler_strength + (1.0 - doppler_strength);
+				doppler_pitch_scale = CLAMP(doppler_pitch_scale, (1 / doppler_clamp), doppler_clamp); //avoid crazy stuff
 
 				actual_pitch_scale = doppler_pitch_scale;
 			} else {
@@ -696,6 +697,23 @@ AudioStreamPlayer3D::DopplerTracking AudioStreamPlayer3D::get_doppler_tracking()
 	return doppler_tracking;
 }
 
+void AudioStreamPlayer3D::set_doppler_strength(float p_doppler_strength) {
+	doppler_strength = p_doppler_strength;
+}
+
+float AudioStreamPlayer3D::get_doppler_strength() const {
+	return doppler_strength;
+}
+
+void AudioStreamPlayer3D::set_doppler_clamp(float p_doppler_clamp) {
+	ERR_FAIL_COND_MSG(p_doppler_clamp < 1, "Doppler clamp can't be less than 1.");
+	doppler_clamp = p_doppler_clamp;
+}
+
+float AudioStreamPlayer3D::get_doppler_clamp() const {
+	return doppler_clamp;
+}
+
 void AudioStreamPlayer3D::set_stream_paused(bool p_pause) {
 	internal->set_stream_paused(p_pause);
 }
@@ -808,6 +826,12 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &AudioStreamPlayer3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &AudioStreamPlayer3D::get_doppler_tracking);
 
+	ClassDB::bind_method(D_METHOD("set_doppler_strength", "doppler_strength"), &AudioStreamPlayer3D::set_doppler_strength);
+	ClassDB::bind_method(D_METHOD("get_doppler_strength"), &AudioStreamPlayer3D::get_doppler_strength);
+
+	ClassDB::bind_method(D_METHOD("set_doppler_clamp", "doppler_clamp"), &AudioStreamPlayer3D::set_doppler_clamp);
+	ClassDB::bind_method(D_METHOD("get_doppler_clamp"), &AudioStreamPlayer3D::get_doppler_clamp);
+
 	ClassDB::bind_method(D_METHOD("set_stream_paused", "pause"), &AudioStreamPlayer3D::set_stream_paused);
 	ClassDB::bind_method(D_METHOD("get_stream_paused"), &AudioStreamPlayer3D::get_stream_paused);
 
@@ -847,6 +871,8 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "attenuation_filter_db", PROPERTY_HINT_RANGE, "-80,0,0.1,suffix:dB"), "set_attenuation_filter_db", "get_attenuation_filter_db");
 	ADD_GROUP("Doppler", "doppler_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doppler_strength", PROPERTY_HINT_RANGE, "0.0,2.0"), "set_doppler_strength", "get_doppler_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doppler_clamp", PROPERTY_HINT_RANGE, "1.0,10.0"), "set_doppler_clamp", "get_doppler_clamp");
 
 	BIND_ENUM_CONSTANT(ATTENUATION_INVERSE_DISTANCE);
 	BIND_ENUM_CONSTANT(ATTENUATION_INVERSE_SQUARE_DISTANCE);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -109,6 +109,9 @@ private:
 
 	DopplerTracking doppler_tracking = DOPPLER_TRACKING_DISABLED;
 
+	float doppler_strength = 1.0f;
+	float doppler_clamp = 8.0f;
+
 	float _get_attenuation_db(float p_distance) const;
 
 	float panning_strength = 1.0f;
@@ -185,6 +188,12 @@ public:
 
 	void set_doppler_tracking(DopplerTracking p_tracking);
 	DopplerTracking get_doppler_tracking() const;
+
+	void set_doppler_strength(float p_doppler_strength);
+	float get_doppler_strength() const;
+
+	void set_doppler_clamp(float p_doppler_clamp);
+	float get_doppler_clamp() const;
 
 	void set_stream_paused(bool p_pause);
 	bool get_stream_paused() const;


### PR DESCRIPTION
Adds and exposes 2 parameters to AudioStreamPlayer3D:
doppler_strength - makes doppler effect more / less noticable
doppler_clamp - clamps doppler effect pitch scale between 1/doppler_clamp and doppler_clamp