### PR TITLE
Add godot steam as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "modules/godotsteam"]
+	path = modules/godotsteam
+	url = https://github.com/blazium-engine/GodotSteam
+	branch = godot4


### PR DESCRIPTION
Adds godot steam as submodule. Still draft as the size of the repo seems to be rather large. So far deleted the branches that have releases and it's a bit smaller, but still it might affect people cloning this repo.
As for building locally, it will not work normally, so will update the fork to not build if it doesnt have the dlls.