### PR TITLE
Add global export include/exclude filters to ProjectSettings.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1450,6 +1450,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/auto_accept_quit", true);
 	GLOBAL_DEF("application/config/quit_on_go_back", true);
 
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/export/global_include_filter"), "");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/export/global_exclude_filter"), "");
+
 	// The default window size is tuned to:
 	// - Have a 16:9 aspect ratio,
 	// - Have both dimensions divisible by 8 to better play along with video recording,

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -308,6 +308,14 @@
 		<member name="application/config/windows_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
+		<member name="application/export/global_exclude_filter" type="String" setter="" getter="" default="&quot;&quot;">
+			Global filters to exclude files/folders from project, (comma-separated, e.g: *.json, *.txt, docs/*).
+			[b]Note:[/b] This filter is applied to all export presets before the preset's own exclude filters, ensuring global exclusions take precedence.
+		</member>
+		<member name="application/export/global_include_filter" type="String" setter="" getter="" default="&quot;&quot;">
+			Global filters to export non-resource files/folders, (comma-separated, e.g: *.json, *.txt, docs/*).
+			[b]Note:[/b] This filter is applied to all export presets before the preset's own include filters, ensuring global inclusions take precedence.
+		</member>
 		<member name="application/run/delta_smoothing" type="bool" setter="" getter="" default="true">
 			Time samples for frame deltas are subject to random variation introduced by the platform, even when frames are displayed at regular intervals thanks to V-Sync. This can lead to jitter. Delta smoothing can often give a better result by filtering the input deltas to correct for minor fluctuations from the refresh rate.
 			[b]Note:[/b] Delta smoothing is only attempted when [member display/window/vsync/vsync_mode] is set to [code]enabled[/code], as it does not work well without V-Sync.

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1044,6 +1044,9 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	_edit_filter_list(paths, String("*.icns"), false);
 	_edit_filter_list(paths, String("*.ico"), false);
 
+	_edit_filter_list(paths, ProjectSettings::get_singleton()->get_setting("application/export/global_include_filter", ""), false);
+	_edit_filter_list(paths, ProjectSettings::get_singleton()->get_setting("application/export/global_exclude_filter", ""), true);
+
 	_edit_filter_list(paths, p_preset->get_include_filter(), false);
 	_edit_filter_list(paths, p_preset->get_exclude_filter(), true);
 


### PR DESCRIPTION
Makes it easier to include/exclude files and folders for all export presets, meant for global inclusion/exclusion to save you from adding those filters for each export preset manually.