### PR TITLE
Show better error message for missing commas in dictionary

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3171,6 +3171,19 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 			if (key != nullptr && value != nullptr) {
 				dictionary->elements.push_back({ key, value });
 			}
+
+			if (!check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
+				switch (current.type) {
+					case GDScriptTokenizer::Token::IDENTIFIER:
+					case GDScriptTokenizer::Token::LITERAL:
+					case GDScriptTokenizer::Token::BRACKET_OPEN:
+					case GDScriptTokenizer::Token::PARENTHESIS_OPEN:
+						push_error(R"(Expected ',' between dictionary entries.)");
+						break;
+					default:
+						break;
+				}
+			}
 		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end());
 	}
 	pop_multiline();


### PR DESCRIPTION
fix mislabeled error from comma check in dictionary
old:
```
var ExampleDictionary = {
    "Key1": "Value1" # <- Expected closing "}" after dictionary elements.
    "Key2": "Value2"
} 
```
new:
```
var ExampleDictionary = {
    "Key1": "Value1" # <- Expected ',' between dictionary entries.
    "Key2": "Value2"
} 
```
fixes https://github.com/godotengine/godot/issues/98244
