### PR TITLE
Fix CanvasItemEditor input when no scene is open.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1127,7 +1127,7 @@ void CanvasItemEditor::_is_hovering_guide(Point2 p_pos, bool p_is_pressed) {
 bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_event) {
 	Node *const scene = EditorNode::get_singleton()->get_edited_scene();
 	if (!scene) {
-		return true;
+		return false;
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();


### PR DESCRIPTION
Fix CanvasItemEditor input when no scene is open