### PR TITLE
Remove DISABLE_DEPRECATED preprocessor from SplitContainer clamp_split_offset bindings

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -597,6 +597,7 @@ Control *SplitContainer::get_dragger_control() const {
 void SplitContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_split_offset", "offset"), &SplitContainer::set_split_offset);
 	ClassDB::bind_method(D_METHOD("get_split_offset"), &SplitContainer::get_split_offset);
+	ClassDB::bind_method(D_METHOD("clamp_split_offset"), &SplitContainer::clamp_split_offset);
 
 	ClassDB::bind_method(D_METHOD("set_collapsed", "collapsed"), &SplitContainer::set_collapsed);
 	ClassDB::bind_method(D_METHOD("is_collapsed"), &SplitContainer::is_collapsed);
@@ -617,10 +618,6 @@ void SplitContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_dragging_enabled"), &SplitContainer::is_dragging_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_drag_area_control"), &SplitContainer::get_dragger_control);
-
-#ifndef DISABLE_DEPRECATED
-	ClassDB::bind_method(D_METHOD("clamp_split_offset"), &SplitContainer::clamp_split_offset);
-#endif // !DISABLE_DEPRECATED
 
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::INT, "offset")));
 	ADD_SIGNAL(MethodInfo("drag_started"));

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -126,6 +126,7 @@ protected:
 public:
 	void set_split_offset(int p_offset);
 	int get_split_offset() const;
+	void clamp_split_offset();
 
 	void set_collapsed(bool p_collapsed);
 	bool is_collapsed() const;
@@ -144,8 +145,6 @@ public:
 
 	void set_show_drag_area(bool p_enabled);
 	bool is_showing_drag_area() const;
-
-	void clamp_split_offset();
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
`SplitContainer` `clamp_split_offset` is not deprecated nor should it have been marked as such by us.

Also moves `clamp_split_offset` related things back to original positions in the header and cpp files.