### PR TITLE
[4.5] Avoid unnecessary accessibility calls when not supported.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4903,8 +4903,12 @@ bool Main::iteration() {
 		return exit;
 	}
 
+#ifdef ACCESSKIT_ENABLED
 	SceneTree *scene_tree = SceneTree::get_singleton();
 	bool wake_for_events = scene_tree && scene_tree->is_accessibility_enabled();
+#else
+	bool wake_for_events = false;
+#endif // ACCESSKIT_ENABLED
 
 	OS::get_singleton()->add_frame_delay(DisplayServer::get_singleton()->window_can_draw(), wake_for_events);
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2269,8 +2269,7 @@ Control::FocusBehaviorRecursive Control::get_focus_behavior_recursive() const {
 }
 
 bool Control::_is_focusable() const {
-	bool ac_enabled = is_inside_tree() && get_tree()->is_accessibility_enabled();
-	return (is_visible_in_tree() && ((get_focus_mode_with_override() == FOCUS_ALL) || (get_focus_mode_with_override() == FOCUS_CLICK) || (ac_enabled && get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)));
+	return (is_visible_in_tree() && ((get_focus_mode_with_override() == FOCUS_ALL) || (get_focus_mode_with_override() == FOCUS_CLICK) || (get_focus_mode_with_override() == FOCUS_ACCESSIBILITY && is_inside_tree() && _is_accessibility_enabled())));
 }
 
 bool Control::_is_focus_mode_enabled() const {
@@ -2391,7 +2390,6 @@ Control *Control::find_next_valid_focus() const {
 	}
 
 	Control *from = const_cast<Control *>(this);
-	bool ac_enabled = get_tree() && get_tree()->is_accessibility_enabled();
 
 	// Index of the current `Control` subtree within the containing `Window`.
 	int window_next = -1;
@@ -2452,7 +2450,7 @@ Control *Control::find_next_valid_focus() const {
 			break;
 		}
 
-		if ((next_child->get_focus_mode_with_override() == FOCUS_ALL) || (ac_enabled && next_child->get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)) {
+		if ((next_child->get_focus_mode_with_override() == FOCUS_ALL) || (_is_accessibility_enabled() && next_child->get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)) {
 			return next_child;
 		}
 
@@ -2495,7 +2493,6 @@ Control *Control::find_prev_valid_focus() const {
 	}
 
 	Control *from = const_cast<Control *>(this);
-	bool ac_enabled = get_tree() && get_tree()->is_accessibility_enabled();
 
 	// Index of the current `Control` subtree within the containing `Window`.
 	int window_prev = -1;
@@ -2550,7 +2547,7 @@ Control *Control::find_prev_valid_focus() const {
 			}
 		}
 
-		if ((prev_child->get_focus_mode_with_override() == FOCUS_ALL) || (ac_enabled && prev_child->get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)) {
+		if ((prev_child->get_focus_mode_with_override() == FOCUS_ALL) || (_is_accessibility_enabled() && prev_child->get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)) {
 			return prev_child;
 		}
 
@@ -2727,13 +2724,11 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 		return; // Bye.
 	}
 
-	bool ac_enabled = get_tree() && get_tree()->is_accessibility_enabled();
-
 	Control *c = Object::cast_to<Control>(p_at);
 	Container *container = Object::cast_to<Container>(p_at);
 	bool in_container = container ? container->is_ancestor_of(this) : false;
 
-	if (c && c != this && ((c->get_focus_mode_with_override() == FOCUS_ALL) || (ac_enabled && c->get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)) && !in_container && p_clamp.intersects(c->get_global_rect())) {
+	if (c && c != this && ((c->get_focus_mode_with_override() == FOCUS_ALL) || (_is_accessibility_enabled() && c->get_focus_mode_with_override() == FOCUS_ACCESSIBILITY)) && !in_container && p_clamp.intersects(c->get_global_rect())) {
 		Rect2 r_c = c->get_global_rect();
 		r_c = r_c.intersection(p_clamp);
 		real_t begin_d = p_dir.dot(r_c.get_position());

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -407,8 +407,7 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_pressed() && slot_count > 0) {
-		bool ac_enabled = get_tree() && get_tree()->is_accessibility_enabled();
-		if ((ac_enabled && slots_focus_mode == Control::FOCUS_ACCESSIBILITY) || slots_focus_mode == Control::FOCUS_ALL) {
+		if ((_is_accessibility_enabled() && slots_focus_mode == Control::FOCUS_ACCESSIBILITY) || slots_focus_mode == Control::FOCUS_ALL) {
 			if (p_event->is_action("ui_up", true)) {
 				selected_slot--;
 				if (selected_slot < 0) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4837,6 +4837,7 @@ void Tree::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE:
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
+#ifdef ACCESSKIT_ENABLED
 			if (root) {
 				_accessibility_clean_info(root);
 			}
@@ -4844,8 +4845,10 @@ void Tree::_notification(int p_what) {
 				col.accessibility_col_element = RID();
 			}
 			accessibility_scroll_element = RID();
+#endif // ACCESSKIT_ENABLED
 		} break;
 
+#ifdef ACCESSKIT_ENABLED
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
@@ -4902,8 +4905,8 @@ void Tree::_notification(int p_what) {
 				_accessibility_update_item(origin, root, rows, 0);
 			}
 			DisplayServer::get_singleton()->accessibility_update_set_table_row_count(ae, rows);
-
 		} break;
+#endif // ACCESSKIT_ENABLED
 
 		case NOTIFICATION_FOCUS_ENTER: {
 			if (get_viewport()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -91,6 +91,7 @@ void Node::_notification(int p_notification) {
 			ERR_FAIL_NULL(get_viewport());
 			ERR_FAIL_NULL(data.tree);
 
+#ifdef ACCESSKIT_ENABLED
 			if (data.tree->is_accessibility_supported() && !is_part_of_edited_scene()) {
 				data.tree->_accessibility_force_update();
 				data.tree->_accessibility_notify_change(this);
@@ -100,6 +101,7 @@ void Node::_notification(int p_notification) {
 					data.tree->_accessibility_notify_change(get_window()); // Root node.
 				}
 			}
+#endif // ACCESSKIT_ENABLED
 
 			// Update process mode.
 			if (data.process_mode == PROCESS_MODE_INHERIT) {
@@ -179,6 +181,7 @@ void Node::_notification(int p_notification) {
 			ERR_FAIL_NULL(get_viewport());
 			ERR_FAIL_NULL(data.tree);
 
+#ifdef ACCESSKIT_ENABLED
 			if (data.tree->is_accessibility_supported() && !is_part_of_edited_scene()) {
 				if (data.accessibility_element.is_valid()) {
 					DisplayServer::get_singleton()->accessibility_free_element(data.accessibility_element);
@@ -191,6 +194,7 @@ void Node::_notification(int p_notification) {
 					data.tree->_accessibility_notify_change(get_window()); // Root node.
 				}
 			}
+#endif // ACCESSKIT_ENABLED
 
 			data.tree->nodes_in_tree_count--;
 			orphan_node_count++;
@@ -3687,6 +3691,32 @@ void Node::notify_thread_safe(int p_notification) {
 	}
 }
 
+bool Node::_is_accessibility_enabled() const {
+#ifdef ACCESSKIT_ENABLED
+	if (data.tree) {
+		return data.tree->is_accessibility_enabled();
+	}
+
+	ERR_FAIL_NULL_V(SceneTree::get_singleton(), false);
+	return SceneTree::get_singleton()->is_accessibility_enabled();
+#else
+	return false;
+#endif // ACCESSKIT_ENABLED
+}
+
+bool Node::_is_accessibility_supported() const {
+#ifdef ACCESSKIT_ENABLED
+	if (data.tree) {
+		return data.tree->is_accessibility_supported();
+	}
+
+	ERR_FAIL_NULL_V(SceneTree::get_singleton(), false);
+	return SceneTree::get_singleton()->is_accessibility_supported();
+#else
+	return false;
+#endif // ACCESSKIT_ENABLED
+}
+
 RID Node::get_focused_accessibility_element() const {
 	RID id;
 	if (GDVIRTUAL_CALL(_get_focused_accessibility_element, id)) {
@@ -3697,9 +3727,11 @@ RID Node::get_focused_accessibility_element() const {
 }
 
 void Node::queue_accessibility_update() {
+#ifdef ACCESSKIT_ENABLED
 	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		data.tree->_accessibility_notify_change(this);
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 RID Node::get_accessibility_element() const {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -384,6 +384,9 @@ protected:
 	void _call_unhandled_input(const Ref<InputEvent> &p_event);
 	void _call_unhandled_key_input(const Ref<InputEvent> &p_event);
 
+	bool _is_accessibility_enabled() const;
+	bool _is_accessibility_supported() const;
+
 	void _validate_property(PropertyInfo &p_property) const;
 
 	Variant _get_node_rpc_config_bind() const {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -203,6 +203,7 @@ void SceneTree::flush_transform_notifications() {
 }
 
 bool SceneTree::is_accessibility_enabled() const {
+#ifdef ACCESSKIT_ENABLED
 	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_ACCESSIBILITY_SCREEN_READER)) {
 		return false;
 	}
@@ -213,9 +214,13 @@ bool SceneTree::is_accessibility_enabled() const {
 		return false;
 	}
 	return true;
+#else
+	return false;
+#endif // ACCESSKIT_ENABLED
 }
 
 bool SceneTree::is_accessibility_supported() const {
+#ifdef ACCESSKIT_ENABLED
 	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_ACCESSIBILITY_SCREEN_READER)) {
 		return false;
 	}
@@ -225,6 +230,9 @@ bool SceneTree::is_accessibility_supported() const {
 		return false;
 	}
 	return true;
+#else
+	return false;
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_accessibility_force_update() {
@@ -232,6 +240,7 @@ void SceneTree::_accessibility_force_update() {
 }
 
 void SceneTree::_accessibility_notify_change(const Node *p_node, bool p_remove) {
+#ifdef ACCESSKIT_ENABLED
 	if (p_node) {
 		if (p_remove) {
 			accessibility_change_queue.erase(p_node->get_instance_id());
@@ -239,9 +248,11 @@ void SceneTree::_accessibility_notify_change(const Node *p_node, bool p_remove) 
 			accessibility_change_queue.insert(p_node->get_instance_id());
 		}
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_process_accessibility_changes(DisplayServer::WindowID p_window_id) {
+#ifdef ACCESSKIT_ENABLED
 	// Process NOTIFICATION_ACCESSIBILITY_UPDATE.
 	Vector<ObjectID> processed;
 	for (const ObjectID &id : accessibility_change_queue) {
@@ -291,9 +302,11 @@ void SceneTree::_process_accessibility_changes(DisplayServer::WindowID p_window_
 	for (const ObjectID &id : processed) {
 		accessibility_change_queue.erase(id);
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_flush_accessibility_changes() {
+#ifdef ACCESSKIT_ENABLED
 	if (is_accessibility_enabled()) {
 		uint64_t time = OS::get_singleton()->get_ticks_msec();
 		if (!accessibility_force_update) {
@@ -307,6 +320,7 @@ void SceneTree::_flush_accessibility_changes() {
 		// Push update to the accessibility driver.
 		DisplayServer::get_singleton()->accessibility_update_if_active(callable_mp(this, &SceneTree::_process_accessibility_changes));
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_flush_ugc() {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -955,12 +955,12 @@ void Window::set_visible(bool p_visible) {
 	}
 
 	if (visible) {
-		if (get_tree() && get_tree()->is_accessibility_supported()) {
+		if (_is_accessibility_supported()) {
 			get_tree()->_accessibility_force_update();
 			_accessibility_notify_enter(this);
 		}
 	} else {
-		if (get_tree() && get_tree()->is_accessibility_supported()) {
+		if (_is_accessibility_supported()) {
 			_accessibility_notify_exit(this);
 		}
 		focused = false;
@@ -1554,7 +1554,7 @@ void Window::_notification(int p_what) {
 				_make_transient();
 			}
 			if (visible) {
-				if (window_id != DisplayServer::MAIN_WINDOW_ID && get_tree() && get_tree()->is_accessibility_supported()) {
+				if (window_id != DisplayServer::MAIN_WINDOW_ID && _is_accessibility_supported()) {
 					get_tree()->_accessibility_force_update();
 					_accessibility_notify_enter(this);
 				}
@@ -1609,7 +1609,7 @@ void Window::_notification(int p_what) {
 			set_theme_context(nullptr, false);
 
 			if (visible && window_id != DisplayServer::MAIN_WINDOW_ID) {
-				if (get_tree() && get_tree()->is_accessibility_supported()) {
+				if (_is_accessibility_supported()) {
 					_accessibility_notify_exit(this);
 					if (get_parent()) {
 						get_parent()->queue_accessibility_update();


### PR DESCRIPTION
Useful to have it early after restoring windows 7 support and disabling accesskit here https://github.com/blazium-engine/blazium/pull/540.