### PR TITLE
Disable joints when process mode is set for node to disable

### DIFF
--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -24,6 +24,9 @@
 		<member name="disable_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
 			If [code]true[/code], the two bodies bound together do not collide with each other.
 		</member>
+		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="Joint2D.DisableMode" default="0">
+			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
+		</member>
 		<member name="node_a" type="NodePath" setter="set_node_a" getter="get_node_a" default="NodePath(&quot;&quot;)">
 			Path to the first body (A) attached to the joint. The node must inherit [PhysicsBody2D].
 		</member>
@@ -31,4 +34,13 @@
 			Path to the second body (B) attached to the joint. The node must inherit [PhysicsBody2D].
 		</member>
 	</members>
+	<constants>
+		<constant name="DISABLE_MODE_REMOVE" value="0" enum="DisableMode">
+			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], remove from the physics simulation to stop all physics interactions with this [Joint2D].
+			Automatically re-added to the physics simulation when the [Node] is processed again with initial transforms for bodies.
+		</constant>
+		<constant name="DISABLE_MODE_KEEP_ACTIVE" value="1" enum="DisableMode">
+			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], do not affect the physics simulation.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/Joint3D.xml
+++ b/doc/classes/Joint3D.xml
@@ -18,6 +18,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="Joint3D.DisableMode" default="0">
+			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
+		</member>
 		<member name="exclude_nodes_from_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
 			If [code]true[/code], the two bodies bound together do not collide with each other.
 		</member>
@@ -33,4 +36,13 @@
 			The priority used to define which solver is executed first for multiple joints. The lower the value, the higher the priority.
 		</member>
 	</members>
+	<constants>
+		<constant name="DISABLE_MODE_REMOVE" value="0" enum="DisableMode">
+			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], remove from the physics simulation to stop all physics interactions with this [Joint3D].
+			Automatically re-added to the physics simulation when the [Node] is processed again with initial transforms for bodies.
+		</constant>
+		<constant name="DISABLE_MODE_KEEP_ACTIVE" value="1" enum="DisableMode">
+			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], do not affect the physics simulation.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -812,6 +812,13 @@
 				Returns whether the bodies attached to the [Joint2D] will collide with each other.
 			</description>
 		</method>
+		<method name="joint_is_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Gets joint enable state.
+			</description>
+		</method>
 		<method name="joint_make_damped_spring">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
@@ -843,6 +850,14 @@
 			<param index="3" name="body_b" type="RID" default="RID()" />
 			<description>
 				Makes the joint a pin joint. If [param body_b] is an empty [RID], then [param body_a] is pinned to the point [param anchor] (given in global coordinates); otherwise, [param body_a] is pinned to [param body_b] at the point [param anchor] (given in global coordinates). To set the parameters which are specific to the pin joint, see [method pin_joint_set_param].
+			</description>
+		</method>
+		<method name="joint_set_enabled">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Enable or disable a joint.
 			</description>
 		</method>
 		<method name="joint_set_param">

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -862,6 +862,13 @@
 				Overridable version of [method PhysicsServer2D.joint_is_disabled_collisions_between_bodies].
 			</description>
 		</method>
+		<method name="_joint_is_enabled" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Overridable version of [method PhysicsServer2D.joint_is_enabled].
+			</description>
+		</method>
 		<method name="_joint_make_damped_spring" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
@@ -893,6 +900,14 @@
 			<param index="3" name="body_b" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_make_pin].
+			</description>
+		</method>
+		<method name="_joint_set_enabled" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Overridable version of [method PhysicsServer2D.joint_set_enabled].
 			</description>
 		</method>
 		<method name="_joint_set_param" qualifiers="virtual">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -876,6 +876,13 @@
 				Returns whether the bodies attached to the [Joint3D] will collide with each other.
 			</description>
 		</method>
+		<method name="joint_is_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Gets the joint enabled state.
+			</description>
+		</method>
 		<method name="joint_make_cone_twist">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
@@ -925,6 +932,14 @@
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
 			<description>
+			</description>
+		</method>
+		<method name="joint_set_enabled">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Enable or disable the joint.
 			</description>
 		</method>
 		<method name="joint_set_solver_priority">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -801,6 +801,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_joint_is_enabled" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_joint_make_cone_twist" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
@@ -860,6 +866,13 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_set_enabled" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/modules/godot_physics_2d/godot_joints_2d.cpp
+++ b/modules/godot_physics_2d/godot_joints_2d.cpp
@@ -61,6 +61,7 @@ void GodotJoint2D::copy_settings_from(GodotJoint2D *p_joint) {
 	set_bias(p_joint->get_bias());
 	set_max_bias(p_joint->get_max_bias());
 	disable_collisions_between_bodies(p_joint->is_disabled_collisions_between_bodies());
+	set_enabled(p_joint->is_enabled());
 }
 
 static inline real_t k_scalar(GodotBody2D *a, GodotBody2D *b, const Vector2 &rA, const Vector2 &rB, const Vector2 &n) {
@@ -315,15 +316,14 @@ bool GodotPinJoint2D::get_flag(PhysicsServer2D::PinJointFlag p_flag) const {
 }
 
 GodotPinJoint2D::GodotPinJoint2D(const Vector2 &p_pos, GodotBody2D *p_body_a, GodotBody2D *p_body_b) :
-		GodotJoint2D(_arr, p_body_b ? 2 : 1) {
+		GodotJoint2D(p_body_b ? 2 : 1) {
 	A = p_body_a;
 	B = p_body_b;
 	anchor_A = p_body_a->get_inv_transform().xform(p_pos);
 	anchor_B = p_body_b ? p_body_b->get_inv_transform().xform(p_pos) : p_pos;
 
-	p_body_a->add_constraint(this, 0);
+	add_constraint_to_bodies();
 	if (p_body_b) {
-		p_body_b->add_constraint(this, 1);
 		initial_angle = A->get_transform().get_origin().angle_to_point(B->get_transform().get_origin());
 	}
 }
@@ -471,7 +471,7 @@ void GodotGrooveJoint2D::solve(real_t p_step) {
 }
 
 GodotGrooveJoint2D::GodotGrooveJoint2D(const Vector2 &p_a_groove1, const Vector2 &p_a_groove2, const Vector2 &p_b_anchor, GodotBody2D *p_body_a, GodotBody2D *p_body_b) :
-		GodotJoint2D(_arr, 2) {
+		GodotJoint2D(2) {
 	A = p_body_a;
 	B = p_body_b;
 
@@ -480,8 +480,7 @@ GodotGrooveJoint2D::GodotGrooveJoint2D(const Vector2 &p_a_groove1, const Vector2
 	B_anchor = B->get_inv_transform().xform(p_b_anchor);
 	A_groove_normal = -(A_groove_2 - A_groove_1).normalized().orthogonal();
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }
 
 //////////////////////////////////////////////
@@ -582,14 +581,12 @@ real_t GodotDampedSpringJoint2D::get_param(PhysicsServer2D::DampedSpringParam p_
 }
 
 GodotDampedSpringJoint2D::GodotDampedSpringJoint2D(const Vector2 &p_anchor_a, const Vector2 &p_anchor_b, GodotBody2D *p_body_a, GodotBody2D *p_body_b) :
-		GodotJoint2D(_arr, 2) {
+		GodotJoint2D(2) {
 	A = p_body_a;
 	B = p_body_b;
 	anchor_A = A->get_inv_transform().xform(p_anchor_a);
 	anchor_B = B->get_inv_transform().xform(p_anchor_b);
 
 	rest_length = p_anchor_a.distance_to(p_anchor_b);
-
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }

--- a/modules/godot_physics_2d/godot_joints_2d.h
+++ b/modules/godot_physics_2d/godot_joints_2d.h
@@ -38,10 +38,38 @@ class GodotJoint2D : public GodotConstraint2D {
 	real_t bias = 0;
 	real_t max_bias = 3.40282e+38;
 	real_t max_force = 3.40282e+38;
+	bool enabled = true;
 
 protected:
 	bool dynamic_A = false;
 	bool dynamic_B = false;
+
+	union {
+		struct {
+			GodotBody2D *A;
+			GodotBody2D *B;
+		};
+
+		GodotBody2D *_arr[2] = { nullptr, nullptr };
+	};
+
+	void add_constraint_to_bodies() {
+		if (A) {
+			A->add_constraint(this, 0);
+		}
+		if (B) {
+			B->add_constraint(this, 1);
+		}
+	}
+
+	void remove_constraint_from_bodies() {
+		for (int i = 0; i < get_body_count(); i++) {
+			GodotBody2D *body = get_body_ptr()[i];
+			if (body) {
+				body->remove_constraint(this, i);
+			}
+		}
+	}
 
 public:
 	_FORCE_INLINE_ void set_max_force(real_t p_force) { max_force = p_force; }
@@ -53,6 +81,16 @@ public:
 	_FORCE_INLINE_ void set_max_bias(real_t p_bias) { max_bias = p_bias; }
 	_FORCE_INLINE_ real_t get_max_bias() const { return max_bias; }
 
+	_FORCE_INLINE_ void set_enabled(bool p_enabled) {
+		enabled = p_enabled;
+		if (enabled) {
+			add_constraint_to_bodies();
+		} else {
+			remove_constraint_from_bodies();
+		}
+	}
+	_FORCE_INLINE_ bool is_enabled() const { return enabled; }
+
 	virtual bool setup(real_t p_step) override { return false; }
 	virtual bool pre_solve(real_t p_step) override { return false; }
 	virtual void solve(real_t p_step) override {}
@@ -60,29 +98,15 @@ public:
 	void copy_settings_from(GodotJoint2D *p_joint);
 
 	virtual PhysicsServer2D::JointType get_type() const { return PhysicsServer2D::JOINT_TYPE_MAX; }
-	GodotJoint2D(GodotBody2D **p_body_ptr = nullptr, int p_body_count = 0) :
-			GodotConstraint2D(p_body_ptr, p_body_count) {}
+	GodotJoint2D(int p_body_count = 0) :
+			GodotConstraint2D(_arr, p_body_count) {}
 
 	virtual ~GodotJoint2D() {
-		for (int i = 0; i < get_body_count(); i++) {
-			GodotBody2D *body = get_body_ptr()[i];
-			if (body) {
-				body->remove_constraint(this, i);
-			}
-		}
-	};
+		remove_constraint_from_bodies();
+	}
 };
 
 class GodotPinJoint2D : public GodotJoint2D {
-	union {
-		struct {
-			GodotBody2D *A;
-			GodotBody2D *B;
-		};
-
-		GodotBody2D *_arr[2] = { nullptr, nullptr };
-	};
-
 	Transform2D M;
 	Vector2 rA, rB;
 	Vector2 anchor_A;
@@ -119,15 +143,6 @@ public:
 };
 
 class GodotGrooveJoint2D : public GodotJoint2D {
-	union {
-		struct {
-			GodotBody2D *A;
-			GodotBody2D *B;
-		};
-
-		GodotBody2D *_arr[2] = { nullptr, nullptr };
-	};
-
 	Vector2 A_groove_1;
 	Vector2 A_groove_2;
 	Vector2 A_groove_normal;
@@ -153,15 +168,6 @@ public:
 };
 
 class GodotDampedSpringJoint2D : public GodotJoint2D {
-	union {
-		struct {
-			GodotBody2D *A;
-			GodotBody2D *B;
-		};
-
-		GodotBody2D *_arr[2] = { nullptr, nullptr };
-	};
-
 	Vector2 anchor_A;
 	Vector2 anchor_B;
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1080,6 +1080,20 @@ void GodotPhysicsServer2D::joint_clear(RID p_joint) {
 	}
 }
 
+void GodotPhysicsServer2D::joint_set_enabled(RID p_joint, bool p_enabled) {
+	GodotJoint2D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	joint->set_enabled(p_enabled);
+}
+
+bool GodotPhysicsServer2D::joint_is_enabled(RID p_joint) const {
+	const GodotJoint2D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+
+	return joint->is_enabled();
+}
+
 void GodotPhysicsServer2D::joint_set_param(RID p_joint, JointParam p_param, real_t p_value) {
 	GodotJoint2D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -267,6 +267,9 @@ public:
 
 	virtual void joint_clear(RID p_joint) override;
 
+	virtual void joint_set_enabled(RID p_joint, bool p_enabled) override;
+	virtual bool joint_is_enabled(RID p_joint) const override;
+
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) override;
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const override;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1258,6 +1258,20 @@ void GodotPhysicsServer3D::joint_clear(RID p_joint) {
 	}
 }
 
+void GodotPhysicsServer3D::joint_set_enabled(RID p_joint, bool p_enabled) {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	joint->set_enabled(p_enabled);
+}
+
+bool GodotPhysicsServer3D::joint_is_enabled(RID p_joint) const {
+	const GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+
+	return joint->is_enabled();
+}
+
 void GodotPhysicsServer3D::joint_make_pin(RID p_joint, RID p_body_A, const Vector3 &p_local_A, RID p_body_B, const Vector3 &p_local_B) {
 	GodotBody3D *body_A = body_owner.get_or_null(p_body_A);
 	ERR_FAIL_NULL(body_A);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -318,6 +318,9 @@ public:
 
 	virtual void joint_clear(RID p_joint) override; //resets type
 
+	virtual void joint_set_enabled(RID p_joint, bool p_enabled) override;
+	virtual bool joint_is_enabled(RID p_joint) const override;
+
 	virtual void joint_make_pin(RID p_joint, RID p_body_A, const Vector3 &p_local_A, RID p_body_B, const Vector3 &p_local_B) override;
 
 	virtual void pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value) override;

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -52,15 +52,14 @@ Written by: Marcus Hennix
 #include "godot_cone_twist_joint_3d.h"
 
 GodotConeTwistJoint3D::GodotConeTwistJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &rbAFrame, const Transform3D &rbBFrame) :
-		GodotJoint3D(_arr, 2) {
+		GodotJoint3D() {
 	A = rbA;
 	B = rbB;
 
 	m_rbAFrame = rbAFrame;
 	m_rbBFrame = rbBFrame;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }
 
 bool GodotConeTwistJoint3D::setup(real_t p_timestep) {

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
@@ -60,16 +60,6 @@ class GodotConeTwistJoint3D : public GodotJoint3D {
 #ifdef IN_PARALLELL_SOLVER
 public:
 #endif
-
-	union {
-		struct {
-			GodotBody3D *A;
-			GodotBody3D *B;
-		};
-
-		GodotBody3D *_arr[2] = { nullptr, nullptr };
-	};
-
 	GodotJacobianEntry3D m_jac[3] = {}; //3 orthogonal linear constraints
 
 	real_t m_appliedImpulse = 0.0;

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -219,7 +219,7 @@ real_t GodotG6DOFTranslationalLimitMotor3D::solveLinearAxis(
 //////////////////////////// GodotGeneric6DOFJoint3D ////////////////////////////////////
 
 GodotGeneric6DOFJoint3D::GodotGeneric6DOFJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &frameInA, const Transform3D &frameInB, bool useLinearReferenceFrameA) :
-		GodotJoint3D(_arr, 2),
+		GodotJoint3D(),
 		m_frameInA(frameInA),
 		m_frameInB(frameInB),
 		m_useLinearReferenceFrameA(useLinearReferenceFrameA) {

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
@@ -141,15 +141,6 @@ public:
 
 class GodotGeneric6DOFJoint3D : public GodotJoint3D {
 protected:
-	union {
-		struct {
-			GodotBody3D *A;
-			GodotBody3D *B;
-		};
-
-		GodotBody3D *_arr[2] = { nullptr, nullptr };
-	};
-
 	//! relative_frames
 	//!@{
 	Transform3D m_frameInA; //!< the constraint space w.r.t body A

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
@@ -50,7 +50,7 @@ subject to the following restrictions:
 #include "godot_hinge_joint_3d.h"
 
 GodotHingeJoint3D::GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &frameA, const Transform3D &frameB) :
-		GodotJoint3D(_arr, 2) {
+		GodotJoint3D() {
 	A = rbA;
 	B = rbB;
 
@@ -61,13 +61,12 @@ GodotHingeJoint3D::GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const T
 	m_rbBFrame.basis[1][2] *= real_t(-1.);
 	m_rbBFrame.basis[2][2] *= real_t(-1.);
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }
 
 GodotHingeJoint3D::GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Vector3 &pivotInA, const Vector3 &pivotInB,
 		const Vector3 &axisInA, const Vector3 &axisInB) :
-		GodotJoint3D(_arr, 2) {
+		GodotJoint3D() {
 	A = rbA;
 	B = rbB;
 
@@ -102,8 +101,7 @@ GodotHingeJoint3D::GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const V
 			rbAxisB1.y, rbAxisB2.y, -axisInB.y,
 			rbAxisB1.z, rbAxisB2.z, -axisInB.z);
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }
 
 bool GodotHingeJoint3D::setup(real_t p_step) {

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.h
@@ -54,15 +54,6 @@ subject to the following restrictions:
 */
 
 class GodotHingeJoint3D : public GodotJoint3D {
-	union {
-		struct {
-			GodotBody3D *A;
-			GodotBody3D *B;
-		};
-
-		GodotBody3D *_arr[2] = {};
-	};
-
 	GodotJacobianEntry3D m_jac[3]; //3 orthogonal linear constraints
 	GodotJacobianEntry3D m_jacAng[3]; //2 orthogonal angular constraints+ 1 for limit/motor
 

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.cpp
@@ -167,14 +167,13 @@ real_t GodotPinJoint3D::get_param(PhysicsServer3D::PinJointParam p_param) const 
 }
 
 GodotPinJoint3D::GodotPinJoint3D(GodotBody3D *p_body_a, const Vector3 &p_pos_a, GodotBody3D *p_body_b, const Vector3 &p_pos_b) :
-		GodotJoint3D(_arr, 2) {
+		GodotJoint3D() {
 	A = p_body_a;
 	B = p_body_b;
 	m_pivotInA = p_pos_a;
 	m_pivotInB = p_pos_b;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }
 
 GodotPinJoint3D::~GodotPinJoint3D() {

--- a/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_pin_joint_3d.h
@@ -54,15 +54,6 @@ subject to the following restrictions:
 */
 
 class GodotPinJoint3D : public GodotJoint3D {
-	union {
-		struct {
-			GodotBody3D *A;
-			GodotBody3D *B;
-		};
-
-		GodotBody3D *_arr[2] = {};
-	};
-
 	real_t m_tau = 0.3; //bias
 	real_t m_damping = 1.0;
 	real_t m_impulseClamp = 0.0;

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
@@ -58,14 +58,13 @@ April 04, 2008
 //-----------------------------------------------------------------------------
 
 GodotSliderJoint3D::GodotSliderJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &frameInA, const Transform3D &frameInB) :
-		GodotJoint3D(_arr, 2),
+		GodotJoint3D(),
 		m_frameInA(frameInA),
 		m_frameInB(frameInB) {
 	A = rbA;
 	B = rbB;
 
-	A->add_constraint(this, 0);
-	B->add_constraint(this, 1);
+	add_constraint_to_bodies();
 }
 
 //-----------------------------------------------------------------------------

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.h
@@ -67,15 +67,6 @@ April 04, 2008
 
 class GodotSliderJoint3D : public GodotJoint3D {
 protected:
-	union {
-		struct {
-			GodotBody3D *A;
-			GodotBody3D *B;
-		};
-
-		GodotBody3D *_arr[2] = { nullptr, nullptr };
-	};
-
 	Transform3D m_frameInA;
 	Transform3D m_frameInB;
 

--- a/scene/2d/physics/joints/damped_spring_joint_2d.cpp
+++ b/scene/2d/physics/joints/damped_spring_joint_2d.cpp
@@ -47,6 +47,14 @@ void DampedSpringJoint2D::_notification(int p_what) {
 			draw_line(Point2(-10, length), Point2(+10, length), Color(0.7, 0.6, 0.0, 0.5), 3);
 			draw_line(Point2(0, 0), Point2(0, length), Color(0.7, 0.6, 0.0, 0.5), 3);
 		} break;
+
+		case NOTIFICATION_DISABLED: {
+			_apply_disabled();
+		} break;
+
+		case NOTIFICATION_ENABLED: {
+			_apply_enabled();
+		} break;
 	}
 }
 

--- a/scene/2d/physics/joints/groove_joint_2d.cpp
+++ b/scene/2d/physics/joints/groove_joint_2d.cpp
@@ -48,6 +48,14 @@ void GrooveJoint2D::_notification(int p_what) {
 			draw_line(Point2(0, 0), Point2(0, length), Color(0.7, 0.6, 0.0, 0.5), 3);
 			draw_line(Point2(-10, initial_offset), Point2(+10, initial_offset), Color(0.8, 0.8, 0.9, 0.5), 5);
 		} break;
+
+		case NOTIFICATION_DISABLED: {
+			_apply_disabled();
+		} break;
+
+		case NOTIFICATION_ENABLED: {
+			_apply_enabled();
+		} break;
 	}
 }
 

--- a/scene/2d/physics/joints/joint_2d.h
+++ b/scene/2d/physics/joints/joint_2d.h
@@ -38,6 +38,13 @@ class PhysicsBody2D;
 class Joint2D : public Node2D {
 	GDCLASS(Joint2D, Node2D);
 
+public:
+	enum DisableMode {
+		DISABLE_MODE_REMOVE,
+		DISABLE_MODE_KEEP_ACTIVE,
+	};
+
+private:
 	RID joint;
 	RID ba, bb;
 
@@ -48,15 +55,21 @@ class Joint2D : public Node2D {
 	bool exclude_from_collision = true;
 	bool configured = false;
 	String warning;
+	DisableMode disable_mode = DISABLE_MODE_REMOVE;
 
 protected:
 	void _disconnect_signals();
 	void _body_exit_tree();
 	void _update_joint(bool p_only_free = false);
 
+	void _apply_disabled();
+	void _apply_enabled();
+
 	void _notification(int p_what);
 	virtual void _configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBody2D *body_b) = 0;
 
+	void set_disable_mode(DisableMode p_mode);
+	DisableMode get_disable_mode() const;
 	static void _bind_methods();
 
 	_FORCE_INLINE_ bool is_configured() const { return configured; }
@@ -81,4 +94,5 @@ public:
 	~Joint2D();
 };
 
+VARIANT_ENUM_CAST(Joint2D::DisableMode);
 #endif // JOINT_2D_H

--- a/scene/2d/physics/joints/pin_joint_2d.cpp
+++ b/scene/2d/physics/joints/pin_joint_2d.cpp
@@ -46,6 +46,14 @@ void PinJoint2D::_notification(int p_what) {
 			draw_line(Point2(-10, 0), Point2(+10, 0), Color(0.7, 0.6, 0.0, 0.5), 3);
 			draw_line(Point2(0, -10), Point2(0, +10), Color(0.7, 0.6, 0.0, 0.5), 3);
 		} break;
+
+		case NOTIFICATION_DISABLED: {
+			_apply_disabled();
+		} break;
+
+		case NOTIFICATION_ENABLED: {
+			_apply_enabled();
+		} break;
 	}
 }
 

--- a/scene/3d/physics/joints/joint_3d.cpp
+++ b/scene/3d/physics/joints/joint_3d.cpp
@@ -66,6 +66,11 @@ void Joint3D::_update_joint(bool p_only_free) {
 		warning = String();
 		return;
 	}
+	if (!is_enabled() && disable_mode == DISABLE_MODE_REMOVE) {
+		PhysicsServer3D::get_singleton()->joint_set_enabled(get_rid(), false);
+		warning = String();
+		return;
+	}
 
 	Node *node_a = get_node_or_null(a);
 	Node *node_b = get_node_or_null(b);
@@ -181,7 +186,66 @@ void Joint3D::_notification(int p_what) {
 			}
 			_update_joint(true);
 		} break;
+
+		case NOTIFICATION_DISABLED: {
+			_apply_disabled();
+		} break;
+
+		case NOTIFICATION_ENABLED: {
+			_apply_enabled();
+		} break;
 	}
+}
+void Joint3D::_apply_disabled() {
+	switch (disable_mode) {
+		case DISABLE_MODE_REMOVE: {
+			if (is_inside_tree()) {
+				PhysicsServer3D::get_singleton()->joint_set_enabled(get_rid(), false);
+			}
+		} break;
+
+		case DISABLE_MODE_KEEP_ACTIVE: {
+			// Nothing to do.
+		} break;
+	}
+}
+
+void Joint3D::_apply_enabled() {
+	switch (disable_mode) {
+		case DISABLE_MODE_REMOVE: {
+			if (is_inside_tree()) {
+				PhysicsServer3D::get_singleton()->joint_set_enabled(get_rid(), true);
+			}
+		} break;
+
+		case DISABLE_MODE_KEEP_ACTIVE: {
+			// Nothing to do.
+		} break;
+	}
+}
+
+void Joint3D::set_disable_mode(DisableMode p_mode) {
+	if (disable_mode == p_mode) {
+		return;
+	}
+
+	bool disabled = is_inside_tree() && !is_enabled();
+
+	if (disabled) {
+		// Cancel previous disable mode.
+		_apply_enabled();
+	}
+
+	disable_mode = p_mode;
+
+	if (disabled) {
+		// Apply new disable mode.
+		_apply_disabled();
+	}
+}
+
+Joint3D::DisableMode Joint3D::get_disable_mode() const {
+	return disable_mode;
 }
 
 void Joint3D::set_exclude_nodes_from_collision(bool p_enable) {
@@ -223,6 +287,9 @@ void Joint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude_nodes_from_collision", "enable"), &Joint3D::set_exclude_nodes_from_collision);
 	ClassDB::bind_method(D_METHOD("get_exclude_nodes_from_collision"), &Joint3D::get_exclude_nodes_from_collision);
 
+	ClassDB::bind_method(D_METHOD("set_disable_mode", "mode"), &Joint3D::set_disable_mode);
+	ClassDB::bind_method(D_METHOD("get_disable_mode"), &Joint3D::get_disable_mode);
+
 	ClassDB::bind_method(D_METHOD("get_rid"), &Joint3D::get_rid);
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody3D"), "set_node_a", "get_node_a");
@@ -230,6 +297,10 @@ void Joint3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "solver_priority", PROPERTY_HINT_RANGE, "1,8,1"), "set_solver_priority", "get_solver_priority");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_nodes_from_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "disable_mode", PROPERTY_HINT_ENUM, "Remove,Keep Active"), "set_disable_mode", "get_disable_mode");
+
+	BIND_ENUM_CONSTANT(DISABLE_MODE_REMOVE);
+	BIND_ENUM_CONSTANT(DISABLE_MODE_KEEP_ACTIVE);
 }
 
 Joint3D::Joint3D() {

--- a/scene/3d/physics/joints/joint_3d.h
+++ b/scene/3d/physics/joints/joint_3d.h
@@ -37,6 +37,13 @@
 class Joint3D : public Node3D {
 	GDCLASS(Joint3D, Node3D);
 
+public:
+	enum DisableMode {
+		DISABLE_MODE_REMOVE,
+		DISABLE_MODE_KEEP_ACTIVE,
+	};
+
+private:
 	RID ba, bb;
 
 	RID joint;
@@ -49,6 +56,11 @@ class Joint3D : public Node3D {
 	String warning;
 	bool configured = false;
 
+	void _apply_disabled();
+	void _apply_enabled();
+
+	DisableMode disable_mode = DISABLE_MODE_REMOVE;
+
 protected:
 	void _disconnect_signals();
 	void _body_exit_tree();
@@ -57,6 +69,9 @@ protected:
 	void _notification(int p_what);
 
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) = 0;
+
+	void set_disable_mode(DisableMode p_mode);
+	DisableMode get_disable_mode() const;
 
 	static void _bind_methods();
 
@@ -82,4 +97,5 @@ public:
 	~Joint3D();
 };
 
+VARIANT_ENUM_CAST(Joint3D::DisableMode);
 #endif // JOINT_3D_H

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -308,6 +308,9 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_joint_create);
 	GDVIRTUAL_BIND(_joint_clear, "joint");
 
+	GDVIRTUAL_BIND(_joint_set_enabled, "joint", "enabled");
+	GDVIRTUAL_BIND(_joint_is_enabled, "joint");
+
 	GDVIRTUAL_BIND(_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_joint_get_param, "joint", "param");
 

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -411,6 +411,9 @@ public:
 	EXBIND0R(RID, joint_create)
 	EXBIND1(joint_clear, RID)
 
+	EXBIND2(joint_set_enabled, RID, bool)
+	EXBIND1RC(bool, joint_is_enabled, RID)
+
 	EXBIND3(joint_set_param, RID, JointParam, real_t)
 	EXBIND2RC(real_t, joint_get_param, RID, JointParam)
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -365,6 +365,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_joint_create);
 	GDVIRTUAL_BIND(_joint_clear, "joint");
 
+	GDVIRTUAL_BIND(_joint_set_enabled, "joint", "enabled");
+	GDVIRTUAL_BIND(_joint_is_enabled, "joint");
+
 	GDVIRTUAL_BIND(_joint_make_pin, "joint", "body_A", "local_A", "body_B", "local_B");
 
 	GDVIRTUAL_BIND(_pin_joint_set_param, "joint", "param", "value");

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -474,6 +474,9 @@ public:
 	EXBIND0R(RID, joint_create)
 	EXBIND1(joint_clear, RID)
 
+	EXBIND2(joint_set_enabled, RID, bool)
+	EXBIND1RC(bool, joint_is_enabled, RID)
+
 	EXBIND5(joint_make_pin, RID, RID, const Vector3 &, RID, const Vector3 &)
 
 	EXBIND3(pin_joint_set_param, RID, PinJointParam, real_t)

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -770,6 +770,9 @@ void PhysicsServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("joint_clear", "joint"), &PhysicsServer2D::joint_clear);
 
+	ClassDB::bind_method(D_METHOD("joint_set_enabled", "joint", "enabled"), &PhysicsServer2D::joint_set_enabled);
+	ClassDB::bind_method(D_METHOD("joint_is_enabled", "joint"), &PhysicsServer2D::joint_is_enabled);
+
 	ClassDB::bind_method(D_METHOD("joint_set_param", "joint", "param", "value"), &PhysicsServer2D::joint_set_param);
 	ClassDB::bind_method(D_METHOD("joint_get_param", "joint", "param"), &PhysicsServer2D::joint_get_param);
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -538,6 +538,9 @@ public:
 		JOINT_TYPE_MAX
 	};
 
+	virtual void joint_set_enabled(RID p_joint, bool p_enabled) = 0;
+	virtual bool joint_is_enabled(RID p_joint) const = 0;
+
 	enum JointParam {
 		JOINT_PARAM_BIAS,
 		JOINT_PARAM_MAX_BIAS,

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -305,6 +305,9 @@ public:
 
 	virtual void joint_clear(RID p_joint) override {}
 
+	virtual void joint_set_enabled(RID p_joint, bool p_enabled) override {}
+	virtual bool joint_is_enabled(RID p_joint) const override { return false; }
+
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) override {}
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const override { return 0; }
 

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -281,6 +281,9 @@ public:
 	FUNC3(joint_set_param, RID, JointParam, real_t);
 	FUNC2RC(real_t, joint_get_param, RID, JointParam);
 
+	FUNC2(joint_set_enabled, RID, bool);
+	FUNC1RC(bool, joint_is_enabled, RID);
+
 	FUNC2(joint_disable_collisions_between_bodies, RID, const bool);
 	FUNC1RC(bool, joint_is_disabled_collisions_between_bodies, RID);
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -902,6 +902,9 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("joint_create"), &PhysicsServer3D::joint_create);
 	ClassDB::bind_method(D_METHOD("joint_clear", "joint"), &PhysicsServer3D::joint_clear);
 
+	ClassDB::bind_method(D_METHOD("joint_set_enabled", "joint", "enabled"), &PhysicsServer3D::joint_set_enabled);
+	ClassDB::bind_method(D_METHOD("joint_is_enabled", "joint"), &PhysicsServer3D::joint_is_enabled);
+
 	BIND_ENUM_CONSTANT(JOINT_TYPE_PIN);
 	BIND_ENUM_CONSTANT(JOINT_TYPE_HINGE);
 	BIND_ENUM_CONSTANT(JOINT_TYPE_SLIDER);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -642,6 +642,9 @@ public:
 
 	virtual void joint_clear(RID p_joint) = 0;
 
+	virtual void joint_set_enabled(RID p_joint, bool p_enabled) = 0;
+	virtual bool joint_is_enabled(RID p_joint) const = 0;
+
 	virtual JointType joint_get_type(RID p_joint) const = 0;
 
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) = 0;

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -366,6 +366,9 @@ public:
 
 	virtual void joint_clear(RID p_joint) override {}
 
+	virtual void joint_set_enabled(RID p_joint, bool p_enabled) override {}
+	virtual bool joint_is_enabled(RID p_joint) const override { return false; }
+
 	virtual JointType joint_get_type(RID p_joint) const override { return JointType::JOINT_TYPE_PIN; }
 
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override {}

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -333,6 +333,9 @@ public:
 
 	FUNC1(joint_clear, RID)
 
+	FUNC2(joint_set_enabled, RID, bool)
+	FUNC1RC(bool, joint_is_enabled, RID)
+
 	FUNC5(joint_make_pin, RID, RID, const Vector3 &, RID, const Vector3 &)
 
 	FUNC3(pin_joint_set_param, RID, PinJointParam, real_t)


### PR DESCRIPTION
Allows physics joints to be disabled. The original PR from @Ughuuu was targeting 4.4, this is just simple backport.