### PR TITLE
Fix ScrollContainer vertical SCROLL_MODE_RESERVE

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -311,7 +311,7 @@ void ScrollContainer::_reposition_children() {
 	}
 
 	if (v_scroll->get_parent() == this) {
-		if (v_scroll->is_visible() && v_scroll->get_parent() == this) {
+		if (v_scroll->is_visible() || vertical_scroll_mode == SCROLL_MODE_RESERVE) {
 			size.x -= theme_cache.h_separation + v_scroll->get_minimum_size().x;
 		}
 	}


### PR DESCRIPTION
`v_scroll->get_parent() == this` was checked twice and `vertical_scroll_mode == SCROLL_MODE_RESERVE` not at all