### PR TITLE
Update FoldableContainer

### DIFF
--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="FoldableContainer" inherits="Container" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="FoldableContainer" inherits="Container" keywords="expandable, collapsible, collapse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A container that can be expanded/collapsed.
 	</brief_description>
 	<description>
 		A container that can be expanded/collapsed, with a title that can contain buttons.
 		The title can be positioned at the top or bottom of the container.
-		The container can be expanded or collapsed by clicking the title.
-		Buttons can be added with [method add_button].
-		Buttons can be toggled by setting the [code]toggle_mode[/code] property to [code]true[/code].
-		Buttons can be hidden or disabled with [method set_button_hidden] and [method set_button_disabled].
-		Buttons can have metadata associated with them, which can be retrieved with [method get_button_metadata] and set with [method set_button_metadata].
-		Buttons can have tooltips associated with them, which can be retrieved with [method get_button_tooltip] and set with [method set_button_tooltip].
-		Buttons can have an ID associated with them, which can be retrieved with [method get_button_id] and set with [method set_button_id].
-		Buttons only support icons not text, and it can be retrieved with [method get_button_icon] and changed with [method set_button_icon].
+		The container can be expanded or collapsed by clicking the title or by pressing [code]ui_accept[/code] when focused.
+		Child control nodes are hidden when the container is collapsed. Ignores non-control children.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -27,17 +21,16 @@
 				Adds a button to the title.
 			</description>
 		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="get_button_at_position" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the button's ID at the given position.
-			</description>
-		</method>
-		<method name="get_button_count" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the total number of buttons.
+				Returns the button's ID at the given position. Returns -1 if no button was found at this position, or if the button is disabled or hidden.
 			</description>
 		</method>
 		<method name="get_button_icon" qualifiers="const">
@@ -72,11 +65,11 @@
 			<return type="Rect2" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the Rect2 which represents the position and size of the button.
+				Returns the [Rect2] which represents the position and size of the button.
 			</description>
 		</method>
 		<method name="get_button_toggle_mode" qualifiers="const">
-			<return type="int" />
+			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns whether the button at the given index is a toggle button.
@@ -115,7 +108,7 @@
 			<param index="0" name="from" type="int" />
 			<param index="1" name="to" type="int" />
 			<description>
-				Changes the button's position ie. index.
+				Changes the button's index.
 			</description>
 		</method>
 		<method name="remove_button">
@@ -191,6 +184,8 @@
 		</method>
 	</methods>
 	<members>
+		<member name="button_count" type="int" setter="set_button_count" getter="get_button_count" default="0">
+		</member>
 		<member name="expanded" type="bool" setter="set_expanded" getter="is_expanded" default="true">
 			If [code]false[/code], the container will becomes folded and will hide all it's children.
 		</member>
@@ -209,7 +204,7 @@
 			The Container's title text.
 		</member>
 		<member name="title_alignment" type="int" setter="set_title_alignment" getter="get_title_alignment" enum="HorizontalAlignment" default="0">
-			Title's text horizontal alignment as defined in the [enum HorizontalAlignment] enum.
+			Title's horizontal text alignment as defined in the [enum HorizontalAlignment] enum.
 		</member>
 		<member name="title_position" type="int" setter="set_title_position" getter="get_title_position" enum="FoldableContainer.TitlePosition" default="0">
 			Title's position as defined in the [enum TitlePosition] enum.
@@ -217,16 +212,14 @@
 	</members>
 	<signals>
 		<signal name="button_pressed">
-			<param index="0" name="id" type="int" />
-			<param index="1" name="index" type="int" />
+			<param index="0" name="index" type="int" />
 			<description>
 				Emitted when a button is pressed.
 			</description>
 		</signal>
 		<signal name="button_toggled">
 			<param index="0" name="toggled_on" type="bool" />
-			<param index="1" name="id" type="int" />
-			<param index="2" name="index" type="int" />
+			<param index="1" name="index" type="int" />
 			<description>
 				Emitted when a button is toggled.
 			</description>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1269,7 +1269,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_stylebox("title_hover_panel", "FoldableContainer", foldable_container_hover);
 		p_theme->set_stylebox("title_collapsed_panel", "FoldableContainer", make_flat_stylebox(p_config.dark_color_1.darkened(0.125), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
 		p_theme->set_stylebox("title_collapsed_hover_panel", "FoldableContainer", make_flat_stylebox(p_config.dark_color_1.lerp(p_config.base_color, 0.4), p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin));
-		Ref<StyleBoxFlat> foldable_container_panel = make_flat_stylebox(p_config.dark_color_1, p_config.forced_even_separation, p_config.base_margin, p_config.base_margin, p_config.base_margin);
+		Ref<StyleBoxFlat> foldable_container_panel = make_flat_stylebox(p_config.dark_color_1, p_config.base_margin, p_config.base_margin, p_config.base_margin, p_config.base_margin);
 		foldable_container_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
 		foldable_container_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
 		p_theme->set_stylebox(SceneStringName(panel), "FoldableContainer", foldable_container_panel);

--- a/scene/gui/foldable_container.h
+++ b/scene/gui/foldable_container.h
@@ -32,6 +32,7 @@
 #define FOLDABLE_CONTAINER_H
 
 #include "scene/gui/container.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/text_line.h"
 
 class FoldableContainer : public Container {
@@ -46,19 +47,20 @@ public:
 
 private:
 	struct Button {
-		int id = -1;
 		Ref<Texture2D> icon = nullptr;
 		String tooltip;
+		Variant metadata;
+		Rect2 rect;
 
+		int id = -1;
 		bool disabled = false;
 		bool hidden = false;
 		bool toggle_mode = false;
 		bool toggled_on = false;
-
-		Rect2 rect;
-
-		Variant metadata;
 	};
+
+	static inline PropertyListHelper base_property_helper;
+	PropertyListHelper property_helper;
 
 	Vector<FoldableContainer::Button> buttons;
 	int _hovered = -1;
@@ -120,6 +122,11 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 	void _notification(int p_what);
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const { return property_helper.property_get_value(p_name, r_ret); }
+	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }
+	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 	static void _bind_methods();
 
 public:
@@ -135,8 +142,8 @@ public:
 	void set_language(const String &p_language);
 	String get_language() const;
 
-	void set_text_direction(TextDirection p_text_direction);
-	TextDirection get_text_direction() const;
+	void set_text_direction(Control::TextDirection p_text_direction);
+	Control::TextDirection get_text_direction() const;
 
 	void set_text_overrun_behavior(TextServer::OverrunBehavior p_overrun_behavior);
 	TextServer::OverrunBehavior get_text_overrun_behavior() const;
@@ -147,8 +154,11 @@ public:
 	void add_button(const Ref<Texture2D> &p_icon, int p_position = -1, int p_id = -1);
 	void remove_button(int p_index);
 
+	void set_button_count(int p_count);
 	int get_button_count() const;
+
 	Rect2 get_button_rect(int p_index) const;
+	void clear();
 
 	void set_button_id(int p_index, int p_id);
 	int get_button_id(int p_index) const;
@@ -157,7 +167,7 @@ public:
 	int get_button_index(int p_id) const;
 
 	void set_button_toggle_mode(int p_index, bool p_mode);
-	int get_button_toggle_mode(int p_index) const;
+	bool get_button_toggle_mode(int p_index) const;
 
 	void set_button_toggled(int p_index, bool p_toggled_on);
 	bool is_button_toggled(int p_index) const;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1217,7 +1217,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("title_hover_panel", "FoldableContainer", foldable_container_hover);
 	theme->set_stylebox("title_collapsed_panel", "FoldableContainer", make_flat_stylebox(style_pressed_color));
 	theme->set_stylebox("title_collapsed_hover_panel", "FoldableContainer", make_flat_stylebox(style_hover_color));
-	Ref<StyleBoxFlat> foldable_container_panel = make_flat_stylebox(style_normal_color, 18);
+	Ref<StyleBoxFlat> foldable_container_panel = make_flat_stylebox(style_normal_color);
+	foldable_container_panel->set_content_margin_all(default_margin);
 	foldable_container_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
 	foldable_container_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
 	theme->set_stylebox(SceneStringName(panel), "FoldableContainer", foldable_container_panel);


### PR DESCRIPTION
Fix shaping when font is null.
Unify the panel content margin.
Make allowed size flags empty.
Handle children visibility when sorting.