### PR TITLE
Use non-transparent fonts in most places Godot does

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -83,13 +83,13 @@
 		</member>
 	</members>
 	<theme_items>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the [Button].
 		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
 			Text [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Text [Color] used when the [Button] is focused. Only replaces the normal text color of the button. Disabled, hovered, and pressed states take precedence over this color.
 		</theme_item>
 		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
@@ -107,7 +107,7 @@
 		<theme_item name="icon_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
 			Icon modulate [Color] used when the [Button] is disabled.
 		</theme_item>
-		<theme_item name="icon_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="icon_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Icon modulate [Color] used when the [Button] is focused. Only replaces the normal modulate color of the button. Disabled, hovered, and pressed states take precedence over this color.
 		</theme_item>
 		<theme_item name="icon_hover_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
@@ -116,7 +116,7 @@
 		<theme_item name="icon_hover_pressed_color" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
 			Icon modulate [Color] used when the [Button] is being hovered and pressed.
 		</theme_item>
-		<theme_item name="icon_normal_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="icon_normal_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default icon modulate [Color] of the [Button].
 		</theme_item>
 		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -228,10 +228,10 @@
 		<theme_item name="file_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
-		<theme_item name="file_icon_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="file_icon_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color modulation applied to the file icon.
 		</theme_item>
-		<theme_item name="folder_icon_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="folder_icon_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color modulation applied to the folder icon.
 		</theme_item>
 		<theme_item name="back_folder" data_type="icon" type="Texture2D">

--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -293,7 +293,7 @@
 		<theme_item name="arrow_hover_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The arrow's icon color when hovered and expanded.
 		</theme_item>
-		<theme_item name="arrow_normal_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="arrow_normal_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The arrow's icon color expanded.
 		</theme_item>
 		<theme_item name="button_icon_disabled" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
@@ -302,7 +302,7 @@
 		<theme_item name="button_icon_hovered" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The title's icon color when hovered.
 		</theme_item>
-		<theme_item name="button_icon_normal" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="button_icon_normal" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The title's icon color when normal.
 		</theme_item>
 		<theme_item name="button_icon_pressed" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
@@ -311,7 +311,7 @@
 		<theme_item name="collapsed_font_color" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
 			The title's font color when collapsed.
 		</theme_item>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The title's font color when expanded.
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">

--- a/doc/classes/GraphFrame.xml
+++ b/doc/classes/GraphFrame.xml
@@ -47,7 +47,7 @@
 		</signal>
 	</signals>
 	<theme_items>
-		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color modulation applied to the resizer icon.
 		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -284,7 +284,7 @@
 		</signal>
 	</signals>
 	<theme_items>
-		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color modulation applied to the resizer icon.
 		</theme_item>
 		<theme_item name="port_h_offset" data_type="constant" type="int" default="0">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -478,7 +478,7 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the item.
 		</theme_item>
 		<theme_item name="font_hovered_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -115,7 +115,7 @@
 		</member>
 	</members>
 	<theme_items>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the [Label].
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -508,16 +508,16 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Color of the [LineEdit]'s caret (text cursor). This can be set to a fully transparent color to hide the caret entirely.
 		</theme_item>
-		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Color used as default tint for the clear button.
 		</theme_item>
 		<theme_item name="clear_button_color_pressed" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
 			Color used for the clear button when it's pressed.
 		</theme_item>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default font color.
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -64,13 +64,13 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
 			Text [Color] used when the [LinkButton] is disabled.
 		</theme_item>
-		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Text [Color] used when the [LinkButton] is focused. Only replaces the normal text color of the button. Disabled, hovered, and pressed states take precedence over this color.
 		</theme_item>
 		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">

--- a/doc/classes/MenuBar.xml
+++ b/doc/classes/MenuBar.xml
@@ -119,13 +119,13 @@
 		</member>
 	</members>
 	<theme_items>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the menu item.
 		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
 			Text [Color] used when the menu item is disabled.
 		</theme_item>
-		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="font_focus_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Text [Color] used when the menu item is focused. Only replaces the normal text color of the menu item. Disabled, hovered, and pressed states take precedence over this color.
 		</theme_item>
 		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -682,7 +682,7 @@
 		<theme_item name="font_accelerator_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.6)">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The default text [Color] for menu items' names.
 		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.6)">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -816,7 +816,7 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="default_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="default_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The default text color.
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -76,7 +76,7 @@
 		<theme_item name="down_hover_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Down button icon modulation color, when the button is hovered.
 		</theme_item>
-		<theme_item name="down_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="down_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Down button icon modulation color.
 		</theme_item>
 		<theme_item name="down_pressed_icon_modulate" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">
@@ -88,7 +88,7 @@
 		<theme_item name="up_hover_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Up button icon modulation color, when the button is hovered.
 		</theme_item>
-		<theme_item name="up_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="up_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Up button icon modulation color.
 		</theme_item>
 		<theme_item name="up_pressed_icon_modulate" data_type="color" type="Color" default="Color(0.226, 0.478, 0.921, 1)">

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -382,7 +382,7 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -313,7 +313,7 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="icon_max_width" data_type="constant" type="int" default="0">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1587,13 +1587,13 @@
 		<theme_item name="caret_background_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			[Color] of the text behind the caret when using a block caret.
 		</theme_item>
-		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			[Color] of the caret. This can be set to a fully transparent color to hide the caret entirely.
 		</theme_item>
 		<theme_item name="current_line_color" data_type="color" type="Color" default="Color(0.16544, 0.16544, 0.16544, 1)">
 			Background [Color] of the line containing the caret.
 		</theme_item>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Sets the font [Color].
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -497,16 +497,16 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="children_hl_line_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="children_hl_line_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its children.
 		</theme_item>
-		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
 		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
 		</theme_item>
-		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the item.
 		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
@@ -527,13 +527,13 @@
 		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.4)">
 			[Color] of the guideline.
 		</theme_item>
-		<theme_item name="parent_hl_line_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="parent_hl_line_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its parents.
 		</theme_item>
 		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.6)">
 			The default [Color] of the relationship lines.
 		</theme_item>
-		<theme_item name="title_button_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.8)">
+		<theme_item name="title_button_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default text [Color] of the title button.
 		</theme_item>
 		<theme_item name="button_margin" data_type="constant" type="int" default="4">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -947,7 +947,7 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="title_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.9)">
+		<theme_item name="title_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			The color of the title's text.
 		</theme_item>
 		<theme_item name="title_outline_modulate" data_type="color" type="Color" default="Color(0, 0, 0, 1)">

--- a/scene/theme/blazium_default_theme.cpp
+++ b/scene/theme/blazium_default_theme.cpp
@@ -668,9 +668,9 @@ void update_font_color(Ref<Theme> &p_theme, const Color &p_color) {
 	p_theme->set_color("hover_font_color", "FoldableContainer", font_color);
 	p_theme->set_color("button_icon_hovered", "FoldableContainer", font_color);
 	p_theme->set_color("arrow_hover_color", "FoldableContainer", font_color);
-	font_color.a = 0.9;
-	p_theme->set_color("icon_focus_color", "Button", font_color);
+
 	p_theme->set_color("font_focus_color", "Button", font_color);
+	p_theme->set_color("icon_focus_color", "Button", font_color);
 	p_theme->set_color("parent_hl_line_color", "Tree", font_color);
 	p_theme->set_color("font_focus_color", "LinkButton", font_color);
 	p_theme->set_color("font_focus_color", "MenuBar", font_color);
@@ -683,7 +683,7 @@ void update_font_color(Ref<Theme> &p_theme, const Color &p_color) {
 	p_theme->set_color("resizer_color", "GraphEditMinimap", font_color);
 	p_theme->set_color("resizer_color", "GraphNode", font_color);
 	p_theme->set_color("resizer_color", "GraphFrame", font_color);
-	font_color.a = 0.8;
+
 	p_theme->set_color(SceneStringName(font_color), "Button", font_color);
 	p_theme->set_color(SceneStringName(font_color), "Tree", font_color);
 	p_theme->set_color(SceneStringName(font_color), "LinkButton", font_color);


### PR DESCRIPTION
Makes more font colors solid rather than transparent to avoid sometimes making theme creation much more time consuming.

Added transparency has caused difficulty according to some users. I found that it made setting up themes for certain fonts significantly more time consuming due to having to manually set font colors in around 40 places just to remove transparency.