### PR TITLE
Fix Node3DEditor snapping and EditorInspector minimum size.

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -28,6 +28,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="custom_minimum_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" overrides="Control" default="Vector2(220, 0)" />
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>
 	<signals>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4365,6 +4365,7 @@ EditorInspector::EditorInspector() {
 	object = nullptr;
 	main_vbox = memnew(VBoxContainer);
 	main_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	set_custom_minimum_size(Size2(220 * EDSCALE, 0));
 	add_child(main_vbox);
 	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
 	set_follow_focus(true);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8116,14 +8116,12 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 	}
 }
 
-void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(p_event.is_null());
-
+bool Node3DEditor::is_snap_enabled() const {
 	if (!is_visible_in_tree()) {
-		return;
+		return false;
 	}
 
-	snap_key_enabled = Input::get_singleton()->is_key_pressed(Key::CTRL);
+	return snap_enabled ^ Input::get_singleton()->is_key_pressed(Key::CTRL);
 }
 
 void Node3DEditor::_sun_environ_settings_pressed() {
@@ -8863,8 +8861,6 @@ Node3DEditor::Node3DEditor() {
 	editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
 
-	snap_enabled = false;
-	snap_key_enabled = false;
 	tool_mode = TOOL_MODE_SELECT;
 
 	camera_override_viewport_id = 0;
@@ -9283,7 +9279,6 @@ Node3DEditor::Node3DEditor() {
 
 	selected = nullptr;
 
-	set_process_shortcut_input(true);
 	add_to_group(SceneStringName(_spatial_editor_group));
 
 	current_hover_gizmo_handle = -1;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -761,8 +761,7 @@ private:
 	ConfirmationDialog *xform_dialog = nullptr;
 	ConfirmationDialog *settings_dialog = nullptr;
 
-	bool snap_enabled;
-	bool snap_key_enabled;
+	bool snap_enabled = false;
 	LineEdit *snap_translate = nullptr;
 	LineEdit *snap_rotate = nullptr;
 	LineEdit *snap_scale = nullptr;
@@ -901,7 +900,6 @@ private:
 protected:
 	void _notification(int p_what);
 	//void _gui_input(InputEvent p_event);
-	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	static void _bind_methods();
 
@@ -922,7 +920,7 @@ public:
 	ToolMode get_tool_mode() const { return tool_mode; }
 	bool are_local_coords_enabled() const;
 	void set_local_coords_enabled(bool p_toggled_on) const;
-	bool is_snap_enabled() const { return snap_enabled ^ snap_key_enabled; }
+	bool is_snap_enabled() const;
 	real_t get_translate_snap() const;
 	real_t get_rotate_snap() const;
 	real_t get_scale_snap() const;


### PR DESCRIPTION
Fixes Node3D editor snapping when the saving popup blocks the CTRL release input.
Fixes EditorInspector minimum size to avoid changing the split offset when it's changed.
