### PR TITLE
Add TitleBarLogo to saturation_exeptions

### DIFF
--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -133,6 +133,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	saturation_exceptions.insert("DefaultProjectIcon");
 	saturation_exceptions.insert("Godot");
 	saturation_exceptions.insert("Logo");
+	saturation_exceptions.insert("TitleBarLogo");
 
 	// Accent color conversion map.
 	// It is used on some icons (checkbox, radio, toggle, etc.), regardless of the dark


### PR DESCRIPTION
This is how the title bar logo looks like with icon saturation set at 2.0
![image](https://github.com/user-attachments/assets/3eaa5679-d7ee-4d4f-b4c0-8be23e94f342)
This pr adds `TitleBarLogo` to the `saturation_exeptions` list

