### PR TITLE
Added get_open_scenes_roots to Editor Interface API

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -150,6 +150,12 @@
 				Returns an [Array] with the file paths of the currently opened scenes.
 			</description>
 		</method>
+		<method name="get_open_scenes_roots" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns an [Array] with the root nodes of the currently opened scenes.
+			</description>
+		</method>
 		<method name="get_playing_scene" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -435,6 +435,20 @@ PackedStringArray EditorInterface::get_open_scenes() const {
 	return ret;
 }
 
+Array EditorInterface::get_open_scenes_roots() const {
+	Array ret;
+	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
+
+	int scns_amount = scenes.size();
+	for (int idx_scn = 0; idx_scn < scns_amount; idx_scn++) {
+		if (scenes[idx_scn].root == nullptr) {
+			continue;
+		}
+		ret.push_back(scenes[idx_scn].root);
+	}
+	return ret;
+}
+
 Error EditorInterface::save_scene() {
 	if (!get_edited_scene_root()) {
 		return ERR_CANT_CREATE;
@@ -583,6 +597,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
 
 	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
+	ClassDB::bind_method(D_METHOD("get_open_scenes_roots"), &EditorInterface::get_open_scenes_roots);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -151,6 +151,7 @@ public:
 	void reload_scene_from_path(const String &scene_path);
 
 	PackedStringArray get_open_scenes() const;
+	Array get_open_scenes_roots() const;
 	Node *get_edited_scene_root() const;
 
 	Error save_scene();


### PR DESCRIPTION
Original `get_open_scenes` function provided by Godot is quite limited as it only returns a string array containing the names of opened scenes. This feature is necessary for situations where accessing all opened scenes in depth is required and it is also essential for the Jenova Framework Hot-Reloading feature.

**This commit includes :**
- Changes to the Editor Interface API (`editor_interface.h` and `editor_interface.cpp`)
- Updates to the Editor Interface documentation (`EditorInterface.xml`)