### PR TITLE
Suppress non-virtual dtor error on IAudioClient3

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -52,6 +52,12 @@ typedef interface IAudioClient3 IAudioClient3;
 #ifndef __IAudioClient3_INTERFACE_DEFINED__
 #define __IAudioClient3_INTERFACE_DEFINED__
 
+// Silence warning due to a COM API weirdness (GH-35194).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
+
 MIDL_INTERFACE("7ED4EE07-8E67-4CD4-8C1A-2B7A5987AD42")
 IAudioClient3 : public IAudioClient2 {
 public:
@@ -84,6 +90,10 @@ public:
 			_In_opt_ LPCGUID AudioSessionGuid) = 0;
 };
 __CRT_UUID_DECL(IAudioClient3, 0x7ED4EE07, 0x8E67, 0x4CD4, 0x8C, 0x1A, 0x2B, 0x7A, 0x59, 0x87, 0xAD, 0x42)
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif // __IAudioClient3_INTERFACE_DEFINED__
 


### PR DESCRIPTION
When running `scons dev_mode=yes` using the MinGW compiler, the following error is produced:
`'struct IAudioClient3' has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]`
This error is due to MinGW not understanding how Windows COM interfaces are used, and cannot be fixed on our end as it requires modifying Windows header files. This PR suppresses this error.