### PR TITLE
error message for match statement case _: wrong indent

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1954,6 +1954,11 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 			}
 			break;
 		}
+		case GDScriptTokenizer::Token::UNDERSCORE: {
+			advance();
+			push_error(R"(Check "_:" indent.)");
+			break;
+		}
 		default: {
 			// Expression statement.
 			ExpressionNode *expression = parse_expression(true); // Allow assignment here.

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1956,7 +1956,7 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 		}
 		case GDScriptTokenizer::Token::UNDERSCORE: {
 			advance();
-			push_error(R"(Check "_:" indent.)");
+			push_error(R"(Incorrect indentation for "_:")");
 			break;
 		}
 		default: {


### PR DESCRIPTION
Example error:
```
	match variable:
		"Something":
			pass
	_:
		pass
```
old error message:
Expected statement, found "_" instead.

new error message:
Check "_:" indent.

fixes: https://github.com/godotengine/godot/issues/98384
