### PR TITLE
SplitContainer, preserve compatibility when collapse mode is disabled.

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -194,6 +194,10 @@ Control *SplitContainer::_get_child(int p_idx) const {
 			continue;
 		}
 
+		if (collapse_mode == COLLAPSE_NONE && !c->is_visible()) {
+			continue;
+		}
+
 		if (idx == p_idx) {
 			return c;
 		}


### PR DESCRIPTION
* Fixes: https://github.com/blazium-engine/blazium/issues/291