### PR TITLE
Allow project settings to be overridden by environment variables

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -631,6 +631,9 @@
 		<member name="debug/settings/crash_handler/message.editor" type="String" setter="" getter="" default="&quot;Please include this when reporting the bug on: https://github.com/blazium-engine/blazium/issues&quot;">
 			Editor-only override for [member debug/settings/crash_handler/message]. Does not affect exported projects in debug or release mode.
 		</member>
+		<member name="debug/settings/environment_variables/enable_release" type="bool" setter="" getter="" default="false">
+			In debug builds, environment variables can be used to temporarily override project settings without changing [code]project.godot[/code]. By default, this feature is disabled in release builds to prevent players from abusing settings such as [member application/run/main_scene].
+		</member>
 		<member name="debug/settings/gdscript/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack allowed for debugging GDScript.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1895,6 +1895,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 #endif
 
+	GLOBAL_DEF("debug/settings/environment_variables/enable_release", false);
+
 	GLOBAL_DEF("debug/file_logging/enable_file_logging", false);
 	// Only file logging by default on desktop platforms as logs can't be
 	// accessed easily on mobile/Web platforms (if at all).


### PR DESCRIPTION
Makes it easier to test project settings from the command line.