### PR TITLE
fix macos args not being passed if app is sandboxed

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -959,6 +959,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		args.push_back(String::utf8(argv[i]));
 	}
 
+	// On macos if the app is sandboxed, read the arguments from file.
+	if (OS::get_singleton()->is_sandboxed()) {
+		args.clear();
+		String args_path = OS::get_singleton()->get_temp_path().path_join("blazium_args.txt");
+		Ref<FileAccess> file = FileAccess::open(args_path, FileAccess::READ);
+		while (file.is_valid() && !file->eof_reached()) {
+			String line = file->get_line().strip_edges();
+			if (!line.is_empty()) {
+				args.push_back(line);
+			}
+		}
+		DirAccess::remove_file_or_error(args_path);
+	}
+
 	// Add arguments received from macOS LaunchService (URL schemas, file associations).
 	for (const String &arg : platform_args) {
 		args.push_back(arg);

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -665,6 +665,17 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 	// Use NSWorkspace if path is an .app bundle.
 	NSURL *url = [NSURL fileURLWithPath:@(p_path.utf8().get_data())];
 	NSBundle *bundle = [NSBundle bundleWithURL:url];
+	// if sandboxed, put arguments in a file
+	if (is_sandboxed()) {
+		String args_path = get_temp_path().path_join("blazium_args.txt");
+		Ref<FileAccess> file = FileAccess::open(args_path, FileAccess::WRITE);
+		if (file.is_valid()) {
+			for (const String &arg : p_arguments) {
+				file->store_line(arg);
+			}
+			file->close();
+		}
+	}
 	if (bundle) {
 		NSMutableArray *arguments = [[NSMutableArray alloc] init];
 		for (const String &arg : p_arguments) {


### PR DESCRIPTION
As a wordaround, put them in a file that is deleted after app is launched. This should fix arguments not being passed.