### PR TITLE
Enable fast saving mode for PNGs

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2600,6 +2600,14 @@ Ref<Image> Image::load_from_file(const String &p_path) {
 	return image;
 }
 
+void Image::set_png_flags(BitField<PNGFlags> p_flags) {
+	png_flags = p_flags;
+}
+
+BitField<Image::PNGFlags> Image::get_png_flags() const {
+	return png_flags;
+}
+
 Error Image::save_png(const String &p_path) const {
 	if (save_png_func == nullptr) {
 		return ERR_UNAVAILABLE;
@@ -3563,6 +3571,8 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_static_method("Image", D_METHOD("load_from_file", "path"), &Image::load_from_file);
+	ClassDB::bind_method(D_METHOD("set_png_flags", "flags"), &Image::set_png_flags);
+	ClassDB::bind_method(D_METHOD("get_png_flags"), &Image::get_png_flags);
 	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
 	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
 	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));
@@ -3701,6 +3711,9 @@ void Image::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(ASTC_FORMAT_4x4);
 	BIND_ENUM_CONSTANT(ASTC_FORMAT_8x8);
+
+	BIND_BITFIELD_FLAG(PNG_FLAG_NOT_SRGB);
+	BIND_BITFIELD_FLAG(PNG_FLAG_FAST);
 }
 
 void Image::set_compress_bc_func(void (*p_compress_func)(Image *, UsedChannels)) {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -144,6 +144,11 @@ public:
 		ASTC_FORMAT_8x8,
 	};
 
+	enum PNGFlags {
+		PNG_FLAG_NOT_SRGB = 1 << 0,
+		PNG_FLAG_FAST = 1 << 1,
+	};
+
 	static ImageMemLoadFunc _png_mem_loader_func;
 	static ImageMemLoadFunc _png_mem_unpacker_func;
 	static ImageMemLoadFunc _jpg_mem_loader_func;
@@ -188,6 +193,7 @@ private:
 	int width = 0;
 	int height = 0;
 	bool mipmaps = false;
+	BitField<PNGFlags> png_flags = PNG_FLAG_FAST;
 
 	void _copy_internals_from(const Image &p_image) {
 		format = p_image.format;
@@ -195,6 +201,7 @@ private:
 		height = p_image.height;
 		mipmaps = p_image.mipmaps;
 		data = p_image.data;
+		png_flags = p_image.png_flags;
 	}
 
 	_FORCE_INLINE_ void _get_mipmap_offset_and_size(int p_mipmap, int64_t &r_offset, int &r_width, int &r_height) const; //get where the mipmap begins in data
@@ -313,6 +320,8 @@ public:
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);
+	void set_png_flags(BitField<PNGFlags> p_flags);
+	BitField<PNGFlags> get_png_flags() const;
 	Error save_png(const String &p_path) const;
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Vector<uint8_t> save_png_to_buffer() const;
@@ -448,6 +457,7 @@ public:
 		height = p_image->height;
 		mipmaps = p_image->mipmaps;
 		data = p_image->data;
+		png_flags = p_image->png_flags;
 	}
 
 	Dictionary compute_image_metrics(const Ref<Image> p_compared_image, bool p_luma_metric = true);
@@ -461,5 +471,6 @@ VARIANT_ENUM_CAST(Image::UsedChannels)
 VARIANT_ENUM_CAST(Image::AlphaMode)
 VARIANT_ENUM_CAST(Image::RoughnessChannel)
 VARIANT_ENUM_CAST(Image::ASTCFormat)
+VARIANT_BITFIELD_CAST(Image::PNGFlags)
 
 #endif // IMAGE_H

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -272,6 +272,12 @@
 				This is the same as [method get_pixel], but with a [Vector2i] argument instead of two integer arguments.
 			</description>
 		</method>
+		<method name="get_png_flags" qualifiers="const">
+			<return type="int" enum="Image.PNGFlags" is_bitfield="true" />
+			<description>
+				Returns the PNG flags used when saving the image as a PNG.
+			</description>
+		</method>
 		<method name="get_region" qualifiers="const">
 			<return type="Image" />
 			<param index="0" name="region" type="Rect2i" />
@@ -579,6 +585,13 @@
 				This is the same as [method set_pixel], but with a [Vector2i] argument instead of two integer arguments.
 			</description>
 		</method>
+		<method name="set_png_flags">
+			<return type="void" />
+			<param index="0" name="flags" type="int" enum="Image.PNGFlags" is_bitfield="true" />
+			<description>
+				Set the PNG flags used when saving the image to PNG. Defaults to [constant PNG_FLAG_FAST].
+			</description>
+		</method>
 		<method name="shrink_x2">
 			<return type="void" />
 			<description>
@@ -811,6 +824,16 @@
 		</constant>
 		<constant name="ASTC_FORMAT_8x8" value="1" enum="ASTCFormat">
 			Hint to indicate that the low quality 8×8 ASTC compression format should be used.
+		</constant>
+		<constant name="PNG_FLAG_NOT_SRGB" value="1" enum="PNGFlags" is_bitfield="true">
+			This indicates that the RGB values of the in-memory bitmap do not correspond to the red, green and blue end-points defined by sRGB.
+		</constant>
+		<constant name="PNG_FLAG_FAST" value="2" enum="PNGFlags" is_bitfield="true">
+			On write emphasize speed over compression.
+			The resultant PNG file will be larger but will be produced significantly faster, particular for large images.
+			Do not use this option for images which will be distributed, only used it when producing intermediate files that will be read back in repeatedly.
+			For a typical 24-bit image the option will double the read speed at the cost of increasing the image size by 25%,
+			however for many more compressible images the PNG file can be 10 times larger with only a slight speed gain.
 		</constant>
 	</constants>
 </class>

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -138,6 +138,7 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	png_img.version = PNG_IMAGE_VERSION;
 	png_img.width = source_image->get_width();
 	png_img.height = source_image->get_height();
+	png_img.flags = source_image->get_png_flags();
 
 	switch (source_image->get_format()) {
 		case Image::FORMAT_L8:


### PR DESCRIPTION
Makes saving PNGs 2-5x faster, at a cost of file sizes increasing by 2%-30%.