### PR TITLE
Use ResourceLoader for AudioStreamImportSettingsDialog

### DIFF
--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -87,7 +87,7 @@ bool ResourceImporterMP3::has_advanced_options() const {
 }
 
 void ResourceImporterMP3::show_advanced_options(const String &p_path) {
-	Ref<AudioStreamMP3> mp3_stream = AudioStreamMP3::load_from_file(p_path);
+	Ref<AudioStreamMP3> mp3_stream = ResourceLoader::load(p_path, "AudioStreamMP3");
 	if (mp3_stream.is_valid()) {
 		AudioStreamImportSettingsDialog::get_singleton()->edit(p_path, "mp3", mp3_stream);
 	}

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -86,7 +86,7 @@ bool ResourceImporterOggVorbis::has_advanced_options() const {
 }
 
 void ResourceImporterOggVorbis::show_advanced_options(const String &p_path) {
-	Ref<AudioStreamOggVorbis> ogg_stream = AudioStreamOggVorbis::load_from_file(p_path);
+	Ref<AudioStreamOggVorbis> ogg_stream = ResourceLoader::load(p_path, "AudioStreamOggVorbis");
 	if (ogg_stream.is_valid()) {
 		AudioStreamImportSettingsDialog::get_singleton()->edit(p_path, "oggvorbisstr", ogg_stream);
 	}


### PR DESCRIPTION
Fix redundant audio file caching in editor when opening Advanced Audio Importer.

Issue:

https://github.com/user-attachments/assets/e028970a-c91a-476c-926c-09ae25c3a77f