### PR TITLE
[backport] CheckBox and CheckButton check state icon colors

### DIFF
--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -15,6 +15,12 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>
 	<theme_items>
+		<theme_item name="checkbox_checked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the checked icon when the checkbox is pressed.
+		</theme_item>
+		<theme_item name="checkbox_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the unchecked icon when the checkbox is not pressed.
+		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -15,10 +15,10 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>
 	<theme_items>
-		<theme_item name="checkbox_checked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="checkbox_checked_color" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
 			The color of the checked icon when the checkbox is pressed.
 		</theme_item>
-		<theme_item name="checkbox_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="checkbox_unchecked_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color of the unchecked icon when the checkbox is not pressed.
 		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -14,6 +14,12 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>
 	<theme_items>
+		<theme_item name="button_checked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the checked icon when the checkbox is pressed.
+		</theme_item>
+		<theme_item name="button_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the unchecked icon when the checkbox is not pressed.
+		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -14,10 +14,10 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>
 	<theme_items>
-		<theme_item name="button_checked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="button_checked_color" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
 			The color of the checked icon when the checkbox is pressed.
 		</theme_item>
-		<theme_item name="button_unchecked_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="button_unchecked_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color of the unchecked icon when the checkbox is not pressed.
 		</theme_item>
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -127,9 +127,9 @@ void CheckBox::_notification(int p_what) {
 			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
+				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())), false, theme_cache.checkbox_checked_color);
 			} else {
-				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
+				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())), false, theme_cache.checkbox_unchecked_color);
 			}
 		} break;
 	}
@@ -152,6 +152,9 @@ void CheckBox::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, unchecked_disabled);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, radio_checked_disabled);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, radio_unchecked_disabled);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckBox, checkbox_checked_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckBox, checkbox_unchecked_color);
 }
 
 CheckBox::CheckBox(const String &p_text) :

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -49,6 +49,9 @@ class CheckBox : public Button {
 		Ref<Texture2D> unchecked_disabled;
 		Ref<Texture2D> radio_checked_disabled;
 		Ref<Texture2D> radio_unchecked_disabled;
+
+		Color checkbox_checked_color;
+		Color checkbox_unchecked_color;
 	} theme_cache;
 
 protected:

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -134,9 +134,9 @@ void CheckButton::_notification(int p_what) {
 			ofs.y = (get_size().height - tex_size.height) / 2 + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())));
+				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())), false, theme_cache.button_checked_color);
 			} else {
-				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())));
+				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())), false, theme_cache.button_unchecked_color);
 			}
 		} break;
 	}
@@ -155,6 +155,9 @@ void CheckButton::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, unchecked_mirrored);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, checked_disabled_mirrored);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckButton, unchecked_disabled_mirrored);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckButton, button_checked_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CheckButton, button_unchecked_color);
 }
 
 CheckButton::CheckButton(const String &p_text) :

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -49,6 +49,9 @@ class CheckButton : public Button {
 		Ref<Texture2D> unchecked_mirrored;
 		Ref<Texture2D> checked_disabled_mirrored;
 		Ref<Texture2D> unchecked_disabled_mirrored;
+
+		Color button_checked_color;
+		Color button_unchecked_color;
 	} theme_cache;
 
 protected:

--- a/scene/theme/blazium_default_theme.cpp
+++ b/scene/theme/blazium_default_theme.cpp
@@ -551,8 +551,10 @@ void update_theme_colors(Ref<Theme> &p_theme, const Color &p_base_color, const C
 	p_theme->set_color("font_pressed_color", "MenuButton", accent_color);
 	p_theme->set_color("font_pressed_color", "CheckBox", accent_color);
 	p_theme->set_color("font_hover_pressed_color", "CheckBox", accent_color);
+	p_theme->set_color("checkbox_checked_color", "CheckBox", accent_color);
 	p_theme->set_color("font_pressed_color", "CheckButton", accent_color);
 	p_theme->set_color("font_hover_pressed_color", "CheckButton", accent_color);
+	p_theme->set_color("button_checked_color", "CheckButton", accent_color);
 	p_theme->set_color("down_pressed_icon_modulate", "SpinBox", accent_color);
 	p_theme->set_color("up_pressed_icon_modulate", "SpinBox", accent_color);
 	p_theme->set_color("selection_stroke", "GraphEdit", accent_color);
@@ -654,7 +656,9 @@ void update_font_color(Ref<Theme> &p_theme, const Color &p_color) {
 	p_theme->set_color("font_hover_color", "OptionButton", font_color);
 	p_theme->set_color("font_hover_pressed_color", "OptionButton", font_color);
 	p_theme->set_color("font_hover_color", "MenuButton", font_color);
+	p_theme->set_color("checkbox_unchecked_color", "CheckBox", font_color);
 	p_theme->set_color("font_hover_color", "CheckBox", font_color);
+	p_theme->set_color("button_unchecked_color", "CheckButton", font_color);
 	p_theme->set_color("font_hover_color", "CheckButton", font_color);
 	p_theme->set_color("drop_position_color", "Tree", font_color);
 	p_theme->set_color("up_hover_icon_modulate", "SpinBox", font_color);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -326,6 +326,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("check_v_offset", "CheckBox", 0);
 	theme->set_constant("outline_size", "CheckBox", 0);
 
+	theme->set_color("checkbox_checked_color", "CheckBox", Color(1, 1, 1));
+	theme->set_color("checkbox_unchecked_color", "CheckBox", Color(1, 1, 1));
+
 	// CheckButton
 
 	Ref<StyleBox> cb_empty = memnew(StyleBoxEmpty);
@@ -362,6 +365,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("h_separation", "CheckButton", Math::round(4 * scale));
 	theme->set_constant("check_v_offset", "CheckButton", 0);
 	theme->set_constant("outline_size", "CheckButton", 0);
+
+	theme->set_color("button_checked_color", "CheckButton", Color(1, 1, 1));
+	theme->set_color("button_unchecked_color", "CheckButton", Color(1, 1, 1));
 
 	// Button variations
 


### PR DESCRIPTION
This is split into a commit for the cherry-pick and changes needed for the Blazium theme system. Font color is used for the unchecked state, and accent color for the checked state.