### PR TITLE
Add editor quick logo menu

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -924,6 +924,9 @@
 			If [code]true[/code], redraws the editor every frame even if nothing has changed on screen. When this setting is enabled, the update spinner displays in red (see [member interface/editor/show_update_spinner]).
 			[b]Warning:[/b] This greatly increases CPU and GPU utilization, leading to increased power usage. This should only be enabled for troubleshooting purposes.
 		</member>
+		<member name="interface/editor/use_editor_logo_quick_menu" type="bool" setter="" getter="">
+			A quick menu button that provides easy access to commonly used editor actions when this option is enabled.
+		</member>
 		<member name="interface/editor/use_embedded_menu" type="bool" setter="" getter="">
 			If [code]true[/code], editor main menu is using embedded [MenuBar] instead of system global menu.
 			Specific to the macOS platform.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -558,6 +558,10 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 		distraction_free->set_button_icon(theme->get_icon(SNAME("DistractionFree"), EditorStringName(EditorIcons)));
 		distraction_free->add_theme_style_override(SceneStringName(pressed), theme->get_stylebox(CoreStringName(normal), "FlatMenuButton"));
 
+		if (EDITOR_GET("interface/editor/use_editor_logo_quick_menu")) {
+			editor_logo_quick_menu->set_button_icon(theme->get_icon(SNAME("TitleBarLogo"), EditorStringName(EditorIcons)));
+		}
+
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_SEARCH), theme->get_icon(SNAME("HelpSearch"), EditorStringName(EditorIcons)));
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_COPY_SYSTEM_INFO), theme->get_icon(SNAME("ActionCopy"), EditorStringName(EditorIcons)));
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_ABOUT), theme->get_icon(SNAME("Godot"), EditorStringName(EditorIcons)));
@@ -3190,6 +3194,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case EDITOR_COMMAND_PALETTE: {
 			command_palette->open_popup();
+		} break;
+		case HELP_DEV_TOOLS: {
+			OS::get_singleton()->shell_open("https://blazium.app/dev-tools");
 		} break;
 		case HELP_DOCS: {
 			OS::get_singleton()->shell_open(VERSION_DOCS_URL "/");
@@ -7330,6 +7337,24 @@ EditorNode::EditorNode() {
 		left_menu_spacer = memnew(Control);
 		left_menu_spacer->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 		title_bar->add_child(left_menu_spacer);
+	}
+
+	if (EDITOR_GET("interface/editor/use_editor_logo_quick_menu")) {
+		editor_logo_quick_menu = memnew(MenuButton);
+		title_bar->add_child(editor_logo_quick_menu);
+		editor_logo_quick_menu->set_tooltip_text(TTR("Blazium Editor Quick Menu"));
+		editor_logo_quick_menu->get_popup()->add_item(TTR("About"), HELP_ABOUT);
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Copy System Info"), HELP_COPY_SYSTEM_INFO);
+		editor_logo_quick_menu->get_popup()->add_separator();
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Search Help"), HELP_SEARCH);
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Online Documentation"), HELP_DOCS);
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Developer Tools"), HELP_DEV_TOOLS);
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Export"), PROJECT_EXPORT);
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Manage Runtimes"), EDITOR_MANAGE_EXPORT_TEMPLATES);
+		editor_logo_quick_menu->get_popup()->add_separator();
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Quit to Project Manager"), PROJECT_QUIT_TO_PROJECT_MANAGER);
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Quit"), FILE_QUIT);
+		editor_logo_quick_menu->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 	}
 
 	menu_scroll_box = memnew(EditorHScrollBox);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -193,6 +193,7 @@ public:
 		HELP_FORUM,
 		HELP_COMMUNITY,
 		HELP_COPY_SYSTEM_INFO,
+		HELP_DEV_TOOLS,
 		HELP_REPORT_A_BUG,
 		HELP_SUGGEST_A_FEATURE,
 		HELP_SEND_DOCS_FEEDBACK,
@@ -260,6 +261,8 @@ private:
 	EditorSelection *editor_selection = nullptr;
 	EditorSettingsDialog *editor_settings_dialog = nullptr;
 	HistoryDock *history_dock = nullptr;
+
+	MenuButton *editor_logo_quick_menu = nullptr;
 
 	ProjectExportDialog *project_export = nullptr;
 	ProjectSettingsEditor *project_settings_editor = nullptr;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -453,6 +453,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_embedded_menu", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_native_file_dialogs", false, "", PROPERTY_USAGE_DEFAULT)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/expand_to_title", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/use_editor_logo_quick_menu", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/main_font_size", 13, "8,48,1")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/code_font_size", 13, "8,48,1")


### PR DESCRIPTION
- Adds editor logo quick menu in the top menubar.
- Adds "interface/editor/use_editor_logo_quick_menu" in Editor Settings to toggle the quick menu on and off.
- Adds HELP_DEV_TOOLS case to open browser to https://blazium.app/dev-tools

I implemented this so I could keep commonly used menu items in a single, easy-to-access menu while working in the editor.  I have been using it in my own personal branch of the engine and have really enjoyed having it.  I know some people are concerned about application canvas size so I added the ability to disable it entirely.



