### PR TITLE
Exposed Engine.get_frame_ticks to GDScript.

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -105,6 +105,10 @@ uint32_t Engine::get_frame_delay() const {
 	return _frame_delay;
 }
 
+uint64_t Engine::get_frame_ticks() const {
+	return _frame_ticks;
+}
+
 void Engine::set_time_scale(double p_scale) {
 	_time_scale = p_scale;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -120,7 +120,7 @@ public:
 	uint64_t get_physics_frames() const { return _physics_frames; }
 	uint64_t get_process_frames() const { return _process_frames; }
 	bool is_in_physics_frame() const { return _in_physics; }
-	uint64_t get_frame_ticks() const { return _frame_ticks; }
+	uint64_t get_frame_ticks() const;
 	double get_process_step() const { return _process_step; }
 	double get_physics_interpolation_fraction() const { return _physics_interpolation_fraction; }
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1687,6 +1687,10 @@ double Engine::get_time_scale() {
 	return ::Engine::get_singleton()->get_time_scale();
 }
 
+uint64_t Engine::get_frame_ticks() const {
+	return ::Engine::get_singleton()->get_frame_ticks();
+}
+
 int Engine::get_frames_drawn() {
 	return ::Engine::get_singleton()->get_frames_drawn();
 }
@@ -1825,6 +1829,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &Engine::set_time_scale);
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);
 
+	ClassDB::bind_method(D_METHOD("get_frame_ticks"), &Engine::get_frame_ticks);
 	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &Engine::get_frames_drawn);
 	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &Engine::get_frames_per_second);
 	ClassDB::bind_method(D_METHOD("get_physics_frames"), &Engine::get_physics_frames);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -508,6 +508,7 @@ public:
 	uint64_t get_process_frames() const;
 
 	int get_frames_drawn();
+	uint64_t get_frame_ticks() const;
 
 	void set_time_scale(double p_scale);
 	double get_time_scale();

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -54,6 +54,12 @@
 				{[code]platinum_sponsors[/code], [code]gold_sponsors[/code], [code]silver_sponsors[/code], [code]bronze_sponsors[/code], [code]mini_sponsors[/code], [code]gold_donors[/code], [code]silver_donors[/code], [code]bronze_donors[/code]}
 			</description>
 		</method>
+		<method name="get_frame_ticks" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the tick count at the start of the frame.
+			</description>
+		</method>
 		<method name="get_frames_drawn">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
This exposes Engine.get_frame_ticks to GDScript. This gives us the ticks at the very start of the frame. This is extremely useful for loading and budgeting things in open world games.