### PR TITLE
Add external version info to `Engine.get_version_info`

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -148,6 +148,14 @@ Dictionary Engine::get_version_info() const {
 	stringver += "-" + String(dict["status"]) + " (" + String(dict["build"]) + ")";
 	dict["string"] = stringver;
 
+	// Blazium Engine version info
+	dict["external_major"] = EXTERNAL_VERSION_MAJOR;
+	dict["external_minor"] = EXTERNAL_VERSION_MINOR;
+	dict["external_patch"] = EXTERNAL_VERSION_PATCH;
+	dict["external_hex"] = EXTERNAL_VERSION_HEX;
+	dict["external_status"] = EXTERNAL_VERSION_STATUS;
+	dict["external_string"] = String(EXTERNAL_VERSION_NUMBER) + "-" + String(EXTERNAL_VERSION_STATUS) + " (" + String(VERSION_BUILD) + ")";
+
 	return dict;
 }
 

--- a/core/version.h
+++ b/core/version.h
@@ -65,7 +65,7 @@
 
 // External Version number encoded as hexadecimal int with one byte for each number,
 // for easy comparison from code.
-#define EXTERNAL_VERSION_HEX 0x10000 * EXTERNAL_VERSION_MAJOR + 0x100 * EXTERNAL_VERSION_MINOR + EXTERNAL_VERSION_PATCH
+#define EXTERNAL_VERSION_HEX 0x100000 * EXTERNAL_VERSION_MAJOR + 0x1000 * EXTERNAL_VERSION_MINOR + EXTERNAL_VERSION_PATCH
 
 // Describes the full configuration of that Godot version, including the version number,
 // the status (beta, stable, etc.) and potential module-specific features (e.g. mono).

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -165,17 +165,27 @@
 			<return type="Dictionary" />
 			<description>
 				Returns the current engine version information as a [Dictionary] containing the following entries:
-				- [code]major[/code] - Major version number as an int;
-				- [code]minor[/code] - Minor version number as an int;
-				- [code]patch[/code] - Patch version number as an int;
-				- [code]hex[/code] - Full version encoded as a hexadecimal int with one byte (2 hex digits) per number (see example below);
-				- [code]status[/code] - Status (such as "beta", "rc1", "rc2", "stable", etc.) as a String;
+
+				- [code]external_major[/code] - Blazium Engine's major version number as an int;
+				- [code]external_minor[/code] - Blazium Engine's minor version number as an int;
+				- [code]external_patch[/code] - Blazium Engine's patch version number as an int;
+				- [code]external_hex[/code] - Blazium Engine's full version encoded as a hexadecimal int with one byte (2 hex digits) for the major number and one for the minor number, and 12 bits (3 hex digits) for the patch number (see example below);
+				- [code]external_status[/code] - Blazium Engine's status ("nightly", "release") as a String;
+				- [code]external_string[/code] - [code]external_major[/code], [code]external_minor[/code], [code]external_patch[/code], [code]external_status[/code], and [code]build[/code] in a single String.
+				- [code]major[/code] - Godot Engine's major version number as an int;
+				- [code]minor[/code] - Godot Engine's minor version number as an int;
+				- [code]patch[/code] - Godot Engine's patch version number as an int;
+				- [code]hex[/code] - Godot Engine's full version encoded as a hexadecimal int with one byte (2 hex digits) per number (see example below);
+				- [code]status[/code] - Godot Engine's status (such as "beta", "rc1", "rc2", "stable", etc.) as a String;
+				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], [code]status[/code], and [code]build[/code] in a single String.
 				- [code]build[/code] - Build name (e.g. "custom_build") as a String;
 				- [code]hash[/code] - Full Git commit hash as a String;
 				- [code]timestamp[/code] - Holds the Git commit date UNIX timestamp in seconds as an int, or [code]0[/code] if unavailable;
-				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], [code]status[/code], and [code]build[/code] in a single String.
+
+				The [code]external_hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte and four bits for the patch version. For example, "0.5.291" would be [code]0x0005123[/code].
 				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code].
-				[b]Note:[/b] The [code]hex[/code] value is still an [int] internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for quick version comparisons from code:
+
+				[b]Note:[/b] Both the [code]external_hex[/code] and [code]hex[/code] values is still an [int] internally, and printing one of them will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for quick version comparisons from code:
 				[codeblocks]
 				[gdscript]
 				if Engine.get_version_info().hex &gt;= 0x040100:


### PR DESCRIPTION
Adds the following to the dictionary returned by `Engine.get_version_info`:
- `external_major`
- `external_minor`
- `external_patch`
- `external_hex`
- `external_status`
- `external_string`

And also changes `EXTERNAL_VERSION_HEX` packing to be 1 byte (2 hex chars) for major, 1 byte (2 hex chars) for minor and 1 byte and 4 bits (3 hex chars) for patch to have a bigger number range [0, 2730].

Also updates the method's documentation.