### PR TITLE
macos use documents directory for sandboxed

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -686,42 +686,6 @@ Error OS_Unix::create_process(const String &p_path, const List<String> &p_argume
 	// Don't compile this code at all to avoid undefined references.
 	// Actual virtual call goes to OS_Web.
 	ERR_FAIL_V(ERR_BUG);
-#elif defined(MACOS_ENABLED)
-	Vector<CharString> cs;
-	cs.push_back(p_path.utf8());
-	for (const String &arg : p_arguments) {
-		cs.push_back(arg.utf8());
-	}
-
-	Vector<char *> args;
-	args.push_back((char *)"/usr/bin/open");
-	args.push_back((char *)"-n");
-	args.push_back((char *)"-a");
-	args.push_back((char *)cs[0].get_data());
-	args.push_back((char *)"--args");
-	for (int i = 1; i < cs.size(); i++) {
-		args.push_back((char *)cs[i].get_data());
-	}
-	args.push_back(0);
-
-	pid_t pid;
-	char *const envp[] = { NULL };
-	int status = posix_spawn(&pid, "/usr/bin/open", NULL, NULL, &args[0], envp);
-
-	if (status == 0) {
-		ProcessInfo pi;
-		process_map_mutex.lock();
-		process_map->insert(pid, pi);
-		process_map_mutex.unlock();
-		if (r_child_id) {
-			*r_child_id = pid;
-		}
-	} else {
-		// The posix_spawn() function errored
-		ERR_PRINT("Could not create child process: " + p_path);
-		raise(SIGKILL);
-	}
-	return OK;
 #else
 	pid_t pid = fork();
 	ERR_FAIL_COND_V(pid < 0, ERR_CANT_FORK);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -585,7 +585,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Directories
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", "", "")
-	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
+	String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
+	// On Macos sandboxed, don't get HOME as it points to sandboxed place. Get Documents.
+#ifdef MACOS_ENABLED
+	if (OS::get_singleton()->is_sandboxed()) {
+		fs_dir_default_project_path = OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
+	}
+#endif
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
 
 	// On save


### PR DESCRIPTION
Continuation of https://github.com/blazium-engine/blazium/pull/354 . Both things tried there didn't work on MacApp store. Trying to add this time the following entitlement for release: https://github.com/blazium-engine/ci_cd/pull/35 . And to set Documents path if its sandboxed.