### PR TITLE
[4.5] Opt-in .NET 6 runtime support

### DIFF
--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -231,7 +231,7 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
 
         core_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharp", "bin", build_config))
         editor_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharpEditor", "bin", build_config))
-        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net8.0"))
+        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net6.0"))
 
         if not os.path.isdir(editor_api_dir):
             assert not os.path.isfile(editor_api_dir)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <ProjectGuid>{639E48BD-44E5-4091-8EDD-22D36DC0768D}</ProjectGuid>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <ProjectGuid>{A8CDAD94-C6D4-4B19-A7E7-76C53CC92984}</ProjectGuid>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -26,6 +26,9 @@ namespace GodotTools.ProjectEditor
             var mainGroup = root.AddPropertyGroup();
             mainGroup.AddProperty("TargetFramework", GodotMinimumRequiredTfm);
 
+            var net8 = mainGroup.AddProperty("TargetFramework", "net8.0");
+            net8.Condition = " '$(GodotTargetPlatform)' == 'ios' ";
+
             // Non-gradle builds require .NET 9 to match the jar libraries included in the export template.
             var net9 = mainGroup.AddProperty("TargetFramework", "net9.0");
             net9.Condition = " '$(GodotTargetPlatform)' == 'android' ";

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
@@ -25,8 +25,6 @@ namespace GodotTools.ProjectEditor
 
     public static partial class ProjectUtils
     {
-        [GeneratedRegex(@"\s*'\$\(GodotTargetPlatform\)'\s*==\s*'(?<platform>[A-z]+)'\s*", RegexOptions.IgnoreCase)]
-        private static partial Regex GodotTargetPlatformConditionRegex();
 
         private static readonly string[] _platformNames =
         {
@@ -65,10 +63,9 @@ namespace GodotTools.ProjectEditor
             MigrateToProjectSdksStyle(project, projectName);
 
             EnsureGodotSdkIsUpToDate(project);
-            EnsureTargetFrameworkMatchesMinimumRequirement(project);
         }
 
-        private static void MigrateToProjectSdksStyle(MSBuildProject project, string projectName)
+        public static void MigrateToProjectSdksStyle(MSBuildProject project, string projectName)
         {
             var origRoot = project.Root;
 
@@ -93,134 +90,5 @@ namespace GodotTools.ProjectEditor
             project.HasUnsavedChanges = true;
         }
 
-        private static void EnsureTargetFrameworkMatchesMinimumRequirement(MSBuildProject project)
-        {
-            var root = project.Root;
-            string minTfmValue = ProjectGenerator.GodotMinimumRequiredTfm;
-            var minTfmVersion = NuGetFramework.Parse(minTfmValue).Version;
-
-            ProjectPropertyGroupElement? mainPropertyGroup = null;
-            ProjectPropertyElement? mainTargetFrameworkProperty = null;
-
-            var propertiesToChange = new List<ProjectPropertyElement>();
-
-            foreach (var propertyGroup in root.PropertyGroups)
-            {
-                bool groupHasCondition = !string.IsNullOrEmpty(propertyGroup.Condition);
-
-                // Check if the property group should be excluded from checking for 'TargetFramework' properties.
-                if (groupHasCondition && !ConditionMatchesGodotPlatform(propertyGroup.Condition))
-                {
-                    continue;
-                }
-
-                // Store a reference to the first property group without conditions,
-                // in case we need to add a new 'TargetFramework' property later.
-                if (mainPropertyGroup == null && !groupHasCondition)
-                {
-                    mainPropertyGroup = propertyGroup;
-                }
-
-                foreach (var property in propertyGroup.Properties)
-                {
-                    // We are looking for 'TargetFramework' properties.
-                    if (property.Name != "TargetFramework")
-                    {
-                        continue;
-                    }
-
-                    bool propertyHasCondition = !string.IsNullOrEmpty(property.Condition);
-
-                    // Check if the property should be excluded.
-                    if (propertyHasCondition && !ConditionMatchesGodotPlatform(property.Condition))
-                    {
-                        continue;
-                    }
-
-                    if (!groupHasCondition && !propertyHasCondition)
-                    {
-                        // Store a reference to the 'TargetFramework' that has no conditions
-                        // because it applies to all platforms.
-                        if (mainTargetFrameworkProperty == null)
-                        {
-                            mainTargetFrameworkProperty = property;
-                        }
-                        continue;
-                    }
-
-                    // If the 'TargetFramework' property is conditional, it may no longer be needed
-                    // when the main one is upgraded to the new minimum version.
-                    var tfmVersion = NuGetFramework.Parse(property.Value).Version;
-                    if (tfmVersion <= minTfmVersion)
-                    {
-                        propertiesToChange.Add(property);
-                    }
-                }
-            }
-
-            if (mainTargetFrameworkProperty == null)
-            {
-                // We haven't found a 'TargetFramework' property without conditions,
-                // we'll just add one in the first property group without conditions.
-                if (mainPropertyGroup == null)
-                {
-                    // We also don't have a property group without conditions,
-                    // so we'll add a new one to the project.
-                    mainPropertyGroup = root.AddPropertyGroup();
-                }
-
-                mainTargetFrameworkProperty = mainPropertyGroup.AddProperty("TargetFramework", minTfmValue);
-                project.HasUnsavedChanges = true;
-            }
-            else
-            {
-                var tfmVersion = NuGetFramework.Parse(mainTargetFrameworkProperty.Value).Version;
-                if (tfmVersion < minTfmVersion)
-                {
-                    mainTargetFrameworkProperty.Value = minTfmValue;
-                    project.HasUnsavedChanges = true;
-                }
-            }
-
-            var mainTfmVersion = NuGetFramework.Parse(mainTargetFrameworkProperty.Value).Version;
-            foreach (var property in propertiesToChange)
-            {
-                // If the main 'TargetFramework' property targets a version newer than
-                // the minimum required by Godot, we don't want to remove the conditional
-                // 'TargetFramework' properties, only upgrade them to the new minimum.
-                // Otherwise, it can be removed.
-                if (mainTfmVersion > minTfmVersion)
-                {
-                    var propertyTfmVersion = NuGetFramework.Parse(property.Value).Version;
-                    if (propertyTfmVersion == minTfmVersion)
-                    {
-                        // The 'TargetFramework' property already matches the minimum version.
-                        continue;
-                    }
-
-                    property.Value = minTfmValue;
-                }
-                else
-                {
-                    property.Parent.RemoveChild(property);
-                }
-
-                project.HasUnsavedChanges = true;
-            }
-
-            static bool ConditionMatchesGodotPlatform(string condition)
-            {
-                // Check if the condition is checking the 'GodotTargetPlatform' for one of the
-                // Godot platforms with built-in support in the Godot.NET.Sdk.
-                var match = GodotTargetPlatformConditionRegex().Match(condition);
-                if (match.Success)
-                {
-                    string platform = match.Groups["platform"].Value;
-                    return _platformNames.Contains(platform, StringComparer.OrdinalIgnoreCase);
-                }
-
-                return false;
-            }
-        }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
-      <LangVersion>12</LangVersion>
+      <TargetFramework>net6.0</TargetFramework>
+      <EnablePreviewFeatures>true</EnablePreviewFeatures>
+      <LangVersion>11</LangVersion>
       <!-- Specify compile items manually to avoid including dangling generated items. -->
       <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools/CsTranslationParserPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/CsTranslationParserPlugin.cs
@@ -36,17 +36,17 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
     private const string TranslationClass = "Godot.GodotObject";
     private const string TranslationMethodTr = "Tr";
     private const string TranslationMethodTrN = "TrN";
-    private static readonly string[] _configurations = ["Debug", "Release"];
-    private static readonly string[] _targetPlatforms = ["windows", "linuxbsd", "macos", "android", "ios", "web"];
+    private static readonly string[] _configurations = new string[] { "Debug", "Release" };
+    private static readonly string[] _targetPlatforms = new string[] { "windows", "linuxbsd", "macos", "android", "ios", "web" };
 
     public override string[] _GetRecognizedExtensions()
     {
-        return ["cs"];
+        return new string[] { "cs" };
     }
 
     public override Array<string[]> _ParseFile(string path)
     {
-        _ret = [];
+        _ret = new Array<string[]>();
 
         if (_projectReferences == null)
         {
@@ -297,7 +297,7 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
 
                 if (constantValue is { HasValue: true, Value: string message })
                 {
-                    _ret.Add([message, "", "", comment]);
+                    _ret.Add(new string[] { message, "", "", comment });
                 }
 
                 break;
@@ -313,7 +313,7 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
                 if (msgValue is { HasValue: true, Value: string message } &&
                     ctxValue is { HasValue: true, Value: string context })
                 {
-                    _ret.Add([message, context, "", comment]);
+                    _ret.Add(new string[] { message, context, "", comment });
                 }
 
                 break;
@@ -345,7 +345,7 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
                 context = ctx;
             }
         }
-        _ret.Add([singular, context, plural, comment]);
+        _ret.Add(new string[] { singular, context, plural, comment });
     }
 
     private List<MetadataReference> GetProjectReferences(string projectPath, string configuration = "Debug", string? targetPlatform = null)
@@ -382,7 +382,7 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
         project.SetProperty("GodotTargetPlatform", targetPlatform);
 
         var buildParameters = new BuildParameters(projectCollection);
-        var buildRequest = new BuildRequestData(project.FullPath, project.GlobalProperties, null, ["GetTargetPath"], null);
+        var buildRequest = new BuildRequestData(project.FullPath, project.GlobalProperties, null, new string[] { "GetTargetPath" }, null);
         var buildResult = BuildManager.DefaultBuildManager.Build(buildParameters, buildRequest);
 
         if (buildResult.OverallResult == BuildResultCode.Success)
@@ -402,7 +402,7 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
         {
             MSBuildLocator.RegisterDefaults();
         }
-        string[] defineConstants = [];
+        string[] defineConstants = new string[0];
 
         var projectCollection = new ProjectCollection();
         var project = projectCollection.LoadProject(projectPath);
@@ -423,7 +423,7 @@ public partial class CsTranslationParserPlugin : EditorTranslationParserPlugin
         task.SetParameter("Overwrite", "true");
 
         var buildParameters = new BuildParameters(projectCollection);
-        var buildRequest = new BuildRequestData(project.FullPath, project.GlobalProperties, null, ["GetDefineConstants"], null);
+        var buildRequest = new BuildRequestData(project.FullPath, project.GlobalProperties, null, new string[] { "GetDefineConstants" }, null);
         var buildResult = BuildManager.DefaultBuildManager.Build(buildParameters, buildRequest);
 
         if (buildResult.OverallResult == BuildResultCode.Success)

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -191,7 +191,7 @@ namespace GodotTools.Export
                 BuildConfig = isDebug ? "ExportDebug" : "ExportRelease",
                 IncludeDebugSymbols = (bool)GetOption("dotnet/include_debug_symbols"),
                 RidOS = DetermineRuntimeIdentifierOS(platform, useAndroidLinuxBionic),
-                Archs = [],
+                Archs = new(),
                 UseTempDir = platform != OS.Platforms.iOS, // xcode project links directly to files in the publish dir, so use one that sticks around.
                 BundleOutputs = true,
             };
@@ -232,7 +232,7 @@ namespace GodotTools.Export
                 targets.Add(new PublishConfig
                 {
                     BuildConfig = publishConfig.BuildConfig,
-                    Archs = ["arm64", "x86_64"],
+                    Archs = new() { "arm64", "x86_64" },
                     BundleOutputs = false,
                     IncludeDebugSymbols = publishConfig.IncludeDebugSymbols,
                     RidOS = OS.DotNetOS.iOSSimulator,

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -440,7 +440,12 @@ namespace GodotTools
                 var msbuildProject = ProjectUtils.Open(GodotSharpDirs.ProjectCsProjPath)
                                      ?? throw new InvalidOperationException("Cannot open C# project.");
 
-                ProjectUtils.UpgradeProjectIfNeeded(msbuildProject, GodotSharpDirs.ProjectAssemblyName);
+                // NOTE: The order in which changes are made to the project is important
+
+                // Migrate to MSBuild project Sdks style if using the old style
+                ProjectUtils.MigrateToProjectSdksStyle(msbuildProject, GodotSharpDirs.ProjectAssemblyName);
+
+                ProjectUtils.EnsureGodotSdkIsUpToDate(msbuildProject);
 
                 if (msbuildProject.HasUnsavedChanges)
                 {

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <ProjectGuid>{27B00618-A6F2-4828-B922-05CAEB08C286}</ProjectGuid>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Nullable>enable</Nullable>
     <!-- The Godot editor uses the Debug Godot API assemblies -->

--- a/modules/mono/global.json
+++ b/modules/mono/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "6.0.0",
     "rollForward": "latestMajor"
   }
 }

--- a/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -480,7 +480,7 @@ namespace Godot
         public readonly bool IntersectsPlane(Plane plane)
         {
             ReadOnlySpan<Vector3> points =
-            [
+            stackalloc Vector3[] {
                 new Vector3(_position.X, _position.Y, _position.Z),
                 new Vector3(_position.X, _position.Y, _position.Z + _size.Z),
                 new Vector3(_position.X, _position.Y + _size.Y, _position.Z),
@@ -489,7 +489,7 @@ namespace Godot
                 new Vector3(_position.X + _size.X, _position.Y, _position.Z + _size.Z),
                 new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z),
                 new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z)
-            ];
+            };
 
             bool over = false;
             bool under = false;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Frozen;
 
 namespace Godot
 {
@@ -10,7 +9,7 @@ namespace Godot
     public static class Colors
     {
         // Color names and values are derived from core/math/color_names.inc
-        internal static readonly FrozenDictionary<string, Color> NamedColors = new Dictionary<string, Color> {
+        internal static readonly Dictionary<string, Color> NamedColors = new Dictionary<string, Color> {
             { "ALICEBLUE", Colors.AliceBlue },
             { "ANTIQUEWHITE", Colors.AntiqueWhite },
             { "AQUA", Colors.Aqua },
@@ -157,7 +156,7 @@ namespace Godot
             { "WHITESMOKE", Colors.WhiteSmoke },
             { "YELLOW", Colors.Yellow },
             { "YELLOWGREEN", Colors.YellowGreen },
-        }.ToFrozenDictionary();
+        };
 
 #pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
         public static Color AliceBlue => new Color(0xF0F8FFFF);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
@@ -87,7 +87,8 @@ namespace Godot
 
             public void Resize(int size)
             {
-                ArgumentOutOfRangeException.ThrowIfNegative(size);
+                if (size < 0)
+                    throw new ArgumentOutOfRangeException(nameof(size));
 
                 var err = NativeFuncs.godotsharp_stack_info_vector_resize(ref this, size);
                 if (err != Error.Ok)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -90,7 +90,8 @@ namespace Godot
             // NativePtr is assigned, that would result in UB or crashes when calling
             // native functions that receive the pointer, which can happen because the
             // debugger calls ToString() and tries to get the value of properties.
-            ObjectDisposedException.ThrowIf(instance._disposed || instance.NativePtr == IntPtr.Zero, instance);
+            if (instance._disposed || instance.NativePtr == IntPtr.Zero)
+                throw new ObjectDisposedException(instance.GetType().FullName);
 
             return instance.NativePtr;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1666,7 +1666,7 @@ namespace Godot
         public static int StepDecimals(double step)
         {
             ReadOnlySpan<double> sd =
-            [
+            stackalloc double[] {
                 0.9999,
                 0.09999,
                 0.009999,
@@ -1675,8 +1675,8 @@ namespace Godot
                 0.000009999,
                 0.0000009999,
                 0.00000009999,
-                0.000000009999,
-            ];
+                0.000000009999
+            };
             double abs = Math.Abs(step);
             double decs = abs - (int)abs; // Strip away integer part
             for (int i = 0; i < sd.Length; i++)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -59,7 +59,7 @@ namespace Godot
                 }
                 else
                 {
-                    awaiter._result = [];
+                    awaiter._result = Array.Empty<Variant>();
                 }
 
                 awaiter._continuation?.Invoke();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1539,7 +1539,7 @@ namespace Godot
                 if (end < 0)
                     end = len;
                 if (allowEmpty || end > from)
-                    ret.Add(float.Parse(instance.AsSpan(from), CultureInfo.InvariantCulture));
+                    ret.Add(float.Parse(instance.Substring(from), CultureInfo.InvariantCulture));
                 if (end == len)
                     break;
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <ProjectGuid>{AEBF0036-DA76-4341-B651-A3F2856AB2FA}</ProjectGuid>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{8FBEC238-D944-4074-8548-B3B524305905}</ProjectGuid>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <LangVersion>11</LangVersion>
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -440,7 +440,7 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 
 	if (load_assembly_and_get_function_pointer == nullptr) {
 		// Show a message box to the user to make the problem explicit (and explain a potential crash).
-		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, no compatible version was found.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
+		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, no compatible version was found.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 6.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
 		ERR_FAIL_V_MSG(nullptr, ".NET: Failed to load compatible .NET runtime");
 	}
 
@@ -669,7 +669,7 @@ void GDMono::initialize() {
 #else
 
 		// Show a message box to the user to make the problem explicit (and explain a potential crash).
-		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
+		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 6.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
 		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 #endif
 	}


### PR DESCRIPTION
Allows for setting `<TargetFramework>net6.0</TargetFramework>` in a projects `.csproj` so .NET 6 can be targeted when exporting to non-mobile platforms. The Mono glue must still be built using .NET 8 or later, though.