### PR TITLE
Show better error message for two consecutive periods in an if condition

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2183,7 +2183,9 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 		push_error(vformat(R"(Expected conditional expression after "%s".)", p_token));
 	}
 
-	consume(GDScriptTokenizer::Token::COLON, vformat(R"(Expected ":" after "%s" condition.)", p_token));
+	if (!check(GDScriptTokenizer::Token::PERIOD_PERIOD)) {
+		consume(GDScriptTokenizer::Token::COLON, vformat(R"(Expected ":" after "%s" condition.)", p_token));
+	}
 
 	n_if->true_block = parse_suite(vformat(R"("%s" block)", p_token));
 	n_if->true_block->parent_if = n_if;


### PR DESCRIPTION
example to force error:
```
if not head_ledge_obj..is_in_group("ledge") and shoulder_ledge_obj.is_in_group("ledge"):
    return true
```

old error message: "Expected ':' after 'if' condition"
new error message: Token 'if' contains two consecutive '.'

Fixes godotengine/godot/issues/96003
