### PR TITLE
Improve: prevent ProjectSettings from emitting settings changes.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1028,9 +1028,10 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		}
 	}
 	project_features = _trim_to_supported_features(project_features);
-	if (get_setting("application/config/features") != project_features) {
-		set_setting("application/config/features", project_features);
-	}
+
+	is_changed = true;
+	set_setting("application/config/features", project_features);
+	is_changed = false;
 #endif // TOOLS_ENABLED
 
 	RBSet<_VCSort> vclist;


### PR DESCRIPTION
Included in 4.4.