### PR TITLE
Update `ColorPicker`, `Range`, `SpinBox`, `Color`, `RichTextLabel` and `Animation` classes.

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -368,22 +368,20 @@ Color Color::html(const String &p_rgba) {
 bool Color::html_is_valid(const String &p_color) {
 	String color = p_color;
 
-	if (color.length() == 0) {
+	if (color.is_empty()) {
 		return false;
 	}
-	if (color[0] == '#') {
-		color = color.substr(1);
-	}
 
-	// Check if the amount of hex digits is valid.
+	int current_pos = (color[0] == '#') ? 1 : 0;
 	int len = color.length();
-	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
+	int num_of_digits = len - current_pos;
+	if (!(num_of_digits == 3 || num_of_digits == 4 || num_of_digits == 6 || num_of_digits == 8)) {
 		return false;
 	}
 
 	// Check if each hex digit is valid.
-	for (int i = 0; i < len; i++) {
-		if (_parse_col4(color, i) == -1) {
+	for (int i = current_pos; i < len; i++) {
+		if (!is_hex_digit(p_color[i])) {
 			return false;
 		}
 	}

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -246,6 +246,19 @@ void Color::set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha) {
 	a = c.a;
 }
 
+void Color::set_ok_hsv(float p_h, float p_s, float p_v, float p_alpha) {
+	ok_color::HSV hsv;
+	hsv.h = p_h;
+	hsv.s = p_s;
+	hsv.v = p_v;
+	ok_color::RGB rgb = ok_color::okhsv_to_srgb(hsv);
+	Color c = Color(rgb.r, rgb.g, rgb.b, p_alpha).clamp();
+	r = c.r;
+	g = c.g;
+	b = c.b;
+	a = c.a;
+}
+
 bool Color::is_equal_approx(const Color &p_color) const {
 	return Math::is_equal_approx(r, p_color.r) && Math::is_equal_approx(g, p_color.g) && Math::is_equal_approx(b, p_color.b) && Math::is_equal_approx(a, p_color.a);
 }
@@ -473,6 +486,12 @@ Color::operator String() const {
 Color Color::from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha) {
 	Color c;
 	c.set_ok_hsl(p_h, p_s, p_l, p_alpha);
+	return c;
+}
+
+Color Color::from_ok_hsv(float p_h, float p_s, float p_l, float p_alpha) {
+	Color c;
+	c.set_ok_hsv(p_h, p_s, p_l, p_alpha);
 	return c;
 }
 

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -316,47 +316,38 @@ Color Color::inverted() const {
 }
 
 Color Color::html(const String &p_rgba) {
-	String color = p_rgba;
-	if (color.length() == 0) {
+	if (p_rgba.is_empty()) {
 		return Color();
 	}
-	if (color[0] == '#') {
-		color = color.substr(1);
-	}
 
-	// If enabled, use 1 hex digit per channel instead of 2.
-	// Other sizes aren't in the HTML/CSS spec but we could add them if desired.
-	bool is_shorthand = color.length() < 5;
-	bool alpha = false;
+	const int current_pos = (p_rgba[0] == '#') ? 1 : 0;
+	const int num_of_digits = p_rgba.length() - current_pos;
 
-	if (color.length() == 8) {
-		alpha = true;
-	} else if (color.length() == 6) {
-		alpha = false;
-	} else if (color.length() == 4) {
-		alpha = true;
-	} else if (color.length() == 3) {
-		alpha = false;
+	float r, g, b, a = 1.0f;
+
+	if (num_of_digits == 3) {
+		// #rgb
+		r = _parse_col4(p_rgba, current_pos) / 15.0f;
+		g = _parse_col4(p_rgba, current_pos + 1) / 15.0f;
+		b = _parse_col4(p_rgba, current_pos + 2) / 15.0f;
+	} else if (num_of_digits == 4) {
+		r = _parse_col4(p_rgba, current_pos) / 15.0f;
+		g = _parse_col4(p_rgba, current_pos + 1) / 15.0f;
+		b = _parse_col4(p_rgba, current_pos + 2) / 15.0f;
+		a = _parse_col4(p_rgba, current_pos + 3) / 15.0f;
+	} else if (num_of_digits == 6) {
+		r = _parse_col8(p_rgba, current_pos) / 255.0f;
+		g = _parse_col8(p_rgba, current_pos + 2) / 255.0f;
+		b = _parse_col8(p_rgba, current_pos + 4) / 255.0f;
+	} else if (num_of_digits == 8) {
+		r = _parse_col8(p_rgba, current_pos) / 255.0f;
+		g = _parse_col8(p_rgba, current_pos + 2) / 255.0f;
+		b = _parse_col8(p_rgba, current_pos + 4) / 255.0f;
+		a = _parse_col8(p_rgba, current_pos + 6) / 255.0f;
 	} else {
 		ERR_FAIL_V_MSG(Color(), "Invalid color code: " + p_rgba + ".");
 	}
 
-	float r, g, b, a = 1.0f;
-	if (is_shorthand) {
-		r = _parse_col4(color, 0) / 15.0f;
-		g = _parse_col4(color, 1) / 15.0f;
-		b = _parse_col4(color, 2) / 15.0f;
-		if (alpha) {
-			a = _parse_col4(color, 3) / 15.0f;
-		}
-	} else {
-		r = _parse_col8(color, 0) / 255.0f;
-		g = _parse_col8(color, 2) / 255.0f;
-		b = _parse_col8(color, 4) / 255.0f;
-		if (alpha) {
-			a = _parse_col8(color, 6) / 255.0f;
-		}
-	}
 	ERR_FAIL_COND_V_MSG(r < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
 	ERR_FAIL_COND_V_MSG(g < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
 	ERR_FAIL_COND_V_MSG(b < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
@@ -372,9 +363,9 @@ bool Color::html_is_valid(const String &p_color) {
 		return false;
 	}
 
-	int current_pos = (color[0] == '#') ? 1 : 0;
-	int len = color.length();
-	int num_of_digits = len - current_pos;
+	const int current_pos = (color[0] == '#') ? 1 : 0;
+	const int len = color.length();
+	const int num_of_digits = len - current_pos;
 	if (!(num_of_digits == 3 || num_of_digits == 4 || num_of_digits == 6 || num_of_digits == 8)) {
 		return false;
 	}

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -62,6 +62,7 @@ struct [[nodiscard]] Color {
 	float get_ok_hsl_s() const;
 	float get_ok_hsl_l() const;
 	void set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
+	void set_ok_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 
 	_FORCE_INLINE_ float &operator[](int p_idx) {
 		return components[p_idx];
@@ -214,6 +215,7 @@ struct [[nodiscard]] Color {
 	static Color from_string(const String &p_string, const Color &p_default);
 	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
+	static Color from_ok_hsv(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	static Color from_rgbe9995(uint32_t p_rgbe);
 	static Color from_rgba8(int64_t p_r8, int64_t p_g8, int64_t p_b8, int64_t p_a8 = 255);
 

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -164,6 +164,12 @@
 		<constant name="SHAPE_NONE" value="4" enum="PickerShapeType">
 			The color space shape and the shape select button are hidden. Can't be selected from the shapes popup.
 		</constant>
+		<constant name="SHAPE_OK_HS_RECTANGLE" value="5" enum="PickerShapeType">
+			OKHSL Color Model rectangle with constant lightness.
+		</constant>
+		<constant name="SHAPE_OK_HL_RECTANGLE" value="6" enum="PickerShapeType">
+			OKHSL Color Model rectangle with constant saturation.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="focused_not_editing_cursor_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -211,6 +211,9 @@
 		<theme_item name="code_icon" data_type="icon" type="Texture2D">
 			The icon displayed when the hex [LineEdit] is showing the color code.
 		</theme_item>
+		<theme_item name="color_copy" data_type="icon" type="Texture2D">
+			The icon for the button that copies the color in text format to the clipboard.
+		</theme_item>
 		<theme_item name="color_hue" data_type="icon" type="Texture2D">
 			Custom texture for the hue selection slider on the right.
 		</theme_item>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -518,6 +518,10 @@
 			If [code]true[/code], display a confirmation dialog when adding a new track to an animation by pressing the "key" icon next to a property. Holding Shift will bypass the dialog.
 			If [code]false[/code], the behavior is reversed, i.e. the dialog only appears when Shift is held.
 		</member>
+		<member name="editors/animation/default_animation_step" type="float" setter="" getter="">
+			Default step used when creating a new [Animation] in the Animation bottom panel. Only affects the first animation created in the [AnimationPlayer]. By default, other newly created animations will use the step from the previous ones.
+			This value is always expressed in seconds. If you want e.g. [code]10[/code] FPS to be the default, you need to set the default step to [code]0.1[/code].
+		</member>
 		<member name="editors/animation/default_create_bezier_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], create a Bezier track instead of a standard track when pressing the "key" icon next to a property. Bezier tracks provide more control over animation curves, but are more difficult to adjust quickly.
 		</member>

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -64,7 +64,7 @@
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" default="0.01">
-			If greater than 0, [member value] will always be rounded to a multiple of this property's value. If [member rounded] is also [code]true[/code], [member value] will first be rounded to a multiple of this property's value, then rounded to the nearest integer.
+			If greater than 0, [member value] will always be rounded to a multiple of this property's value above [member min_value]. For example, if [member min_value] is [code]0.1[/code] and step is 0.2, then [member value] is limited to [code]0.1[/code], [code]0.3[/code], [code]0.5[/code], and so on. If [member rounded] is also [code]true[/code], [member value] will first be rounded to a multiple of this property's value, then rounded to the nearest integer.
 		</member>
 		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">
 			Range's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -49,7 +49,8 @@
 			Changes the alignment of the underlying [LineEdit].
 		</member>
 		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
-			If not [code]0[/code], [member Range.value] will always be rounded to a multiple of [member custom_arrow_step] when interacting with the arrow buttons of the [SpinBox].
+			If not [code]0[/code], sets the step when interacting with the arrow buttons of the [SpinBox].
+			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member step].
 		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -50,7 +50,7 @@
 		</member>
 		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
 			If not [code]0[/code], sets the step when interacting with the arrow buttons of the [SpinBox].
-			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member step].
+			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member Range.step].
 		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -48,6 +48,9 @@
 		<member name="alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
 			Changes the alignment of the underlying [LineEdit].
 		</member>
+		<member name="custom_arrow_round" type="bool" setter="set_custom_arrow_round" getter="is_custom_arrow_rounding" default="false">
+			If [code]true[/code], the value will be rounded to a multiple of [member custom_arrow_step] when interacting with the arrow buttons. Otherwise, increments the value by [member custom_arrow_step] and then rounds it according to [member Range.step].
+		</member>
 		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
 			If not [code]0[/code], sets the step when interacting with the arrow buttons of the [SpinBox].
 			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member Range.step].

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2181,6 +2181,12 @@ def format_text_block(
                                         state,
                                     )
 
+                                elif class_def.properties[target_name].overrides is not None:
+                                    print_error(
+                                        f'{state.current_class}.xml: Invalid member reference "{link_target}" in {context_name}. The reference must point to the original definition, not to the override.',
+                                        state,
+                                    )
+
                             elif tag_state.name == "signal" and target_name not in class_def.signals:
                                 print_error(
                                     f'{state.current_class}.xml: Unresolved signal reference "{link_target}" in {context_name}.',

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -75,7 +75,7 @@ public:
 class EditorResourcePreview : public Node {
 	GDCLASS(EditorResourcePreview, Node);
 
-	inline static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
+	static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
 	inline static EditorResourcePreview *singleton = nullptr;
 
 	struct QueueItem {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -531,7 +531,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/inspector/resources_to_open_in_new_inspector", open_in_new_inspector_defaults);
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_mode", (int32_t)ColorPicker::MODE_RGB, "RGB,HSV,RAW,OKHSL")
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_OKHSL_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_OKHSL_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,OK HS Rectangle:5,OK HL Rectangle") // `SHAPE_NONE` is 4.
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/color_picker_show_intensity", true, "");
 
 	// Theme

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -54,6 +54,7 @@
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
+#include "scene/resources/animation.h"
 
 // PRIVATE METHODS
 
@@ -910,6 +911,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/polygon_editor/auto_bake_delay", 1.5, "-1.0,10.0,0.01");
 
 	// Animation
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/animation/default_animation_step", Animation::DEFAULT_STEP, "0.0,10.0,0.00000001");
 	_initial_set("editors/animation/autorename_animation_tracks", true);
 	_initial_set("editors/animation/confirm_insert_track", true, true);
 	_initial_set("editors/animation/default_create_bezier_tracks", false, true);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -665,6 +665,8 @@ void AnimationPlayerEditor::_animation_name_edited() {
 				if (current_anim.is_valid()) {
 					new_anim->set_step(current_anim->get_step());
 				}
+			} else {
+				new_anim->set_step(EDITOR_GET("editors/animation/default_animation_step"));
 			}
 
 			String library_name;

--- a/editor/plugins/editor_context_menu_plugin.h
+++ b/editor/plugins/editor_context_menu_plugin.h
@@ -43,7 +43,7 @@ class EditorContextMenuPlugin : public RefCounted {
 
 	friend class EditorContextMenuPluginManager;
 
-	inline static constexpr int MAX_ITEMS = 100;
+	static constexpr int MAX_ITEMS = 100;
 
 public:
 	enum ContextMenuSlot {
@@ -55,7 +55,7 @@ public:
 		CONTEXT_SLOT_SCENE_TABS,
 		CONTEXT_SLOT_2D_EDITOR,
 	};
-	inline static constexpr int BASE_ID = 2000;
+	static constexpr int BASE_ID = 2000;
 
 private:
 	int slot = -1;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -50,7 +50,6 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
-#include "scene/gui/slider.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2852,7 +2852,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	inline_color_options->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	inline_color_options->set_fit_to_longest_item(false);
 	inline_color_options->connect("item_selected", callable_mp(this, &ScriptTextEditor::_update_color_text).unbind(1));
-	inline_color_picker->get_child(0)->get_child(0)->get_child(2)->add_child(inline_color_options);
+	inline_color_picker->get_color_mode_vbox()->add_child(inline_color_options);
 
 	connection_info_dialog = memnew(ConnectionInfoDialog);
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1878,6 +1878,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_icon("picker_cursor_bg", "ColorPicker", p_theme->get_icon(SNAME("PickerCursorBg"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("hex_icon", "ColorPicker", p_theme->get_icon(SNAME("PickerHex"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("code_icon", "ColorPicker", p_theme->get_icon(SNAME("Script"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("color_copy", "ColorPicker", p_theme->get_icon(SNAME("ActionCopy"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("expanded_arrow", "ColorPicker", p_theme->get_icon(SNAME("GuiTreeArrowDown"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("folded_arrow", "ColorPicker", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("folded_arrow_mirrored", "ColorPicker", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));

--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -288,7 +288,7 @@ void ColorModeLinear::slider_draw(int p_which) {
 	Size2 size = slider->get_size();
 	Color left_color;
 	Color right_color;
-	Color color = color_picker->color_normalized.linear_to_srgb();
+	Color color = color_picker->color_normalized;
 	const real_t margin = 16 * color_picker->theme_cache.base_scale;
 
 	left_color = Color(

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -129,8 +129,9 @@ public:
 
 	virtual Color get_color() const override;
 
-	virtual void slider_draw(int p_which) override;
 	virtual void _greater_value_inputted() override;
+
+	virtual void slider_draw(int p_which) override;
 
 	ColorModeLinear(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker) {}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -974,7 +974,8 @@ void ColorPicker::_palette_file_selected(const String &p_path) {
 #endif
 		} break;
 		case FileDialog::FileMode::FILE_MODE_SAVE_FILE: {
-			ColorPalette *palette = memnew(ColorPalette);
+			Ref<ColorPalette> palette;
+			palette.instantiate();
 			palette->set_colors(get_presets());
 			Error error = ResourceSaver::save(palette, p_path);
 			ERR_FAIL_COND_MSG(error != Error::OK, vformat("Cannot open color palette file for writing at: %s", p_path));

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -734,6 +734,9 @@ void ColorPicker::_copy_hsv_okhsl_to_normalized() {
 }
 
 Color ColorPicker::_color_apply_intensity(const Color &col) const {
+	if (intensity == 0.0f) {
+		return col;
+	}
 	Color linear_color = col.srgb_to_linear();
 	Color result;
 	float multiplier = Math::pow(2, intensity);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -163,6 +163,7 @@ void ColorPicker::_notification(int p_what) {
 			for (int i = 0; i < MODE_MAX; i++) {
 				mode_btns[i]->begin_bulk_theme_override();
 				mode_btns[i]->add_theme_style_override(SceneStringName(pressed), theme_cache.mode_button_pressed);
+				mode_btns[i]->add_theme_style_override("hover_pressed", theme_cache.mode_button_hover_pressed);
 				mode_btns[i]->add_theme_style_override(CoreStringName(normal), theme_cache.mode_button_normal);
 				mode_btns[i]->add_theme_style_override(SceneStringName(hover), theme_cache.mode_button_hover);
 				mode_btns[i]->add_theme_style_override(SNAME("focus"), theme_cache.mode_button_focus);
@@ -1988,6 +1989,7 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_normal, "tab_unselected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_hovered", "TabContainer");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover_pressed, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_focus, "tab_focus", "TabContainer");
 
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, sliders_panel, "panel", "TabContainer");

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -147,10 +147,10 @@ void ColorPicker::_notification(int p_what) {
 			}
 
 			if (current_shape != SHAPE_NONE) {
-				btn_shape->set_button_icon(shape_popup->get_item_icon(current_shape));
+				btn_shape->set_button_icon(shape_popup->get_item_icon(get_current_shape_index()));
 			}
 
-			for (int i = 0; i < SLIDER_COUNT; i++) {
+			for (int i = 0; i < MODE_SLIDER_COUNT; i++) {
 				labels[i]->set_custom_minimum_size(Size2(theme_cache.label_width, 0));
 				sliders[i]->add_theme_constant_override(SNAME("center_grabber"), theme_cache.center_slider_grabbers);
 			}
@@ -196,7 +196,7 @@ void ColorPicker::_notification(int p_what) {
 			}
 			slider_arrow_size = (slider_arrow_size * 0.5).round();
 
-			for (int i = 0; i < SLIDER_COUNT; i++) {
+			for (int i = 0; i < MODE_SLIDER_COUNT; i++) {
 				sliders[i]->begin_bulk_theme_override();
 				sliders[i]->add_theme_icon_override(SNAME("grabber"), theme_cache.bar_arrow);
 				sliders[i]->add_theme_icon_override(SNAME("grabber_highlight"), theme_cache.bar_arrow);
@@ -242,7 +242,7 @@ void ColorPicker::_notification(int p_what) {
 		case NOTIFICATION_FOCUS_ENTER:
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (current_shape != SHAPE_NONE) {
-				shapes[current_shape]->cursor_editing = false;
+				shapes[get_current_shape_index()]->cursor_editing = false;
 			}
 		} break;
 
@@ -255,7 +255,7 @@ void ColorPicker::_notification(int p_what) {
 						input->is_action_just_released("ui_down")) {
 					gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
 					if (current_shape == SHAPE_NONE) {
-						shapes[current_shape]->echo_multiplier = 1;
+						shapes[get_current_shape_index()]->echo_multiplier = 1;
 					}
 					accept_event();
 					set_process_internal(false);
@@ -274,7 +274,7 @@ void ColorPicker::_notification(int p_what) {
 							input->is_action_pressed("ui_right") - input->is_action_pressed("ui_left"),
 							input->is_action_pressed("ui_down") - input->is_action_pressed("ui_up"));
 
-					shapes[current_shape]->update_cursor(color_change_vector, true);
+					shapes[get_current_shape_index()]->update_cursor(color_change_vector, true);
 					accept_event();
 				}
 				return;
@@ -366,7 +366,7 @@ void fragment() {
 
 	circle_ok_color_shader.instantiate();
 	circle_ok_color_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hsv circle shader.
+// ColorPicker ok color hsl circle shader.
 
 uniform float ok_hsl_l = 1.0;
 
@@ -387,12 +387,40 @@ void fragment() {
 	float b4 = float(sqrt(x * x + y * y) < 0.5);
 	COLOR = vec4(col, (b + b2 + b3 + b4) / 4.00);
 })");
+
+	rectangle_ok_color_hs_shader.instantiate();
+	rectangle_ok_color_hs_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hs rectangle shader.
+
+uniform float ok_hsl_l = 0.0;
+
+void fragment() {
+	float h = UV.x;
+	float s = 1.0 - UV.y;
+	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
+	COLOR = vec4(col, 1.0);
+})");
+
+	rectangle_ok_color_hl_shader.instantiate();
+	rectangle_ok_color_hl_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hl rectangle shader.
+
+uniform float ok_hsl_s = 0.0;
+
+void fragment() {
+	float h = UV.x;
+	float l = 1.0 - UV.y;
+	vec3 col = okhsl_to_srgb(vec3(h, ok_hsl_s, l));
+	COLOR = vec4(col, 1.0);
+})");
 }
 
 void ColorPicker::finish_shaders() {
 	wheel_shader.unref();
 	circle_shader.unref();
 	circle_ok_color_shader.unref();
+	rectangle_ok_color_hs_shader.unref();
+	rectangle_ok_color_hl_shader.unref();
 }
 
 void ColorPicker::set_focus_on_line_edit() {
@@ -400,7 +428,7 @@ void ColorPicker::set_focus_on_line_edit() {
 }
 
 void ColorPicker::set_focus_on_picker_shape() {
-	shapes[current_shape]->grab_focus();
+	shapes[get_current_shape_index()]->grab_focus();
 }
 
 void ColorPicker::_update_controls() {
@@ -435,7 +463,7 @@ void ColorPicker::_update_controls() {
 
 	int i = 0;
 	for (ColorPickerShape *shape : shapes) {
-		bool is_active = current_shape == i;
+		bool is_active = get_current_shape_index() == i;
 		i++;
 
 		if (!shape->is_initialized) {
@@ -604,14 +632,14 @@ void ColorPicker::create_slider(GridContainer *gc, int idx) {
 	slider->connect("drag_started", callable_mp(this, &ColorPicker::_slider_drag_started));
 	slider->connect(SceneStringName(value_changed), callable_mp(this, &ColorPicker::_slider_value_changed).unbind(1));
 	slider->connect("drag_ended", callable_mp(this, &ColorPicker::_slider_drag_ended).unbind(1));
-	if (idx < SLIDER_COUNT) {
+	if (idx < MODE_SLIDER_COUNT) {
 		slider->connect(SceneStringName(draw), callable_mp(this, &ColorPicker::_slider_draw).bind(idx));
 	} else if (idx == SLIDER_ALPHA) {
 		slider->connect(SceneStringName(draw), callable_mp(this, &ColorPicker::_alpha_slider_draw));
 	}
 	slider->connect(SceneStringName(gui_input), callable_mp(this, &ColorPicker::_slider_or_spin_input));
 
-	if (idx < SLIDER_COUNT) {
+	if (idx < MODE_SLIDER_COUNT) {
 		sliders[idx] = slider;
 		values[idx] = val;
 		labels[idx] = lbl;
@@ -669,10 +697,8 @@ void ColorPicker::set_palette_saved_callback(const Callable &p_palette_saved) {
 #endif // TOOLS_ENABLED
 
 HSlider *ColorPicker::get_slider(int p_idx) {
-	if (p_idx < SLIDER_COUNT) {
-		return sliders[p_idx];
-	}
-	return alpha_slider;
+	ERR_FAIL_INDEX_V(p_idx, MODE_MAX, nullptr);
+	return sliders[p_idx];
 }
 
 Vector<float> ColorPicker::get_active_slider_values() {
@@ -700,7 +726,7 @@ void ColorPicker::_copy_normalized_to_hsv_okhsl() {
 }
 
 void ColorPicker::_copy_hsv_okhsl_to_normalized() {
-	if (current_shape != SHAPE_NONE && shapes[current_shape]->is_ok_hsl()) {
+	if (current_shape != SHAPE_NONE && shapes[get_current_shape_index()]->is_ok_hsl()) {
 		color_normalized.set_ok_hsl(ok_hsl_h, ok_hsl_s, ok_hsl_l, color_normalized.a);
 	} else {
 		color_normalized.set_hsv(h, s, v, color_normalized.a);
@@ -843,7 +869,7 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 	_update_text_value();
 
 	if (current_shape != SHAPE_NONE) {
-		for (Control *control : shapes[current_shape]->controls) {
+		for (Control *control : shapes[get_current_shape_index()]->controls) {
 			control->queue_redraw();
 		}
 	}
@@ -935,11 +961,11 @@ void ColorPicker::set_picker_shape(PickerShapeType p_shape) {
 		return;
 	}
 	if (current_shape != SHAPE_NONE) {
-		shape_popup->set_item_checked(current_shape, false);
+		shape_popup->set_item_checked(get_current_shape_index(), false);
 	}
 	if (p_shape != SHAPE_NONE) {
-		shape_popup->set_item_checked(p_shape, true);
-		btn_shape->set_button_icon(shape_popup->get_item_icon(p_shape));
+		shape_popup->set_item_checked(shape_to_index(p_shape), true);
+		btn_shape->set_button_icon(shape_popup->get_item_icon(shape_to_index(p_shape)));
 	}
 
 	current_shape = p_shape;
@@ -1029,7 +1055,7 @@ void ColorPicker::_quick_open_palette_file_selected(const String &p_path) {
 	file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	_palette_file_selected(p_path);
 }
-#endif // ifdef TOOLS_ENABLED
+#endif // TOOLS_ENABLED
 
 void ColorPicker::_palette_file_selected(const String &p_path) {
 	switch (file_dialog->get_file_mode()) {
@@ -1928,7 +1954,7 @@ void ColorPicker::set_sliders_visible(bool p_visible) {
 		return;
 	}
 	sliders_visible = p_visible;
-	slider_vbc->set_visible(p_visible);
+	color_mode_vbc->set_visible(p_visible);
 }
 
 bool ColorPicker::are_sliders_visible() const {
@@ -1987,7 +2013,7 @@ void ColorPicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_intensity"), "set_edit_intensity", "is_editing_intensity");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "color_mode", PROPERTY_HINT_ENUM, "RGB,HSV,LINEAR,OKHSL"), "set_color_mode", "get_color_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deferred_mode"), "set_deferred_mode", "is_deferred_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "picker_shape", PROPERTY_HINT_ENUM, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,None"), "set_picker_shape", "get_picker_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "picker_shape", PROPERTY_HINT_ENUM, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,OK HS Rectangle:5,OK HL Rectangle,None:4"), "set_picker_shape", "get_picker_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "can_add_swatches"), "set_can_add_swatches", "are_swatches_enabled");
 	ADD_GROUP("Customization", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sampler_visible"), "set_sampler_visible", "is_sampler_visible");
@@ -2013,6 +2039,8 @@ void ColorPicker::_bind_methods() {
 	BIND_ENUM_CONSTANT(SHAPE_VHS_CIRCLE);
 	BIND_ENUM_CONSTANT(SHAPE_OKHSL_CIRCLE);
 	BIND_ENUM_CONSTANT(SHAPE_NONE);
+	BIND_ENUM_CONSTANT(SHAPE_OK_HS_RECTANGLE);
+	BIND_ENUM_CONSTANT(SHAPE_OK_HL_RECTANGLE);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, ColorPicker, focused_not_editing_cursor_color);
 
@@ -2100,16 +2128,18 @@ ColorPicker::ColorPicker() {
 	add_shape(memnew(ColorPickerShapeWheel(this)));
 	add_shape(memnew(ColorPickerShapeVHSCircle(this)));
 	add_shape(memnew(ColorPickerShapeOKHSLCircle(this)));
+	add_shape(memnew(ColorPickerShapeOKHSRectangle(this)));
+	add_shape(memnew(ColorPickerShapeOKHLRectangle(this)));
 
 	shape_popup = btn_shape->get_popup();
 	{
 		int i = 0;
 		for (const ColorPickerShape *shape : shapes) {
-			shape_popup->add_radio_check_item(shape->get_name(), i);
+			shape_popup->add_radio_check_item(shape->get_name(), index_to_shape(i));
 			i++;
 		}
 	}
-	shape_popup->set_item_checked(current_shape, true);
+	shape_popup->set_item_checked(get_current_shape_index(), true);
 	shape_popup->connect(SceneStringName(id_pressed), callable_mp(this, &ColorPicker::set_picker_shape));
 	shape_popup->connect("about_to_popup", callable_mp(this, &ColorPicker::_block_input_on_popup_show));
 	shape_popup->connect(SNAME("popup_hide"), callable_mp(this, &ColorPicker::_enable_input_on_popup_hide));
@@ -2119,13 +2149,13 @@ ColorPicker::ColorPicker() {
 	add_mode(memnew(ColorModeLinear(this)));
 	add_mode(memnew(ColorModeOKHSL(this)));
 
-	slider_vbc = memnew(VBoxContainer);
-	slider_vbc->add_theme_constant_override("separation", 0);
-	real_vbox->add_child(slider_vbc);
+	color_mode_vbc = memnew(VBoxContainer);
+	color_mode_vbc->add_theme_constant_override("separation", 0);
+	real_vbox->add_child(color_mode_vbc);
 
 	mode_hbc = memnew(HBoxContainer);
 	mode_hbc->add_theme_constant_override("separation", 0);
-	slider_vbc->add_child(mode_hbc);
+	color_mode_vbc->add_child(mode_hbc);
 
 	mode_group.instantiate();
 
@@ -2143,7 +2173,7 @@ ColorPicker::ColorPicker() {
 
 	sliders_panel = memnew(PanelContainer);
 	sliders_panel->set_h_size_flags(SIZE_EXPAND_FILL);
-	slider_vbc->add_child(sliders_panel);
+	color_mode_vbc->add_child(sliders_panel);
 
 	slider_gc = memnew(GridContainer);
 	sliders_panel->add_child(slider_gc);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -55,7 +55,6 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"
-#include "thirdparty/misc/ok_color_shader.h"
 
 #ifdef MACOS_ENABLED
 #include "scene/gui/link_button.h"
@@ -313,117 +312,6 @@ void ColorPicker::_update_theme_item_cache() {
 	VBoxContainer::_update_theme_item_cache();
 
 	theme_cache.base_scale = get_theme_default_base_scale();
-}
-
-void ColorPicker::init_shaders() {
-	wheel_shader.instantiate();
-	wheel_shader->set_code(R"(
-// ColorPicker wheel shader.
-
-shader_type canvas_item;
-
-uniform float wheel_radius = 0.42;
-
-void fragment() {
-	float x = UV.x - 0.5;
-	float y = UV.y - 0.5;
-	float a = atan(y, x);
-	x += 0.001;
-	y += 0.001;
-	float b = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-	x -= 0.002;
-	float b2 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-	y -= 0.002;
-	float b3 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-	x += 0.002;
-	float b4 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-
-	COLOR = vec4(clamp((abs(fract(((a - TAU) / TAU) + vec3(3.0, 2.0, 1.0) / 3.0) * 6.0 - 3.0) - 1.0), 0.0, 1.0), (b + b2 + b3 + b4) / 4.00);
-}
-)");
-
-	circle_shader.instantiate();
-	circle_shader->set_code(R"(
-// ColorPicker circle shader.
-
-shader_type canvas_item;
-
-uniform float v = 1.0;
-
-void fragment() {
-	float x = UV.x - 0.5;
-	float y = UV.y - 0.5;
-	float a = atan(y, x);
-	x += 0.001;
-	y += 0.001;
-	float b = float(sqrt(x * x + y * y) < 0.5);
-	x -= 0.002;
-	float b2 = float(sqrt(x * x + y * y) < 0.5);
-	y -= 0.002;
-	float b3 = float(sqrt(x * x + y * y) < 0.5);
-	x += 0.002;
-	float b4 = float(sqrt(x * x + y * y) < 0.5);
-
-	COLOR = vec4(mix(vec3(1.0), clamp(abs(fract(vec3((a - TAU) / TAU) + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - vec3(3.0)) - vec3(1.0), 0.0, 1.0), ((float(sqrt(x * x + y * y)) * 2.0)) / 1.0) * vec3(v), (b + b2 + b3 + b4) / 4.00);
-})");
-
-	circle_ok_color_shader.instantiate();
-	circle_ok_color_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hsl circle shader.
-
-uniform float ok_hsl_l = 1.0;
-
-void fragment() {
-	float x = UV.x - 0.5;
-	float y = UV.y - 0.5;
-	float h = atan(y, x) / (2.0 * M_PI);
-	float s = sqrt(x * x + y * y) * 2.0;
-	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
-	x += 0.001;
-	y += 0.001;
-	float b = float(sqrt(x * x + y * y) < 0.5);
-	x -= 0.002;
-	float b2 = float(sqrt(x * x + y * y) < 0.5);
-	y -= 0.002;
-	float b3 = float(sqrt(x * x + y * y) < 0.5);
-	x += 0.002;
-	float b4 = float(sqrt(x * x + y * y) < 0.5);
-	COLOR = vec4(col, (b + b2 + b3 + b4) / 4.00);
-})");
-
-	rectangle_ok_color_hs_shader.instantiate();
-	rectangle_ok_color_hs_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hs rectangle shader.
-
-uniform float ok_hsl_l = 0.0;
-
-void fragment() {
-	float h = UV.x;
-	float s = 1.0 - UV.y;
-	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
-	COLOR = vec4(col, 1.0);
-})");
-
-	rectangle_ok_color_hl_shader.instantiate();
-	rectangle_ok_color_hl_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hl rectangle shader.
-
-uniform float ok_hsl_s = 0.0;
-
-void fragment() {
-	float h = UV.x;
-	float l = 1.0 - UV.y;
-	vec3 col = okhsl_to_srgb(vec3(h, ok_hsl_s, l));
-	COLOR = vec4(col, 1.0);
-})");
-}
-
-void ColorPicker::finish_shaders() {
-	wheel_shader.unref();
-	circle_shader.unref();
-	circle_ok_color_shader.unref();
-	rectangle_ok_color_hs_shader.unref();
-	rectangle_ok_color_hl_shader.unref();
 }
 
 void ColorPicker::set_focus_on_line_edit() {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2366,6 +2366,14 @@ void ColorPickerButton::_modal_closed() {
 void ColorPickerButton::pressed() {
 	_update_picker();
 
+	// Checking if the popup was open before, so we can keep it closed instead of reopening it.
+	// Popups get closed when it's clicked outside of them.
+	if (popup_was_open) {
+		// Reset popup_was_open value.
+		popup_was_open = popup->is_visible();
+		return;
+	}
+
 	Size2 minsize = popup->get_contents_minimum_size();
 	float viewport_height = get_viewport_rect().size.y;
 
@@ -2393,6 +2401,19 @@ void ColorPickerButton::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "color") {
 		p_property.hint = edit_alpha ? PROPERTY_HINT_NONE : PROPERTY_HINT_COLOR_NO_ALPHA;
 	}
+}
+
+void ColorPickerButton::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseButton> mouse_button = p_event;
+	bool ui_accept = p_event->is_action("ui_accept", true) && !p_event->is_echo();
+	bool mouse_left_pressed = mouse_button.is_valid() && mouse_button->get_button_index() == MouseButton::LEFT && mouse_button->is_pressed();
+	if (mouse_left_pressed || ui_accept) {
+		popup_was_open = popup && popup->is_visible();
+	}
+
+	BaseButton::gui_input(p_event);
 }
 
 void ColorPickerButton::_notification(int p_what) {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2347,12 +2347,14 @@ void ColorPickerButton::_color_changed(const Color &p_color) {
 }
 
 void ColorPickerButton::_modal_closed() {
-	if (Input::get_singleton()->is_action_just_pressed(SNAME("ui_cancel"))) {
-		set_pick_color(picker->get_old_color());
-		emit_signal(SNAME("color_changed"), color);
+	if (picker->is_visible_in_tree()) {
+		if (Input::get_singleton()->is_action_just_pressed(SNAME("ui_cancel"))) {
+			set_pick_color(picker->get_old_color());
+			emit_signal(SNAME("color_changed"), color);
+		}
+		emit_signal(SNAME("popup_closed"));
+		set_pressed(false);
 	}
-	emit_signal(SNAME("popup_closed"));
-	set_pressed(false);
 	if (!get_tree()->get_root()->is_embedding_subwindows()) {
 		get_viewport()->set_disable_input(false);
 	}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2483,6 +2483,7 @@ void ColorPickerButton::_update_picker() {
 		picker->connect("color_changed", callable_mp(this, &ColorPickerButton::_color_changed));
 		popup->connect("about_to_popup", callable_mp(this, &ColorPickerButton::_about_to_popup));
 		popup->connect("popup_hide", callable_mp(this, &ColorPickerButton::_modal_closed));
+		popup->connect("tree_exiting", callable_mp(this, &ColorPickerButton::_modal_closed));
 		picker->connect(SceneStringName(minimum_size_changed), callable_mp((Window *)popup, &Window::reset_size));
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -540,14 +540,14 @@ void ColorPicker::create_slider(GridContainer *gc, int idx) {
 		sliders[idx] = slider;
 		values[idx] = val;
 		labels[idx] = lbl;
-	} else if (idx == SLIDER_ALPHA) {
-		alpha_slider = slider;
-		alpha_value = val;
-		alpha_label = lbl;
 	} else if (idx == SLIDER_INTENSITY) {
 		intensity_slider = slider;
 		intensity_value = val;
 		intensity_label = lbl;
+	} else if (idx == SLIDER_ALPHA) {
+		alpha_slider = slider;
+		alpha_value = val;
+		alpha_label = lbl;
 	}
 }
 
@@ -1438,7 +1438,6 @@ void ColorPicker::_text_changed(const String &) {
 	text_changed = true;
 }
 
-// TODO: Add the new 4.4 palette resource and create a popup for it.
 void ColorPicker::_preset_foldable_button_pressed(int p_idx) {
 	if (p_idx == 0) {
 		_add_preset_pressed();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -179,6 +179,8 @@ void ColorPicker::_notification(int p_what) {
 				text_type->set_button_icon(theme_cache.hex_icon);
 			}
 
+			text_copy->set_button_icon(theme_cache.color_copy);
+
 			int margin = MAX(theme_cache.content_margin, 0);
 			internal_margin->begin_bulk_theme_override();
 			internal_margin->add_theme_constant_override(SNAME("margin_bottom"), margin);
@@ -839,6 +841,10 @@ void ColorPicker::_text_type_toggled() {
 	}
 
 	_update_color();
+}
+
+void ColorPicker::_text_copy_pressed() {
+	DisplayServer::get_singleton()->clipboard_set(c_text->get_text());
 }
 
 Color ColorPicker::get_pick_color() const {
@@ -1973,6 +1979,7 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_hue);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, hex_icon);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, code_icon);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_copy);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, sample_focus);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, picker_focus_rectangle);
@@ -2099,9 +2106,8 @@ ColorPicker::ColorPicker() {
 	text_type->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	text_type->set_size_mode(BaseButton::SIZE_MODE_FIT_HEIGHT);
 	text_type->set_tooltip_text(RTR("Switch between hexadecimal and code values."));
-	hex_hbc->add_child(text_type);
-	text_type->set_tooltip_text(RTR("Switch between hexadecimal and code values."));
 	text_type->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+	hex_hbc->add_child(text_type);
 	text_type->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_text_type_toggled));
 
 	c_text = memnew(LineEdit);
@@ -2113,6 +2119,13 @@ ColorPicker::ColorPicker() {
 	c_text->connect(SceneStringName(text_submitted), callable_mp(this, &ColorPicker::_html_submitted));
 	c_text->connect(SceneStringName(text_changed), callable_mp(this, &ColorPicker::_text_changed));
 	c_text->connect(SceneStringName(focus_exited), callable_mp(this, &ColorPicker::_html_focus_exit));
+
+	text_copy = memnew(Button);
+	text_copy->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	text_copy->set_size_mode(BaseButton::SIZE_MODE_FIT_HEIGHT);
+	text_copy->set_tooltip_text(ETR("Copy the color value."));
+	hex_hbc->add_child(text_copy);
+	text_copy->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_text_copy_pressed));
 
 	_update_controls();
 	updating = false;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2088,6 +2088,7 @@ ColorPicker::ColorPicker() {
 	intensity_slider->set_step(0.001);
 	intensity_value->set_allow_greater(true);
 	intensity_value->set_custom_arrow_step(1);
+	intensity_value->set_custom_arrow_round(true);
 
 	hex_hbc = memnew(HBoxContainer);
 	hex_hbc->set_alignment(ALIGNMENT_BEGIN);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -140,6 +140,9 @@ void ColorPicker::_notification(int p_what) {
 				for (ColorPickerShape *shape : shapes) {
 					if (shape->is_initialized) {
 						shape->update_theme();
+						for (Control *c : shape->controls) {
+							c->queue_redraw();
+						}
 					}
 					shape_popup->set_item_icon(i, shape->get_icon());
 					i++;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -396,6 +396,9 @@ void ColorPicker::_set_pick_color(const Color &p_color, bool p_update_sliders, b
 }
 
 void ColorPicker::set_pick_color(const Color &p_color) {
+	if (p_color == color) {
+		return;
+	}
 	_set_pick_color(p_color, true, true); // Because setters can't have more arguments.
 }
 
@@ -1792,7 +1795,7 @@ void ColorPicker::_picker_texture_input(const Ref<InputEvent> &p_event) {
 }
 
 void ColorPicker::_html_focus_exit() {
-	if (c_text->is_menu_visible()) {
+	if (c_text->is_menu_visible() || !text_changed) {
 		return;
 	}
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -41,6 +41,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/popup_menu.h"
@@ -54,15 +55,11 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"
-#include "servers/display_server.h"
 #include "thirdparty/misc/ok_color_shader.h"
 
 #ifdef MACOS_ENABLED
 #include "scene/gui/link_button.h"
 #endif // MACOS_ENABLED
-
-List<Color> ColorPicker::preset_cache;
-List<Color> ColorPicker::recent_preset_cache;
 
 void ColorPicker::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "color") {
@@ -314,10 +311,6 @@ void ColorPicker::_update_theme_item_cache() {
 
 	theme_cache.base_scale = get_theme_default_base_scale();
 }
-
-Ref<Shader> ColorPicker::wheel_shader;
-Ref<Shader> ColorPicker::circle_shader;
-Ref<Shader> ColorPicker::circle_ok_color_shader;
 
 void ColorPicker::init_shaders() {
 	wheel_shader.instantiate();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1347,10 +1347,12 @@ void ColorPicker::_update_text_value() {
 		text_type->set_button_icon(theme_cache.code_icon);
 		text_type->set_disabled(!is_color_valid_hex(color));
 		c_text->set_text(t);
+		c_text->set_tooltip_text(RTR("Execute an expression as a color."));
 	} else {
 		text_type->set_button_icon(theme_cache.hex_icon);
 		text_type->set_disabled(false);
 		c_text->set_text(color.to_html(edit_alpha && color.a < 1));
+		c_text->set_tooltip_text(ETR("Enter a hex code (\"#ff0000\") or named color (\"red\")."));
 	}
 }
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -336,6 +336,7 @@ private:
 		Ref<StyleBox> mode_button_normal;
 		Ref<StyleBox> mode_button_pressed;
 		Ref<StyleBox> mode_button_hover;
+		Ref<StyleBox> mode_button_hover_pressed;
 		Ref<StyleBox> mode_button_focus;
 
 		Ref<StyleBox> sliders_panel;

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -229,6 +229,7 @@ private:
 
 	Button *text_type = nullptr;
 	LineEdit *c_text = nullptr;
+	Button *text_copy = nullptr;
 
 	HSlider *alpha_slider = nullptr;
 	SpinBox *alpha_value = nullptr;
@@ -325,6 +326,7 @@ private:
 
 		Ref<Texture2D> hex_icon;
 		Ref<Texture2D> code_icon;
+		Ref<Texture2D> color_copy;
 
 		Ref<StyleBox> sample_focus;
 		Ref<StyleBox> picker_focus_rectangle;
@@ -355,6 +357,7 @@ private:
 	void _update_color(bool p_update_sliders = true);
 	void _update_text_value();
 	void _text_type_toggled();
+	void _text_copy_pressed();
 	void _sample_input(const Ref<InputEvent> &p_event);
 	void _sample_draw();
 	void _slider_draw(int p_which);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -153,11 +153,6 @@ public:
 	};
 
 private:
-	static inline Ref<Shader> wheel_shader;
-	static inline Ref<Shader> circle_shader;
-	static inline Ref<Shader> circle_ok_color_shader;
-	static inline Ref<Shader> rectangle_ok_color_hs_shader;
-	static inline Ref<Shader> rectangle_ok_color_hl_shader;
 	static inline List<Color> preset_cache;
 	static inline List<Color> recent_preset_cache;
 
@@ -424,9 +419,6 @@ public:
 
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();
-
-	static void init_shaders();
-	static void finish_shaders();
 
 	void add_mode(ColorMode *p_mode);
 	void add_shape(ColorPickerShape *p_shape);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -513,6 +513,7 @@ class ColorPickerButton : public Button {
 	Color color;
 	bool edit_alpha = true;
 	bool edit_intensity = true;
+	bool popup_was_open = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal_style;
@@ -533,6 +534,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int);
 	static void _bind_methods();
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	void set_pick_color(const Color &p_color);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -74,6 +74,8 @@ class ColorPicker : public VBoxContainer {
 	friend class ColorPickerShapeCircle;
 	friend class ColorPickerShapeVHSCircle;
 	friend class ColorPickerShapeOKHSLCircle;
+	friend class ColorPickerShapeOKHSRectangle;
+	friend class ColorPickerShapeOKHLRectangle;
 
 	friend class ColorModeRGB;
 	friend class ColorModeHSV;
@@ -99,19 +101,49 @@ public:
 		SHAPE_VHS_CIRCLE,
 		SHAPE_OKHSL_CIRCLE,
 		SHAPE_NONE,
+		SHAPE_OK_HS_RECTANGLE,
+		SHAPE_OK_HL_RECTANGLE,
 
 		SHAPE_MAX
 	};
 
-	static const int SLIDER_COUNT = 3;
+private:
+	// Ideally, `SHAPE_NONE` should be -1 so that we don't need to convert shape type to index.
+	// In order to avoid breaking compatibility, we have to use these methods for conversion.
+	inline int get_current_shape_index() {
+		return shape_to_index(current_shape);
+	}
+
+	static inline int shape_to_index(PickerShapeType p_shape) {
+		if (p_shape == SHAPE_NONE) {
+			return -1;
+		}
+		if (p_shape > SHAPE_NONE) {
+			return p_shape - 1;
+		}
+		return p_shape;
+	}
+
+	static inline PickerShapeType index_to_shape(int p_index) {
+		if (p_index == -1) {
+			return SHAPE_NONE;
+		}
+		if (p_index >= SHAPE_NONE) {
+			return (PickerShapeType)(p_index + 1);
+		}
+		return (PickerShapeType)p_index;
+	}
+
+public:
+	static const int MODE_SLIDER_COUNT = 3;
+
 	enum SLIDER_EXTRA {
-		SLIDER_ALPHA = 3,
+		SLIDER_ALPHA = MODE_SLIDER_COUNT,
 		SLIDER_INTENSITY,
 
 		SLIDER_MAX
 	};
 
-private:
 	enum class MenuOption {
 		MENU_SAVE,
 		MENU_SAVE_AS,
@@ -120,9 +152,12 @@ private:
 		MENU_CLEAR,
 	};
 
+private:
 	static inline Ref<Shader> wheel_shader;
 	static inline Ref<Shader> circle_shader;
 	static inline Ref<Shader> circle_ok_color_shader;
+	static inline Ref<Shader> rectangle_ok_color_hs_shader;
+	static inline Ref<Shader> rectangle_ok_color_hl_shader;
 	static inline List<Color> preset_cache;
 	static inline List<Color> recent_preset_cache;
 
@@ -130,7 +165,7 @@ private:
 	Object *editor_settings = nullptr;
 #endif
 
-	int current_slider_count = SLIDER_COUNT;
+	int current_slider_count = MODE_SLIDER_COUNT;
 
 	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 1.0 / 2;
 	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 30;
@@ -172,7 +207,7 @@ private:
 	HBoxContainer *mode_hbc = nullptr;
 	HBoxContainer *sample_hbc = nullptr;
 	PanelContainer *sliders_panel = nullptr;
-	VBoxContainer *slider_vbc = nullptr;
+	VBoxContainer *color_mode_vbc = nullptr;
 	GridContainer *slider_gc = nullptr;
 	HBoxContainer *hex_hbc = nullptr;
 	Button *mode_btns[MODE_MAX];
@@ -382,6 +417,10 @@ public:
 
 	void _quick_open_palette_file_selected(const String &p_path);
 #endif // TOOLS_ENABLED
+
+	_ALWAYS_INLINE_ VBoxContainer *get_color_mode_vbox() const {
+		return color_mode_vbc;
+	}
 
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -37,10 +37,6 @@
 
 class AspectRatioContainer;
 class ColorMode;
-class ColorModeRGB;
-class ColorModeHSV;
-class ColorModeRAW;
-class ColorModeOKHSL;
 class ColorPickerShape;
 class GridContainer;
 class HSlider;
@@ -124,11 +120,11 @@ private:
 		MENU_CLEAR,
 	};
 
-	static Ref<Shader> wheel_shader;
-	static Ref<Shader> circle_shader;
-	static Ref<Shader> circle_ok_color_shader;
-	static List<Color> preset_cache;
-	static List<Color> recent_preset_cache;
+	static inline Ref<Shader> wheel_shader;
+	static inline Ref<Shader> circle_shader;
+	static inline Ref<Shader> circle_ok_color_shader;
+	static inline List<Color> preset_cache;
+	static inline List<Color> recent_preset_cache;
 
 #ifdef TOOLS_ENABLED
 	Object *editor_settings = nullptr;

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -807,9 +807,6 @@ void ColorPickerShapeWheel::_wheel_uv_draw() {
 }
 
 void ColorPickerShapeWheel::_initialize_controls() {
-	wheel_margin = memnew(MarginContainer);
-	color_picker->shape_container->add_child(wheel_margin);
-
 	Ref<ShaderMaterial> material;
 	material.instantiate();
 	material->set_shader(ColorPickerShape::wheel_shader);
@@ -817,17 +814,17 @@ void ColorPickerShapeWheel::_initialize_controls() {
 
 	wheel = memnew(Control);
 	wheel->set_material(material);
-	wheel_margin->add_child(wheel);
+	color_picker->shape_container->add_child(wheel);
 	wheel->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeWheel::_wheel_draw));
 
 	wheel_uv = memnew(Control);
-	wheel_margin->add_child(wheel_uv);
+	wheel_uv->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	wheel->add_child(wheel_uv);
 	wheel_uv->connect(SceneStringName(focus_entered), callable_mp(this, &ColorPickerShapeWheel::_reset_wheel_focus));
 	wheel_uv->connect(SceneStringName(gui_input), callable_mp(this, &ColorPickerShapeWheel::_wheel_input));
 	wheel_uv->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeWheel::_wheel_uv_draw));
 	connect_shape_focus(wheel_uv);
 
-	controls.append(wheel_margin);
 	controls.append(wheel);
 	controls.append(wheel_uv);
 }
@@ -848,8 +845,7 @@ void ColorPickerShapeWheel::_update_cursor(const Vector2 &p_color_change_vector,
 
 void ColorPickerShapeWheel::update_theme() {
 	const ColorPicker::ThemeCache &theme_cache = color_picker->theme_cache;
-	wheel_margin->set_custom_minimum_size(Size2(theme_cache.sv_width, theme_cache.sv_height));
-	wheel_margin->add_theme_constant_override(SNAME("margin_bottom"), 8 * theme_cache.base_scale);
+	wheel->set_custom_minimum_size(Size2(theme_cache.sv_width, theme_cache.sv_height));
 }
 
 void ColorPickerShapeWheel::grab_focus() {
@@ -877,16 +873,13 @@ void ColorPickerShapeCircle::update_circle_cursor(const Vector2 &p_color_change_
 }
 
 void ColorPickerShapeCircle::_initialize_controls() {
-	circle_margin = memnew(MarginContainer);
-	color_picker->shape_container->add_child(circle_margin);
-
 	Ref<ShaderMaterial> material;
 	material.instantiate();
 	material->set_shader(_get_shader());
 
 	circle = memnew(Control);
 	circle->set_material(material);
-	circle_margin->add_child(circle);
+	color_picker->shape_container->add_child(circle);
 	circle->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeCircle::_circle_draw));
 
 	circle_overlay = memnew(Control);
@@ -902,7 +895,6 @@ void ColorPickerShapeCircle::_initialize_controls() {
 	value_slider->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeCircle::_value_slider_draw));
 	connect_shape_focus(value_slider);
 
-	controls.append(circle_margin);
 	controls.append(circle);
 	controls.append(circle_overlay);
 	controls.append(value_slider);
@@ -910,8 +902,7 @@ void ColorPickerShapeCircle::_initialize_controls() {
 
 void ColorPickerShapeCircle::update_theme() {
 	const ColorPicker::ThemeCache &theme_cache = color_picker->theme_cache;
-	circle_margin->set_custom_minimum_size(Size2(theme_cache.sv_width, theme_cache.sv_height));
-	circle_margin->add_theme_constant_override(SNAME("margin_bottom"), 8 * theme_cache.base_scale);
+	circle->set_custom_minimum_size(Size2(theme_cache.sv_width, theme_cache.sv_height));
 	value_slider->set_custom_minimum_size(Size2(theme_cache.h_width, 0));
 }
 

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -274,11 +274,11 @@ void ColorPickerShape::draw_cursor(Control *p_control, const Vector2 &p_center, 
 	p_control->draw_texture(color_picker->theme_cache.picker_cursor, position);
 }
 
-void ColorPickerShape::draw_circle_cursor(Control *p_control, float p_hue) {
+void ColorPickerShape::draw_circle_cursor(Control *p_control, float p_hue, float p_saturation) {
 	const Vector2 center = p_control->get_size() * 0.5;
 	const Vector2 cursor_pos(
-			center.x + (center.x * Math::cos(p_hue * Math::TAU) * color_picker->s),
-			center.y + (center.y * Math::sin(p_hue * Math::TAU) * color_picker->s));
+			center.x + (center.x * Math::cos(p_hue * Math::TAU) * p_saturation),
+			center.y + (center.y * Math::sin(p_hue * Math::TAU) * p_saturation));
 
 	draw_cursor(p_control, cursor_pos);
 }
@@ -965,7 +965,7 @@ void ColorPickerShapeVHSCircle::_circle_draw() {
 
 void ColorPickerShapeVHSCircle::_circle_overlay_draw() {
 	draw_focus_circle(circle_overlay);
-	draw_circle_cursor(circle_overlay, color_picker->h);
+	draw_circle_cursor(circle_overlay, color_picker->h, color_picker->s);
 }
 
 void ColorPickerShapeVHSCircle::_value_slider_draw() {
@@ -1050,7 +1050,7 @@ void ColorPickerShapeOKHSLCircle::_circle_draw() {
 
 void ColorPickerShapeOKHSLCircle::_circle_overlay_draw() {
 	draw_focus_circle(circle_overlay);
-	draw_circle_cursor(circle_overlay, color_picker->ok_hsl_h);
+	draw_circle_cursor(circle_overlay, color_picker->ok_hsl_h, color_picker->ok_hsl_s);
 }
 
 void ColorPickerShapeOKHSLCircle::_value_slider_draw() {

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -359,6 +359,7 @@ void ColorPickerShapeRectangle::grab_focus() {
 
 void ColorPickerShapeOKHSRectangle::_initialize_controls() {
 	rectangle_margin = memnew(MarginContainer);
+	rectangle_margin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	color_picker->shape_container->add_child(rectangle_margin);
 
 	Ref<ShaderMaterial> material;

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -31,6 +31,119 @@
 #include "color_picker_shape.h"
 
 #include "scene/gui/margin_container.h"
+#include "scene/resources/material.h"
+#include "thirdparty/misc/ok_color_shader.h"
+
+void ColorPickerShape::init_shaders() {
+	wheel_shader.instantiate();
+	wheel_shader->set_code(R"(
+// ColorPicker wheel shader.
+
+shader_type canvas_item;
+
+uniform float wheel_radius = 0.42;
+
+void fragment() {
+	float x = UV.x - 0.5;
+	float y = UV.y - 0.5;
+	float a = atan(y, x);
+	x += 0.001;
+	y += 0.001;
+	float b = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+	x -= 0.002;
+	float b2 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+	y -= 0.002;
+	float b3 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+	x += 0.002;
+	float b4 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+
+	COLOR = vec4(clamp((abs(fract(((a - TAU) / TAU) + vec3(3.0, 2.0, 1.0) / 3.0) * 6.0 - 3.0) - 1.0), 0.0, 1.0), (b + b2 + b3 + b4) / 4.00);
+}
+)");
+
+	circle_shader.instantiate();
+	circle_shader->set_code(R"(
+// ColorPicker circle shader.
+
+shader_type canvas_item;
+
+uniform float v = 1.0;
+
+void fragment() {
+	float x = UV.x - 0.5;
+	float y = UV.y - 0.5;
+	float a = atan(y, x);
+	x += 0.001;
+	y += 0.001;
+	float b = float(sqrt(x * x + y * y) < 0.5);
+	x -= 0.002;
+	float b2 = float(sqrt(x * x + y * y) < 0.5);
+	y -= 0.002;
+	float b3 = float(sqrt(x * x + y * y) < 0.5);
+	x += 0.002;
+	float b4 = float(sqrt(x * x + y * y) < 0.5);
+
+	COLOR = vec4(mix(vec3(1.0), clamp(abs(fract(vec3((a - TAU) / TAU) + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - vec3(3.0)) - vec3(1.0), 0.0, 1.0), ((float(sqrt(x * x + y * y)) * 2.0)) / 1.0) * vec3(v), (b + b2 + b3 + b4) / 4.00);
+})");
+
+	circle_ok_color_shader.instantiate();
+	circle_ok_color_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hsl circle shader.
+
+uniform float ok_hsl_l = 1.0;
+
+void fragment() {
+	float x = UV.x - 0.5;
+	float y = UV.y - 0.5;
+	float h = atan(y, x) / (2.0 * M_PI);
+	float s = sqrt(x * x + y * y) * 2.0;
+	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
+	x += 0.001;
+	y += 0.001;
+	float b = float(sqrt(x * x + y * y) < 0.5);
+	x -= 0.002;
+	float b2 = float(sqrt(x * x + y * y) < 0.5);
+	y -= 0.002;
+	float b3 = float(sqrt(x * x + y * y) < 0.5);
+	x += 0.002;
+	float b4 = float(sqrt(x * x + y * y) < 0.5);
+	COLOR = vec4(col, (b + b2 + b3 + b4) / 4.00);
+})");
+
+	rectangle_ok_color_hs_shader.instantiate();
+	rectangle_ok_color_hs_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hs rectangle shader.
+
+uniform float ok_hsl_l = 0.0;
+
+void fragment() {
+	float h = UV.x;
+	float s = 1.0 - UV.y;
+	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
+	COLOR = vec4(col, 1.0);
+})");
+
+	rectangle_ok_color_hl_shader.instantiate();
+	rectangle_ok_color_hl_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hl rectangle shader.
+
+uniform float ok_hsl_s = 0.0;
+
+void fragment() {
+	float h = UV.x;
+	float l = 1.0 - UV.y;
+	vec3 col = okhsl_to_srgb(vec3(h, ok_hsl_s, l));
+	COLOR = vec4(col, 1.0);
+})");
+}
+
+void ColorPickerShape::finish_shaders() {
+	wheel_shader.unref();
+	circle_shader.unref();
+	circle_ok_color_shader.unref();
+	rectangle_ok_color_hs_shader.unref();
+	rectangle_ok_color_hl_shader.unref();
+}
 
 void ColorPickerShape::_emit_color_changed() {
 	color_picker->emit_signal(SNAME("color_changed"), color_picker->color);
@@ -699,7 +812,7 @@ void ColorPickerShapeWheel::_initialize_controls() {
 
 	Ref<ShaderMaterial> material;
 	material.instantiate();
-	material->set_shader(ColorPicker::wheel_shader);
+	material->set_shader(ColorPickerShape::wheel_shader);
 	material->set_shader_parameter("wheel_radius", WHEEL_RADIUS);
 
 	wheel = memnew(Control);

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -131,7 +131,7 @@ void ColorPickerShape::draw_sv_square(Control *p_control, const Rect2 &p_square,
 		Color(1, 1, 1, 1),
 		Color(1, 1, 1, 1),
 		Color(0, 0, 0, 1),
-		Color(0, 0, 0, 1)
+		Color(0, 0, 0, 1),
 	};
 	p_control->draw_polygon(points, colors);
 
@@ -139,7 +139,7 @@ void ColorPickerShape::draw_sv_square(Control *p_control, const Rect2 &p_square,
 		Color(color1, 0),
 		Color(color1, 1),
 		Color(color2, 1),
-		Color(color2, 0)
+		Color(color2, 0),
 	};
 	p_control->draw_polygon(points, colors);
 
@@ -355,6 +355,220 @@ void ColorPickerShapeRectangle::update_theme() {
 
 void ColorPickerShapeRectangle::grab_focus() {
 	hue_slider->grab_focus();
+}
+
+void ColorPickerShapeOKHSRectangle::_initialize_controls() {
+	rectangle_margin = memnew(MarginContainer);
+	color_picker->shape_container->add_child(rectangle_margin);
+
+	Ref<ShaderMaterial> material;
+	material.instantiate();
+	material->set_shader(_get_shader());
+
+	square = memnew(Control);
+	rectangle_margin->add_child(square);
+	square->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeOKHSRectangle::_square_draw));
+	square->set_material(material);
+
+	square_overlay = memnew(Control);
+	rectangle_margin->add_child(square_overlay);
+	square_overlay->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	square_overlay->connect(SceneStringName(gui_input), callable_mp(this, &ColorPickerShapeOKHSRectangle::_square_overlay_input));
+	square_overlay->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeOKHSRectangle::_square_overlay_draw));
+	connect_shape_focus(square_overlay);
+
+	value_slider = memnew(Control);
+	color_picker->shape_container->add_child(value_slider);
+	value_slider->connect(SceneStringName(gui_input), callable_mp(this, &ColorPickerShapeOKHSRectangle::_value_slider_input));
+	value_slider->connect(SceneStringName(draw), callable_mp(this, &ColorPickerShapeOKHSRectangle::_value_slider_draw));
+	connect_shape_focus(value_slider);
+
+	controls.append(rectangle_margin);
+	controls.append(square);
+	controls.append(square_overlay);
+	controls.append(value_slider);
+}
+
+void ColorPickerShapeOKHSRectangle::update_theme() {
+	const ColorPicker::ThemeCache &theme_cache = color_picker->theme_cache;
+	rectangle_margin->set_custom_minimum_size(Size2(theme_cache.sv_width, theme_cache.sv_height));
+	value_slider->set_custom_minimum_size(Size2(theme_cache.h_width, 0));
+}
+
+void ColorPickerShapeOKHSRectangle::grab_focus() {
+	square_overlay->grab_focus();
+}
+
+void ColorPickerShapeOKHSRectangle::_update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) {
+	if (square_overlay->has_focus()) {
+		color_picker->ok_hsl_h = CLAMP(color_picker->ok_hsl_h + p_color_change_vector.x / 100.0, 0, 1);
+		color_picker->ok_hsl_s = CLAMP(color_picker->ok_hsl_s - p_color_change_vector.y / 100.0, 0, 1);
+	} else if (value_slider->has_focus()) {
+		color_picker->ok_hsl_l = CLAMP(color_picker->ok_hsl_l + p_color_change_vector.y * echo_multiplier / 360.0, 0, 1);
+	}
+}
+
+void ColorPickerShapeOKHSRectangle::_square_draw() {
+	Ref<ShaderMaterial> material = square->get_material();
+	material->set_shader_parameter(SNAME("ok_hsl_l"), color_picker->ok_hsl_l);
+	square->draw_rect(Rect2(Point2(), square->get_size()), Color(1, 1, 1));
+}
+
+void ColorPickerShapeOKHSRectangle::_square_overlay_input(const Ref<InputEvent> &p_event) {
+	handle_cursor_editing(p_event, square_overlay);
+
+	Vector2 event_position;
+	if (!can_handle(p_event, event_position)) {
+		return;
+	}
+	event_position = (event_position / square_overlay->get_size()).clampf(0.0, 1.0);
+
+	color_picker->ok_hsl_h = event_position.x;
+	color_picker->ok_hsl_s = 1.0 - event_position.y;
+
+	apply_color();
+}
+
+void ColorPickerShapeOKHSRectangle::_square_overlay_draw() {
+	const Rect2 rect = Rect2(Vector2(), square_overlay->get_size());
+	const Vector2 end = rect.get_end();
+	Vector2 cursor_pos;
+	cursor_pos.x = CLAMP(rect.position.x + rect.size.x * color_picker->ok_hsl_h, rect.position.x, end.x);
+	cursor_pos.y = CLAMP(rect.position.y + rect.size.y * (1.0 - color_picker->ok_hsl_s), rect.position.y, end.y);
+
+	draw_focus_rect(square_overlay);
+	draw_cursor(square_overlay, cursor_pos);
+}
+
+void ColorPickerShapeOKHSRectangle::_value_slider_input(const Ref<InputEvent> &p_event) {
+	handle_cursor_editing(p_event, value_slider);
+
+	Vector2 event_position;
+	if (!can_handle(p_event, event_position)) {
+		return;
+	}
+	color_picker->ok_hsl_l = 1 - CLAMP(event_position.y / value_slider->get_size().y, 0.0, 1.0);
+	apply_color();
+}
+
+void ColorPickerShapeOKHSRectangle::_value_slider_draw() {
+	const float ok_hsl_h = color_picker->ok_hsl_h;
+	const float ok_hsl_s = color_picker->ok_hsl_s;
+
+	const Vector2 size = value_slider->get_size();
+	PackedVector2Array points{
+		Vector2(size.x, 0),
+		Vector2(size.x, size.y * 0.5),
+		size,
+		Vector2(0, size.y),
+		Vector2(0, size.y * 0.5),
+		Vector2(),
+	};
+
+	Color color1 = Color::from_ok_hsl(ok_hsl_h, ok_hsl_s, 1);
+	Color color2 = Color::from_ok_hsl(ok_hsl_h, ok_hsl_s, 0.5);
+	Color color3 = Color::from_ok_hsl(ok_hsl_h, ok_hsl_s, 0);
+	PackedColorArray colors = {
+		color1,
+		color2,
+		color3,
+		color3,
+		color2,
+		color1,
+	};
+	value_slider->draw_polygon(points, colors);
+
+	draw_focus_rect(value_slider);
+
+	int y = size.y * (1 - CLAMP(color_picker->ok_hsl_l, 0, 1));
+	const Color color = Color::from_ok_hsl(ok_hsl_h, 1, color_picker->ok_hsl_l);
+	value_slider->draw_line(Vector2(0, y), Vector2(size.x, y), color.inverted());
+}
+
+void ColorPickerShapeOKHLRectangle::_update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) {
+	if (square_overlay->has_focus()) {
+		color_picker->ok_hsl_h = CLAMP(color_picker->ok_hsl_h + p_color_change_vector.x / 100.0, 0, 1);
+		color_picker->ok_hsl_l = CLAMP(color_picker->ok_hsl_l - p_color_change_vector.y / 100.0, 0, 1);
+	} else if (value_slider->has_focus()) {
+		color_picker->ok_hsl_s = CLAMP(color_picker->ok_hsl_s + p_color_change_vector.y * echo_multiplier / 360.0, 0, 1);
+	}
+}
+
+void ColorPickerShapeOKHLRectangle::_square_overlay_input(const Ref<InputEvent> &p_event) {
+	handle_cursor_editing(p_event, square_overlay);
+
+	Vector2 event_position;
+	if (!can_handle(p_event, event_position)) {
+		return;
+	}
+	event_position = (event_position / square_overlay->get_size()).clampf(0.0, 1.0);
+
+	color_picker->ok_hsl_h = event_position.x;
+	color_picker->ok_hsl_l = 1.0 - event_position.y;
+
+	apply_color();
+}
+
+void ColorPickerShapeOKHLRectangle::_square_overlay_draw() {
+	const Rect2 rect = Rect2(Vector2(), square_overlay->get_size());
+	const Vector2 end = rect.get_end();
+	Vector2 cursor_pos;
+	cursor_pos.x = CLAMP(rect.position.x + rect.size.x * color_picker->ok_hsl_h, rect.position.x, end.x);
+	cursor_pos.y = CLAMP(rect.position.y + rect.size.y * (1.0 - color_picker->ok_hsl_l), rect.position.y, end.y);
+
+	draw_focus_rect(square_overlay);
+	draw_cursor(square_overlay, cursor_pos);
+}
+
+void ColorPickerShapeOKHLRectangle::_square_draw() {
+	Ref<ShaderMaterial> material = square->get_material();
+	material->set_shader_parameter(SNAME("ok_hsl_s"), color_picker->ok_hsl_s);
+	square->draw_rect(Rect2(Point2(), square->get_size()), Color(1, 1, 1));
+}
+
+void ColorPickerShapeOKHLRectangle::_value_slider_input(const Ref<InputEvent> &p_event) {
+	handle_cursor_editing(p_event, value_slider);
+
+	Vector2 event_position;
+	if (!can_handle(p_event, event_position)) {
+		return;
+	}
+	color_picker->ok_hsl_s = 1 - CLAMP(event_position.y / value_slider->get_size().y, 0.0, 1.0);
+	apply_color();
+}
+
+void ColorPickerShapeOKHLRectangle::_value_slider_draw() {
+	const float ok_hsl_h = color_picker->ok_hsl_h;
+	const float ok_hsl_l = color_picker->ok_hsl_l;
+
+	const Vector2 size = value_slider->get_size();
+	PackedVector2Array points{
+		Vector2(size.x, 0),
+		Vector2(size.x, size.y * 0.5),
+		size,
+		Vector2(0, size.y),
+		Vector2(0, size.y * 0.5),
+		Vector2(),
+	};
+
+	Color color1 = Color::from_ok_hsl(ok_hsl_h, 1, ok_hsl_l);
+	Color color2 = Color::from_ok_hsl(ok_hsl_h, 0.5, ok_hsl_l);
+	Color color3 = Color::from_ok_hsl(ok_hsl_h, 0, ok_hsl_l);
+	PackedColorArray colors = {
+		color1,
+		color2,
+		color3,
+		color3,
+		color2,
+		color1,
+	};
+	value_slider->draw_polygon(points, colors);
+
+	draw_focus_rect(value_slider);
+
+	int y = size.y * (1 - CLAMP(color_picker->ok_hsl_s, 0, 1));
+	const Color color = Color::from_ok_hsl(ok_hsl_h, 1, ok_hsl_l);
+	value_slider->draw_line(Vector2(0, y), Vector2(size.x, y), color.inverted());
 }
 
 float ColorPickerShapeWheel::_get_h_on_wheel(const Vector2 &p_color_change_vector) {
@@ -646,7 +860,7 @@ void ColorPickerShapeVHSCircle::_value_slider_draw() {
 		Vector2(),
 		Vector2(size.x, 0),
 		size,
-		Vector2(0, size.y)
+		Vector2(0, size.y),
 	};
 
 	Color color = Color::from_hsv(color_picker->h, color_picker->s, 1);
@@ -654,7 +868,7 @@ void ColorPickerShapeVHSCircle::_value_slider_draw() {
 		color,
 		color,
 		Color(),
-		Color()
+		Color(),
 	};
 
 	value_slider->draw_polygon(points, colors);
@@ -737,7 +951,7 @@ void ColorPickerShapeOKHSLCircle::_value_slider_draw() {
 		size,
 		Vector2(0, size.y),
 		Vector2(0, size.y * 0.5),
-		Vector2()
+		Vector2(),
 	};
 
 	Color color1 = Color::from_ok_hsl(ok_hsl_h, ok_hsl_s, 1);
@@ -756,7 +970,7 @@ void ColorPickerShapeOKHSLCircle::_value_slider_draw() {
 	draw_focus_rect(value_slider);
 
 	int y = size.y * (1 - CLAMP(ok_hsl_l, 0, 1));
-	value_slider->draw_line(Vector2(0, y), Vector2(size.x, y), Color::from_hsv(ok_hsl_h, 1, ok_hsl_l).inverted());
+	value_slider->draw_line(Vector2(0, y), Vector2(size.x, y), Color::from_ok_hsl(ok_hsl_h, 1, ok_hsl_l).inverted());
 }
 
 void ColorPickerShapeOKHSLCircle::_update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) {

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -38,6 +38,12 @@ class ColorPickerShape : public Object {
 	void _emit_color_changed();
 
 protected:
+	static inline Ref<Shader> wheel_shader;
+	static inline Ref<Shader> circle_shader;
+	static inline Ref<Shader> circle_ok_color_shader;
+	static inline Ref<Shader> rectangle_ok_color_hs_shader;
+	static inline Ref<Shader> rectangle_ok_color_hl_shader;
+
 	ColorPicker *color_picker = nullptr;
 	bool is_dragging = false;
 
@@ -67,6 +73,9 @@ public:
 	bool is_initialized = false;
 	bool cursor_editing = false;
 	float echo_multiplier = 1;
+
+	static void init_shaders();
+	static void finish_shaders();
 
 	virtual String get_name() const = 0;
 	virtual Ref<Texture2D> get_icon() const = 0;
@@ -113,7 +122,7 @@ protected:
 	Control *square = nullptr;
 	Control *square_overlay = nullptr;
 	Control *value_slider = nullptr;
-	virtual Ref<Shader> _get_shader() const { return ColorPicker::rectangle_ok_color_hs_shader; }
+	virtual Ref<Shader> _get_shader() const { return ColorPickerShape::rectangle_ok_color_hs_shader; }
 	virtual void _initialize_controls() override;
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
 
@@ -139,7 +148,7 @@ class ColorPickerShapeOKHLRectangle : public ColorPickerShapeOKHSRectangle {
 	GDCLASS(ColorPickerShapeOKHLRectangle, ColorPickerShapeOKHSRectangle);
 
 protected:
-	virtual Ref<Shader> _get_shader() const override { return ColorPicker::rectangle_ok_color_hl_shader; }
+	virtual Ref<Shader> _get_shader() const override { return ColorPickerShape::rectangle_ok_color_hl_shader; }
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
 
 	virtual void _square_draw() override;
@@ -230,7 +239,7 @@ class ColorPickerShapeVHSCircle : public ColorPickerShapeCircle {
 
 protected:
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
-	virtual Ref<Shader> _get_shader() const override { return ColorPicker::circle_shader; }
+	virtual Ref<Shader> _get_shader() const override { return ColorPickerShape::circle_shader; }
 
 	virtual void _circle_input(const Ref<InputEvent> &p_event) override;
 	virtual void _value_slider_input(const Ref<InputEvent> &p_event) override;
@@ -251,7 +260,7 @@ class ColorPickerShapeOKHSLCircle : public ColorPickerShapeCircle {
 
 protected:
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
-	virtual Ref<Shader> _get_shader() const override { return ColorPicker::circle_ok_color_shader; }
+	virtual Ref<Shader> _get_shader() const override { return ColorPickerShape::circle_ok_color_shader; }
 
 	virtual void _circle_input(const Ref<InputEvent> &p_event) override;
 	virtual void _value_slider_input(const Ref<InputEvent> &p_event) override;

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -104,6 +104,60 @@ public:
 			ColorPickerShape(p_color_picker) {}
 };
 
+class ColorPickerShapeOKHSRectangle : public ColorPickerShape {
+	GDCLASS(ColorPickerShapeOKHSRectangle, ColorPickerShape);
+
+	MarginContainer *rectangle_margin = nullptr;
+
+protected:
+	Control *square = nullptr;
+	Control *square_overlay = nullptr;
+	Control *value_slider = nullptr;
+	virtual Ref<Shader> _get_shader() const { return ColorPicker::rectangle_ok_color_hs_shader; }
+	virtual void _initialize_controls() override;
+	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
+
+	virtual void _square_draw();
+	virtual void _square_overlay_input(const Ref<InputEvent> &p_event);
+	virtual void _square_overlay_draw();
+
+	virtual void _value_slider_input(const Ref<InputEvent> &p_event);
+	virtual void _value_slider_draw();
+
+public:
+	virtual String get_name() const override { return ETR("OK HS Rectangle"); }
+	virtual bool is_ok_hsl() const override { return true; }
+	virtual Ref<Texture2D> get_icon() const override { return color_picker->theme_cache.shape_rect; }
+	virtual void update_theme() override;
+	virtual void grab_focus() override;
+
+	ColorPickerShapeOKHSRectangle(ColorPicker *p_color_picker) :
+			ColorPickerShape(p_color_picker) {}
+};
+
+class ColorPickerShapeOKHLRectangle : public ColorPickerShapeOKHSRectangle {
+	GDCLASS(ColorPickerShapeOKHLRectangle, ColorPickerShapeOKHSRectangle);
+
+protected:
+	virtual Ref<Shader> _get_shader() const override { return ColorPicker::rectangle_ok_color_hl_shader; }
+	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
+
+	virtual void _square_draw() override;
+	virtual void _square_overlay_input(const Ref<InputEvent> &p_event) override;
+	virtual void _square_overlay_draw() override;
+
+	virtual void _value_slider_input(const Ref<InputEvent> &p_event) override;
+	virtual void _value_slider_draw() override;
+
+public:
+	virtual String get_name() const override { return ETR("OK HL Rectangle"); }
+	virtual bool is_ok_hsl() const override { return true; }
+	virtual Ref<Texture2D> get_icon() const override { return color_picker->theme_cache.shape_rect; }
+
+	ColorPickerShapeOKHLRectangle(ColorPicker *p_color_picker) :
+			ColorPickerShapeOKHSRectangle(p_color_picker) {}
+};
+
 class ColorPickerShapeWheel : public ColorPickerShape {
 	GDCLASS(ColorPickerShapeWheel, ColorPickerShape);
 

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -172,7 +172,6 @@ class ColorPickerShapeWheel : public ColorPickerShape {
 
 	inline static constexpr float WHEEL_RADIUS = 0.42;
 
-	MarginContainer *wheel_margin = nullptr;
 	Control *wheel = nullptr;
 	Control *wheel_uv = nullptr;
 
@@ -206,7 +205,6 @@ class ColorPickerShapeCircle : public ColorPickerShape {
 	GDCLASS(ColorPickerShapeCircle, ColorPickerShape);
 
 protected:
-	MarginContainer *circle_margin = nullptr;
 	Control *circle = nullptr;
 	Control *circle_overlay = nullptr;
 	Control *value_slider = nullptr;

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -58,7 +58,7 @@ protected:
 	void draw_focus_circle(Control *p_control);
 	void draw_sv_square(Control *p_control, const Rect2 &p_square, bool p_draw_focus = true);
 	void draw_cursor(Control *p_control, const Vector2 &p_center, bool p_draw_bg = true);
-	void draw_circle_cursor(Control *p_control, float p_hue);
+	void draw_circle_cursor(Control *p_control, float p_hue, float p_saturation);
 
 	void connect_shape_focus(Control *p_shape);
 	void shape_focus_entered();

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -170,7 +170,7 @@ public:
 class ColorPickerShapeWheel : public ColorPickerShape {
 	GDCLASS(ColorPickerShapeWheel, ColorPickerShape);
 
-	inline static constexpr float WHEEL_RADIUS = 0.42;
+	static constexpr float WHEEL_RADIUS = 0.42;
 
 	Control *wheel = nullptr;
 	Control *wheel_uv = nullptr;

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -44,7 +44,7 @@ double Range::_snapped_r128(double p_value, double p_step) {
 	// R128 is fixed-precision with 64 bits after the decimal point, but double already uses 53 of those,
 	// so a step size finer than 2^-11 will lose precision, and in practice even 1e-3 can be problematic.
 	// By rescaling the value and step, we can shift precision into the higher bits (effectively turning R128 into a makeshift float).
-	const int decimals = 14 - Math::floor(std::log10(MAX(Math::abs(p_value), p_step)));
+	const int decimals = MIN(18, 14 - Math::floor(std::log10(MAX(Math::abs(p_value), p_step))));
 	const double scale = Math::pow(10.0, decimals);
 	p_value *= scale;
 	p_step *= scale;

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -33,22 +33,39 @@
 #include "thirdparty/misc/r128.h"
 
 double Range::_snapped_r128(double p_value, double p_step) {
-	if (p_step != 0) {
-		// All these lines are the equivalent of: p_value = Math::floor(p_value / p_step + 0.5) * p_step;
-		// Convert to String to force rounding to a decimal value (not a binary one).
-		String step_str = String::num(p_step);
-		String value_str = String::num(p_value);
-		R128 step_r128;
-		R128 value_r128;
-		const R128 half_r128 = R128(0.5);
-		r128FromString(&step_r128, step_str.ascii().get_data(), nullptr);
-		r128FromString(&value_r128, value_str.ascii().get_data(), nullptr);
-		r128Div(&value_r128, &value_r128, &step_r128);
-		r128Add(&value_r128, &value_r128, &half_r128);
-		r128Floor(&value_r128, &value_r128);
-		r128Mul(&value_r128, &value_r128, &step_r128);
-		p_value = value_r128;
+	if (p_step == 0.0) {
+		return p_value;
 	}
+	if (p_value > (1e18 * p_step) || p_value < -(1e18 * p_step)) {
+		// If the value goes outside of the range R128 supports, fallback to normal snapping.
+		return Math::snapped(p_value, p_step);
+	}
+	// Rescale values to better utilize R128's range before snapping.
+	// R128 is fixed-precision with 64 bits after the decimal point, but double already uses 53 of those,
+	// so a step size finer than 2^-11 will lose precision, and in practice even 1e-3 can be problematic.
+	// By rescaling the value and step, we can shift precision into the higher bits (effectively turning R128 into a makeshift float).
+	const int decimals = 14 - Math::floor(std::log10(MAX(Math::abs(p_value), p_step)));
+	const double scale = Math::pow(10.0, decimals);
+	p_value *= scale;
+	p_step *= scale;
+	// All these lines are the equivalent of: p_value = Math::floor(p_value / p_step + 0.5) * p_step;
+	// Convert to String to force rounding to a decimal value (not a binary one).
+	String step_str = String::num(p_step);
+	String value_str = String::num(p_value);
+	R128 step_r128;
+	R128 value_r128;
+	const R128 half_r128 = R128(0.5);
+	r128FromString(&step_r128, step_str.ascii().get_data(), nullptr);
+	r128FromString(&value_r128, value_str.ascii().get_data(), nullptr);
+	r128Div(&value_r128, &value_r128, &step_r128);
+	r128Add(&value_r128, &value_r128, &half_r128);
+	r128Floor(&value_r128, &value_r128);
+	r128Mul(&value_r128, &value_r128, &step_r128);
+	if (scale != 1.0) {
+		const R128 scale_r128 = R128(scale);
+		r128Div(&value_r128, &value_r128, &scale_r128);
+	}
+	p_value = (double)value_r128;
 	return p_value;
 }
 

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -94,10 +94,6 @@ void Range::set_value(double p_val) {
 }
 
 void Range::_set_value_no_signal(double p_val) {
-	if (!Math::is_finite(p_val)) {
-		return;
-	}
-
 	if (shared->step > 0) {
 		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -99,7 +99,9 @@ void Range::_set_value_no_signal(double p_val) {
 
 double Range::_calc_value(double p_val, double p_step) const {
 	if (p_step > 0) {
-		p_val = Math::round((p_val - shared->min) / p_step) * p_step + shared->min;
+		// TODO: In the future, change `step` to a more suitable type for more robust precise calculations.
+		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
+		p_val = Math::snapped(p_val - shared->min, p_step) + shared->min;
 	}
 
 	if (_rounded_values) {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -94,8 +94,12 @@ void Range::set_value(double p_val) {
 }
 
 void Range::_set_value_no_signal(double p_val) {
-	if (shared->step > 0) {
-		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
+	shared->val = _calc_value(p_val, shared->step);
+}
+
+double Range::_calc_value(double p_val, double p_step) const {
+	if (p_step > 0) {
+		p_val = Math::round((p_val - shared->min) / p_step) * p_step + shared->min;
 	}
 
 	if (_rounded_values) {
@@ -109,12 +113,7 @@ void Range::_set_value_no_signal(double p_val) {
 	if (!shared->allow_lesser && p_val < shared->min) {
 		p_val = shared->min;
 	}
-
-	if (shared->val == p_val) {
-		return;
-	}
-
-	shared->val = p_val;
+	return p_val;
 }
 
 void Range::set_value_no_signal(double p_val) {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -30,6 +30,28 @@
 
 #include "range.h"
 
+#include "thirdparty/misc/r128.h"
+
+double Range::_snapped_r128(double p_value, double p_step) {
+	if (p_step != 0) {
+		// All these lines are the equivalent of: p_value = Math::floor(p_value / p_step + 0.5) * p_step;
+		// Convert to String to force rounding to a decimal value (not a binary one).
+		String step_str = String::num(p_step);
+		String value_str = String::num(p_value);
+		R128 step_r128;
+		R128 value_r128;
+		const R128 half_r128 = R128(0.5);
+		r128FromString(&step_r128, step_str.ascii().get_data(), nullptr);
+		r128FromString(&value_r128, value_str.ascii().get_data(), nullptr);
+		r128Div(&value_r128, &value_r128, &step_r128);
+		r128Add(&value_r128, &value_r128, &half_r128);
+		r128Floor(&value_r128, &value_r128);
+		r128Mul(&value_r128, &value_r128, &step_r128);
+		p_value = value_r128;
+	}
+	return p_value;
+}
+
 PackedStringArray Range::get_configuration_warnings() const {
 	PackedStringArray warnings = Control::get_configuration_warnings();
 
@@ -99,9 +121,8 @@ void Range::_set_value_no_signal(double p_val) {
 
 double Range::_calc_value(double p_val, double p_step) const {
 	if (p_step > 0) {
-		// TODO: In the future, change `step` to a more suitable type for more robust precise calculations.
 		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
-		p_val = Math::snapped(p_val - shared->min, p_step) + shared->min;
+		p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;
 	}
 
 	if (_rounded_values) {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -223,12 +223,12 @@ double Range::get_as_ratio() const {
 	if (shared->exp_ratio && get_min() >= 0) {
 		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
 		double exp_max = Math::log(get_max()) / Math::log((double)2);
-		float value = CLAMP(get_value(), shared->min, shared->max);
+		double value = CLAMP(get_value(), shared->min, shared->max);
 		double v = Math::log(value) / Math::log((double)2);
 
 		return CLAMP((v - exp_min) / (exp_max - exp_min), 0, 1);
 	} else {
-		float value = CLAMP(get_value(), shared->min, shared->max);
+		double value = CLAMP(get_value(), shared->min, shared->max);
 		return CLAMP((value - get_min()) / (get_max() - get_min()), 0, 1);
 	}
 }

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -62,6 +62,7 @@ class Range : public Control {
 	void _set_value_no_signal(double p_val);
 
 protected:
+	static double _snapped_r128(double p_value, double p_step);
 	double _calc_value(double p_val, double p_step) const;
 	virtual void _value_changed(double p_value);
 	void _notify_shared_value_changed() { shared->emit_value_changed(); }

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -62,6 +62,7 @@ class Range : public Control {
 	void _set_value_no_signal(double p_val);
 
 protected:
+	double _calc_value(double p_val, double p_step) const;
 	virtual void _value_changed(double p_value);
 	void _notify_shared_value_changed() { shared->emit_value_changed(); }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1263,7 +1263,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						} else if (item_fx->type == ITEM_RAINBOW) {
 							ItemRainbow *item_rainbow = static_cast<ItemRainbow *>(item_fx);
 
-							font_color = font_color.from_hsv(MAX(item_rainbow->frequency, 0) * Math::abs(item_rainbow->elapsed_time * item_rainbow->speed + ((p_ofs.x + off_step.x) / 50)), item_rainbow->saturation, item_rainbow->value, font_color.a);
+							font_color = font_color.from_ok_hsv(MAX(item_rainbow->frequency, 0) * Math::abs(item_rainbow->elapsed_time * item_rainbow->speed + ((p_ofs.x + off_step.x) / 50)), item_rainbow->saturation, item_rainbow->value, font_color.a);
 						} else if (item_fx->type == ITEM_PULSE) {
 							ItemPulse *item_pulse = static_cast<ItemPulse *>(item_fx);
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -413,8 +413,8 @@ private:
 	};
 
 	struct ItemRainbow : public ItemFX {
-		float saturation = 0.8f;
-		float value = 0.8f;
+		float saturation = 0.9f;
+		float value = 1.0f;
 		float frequency = 1.0f;
 		float speed = 1.0f;
 

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -149,15 +149,24 @@ void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_range_click_timeout() {
 	if (!drag.enabled && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-		bool mouse_on_up_button = get_local_mouse_position().y < (get_size().height / 2);
-		// Arrow button is being pressed. Snap the value to next step.
-		double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
-		temp_step = Math::snapped(temp_step, get_step());
-		double new_value = _calc_value(get_value(), temp_step);
-		if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
-			new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
+		Rect2 up_button_rc = Rect2(sizing_cache.buttons_left, 0, sizing_cache.buttons_width, sizing_cache.button_up_height);
+		Rect2 down_button_rc = Rect2(sizing_cache.buttons_left, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height);
+
+		Vector2 mpos = get_local_mouse_position();
+
+		bool mouse_on_up_button = up_button_rc.has_point(mpos);
+		bool mouse_on_down_button = down_button_rc.has_point(mpos);
+
+		if (mouse_on_up_button || mouse_on_down_button) {
+			// Arrow button is being pressed. Snap the value to next step.
+			double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
+			temp_step = Math::snapped(temp_step, get_step());
+			double new_value = _calc_value(get_value(), temp_step);
+			if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
+				new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
+			}
+			set_value(new_value);
 		}
-		set_value(new_value);
 
 		if (range_click_timer->is_one_shot()) {
 			range_click_timer->set_wait_time(0.075);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -103,8 +103,6 @@ void SpinBox::_text_submitted(const String &p_string) {
 
 	Error err = expr->parse(text);
 
-	use_custom_arrow_step = false;
-
 	if (err != OK) {
 		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
 		text = p_string;
@@ -154,12 +152,12 @@ void SpinBox::_range_click_timeout() {
 		bool mouse_on_up_button = get_local_mouse_position().y < (get_size().height / 2);
 		// Arrow button is being pressed. Snap the value to next step.
 		double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
+		temp_step = Math::snapped(temp_step, get_step());
 		double new_value = _calc_value(get_value(), temp_step);
 		if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
 			new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
 		}
 		set_value(new_value);
-		use_custom_arrow_step = true;
 
 		if (range_click_timer->is_one_shot()) {
 			range_click_timer->set_wait_time(0.075);
@@ -223,12 +221,12 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 				if (mouse_on_up_button || mouse_on_down_button) {
 					// Arrow button is being pressed. Snap the value to next step.
 					double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
+					temp_step = Math::snapped(temp_step, get_step());
 					double new_value = _calc_value(get_value(), temp_step);
 					if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
 						new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
 					}
 					set_value(new_value);
-					use_custom_arrow_step = true;
 				}
 				state_cache.up_button_pressed = mouse_on_up_button;
 				state_cache.down_button_pressed = mouse_on_down_button;
@@ -244,20 +242,17 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			case MouseButton::RIGHT: {
 				line_edit->grab_focus();
 				if (mouse_on_up_button || mouse_on_down_button) {
-					use_custom_arrow_step = false;
 					set_value(mouse_on_up_button ? get_max() : get_min());
 				}
 			} break;
 			case MouseButton::WHEEL_UP: {
 				if (line_edit->is_editing()) {
-					use_custom_arrow_step = false;
 					set_value(get_value() + step * mb->get_factor());
 					accept_event();
 				}
 			} break;
 			case MouseButton::WHEEL_DOWN: {
 				if (line_edit->is_editing()) {
-					use_custom_arrow_step = false;
 					set_value(get_value() - step * mb->get_factor());
 					accept_event();
 				}
@@ -297,7 +292,6 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 		if (drag.enabled) {
 			drag.diff_y += mm->get_relative().y;
 			double diff_y = -0.01 * Math::pow(Math::abs(drag.diff_y), 1.8) * SIGN(drag.diff_y);
-			use_custom_arrow_step = false;
 			set_value(CLAMP(drag.base_val + step * diff_y, get_min(), get_max()));
 		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
 			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -158,14 +158,7 @@ void SpinBox::_range_click_timeout() {
 		bool mouse_on_down_button = down_button_rc.has_point(mpos);
 
 		if (mouse_on_up_button || mouse_on_down_button) {
-			// Arrow button is being pressed. Snap the value to next step.
-			double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
-			temp_step = Math::snapped(temp_step, get_step());
-			double new_value = _calc_value(get_value(), temp_step);
-			if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
-				new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
-			}
-			set_value(new_value);
+			_arrow_clicked(mouse_on_up_button);
 		}
 
 		if (range_click_timer->is_one_shot()) {
@@ -185,6 +178,22 @@ void SpinBox::_release_mouse_from_drag_mode() {
 		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_HIDDEN);
 		warp_mouse(drag.capture_pos);
 		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+	}
+}
+
+void SpinBox::_arrow_clicked(bool p_up) {
+	double arrow_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
+	if (custom_arrow_round) {
+		// Arrow button is being pressed, snap the value to next `arrow_step`.
+		// `arrow_step` should be a multiple of `step`, otherwise it may not be able to increase/decrease the value.
+		arrow_step = Math::snapped(arrow_step, get_step());
+		double new_value = _calc_value(get_value(), arrow_step);
+		if ((p_up && new_value <= get_value()) || (!p_up && new_value >= get_value())) {
+			new_value = _calc_value(get_value() + (p_up ? arrow_step : -arrow_step), arrow_step);
+		}
+		set_value(new_value);
+	} else {
+		set_value(get_value() + (p_up ? arrow_step : -arrow_step));
 	}
 }
 
@@ -228,14 +237,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 				line_edit->grab_focus();
 
 				if (mouse_on_up_button || mouse_on_down_button) {
-					// Arrow button is being pressed. Snap the value to next step.
-					double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
-					temp_step = Math::snapped(temp_step, get_step());
-					double new_value = _calc_value(get_value(), temp_step);
-					if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
-						new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
-					}
-					set_value(new_value);
+					_arrow_clicked(mouse_on_up_button);
 				}
 				state_cache.up_button_pressed = mouse_on_up_button;
 				state_cache.down_button_pressed = mouse_on_down_button;
@@ -562,6 +564,14 @@ double SpinBox::get_custom_arrow_step() const {
 	return custom_arrow_step;
 }
 
+void SpinBox::set_custom_arrow_round(bool p_round) {
+	custom_arrow_round = p_round;
+}
+
+bool SpinBox::is_custom_arrow_rounding() const {
+	return custom_arrow_round;
+}
+
 void SpinBox::_value_changed(double p_value) {
 	_update_buttons_state_for_current_value();
 }
@@ -594,6 +604,8 @@ void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &SpinBox::set_editable);
 	ClassDB::bind_method(D_METHOD("set_custom_arrow_step", "arrow_step"), &SpinBox::set_custom_arrow_step);
 	ClassDB::bind_method(D_METHOD("get_custom_arrow_step"), &SpinBox::get_custom_arrow_step);
+	ClassDB::bind_method(D_METHOD("set_custom_arrow_round", "round"), &SpinBox::set_custom_arrow_round);
+	ClassDB::bind_method(D_METHOD("is_custom_arrow_rounding"), &SpinBox::is_custom_arrow_rounding);
 	ClassDB::bind_method(D_METHOD("is_editable"), &SpinBox::is_editable);
 	ClassDB::bind_method(D_METHOD("set_update_on_text_changed", "enabled"), &SpinBox::set_update_on_text_changed);
 	ClassDB::bind_method(D_METHOD("get_update_on_text_changed"), &SpinBox::get_update_on_text_changed);
@@ -608,6 +620,7 @@ void SpinBox::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "prefix"), "set_prefix", "get_prefix");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "suffix"), "set_suffix", "get_suffix");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_arrow_step", PROPERTY_HINT_RANGE, "0,10000,0.0001,or_greater"), "set_custom_arrow_step", "get_custom_arrow_step");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "custom_arrow_round"), "set_custom_arrow_round", "is_custom_arrow_rounding");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_all_on_focus"), "set_select_all_on_focus", "is_select_all_on_focus");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, buttons_vertical_separation);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -45,9 +45,6 @@ Size2 SpinBox::get_minimum_size() const {
 
 void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	double step = get_step();
-	if (use_custom_arrow_step && custom_arrow_step != 0.0) {
-		step = custom_arrow_step;
-	}
 	String value = String::num(get_value(), Math::range_step_decimals(step));
 	if (is_localizing_numeral_system()) {
 		value = TS->format_number(value);
@@ -154,13 +151,14 @@ void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_range_click_timeout() {
 	if (!drag.enabled && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-		bool up = get_local_mouse_position().y < (get_size().height / 2);
-		double step = get_step();
-		// Arrow button is being pressed, so we also need to set the step to the same value as custom_arrow_step if its not 0.
+		bool mouse_on_up_button = get_local_mouse_position().y < (get_size().height / 2);
+		// Arrow button is being pressed. Snap the value to next step.
 		double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
-		_set_step_no_signal(temp_step);
-		set_value(get_value() + (up ? temp_step : -temp_step));
-		_set_step_no_signal(step);
+		double new_value = _calc_value(get_value(), temp_step);
+		if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
+			new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
+		}
+		set_value(new_value);
 		use_custom_arrow_step = true;
 
 		if (range_click_timer->is_one_shot()) {
@@ -223,11 +221,13 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 				line_edit->grab_focus();
 
 				if (mouse_on_up_button || mouse_on_down_button) {
-					// Arrow button is being pressed, so step is being changed temporarily.
+					// Arrow button is being pressed. Snap the value to next step.
 					double temp_step = get_custom_arrow_step() != 0.0 ? get_custom_arrow_step() : get_step();
-					_set_step_no_signal(temp_step);
-					set_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step));
-					_set_step_no_signal(step);
+					double new_value = _calc_value(get_value(), temp_step);
+					if ((mouse_on_up_button && new_value <= get_value() + CMP_EPSILON) || (!mouse_on_up_button && new_value >= get_value() - CMP_EPSILON)) {
+						new_value = _calc_value(get_value() + (mouse_on_up_button ? temp_step : -temp_step), temp_step);
+					}
+					set_value(new_value);
 					use_custom_arrow_step = true;
 				}
 				state_cache.up_button_pressed = mouse_on_up_button;
@@ -573,12 +573,6 @@ void SpinBox::_update_buttons_state_for_current_value() {
 		state_cache.down_button_disabled = should_disable_down;
 		queue_redraw();
 	}
-}
-
-void SpinBox::_set_step_no_signal(double p_step) {
-	set_block_signals(true);
-	set_step(p_step);
-	set_block_signals(false);
 }
 
 void SpinBox::_validate_property(PropertyInfo &p_property) const {

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -58,6 +58,7 @@ class SpinBox : public Range {
 	Timer *range_click_timer = nullptr;
 	void _range_click_timeout();
 	void _release_mouse_from_drag_mode();
+	void _arrow_clicked(bool p_up);
 
 	void _update_text(bool p_only_update_if_value_changed = false);
 	void _text_submitted(const String &p_string);
@@ -67,6 +68,7 @@ class SpinBox : public Range {
 	String suffix;
 	String last_text_value;
 	double custom_arrow_step = 0.0;
+	bool custom_arrow_round = false;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
@@ -169,6 +171,9 @@ public:
 	void apply();
 	void set_custom_arrow_step(const double p_custom_arrow_step);
 	double get_custom_arrow_step() const;
+
+	void set_custom_arrow_round(bool p_round);
+	bool is_custom_arrow_rounding() const;
 
 	SpinBox();
 };

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -135,7 +135,6 @@ class SpinBox : public Range {
 
 	void _mouse_exited();
 	void _update_buttons_state_for_current_value();
-	void _set_step_no_signal(double p_step);
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -67,7 +67,6 @@ class SpinBox : public Range {
 	String suffix;
 	String last_text_value;
 	double custom_arrow_step = 0.0;
-	bool use_custom_arrow_step = false;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -53,6 +53,7 @@
 #include "scene/gui/code_edit.h"
 #include "scene/gui/color_button.h"
 #include "scene/gui/color_picker.h"
+#include "scene/gui/color_picker_shape.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
@@ -1272,7 +1273,7 @@ void register_scene_types() {
 
 	if (RenderingServer::get_singleton()) {
 		// RenderingServer needs to exist for this to succeed.
-		ColorPicker::init_shaders();
+		ColorPickerShape::init_shaders();
 		GraphEdit::init_shaders();
 	}
 
@@ -1324,7 +1325,7 @@ void unregister_scene_types() {
 
 	ParticleProcessMaterial::finish_shaders();
 	CanvasItemMaterial::finish_shaders();
-	ColorPicker::finish_shaders();
+	ColorPickerShape::finish_shaders();
 	GraphEdit::finish_shaders();
 	SceneStringNames::free();
 

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -43,6 +43,7 @@ public:
 	typedef uint32_t TypeHash;
 
 	static inline String PARAMETERS_BASE_PATH = "parameters/";
+	static inline constexpr real_t DEFAULT_STEP = 1.0 / 30;
 
 	enum TrackType : uint8_t {
 		TYPE_VALUE, // Set a value in a property, can be interpolated.
@@ -280,7 +281,7 @@ private:
 	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const;
 
 	double length = 1.0;
-	real_t step = 1.0 / 30;
+	real_t step = DEFAULT_STEP;
 	LoopMode loop_mode = LOOP_NONE;
 	bool capture_included = false;
 	void _check_capture_included();

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -43,7 +43,7 @@ public:
 	typedef uint32_t TypeHash;
 
 	static inline String PARAMETERS_BASE_PATH = "parameters/";
-	static inline constexpr real_t DEFAULT_STEP = 1.0 / 30;
+	static constexpr real_t DEFAULT_STEP = 1.0 / 30;
 
 	enum TrackType : uint8_t {
 		TYPE_VALUE, // Set a value in a property, can be interpolated.

--- a/scene/theme/blazium_default_theme.cpp
+++ b/scene/theme/blazium_default_theme.cpp
@@ -422,6 +422,7 @@ void update_theme_icons(Ref<Theme> &p_theme, const Color &p_font_color, const Co
 	p_theme->set_icon("picker_cursor_bg", "ColorPicker", icons["color_picker_cursor_bg"]);
 	p_theme->set_icon("hex_icon", "ColorPicker", icons["color_picker_hex"]);
 	p_theme->set_icon("code_icon", "ColorPicker", icons["script"]);
+	p_theme->set_icon("color_copy", "ColorPicker", icons["action_copy"]);
 
 	p_theme->set_icon("bg", "ColorPickerButton", icons["mini_checkerboard"]);
 	p_theme->set_icon("overbright_indicator", "ColorPickerButton", icons["color_picker_overbright"]);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1086,6 +1086,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("picker_cursor_bg", "ColorPicker", icons["color_picker_cursor_bg"]);
 	theme->set_icon("hex_icon", "ColorPicker", icons["color_picker_hex"]);
 	theme->set_icon("code_icon", "ColorPicker", icons["script"]);
+	theme->set_icon("color_copy", "ColorPicker", icons["action_copy"]);
 
 	theme->set_stylebox("sample_focus", "ColorPicker", focus);
 	theme->set_stylebox("picker_focus_rectangle", "ColorPicker", focus);

--- a/scene/theme/icons/action_copy.svg
+++ b/scene/theme/icons/action_copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M2 1a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h1V3h9V2a1 1 0 0 0-1-1zm3 3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1zm1 2h7v7H6z"/></svg>

--- a/thirdparty/misc/ok_color.h
+++ b/thirdparty/misc/ok_color.h
@@ -541,6 +541,11 @@ static RGB okhsl_to_srgb(HSL hsl)
 
 static HSL srgb_to_okhsl(RGB rgb)
 {
+	// Fixes some precision errors.
+	if (rgb.r == 0.0f && rgb.g == 0.0f && rgb.b == 0.0f) {
+		return { 0.0f, 0.0f, 0.0f };
+	}
+
 	Lab lab = linear_srgb_to_oklab({
 		srgb_transfer_function_inv(rgb.r),
 		srgb_transfer_function_inv(rgb.g),

--- a/thirdparty/misc/patches/ok_color-0001-srgb_to_okhsl_precision.patch
+++ b/thirdparty/misc/patches/ok_color-0001-srgb_to_okhsl_precision.patch
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/misc/ok_color.h b/thirdparty/misc/ok_color.h
+index 4d0f0049bd..2cc7f1ceef 100644
+--- a/thirdparty/misc/ok_color.h
++++ b/thirdparty/misc/ok_color.h
+@@ -541,6 +541,11 @@ static RGB okhsl_to_srgb(HSL hsl)
+ 
+ static HSL srgb_to_okhsl(RGB rgb)
+ {
++	// Fixes some precision errors.
++	if (rgb.r == 0.0f && rgb.g == 0.0f && rgb.b == 0.0f) {
++		return { 0.0f, 0.0f, 0.0f };
++	}
++
+ 	Lab lab = linear_srgb_to_oklab({
+ 		srgb_transfer_function_inv(rgb.r),
+ 		srgb_transfer_function_inv(rgb.g),


### PR DESCRIPTION
ColorPicker:
- Untangle includes.
- Add okhsl HS and HL rectangular picker shapes.
- Avoid color conversion roundtrip.
- Enable input when `ColorPicker` popup exits tree.
- Add visibility check to `ColorPicker` popup.
- Move shaders to `ColorPickerShape` class.
- Add a copy button to copy the color hex/code.
- Adds hover pressed style for mode buttons for compatibility with modern theme.
- Fix linear mode sliders color.
- Fix cursor position in `okhsl` circle.
- Fix color picker shape minimum size.
- Fix Color loses precision when the line edit loses focus.
- Return early for `set_pick_color()` when setting a color equal to current color.

Range:
- Allow non-finite values in Range.
- Use double consistently in `get_as_ratio`.
- Fix snapping logic.
- Use `r128.h` for high precision snapping.
- Rescale values to better utilize `R128` range before snapping.
 
SpinBox:
- Fix incorrect step and decimal text when using custom arrow step.
- Fix `custom_arrow_step` by snapping it to step.
- Fix value change when held down on separation between buttons.
- Add a property to set whether `custom_arrow_step` rounds value.

Animation:
- Add editor setting for default animation step.

Color:
- Fix Color precision error in the documentation generated on M3/M4 `macOS`.
- Optimize HTML color validation.
- Optimize `Color::html()`.

RichTextLabel:
- Use `OkHSV` for rainbow labels.