### PR TITLE
Consistent version.h

### DIFF
--- a/core/version.h
+++ b/core/version.h
@@ -86,11 +86,11 @@
 // Similar to EXTERNAL_VERSION_FULL_CONFIG, but also includes the VERSION_FULL_BUILD
 // description.
 // Example: "0.1.0.stable.mono (3.1.4.stable.mono.official)"
-#define EXTERNAL_VERSION_FULL_BUILD EXTERNAL_VERSION_NUMBER "(" VERSION_FULL_BUILD ")"
+#define EXTERNAL_VERSION_FULL_BUILD EXTERNAL_VERSION_FULL_CONFIG " (" VERSION_FULL_BUILD ")"
 
 // Same as above, but prepended with Godot's name and a cosmetic "v" for "version".
-// Example: "Blazium v0.1.0.nightly.mono (base v3.1.4.stable.mono.official)"
-#define VERSION_FULL_NAME VERSION_NAME " v" EXTERNAL_VERSION_NUMBER " (base v" VERSION_FULL_BUILD ")"
+// Example: "Blazium Engine v0.1.0.nightly.mono (3.1.4.stable.mono.official)"
+#define VERSION_FULL_NAME VERSION_NAME " v" EXTERNAL_VERSION_FULL_BUILD
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
 extern const char *const VERSION_HASH;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5015,7 +5015,7 @@ String EditorNode::_get_system_info() const {
 	}
 	const String distribution_version = OS::get_singleton()->get_version();
 
-	String godot_version = "Blazium v" + String(VERSION_FULL_CONFIG);
+	String godot_version = String(VERSION_FULL_NAME);
 	if (String(VERSION_BUILD) != "official") {
 		String hash = String(VERSION_HASH);
 		hash = hash.is_empty() ? String("unknown") : vformat("(%s)", hash.left(9));


### PR DESCRIPTION
- Use `EXTERNAL_VERSION_CONFIG` in `EXTERNAL_VERSION_FULL_BUILD` just like `VERSION_FULL_BUILD`
- Use `EXTERNAL_VERSION_FULL_BUILD` in `VERSION_FULL_NAME` for consistency
- Use `VERSION_FULL_NAME` for `godot_string` in `editor_node.cpp`

Changes before and after
```
System Info before:
Blazium v4.3.stable (5590b1897) - ...
System Info after:
Blazium Engine v0.1.0.nightly (4.3.stable.custom_build) (5590b1897) - ...

Engine Console before:
Blazium Engine v0.1.0 (base v4.3.stable.custom_build) (c)...
Engine Console after:
Blazium Engine v0.1.0.nightly (4.3.stable.custom_build) (c)...

Project Manager before:
v0.1.0(4.3.stable.custom_build) [5590b1897]
Project Manager after:
v0.1.0.nightly (4.3.stable.custom_build) [5590b1897]

Terminal Output before:
Blazium Engine v0.1.0(4.3.stable.custom_build).5590b1897...
Terminal Output after:
Blazium Engine v0.1.0.nightly (4.3.stable.custom_build).5590b1897...
```