### PR TITLE
[Android] Fix path to AAB in copyAndRenameBinary task

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -247,7 +247,7 @@ task copyAndRenameBinary(type: Copy) {
 
     boolean isAab = exportFormat == "aab"
     boolean isMono = exportEdition == "mono"
-    String filenameSuffix = exportBuildType
+    String filenameSuffix = isAab ? "${exportEdition}-${exportBuildType}" : exportBuildType
     if (isMono) {
         filenameSuffix = isAab ? "${exportEdition}-${exportBuildType}" : "${exportEdition}${exportBuildTypeCapitalized}"
     }


### PR DESCRIPTION
Credits to [raulsntos](https://github.com/raulsntos) on https://github.com/godotengine/godot/pull/100756

Without this the android export with .aab without mono doesn't work (unless manually copying files.)