### PR TITLE
Update mirror lists in version.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -12,5 +12,5 @@ external_minor = 1
 external_patch = 0
 external_status = "nightly"
 external_sha = "ff9bc0422349219b337b015643544a0454d4a7ee"
-mirror_list = "https://blazium.app/mirrorlist/"
-version_url = "https://blazium.app/versions-" + external_status + ".json"
+mirror_list = "https://blazium.app/api/mirrorlist/"
+version_url = "https://blazium.app/api/versions-" + external_status + ".json"


### PR DESCRIPTION
Uses `https://blazium.app/api/` instead of just `https://blazium.app/` in the mirror path.