### PR TITLE
Fix improper DBus connection lifetime in FreeDesktopScreenSaver

### DIFF
--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -72,6 +72,7 @@ void FreeDesktopScreenSaver::inhibit() {
 	if (dbus_error_is_set(&error)) {
 		dbus_error_free(&error);
 		dbus_connection_unref(bus);
+		bus = nullptr;
 		unsupported = true;
 		return;
 	}
@@ -104,6 +105,7 @@ void FreeDesktopScreenSaver::uninhibit() {
 	if (dbus_error_is_set(&error)) {
 		dbus_error_free(&error);
 		dbus_connection_unref(bus);
+		bus = nullptr;
 		unsupported = true;
 		return;
 	}

--- a/platform/linuxbsd/freedesktop_screensaver.h
+++ b/platform/linuxbsd/freedesktop_screensaver.h
@@ -35,17 +35,12 @@
 
 #include <stdint.h>
 
-#ifdef SOWRAP_ENABLED
-#include "dbus-so_wrap.h"
-#else
-#include <dbus/dbus.h>
-#endif
+struct DBusConnection;
 
 class FreeDesktopScreenSaver {
 private:
 	uint32_t cookie = 0;
 	DBusConnection *bus;
-	bool is_inhibited = false;
 	bool unsupported = false;
 
 public:

--- a/platform/linuxbsd/freedesktop_screensaver.h
+++ b/platform/linuxbsd/freedesktop_screensaver.h
@@ -35,13 +35,22 @@
 
 #include <stdint.h>
 
+#ifdef SOWRAP_ENABLED
+#include "dbus-so_wrap.h"
+#else
+#include <dbus/dbus.h>
+#endif
+
 class FreeDesktopScreenSaver {
 private:
 	uint32_t cookie = 0;
+	DBusConnection *bus;
+	bool is_inhibited = false;
 	bool unsupported = false;
 
 public:
 	FreeDesktopScreenSaver();
+	~FreeDesktopScreenSaver();
 	void inhibit();
 	void uninhibit();
 };

--- a/platform/linuxbsd/freedesktop_screensaver.h
+++ b/platform/linuxbsd/freedesktop_screensaver.h
@@ -40,7 +40,7 @@ struct DBusConnection;
 class FreeDesktopScreenSaver {
 private:
 	uint32_t cookie = 0;
-	DBusConnection *bus;
+	DBusConnection *bus = nullptr;
 	bool unsupported = false;
 
 public:


### PR DESCRIPTION
<del>Fixes an issue where using "Stop Running Project" with "Keep Screen On" causes the inhibit lock to not be released on Linux occasionally. Previously, the DBus connection was disconnected after each message, now the connection is made in the constructor and disconnected in the destructor. The connection is meant to last for the lifetime of the process, allowing the SessionManager to release the Inhibit lock if the process is killed with SIGKILL (which doesn't allow the process to perform any cleanup), as it can detect that the connection has been lost.

<del>This seems to have only been happening when running the game from the editor, then using the stop button to kill the game, as the editor also interfaces with DBus and disconnects causing the SessionManager to be confused about which process is requesting the Inhibit lock, leaving a dangling lock when both the game and editor have been closed.

Fixes improper handling of the DBus connection lifetime for the FreeDesktopScreenSaver class.