### PR TITLE
Fix exported Node/Resource variables resetting when extending script

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -613,10 +613,34 @@ void InspectorDock::apply_script_properties(Object *p_object) {
 		return;
 	}
 
+	List<PropertyInfo> properties;
+	si->get_property_list(&properties);
+
 	for (const Pair<StringName, Variant> &E : stored_properties) {
 		Variant current_prop;
 		if (si->get(E.first, current_prop) && current_prop.get_type() == E.second.get_type()) {
 			si->set(E.first, E.second);
+		} else if (E.second.get_type() == Variant::OBJECT) {
+			for (const PropertyInfo &pi : properties) {
+				if (E.first == pi.name) {
+					Object *p_property_object = E.second;
+
+					if (p_property_object->is_class(pi.hint_string)) {
+						si->set(E.first, E.second);
+						break;
+					}
+
+					Ref<Script> base_script = p_property_object->get_script();
+					while (base_script.is_valid()) {
+						if (base_script->get_global_name() == pi.hint_string) {
+							si->set(E.first, E.second);
+							break;
+						}
+						base_script = base_script->get_base_script();
+					}
+					break;
+				}
+			}
 		}
 	}
 	stored_properties.clear();


### PR DESCRIPTION
Fixes: #410 

When applying the stored script properties, this now checks if the property type is `Variant::OBJECT` then goes though the script's properties looking for the matching `property_name` then ensures the old property value's type matches the new script's version of that property's type. If it does not match, then the value does not get copied.