### PR TITLE
Add `expand_text` property to Button.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -52,6 +52,10 @@
 		<member name="expand_icon" type="bool" setter="set_expand_icon" getter="is_expand_icon" default="false">
 			When enabled, the button's icon will expand/shrink to fit the button's size while keeping its aspect. See also [theme_item icon_max_width].
 		</member>
+		<member name="expand_text" type="bool" setter="set_expand_text" getter="is_expand_text" default="true">
+			Allows text to expand horizontally.
+			If [code]false[/code], text alignment will only affect multiline text. Also helps to center icon and text properly without overlapping.
+		</member>
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
 			Flat buttons don't display decoration.
 		</member>

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -214,6 +214,7 @@ void Button::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			const RID ci = get_canvas_item();
 			const Size2 size = get_size();
+			const bool rtl = is_layout_rtl();
 
 			Ref<StyleBox> style = _get_current_stylebox();
 			// Draws the stylebox in the current state.
@@ -230,7 +231,8 @@ void Button::_notification(int p_what) {
 				_icon = theme_cache.icon;
 			}
 
-			if (xl_text.is_empty() && _icon.is_null()) {
+			bool draw_text = !xl_text.is_empty();
+			if (!draw_text && _icon.is_null()) {
 				break;
 			}
 
@@ -266,7 +268,7 @@ void Button::_notification(int p_what) {
 			HorizontalAlignment icon_align_rtl_checked = horizontal_icon_alignment;
 			HorizontalAlignment align_rtl_checked = alignment;
 			// Swap icon and text alignment sides if right-to-left layout is set.
-			if (is_layout_rtl()) {
+			if (rtl) {
 				if (horizontal_icon_alignment == HORIZONTAL_ALIGNMENT_RIGHT) {
 					icon_align_rtl_checked = HORIZONTAL_ALIGNMENT_LEFT;
 				} else if (horizontal_icon_alignment == HORIZONTAL_ALIGNMENT_LEFT) {
@@ -343,17 +345,19 @@ void Button::_notification(int p_what) {
 			const bool is_clipped = clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF;
 			const Size2 custom_element_size = drawable_size_remained;
 
+			Size2 icon_size;
+			Point2 icon_ofs;
+			bool align_center_fill = icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER && expand_text;
 			// Draw the icon.
+			bool draw_icon = false;
 			if (_icon.is_valid()) {
-				Size2 icon_size;
-
 				{ // Calculate the drawing size of the icon.
 					icon_size = _icon->get_size();
 
 					if (expand_icon) {
 						const Size2 text_buf_size = text_buf->get_size();
 						Size2 _size = custom_element_size;
-						if (!is_clipped && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER && text_buf_size.width > 0.0f) {
+						if (!is_clipped && !align_center_fill && text_buf_size.width > 0.0f) {
 							// If there is not enough space for icon and h_separation, h_separation will occupy the space first,
 							// so the icon's width may be negative. Keep it negative to make it easier to calculate the space
 							// reserved for text later.
@@ -376,10 +380,9 @@ void Button::_notification(int p_what) {
 					icon_size = _fit_icon_size(icon_size);
 					icon_size = icon_size.round();
 				}
-
 				if (icon_size.width > 0.0f) {
+					draw_icon = true;
 					// Calculate the drawing position of the icon.
-					Point2 icon_ofs;
 
 					switch (icon_align_rtl_checked) {
 						case HORIZONTAL_ALIGNMENT_CENTER: {
@@ -414,14 +417,11 @@ void Button::_notification(int p_what) {
 						} break;
 					}
 					icon_ofs = icon_ofs.floor();
-
-					Rect2 icon_region = Rect2(icon_ofs, icon_size);
-					draw_texture_rect(_icon, icon_region, false, icon_modulate_color);
 				}
 
-				if (!xl_text.is_empty()) {
+				if (draw_text) {
 					// Update the size after the icon is stripped. Stripping only when the icon alignments are not center.
-					if (icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
+					if (!align_center_fill) {
 						// Subtract the space's width occupied by icon and h_separation together.
 						drawable_size_remained.width -= icon_size.width + h_separation;
 					}
@@ -432,18 +432,28 @@ void Button::_notification(int p_what) {
 				}
 			}
 
+			Point2 text_ofs;
+			float text_buf_width = 0; // The space's width filled by the text_buf.
 			// Draw the text.
-			if (!xl_text.is_empty()) {
+			if (draw_text) {
 				text_buf->set_alignment(align_rtl_checked);
-
-				float text_buf_width = Math::ceil(MAX(1.0f, drawable_size_remained.width)); // The space's width filled by the text_buf.
+				if (expand_text) {
+					text_buf_width = Math::ceil(MAX(1.0f, drawable_size_remained.width));
+				} else {
+					text_buf->set_width(drawable_size_remained.width);
+					if (!is_clipped) {
+						text_buf_width = text_buf->get_size().width;
+					} else {
+						text_buf_width = MAX(1.0f, MIN(text_buf->get_size().width, drawable_size_remained.width));
+					}
+				}
 				text_buf->set_width(text_buf_width);
-
-				Point2 text_ofs;
 
 				switch (align_rtl_checked) {
 					case HORIZONTAL_ALIGNMENT_CENTER: {
-						text_ofs.x = (drawable_size_remained.width - text_buf_width) / 2.0f;
+						if (expand_text) {
+							text_ofs.x = (drawable_size_remained.width - text_buf_width) / 2.0f;
+						}
 					}
 						[[fallthrough]];
 					case HORIZONTAL_ALIGNMENT_FILL:
@@ -467,6 +477,34 @@ void Button::_notification(int p_what) {
 				int outline_size = theme_cache.outline_size;
 				if (outline_size > 0 && font_outline_color.a > 0.0f) {
 					text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
+				}
+			}
+
+			bool icon_centered = icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER && !expand_text && vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER;
+			if (draw_icon) {
+				if (draw_text && icon_centered) {
+					if (rtl) {
+						icon_ofs.x += Math::floor((text_buf_width + h_separation) * 0.5);
+					} else {
+						icon_ofs.x -= Math::floor((text_buf_width + h_separation) * 0.5);
+					}
+				}
+				draw_texture_rect(_icon, Rect2(icon_ofs, icon_size), false, icon_modulate_color);
+			}
+
+			if (draw_text) {
+				if (draw_icon && icon_centered) {
+					if (rtl) {
+						text_ofs.x = icon_ofs.x - text_buf_width - h_separation;
+					} else {
+						text_ofs.x = icon_ofs.x + icon_size.width + h_separation;
+					}
+				}
+				if (rtl && !expand_text && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
+					text_ofs.x = size.width - right_internal_margin_with_h_separation - style_margin_right - text_buf_width;
+					if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_RIGHT) {
+						text_ofs.x -= icon_size.width + h_separation;
+					}
 				}
 				text_buf->draw(ci, text_ofs, font_color);
 			}
@@ -509,8 +547,8 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		} else {
 			minsize.height += icon_size.height;
 		}
-
-		if (horizontal_icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
+		bool add_icon_width = horizontal_icon_alignment == HORIZONTAL_ALIGNMENT_CENTER && !expand_text && vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER;
+		if (horizontal_icon_alignment != HORIZONTAL_ALIGNMENT_CENTER || add_icon_width) {
 			minsize.width += icon_size.width;
 			if (!xl_text.is_empty() || !p_text.is_empty()) {
 				minsize.width += MAX(0, theme_cache.h_separation);
@@ -725,6 +763,19 @@ HorizontalAlignment Button::get_text_alignment() const {
 	return alignment;
 }
 
+void Button::set_expand_text(bool p_enabled) {
+	if (expand_text != p_enabled) {
+		expand_text = p_enabled;
+		_shape();
+		update_minimum_size();
+		queue_redraw();
+	}
+}
+
+bool Button::is_expand_text() const {
+	return expand_text;
+}
+
 void Button::set_icon_alignment(HorizontalAlignment p_alignment) {
 	if (horizontal_icon_alignment == p_alignment) {
 		return;
@@ -776,6 +827,8 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_clip_text"), &Button::get_clip_text);
 	ClassDB::bind_method(D_METHOD("set_text_alignment", "alignment"), &Button::set_text_alignment);
 	ClassDB::bind_method(D_METHOD("get_text_alignment"), &Button::get_text_alignment);
+	ClassDB::bind_method(D_METHOD("set_expand_text", "enabled"), &Button::set_expand_text);
+	ClassDB::bind_method(D_METHOD("is_expand_text"), &Button::is_expand_text);
 	ClassDB::bind_method(D_METHOD("set_icon_alignment", "icon_alignment"), &Button::set_icon_alignment);
 	ClassDB::bind_method(D_METHOD("get_icon_alignment"), &Button::get_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_vertical_icon_alignment", "vertical_icon_alignment"), &Button::set_vertical_icon_alignment);
@@ -789,6 +842,7 @@ void Button::_bind_methods() {
 
 	ADD_GROUP("Text Behavior", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_text_alignment", "get_text_alignment");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_text"), "set_expand_text", "is_expand_text");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis,Word Ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Off,Arbitrary,Word,Word (Smart)"), "set_autowrap_mode", "get_autowrap_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_text"), "set_clip_text", "get_clip_text");

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -52,6 +52,7 @@ private:
 	bool expand_icon = false;
 	bool clip_text = false;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
+	bool expand_text = true;
 	HorizontalAlignment horizontal_icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	VerticalAlignment vertical_icon_alignment = VERTICAL_ALIGNMENT_CENTER;
 	float _internal_margin[4] = {};
@@ -151,6 +152,9 @@ public:
 
 	void set_text_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_text_alignment() const;
+
+	void set_expand_text(bool p_expand);
+	bool is_expand_text() const;
 
 	void set_icon_alignment(HorizontalAlignment p_alignment);
 	void set_vertical_icon_alignment(VerticalAlignment p_alignment);


### PR DESCRIPTION
This doesn't affect the default button behavior because it's enabled by default.

![Screenshot from 2025-02-16 10-49-35](https://github.com/user-attachments/assets/3da91d77-3e3b-448d-a8f1-61cb30367d8b)
