### PR TITLE
[ProgressBar] Respect background style margins while drawing the fill style.

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -34,14 +34,11 @@
 #include "scene/theme/theme_db.h"
 
 Size2 ProgressBar::get_minimum_size() const {
-	Size2 minimum_size = theme_cache.background_style->get_minimum_size();
-	minimum_size = minimum_size.max(theme_cache.fill_style->get_minimum_size());
+	Size2 minimum_size = theme_cache.background_style->get_minimum_size() + theme_cache.fill_style->get_minimum_size().maxf(1);
 	if (show_percentage) {
 		String txt = "100%";
 		TextLine tl = TextLine(txt, theme_cache.font, theme_cache.font_size);
 		minimum_size.height = MAX(minimum_size.height, theme_cache.background_style->get_minimum_size().height + tl.get_size().y);
-	} else { // this is needed, else the progressbar will collapse
-		minimum_size = minimum_size.maxf(1);
 	}
 	return minimum_size;
 }
@@ -105,31 +102,32 @@ void ProgressBar::_notification(int p_what) {
 			switch (mode) {
 				case FILL_BEGIN_TO_END:
 				case FILL_END_TO_BEGIN: {
-					int mp = theme_cache.fill_style->get_minimum_size().width;
+					int mp = theme_cache.background_style->get_minimum_size().width;
 					int p = std::round(r * (get_size().width - mp));
 					// We want FILL_BEGIN_TO_END to map to right to left when UI layout is RTL,
 					// and left to right otherwise. And likewise for FILL_END_TO_BEGIN.
 					bool right_to_left = mode == (is_layout_rtl() ? FILL_BEGIN_TO_END : FILL_END_TO_BEGIN);
 					if (p > 0) {
+						Rect2 bg_style_rect = Rect2(Point2(theme_cache.background_style->get_margin(right_to_left ? SIDE_RIGHT : SIDE_LEFT), theme_cache.background_style->get_margin(SIDE_TOP)), theme_cache.background_style->get_minimum_size());
 						if (right_to_left) {
-							int p_remaining = std::round((1.0 - r) * (get_size().width - mp));
-							draw_style_box(theme_cache.fill_style, Rect2(Point2(p_remaining, 0), Size2(p + theme_cache.fill_style->get_minimum_size().width, get_size().height)));
+							int p_remaining = std::round((1.0 - r) * (get_size().width - bg_style_rect.size.width));
+							draw_style_box(theme_cache.fill_style, Rect2(Point2(p_remaining + bg_style_rect.position.x, bg_style_rect.position.y), Size2(p, get_size().height - bg_style_rect.size.height)));
 						} else {
-							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, 0), Size2(p + theme_cache.fill_style->get_minimum_size().width, get_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(bg_style_rect.position, Size2(p, get_size().height - bg_style_rect.size.height)));
 						}
 					}
 				} break;
 				case FILL_TOP_TO_BOTTOM:
 				case FILL_BOTTOM_TO_TOP: {
-					int mp = theme_cache.fill_style->get_minimum_size().height;
+					int mp = theme_cache.background_style->get_minimum_size().height;
 					int p = std::round(r * (get_size().height - mp));
-
+					Rect2 bg_style_rect = Rect2(Point2(theme_cache.background_style->get_margin(is_layout_rtl() ? SIDE_RIGHT : SIDE_LEFT), theme_cache.background_style->get_margin(SIDE_TOP)), theme_cache.background_style->get_minimum_size());
 					if (p > 0) {
 						if (mode == FILL_TOP_TO_BOTTOM) {
-							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, 0), Size2(get_size().width, p + theme_cache.fill_style->get_minimum_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(bg_style_rect.position, Size2(get_size().width - bg_style_rect.size.width, p)));
 						} else {
 							int p_remaining = std::round((1.0 - r) * (get_size().height - mp));
-							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, p_remaining), Size2(get_size().width, p + theme_cache.fill_style->get_minimum_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(Point2(bg_style_rect.position.x, p_remaining + bg_style_rect.position.y), Size2(get_size().width - bg_style_rect.size.width, p)));
 						}
 					}
 				} break;

--- a/scene/theme/blazium_default_theme.cpp
+++ b/scene/theme/blazium_default_theme.cpp
@@ -1202,6 +1202,7 @@ void update_theme_scale(const Ref<Theme> &p_theme) {
 	h_split_bar_background->set_expand_margin_individual(x2_scale, 0, x2_scale, 0);
 	v_split_bar_background->set_expand_margin_individual(0, x2_scale, 0, x2_scale);
 
+	progress_fill_style->set_content_margin_all(x4_scale);
 	grabber_style->set_content_margin_all(x4_scale);
 	h_scroll_style->set_content_margin_individual(0, x4_scale, 0, x4_scale);
 	v_scroll_style->set_content_margin_individual(x4_scale, 0, x4_scale, 0);

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -455,7 +455,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// ProgressBar
 
 	theme->set_stylebox("background", "ProgressBar", make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
-	theme->set_stylebox("fill", "ProgressBar", make_flat_stylebox(style_progress_color, 2, 2, 2, 2, 6));
+	theme->set_stylebox("fill", "ProgressBar", make_flat_stylebox(style_progress_color, 4, 4, 4, 4, 6));
 
 	theme->set_font(SceneStringName(font), "ProgressBar", Ref<Font>());
 	theme->set_font_size(SceneStringName(font_size), "ProgressBar", -1);


### PR DESCRIPTION
Use background style margins for drawing the fill style, which allows more customization for the ProgressBar.

<img width="248" height="156" alt="image" src="https://github.com/user-attachments/assets/54f357c0-af59-46d4-a151-3d9428081c07" />