### PR TITLE
Fix ColorPicker and ColorPickerButton

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -59,6 +59,12 @@
 List<Color> ColorPicker::preset_cache;
 List<Color> ColorPicker::recent_preset_cache;
 
+void ColorPicker::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "color") {
+		p_property.hint = edit_alpha ? PROPERTY_HINT_NONE : PROPERTY_HINT_COLOR_NO_ALPHA;
+	}
+}
+
 void ColorPicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -2044,6 +2050,12 @@ void ColorPickerButton::pressed() {
 	popup->set_position(get_screen_position() + Vector2(h_offset, v_offset));
 	popup->popup();
 	picker->set_focus_on_line_edit();
+}
+
+void ColorPickerButton::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "color") {
+		p_property.hint = edit_alpha ? PROPERTY_HINT_NONE : PROPERTY_HINT_COLOR_NO_ALPHA;
+	}
 }
 
 void ColorPickerButton::_notification(int p_what) {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -282,6 +282,7 @@ private:
 	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control);
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
 	virtual void _update_theme_item_cache() override;
 
 	void _notification(int);
@@ -391,6 +392,7 @@ class ColorPickerButton : public Button {
 	void _update_picker();
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int);
 	static void _bind_methods();
 

--- a/scene/theme/blazium_default_theme.cpp
+++ b/scene/theme/blazium_default_theme.cpp
@@ -420,6 +420,9 @@ void update_theme_icons(Ref<Theme> &p_theme, const Color &p_font_color, const Co
 	p_theme->set_icon("hex_icon", "ColorPicker", icons["color_picker_hex"]);
 	p_theme->set_icon("hex_code_icon", "ColorPicker", icons["color_picker_hex_code"]);
 
+	p_theme->set_icon("bg", "ColorPickerButton", icons["mini_checkerboard"]);
+	p_theme->set_icon("overbright_indicator", "ColorPickerButton", icons["color_picker_overbright"]);
+
 	p_theme->set_icon("bg", "ColorButton", icons["mini_checkerboard"]);
 	p_theme->set_icon("overbright_indicator", "ColorButton", icons["color_picker_overbright"]);
 


### PR DESCRIPTION
* Fix color property hint not changing when edit_alpha changes.

* Add missing ColorPickerButton theme icons to blazium default theme.