### PR TITLE
[Windows] Only use long executable path when necessary

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -97,7 +97,7 @@ static String fix_path(const String &p_path) {
 	}
 	path = path.simplify_path();
 	path = path.replace("/", "\\");
-	if (!path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
+	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
 		path = R"(\\?\)" + path;
 	}
 	return path;


### PR DESCRIPTION
Fixes #365 and #364