### PR TITLE
fix sqlite to return dictionary instead of array

### DIFF
--- a/modules/sqlite/doc_classes/SQLiteQueryResult.xml
+++ b/modules/sqlite/doc_classes/SQLiteQueryResult.xml
@@ -21,7 +21,7 @@
 		<member name="query" type="String" setter="" getter="get_query" default="&quot;&quot;">
 			The query that was run.
 		</member>
-		<member name="result" type="Array[]" setter="" getter="get_result" default="[]">
+		<member name="result" type="Dictionary[]" setter="" getter="get_result" default="[]">
 			The result of the query.
 		</member>
 	</members>

--- a/modules/sqlite/src/godot_sqlite.cpp
+++ b/modules/sqlite/src/godot_sqlite.cpp
@@ -83,7 +83,9 @@ Array fast_parse_row(sqlite3_stmt *stmt) {
 
 SQLiteQuery::SQLiteQuery() {}
 
-SQLiteQuery::~SQLiteQuery() { finalize(); }
+SQLiteQuery::~SQLiteQuery() {
+	finalize();
+}
 
 void SQLiteQuery::init(SQLiteAccess *p_db, const String &p_query, Array p_args) {
 	db = p_db;
@@ -92,7 +94,9 @@ void SQLiteQuery::init(SQLiteAccess *p_db, const String &p_query, Array p_args) 
 	stmt = nullptr;
 }
 
-bool SQLiteQuery::is_ready() const { return stmt != nullptr; }
+bool SQLiteQuery::is_ready() const {
+	return stmt != nullptr;
+}
 
 String SQLiteQuery::get_last_error_message() const {
 	ERR_FAIL_COND_V(db == nullptr, "Database is undefined.");
@@ -234,7 +238,7 @@ sqlite3_stmt *SQLiteAccess::prepare(const char *query) {
 	return stmt;
 }
 
-Dictionary SQLiteAccess::parse_row(sqlite3_stmt *stmt, int result_type) {
+Dictionary parse_row(sqlite3_stmt *stmt) {
 	Dictionary result;
 
 	// Get column count
@@ -279,16 +283,7 @@ Dictionary SQLiteAccess::parse_row(sqlite3_stmt *stmt, int result_type) {
 			default:
 				break;
 		}
-
-		// Set dictionary value
-		if (result_type == RESULT_NUM) {
-			result[i] = value;
-		} else if (result_type == RESULT_ASSOC) {
-			result[key] = value;
-		} else {
-			result[i] = value;
-			result[key] = value;
-		}
+		result[key] = value;
 	}
 
 	return result;
@@ -482,11 +477,11 @@ Ref<SQLiteQueryResult> SQLiteQuery::execute(const Array p_args) {
 		return result;
 	}
 
-	TypedArray<Array> results;
+	TypedArray<Dictionary> results;
 	while (true) {
 		const int res = sqlite3_step(stmt);
 		if (res == SQLITE_ROW) {
-			results.append(fast_parse_row(stmt));
+			results.append(parse_row(stmt));
 		} else if (res == SQLITE_DONE) {
 			break;
 		} else {

--- a/modules/sqlite/src/godot_sqlite.h
+++ b/modules/sqlite/src/godot_sqlite.h
@@ -110,7 +110,7 @@ class SQLiteAccess;
 
 class SQLiteQueryResult : public RefCounted {
 	GDCLASS(SQLiteQueryResult, RefCounted);
-	TypedArray<Array> result;
+	TypedArray<Dictionary> result;
 	Array arguments;
 	String query;
 	String error;
@@ -124,7 +124,7 @@ protected:
 		ClassDB::bind_method(D_METHOD("get_query"), &SQLiteQueryResult::get_query);
 		ClassDB::bind_method(D_METHOD("get_arguments"), &SQLiteQueryResult::get_arguments);
 
-		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "result", PROPERTY_HINT_ARRAY_TYPE, "Array"), "", "get_result");
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "result", PROPERTY_HINT_ARRAY_TYPE, "Dictionary"), "", "get_result");
 		ADD_PROPERTY(PropertyInfo(Variant::STRING, "error"), "", "get_error");
 		ADD_PROPERTY(PropertyInfo(Variant::INT, "error_code"), "", "get_error_code");
 		ADD_PROPERTY(PropertyInfo(Variant::STRING, "query"), "", "get_query");
@@ -133,12 +133,14 @@ protected:
 
 public:
 	Array get_arguments() const { return arguments; }
-	TypedArray<Array> get_result() const { return result; }
+	TypedArray<Dictionary> get_result() const { return result; }
+	Dictionary get_result_as_dictionary() const {
+	}
 	String get_error() const { return error; }
 	int get_error_code() const { return error_code; }
 	String get_query() const { return query; }
 
-	void set_result(TypedArray<Array> p_result) { result = p_result; }
+	void set_result(TypedArray<Dictionary> p_result) { result = p_result; }
 	void set_error(String p_error) { error = p_error; }
 	void set_error_code(int p_error_code) { error_code = p_error_code; }
 	void set_query(String p_query) { query = p_query; }
@@ -189,7 +191,6 @@ private:
 	sqlite3_stmt *prepare(const char *statement);
 	Array fetch_rows(const String &query, const Array &args, int result_type = RESULT_BOTH);
 	sqlite3 *get_handler() const { return memory_read ? spmemvfs_db.handle : db; }
-	Dictionary parse_row(sqlite3_stmt *stmt, int result_type);
 
 public:
 	static String bind_args(sqlite3_stmt *stmt, const Array &args);

--- a/modules/sqlite/src/resource_sqlite.cpp
+++ b/modules/sqlite/src/resource_sqlite.cpp
@@ -245,11 +245,11 @@ TypedArray<SQLiteColumnSchema> SQLiteDatabase::get_columns(const String &p_name)
 	}
 	TypedArray<SQLiteColumnSchema> column_schemas;
 	for (int i = 0; i < result->get_result().size(); i++) {
-		Array row = result->get_result()[i];
+		Dictionary row = result->get_result()[i];
 		Ref<SQLiteColumnSchema> schema;
 		schema.instantiate();
-		schema->set_name(row[1]);
-		String data_type = row[2];
+		schema->set_name(row["name"]);
+		String data_type = row["type"];
 		// data type
 		if (data_type == "INTEGER") {
 			schema->set_type(Variant::Type::INT);
@@ -262,13 +262,13 @@ TypedArray<SQLiteColumnSchema> SQLiteDatabase::get_columns(const String &p_name)
 		} else {
 			schema->set_type(Variant::Type::NIL);
 		}
-		int not_null = row[3];
+		int not_null = row["notnull"];
 		schema->set_not_null(not_null == 1 ? true : false);
-		Variant default_value = row[4];
+		Variant default_value = row["dflt_value"];
 		if (!default_value.is_null()) {
 			schema->set_default_value(default_value);
 		}
-		int primary_key = row[5];
+		int primary_key = row["pk"];
 		schema->set_primary_key(primary_key == 1 ? true : false);
 		column_schemas.append(schema);
 	}


### PR DESCRIPTION
- Fixes https://github.com/blazium-engine/blazium/issues/452
The old method where it returns an array is a bit harder to use, this API makes more sense.