### PR TITLE
feat(justamcp): editor UX improvements without multiuser tools

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -442,8 +442,10 @@
 			Setting to hardcode audio delay when playing video. Best to leave this unchanged unless you know what you are doing.
 		</member>
 		<member name="blazium/justamcp/disable_game_mcp" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], disables the Model Context Protocol (MCP) server from running alongside exported builds or game tests. Ensure this is marked true for strict production releases to deny introspection.
 		</member>
 		<member name="blazium/justamcp/game_control_enabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], allows AI interacting via JustAMCP to natively trigger in-game commands and inputs over the pipeline, granting them orchestration control over gameplay mechanics.
 		</member>
 		<member name="collada/use_ambient" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], ambient lights will be imported from COLLADA models as [DirectionalLight3D]. If [code]false[/code], ambient lights will be ignored.

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -165,14 +165,31 @@ void JustAMCPServer::_on_settings_changed() {
 
 void JustAMCPServer::_setup_settings() {
 #ifdef TOOLS_ENABLED
-	EDITOR_DEF_BASIC("blazium/justamcp/server_enabled", false);
-	EDITOR_DEF_BASIC("blazium/justamcp/server_port", 6506);
-	EDITOR_DEF_BASIC("blazium/justamcp/oauth_enabled", false);
-	EDITOR_DEF_BASIC("blazium/justamcp/client_id", "");
-	EDITOR_DEF_BASIC("blazium/justamcp/client_secret", "");
-	EDITOR_DEF_BASIC("blazium/justamcp/z_mcp_config", "");
-	EDITOR_DEF_BASIC("blazium/justamcp/enable_debug_logging", true);
-	EDITOR_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
+	if (EditorSettings::get_singleton()) {
+		EDITOR_DEF_BASIC("blazium/justamcp/server_enabled", false);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/server_enabled"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/server_port", 6506);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/server_port"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/oauth_enabled", false);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/oauth_enabled"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/client_id", "");
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/client_id"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/client_secret", "");
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/client_secret"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/z_mcp_config", "");
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/z_mcp_config"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/enable_debug_logging", true);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/enable_debug_logging"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/bind_to_localhost_only"));
+	}
 #endif
 
 	// Ensure ProjectSettings equivalents exist for override

--- a/modules/justamcp/tools/justamcp_scene_tools.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools.cpp
@@ -41,12 +41,21 @@
 #include "editor/editor_file_system.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
+#include "editor/editor_undo_redo_manager.h"
 #include "scene/2d/sprite_2d.h"
 #include "scene/3d/sprite_3d.h"
 #include "scene/resources/packed_scene.h"
 
 void JustAMCPSceneTools::_bind_methods() {
 	// Bindings for tool methods
+}
+
+static bool _is_active_scene(const String &p_scene_path) {
+	if (!EditorNode::get_singleton() || !EditorInterface::get_singleton()) {
+		return false;
+	}
+	Node *root = EditorInterface::get_singleton()->get_edited_scene_root();
+	return root && root->get_scene_file_path() == p_scene_path;
 }
 
 JustAMCPSceneTools::JustAMCPSceneTools() {
@@ -814,16 +823,24 @@ Dictionary JustAMCPSceneTools::add_node(const Dictionary &p_args) {
 		return ret;
 	}
 
-	Array result = _load_scene(scene_path);
-	Dictionary err = result[1];
-	if (!err.is_empty()) {
-		return err;
+	bool is_active = _is_active_scene(scene_path);
+	Node *root = nullptr;
+	if (is_active) {
+		root = EditorInterface::get_singleton()->get_edited_scene_root();
+	} else {
+		Array result = _load_scene(scene_path);
+		Dictionary load_err = result[1];
+		if (!load_err.is_empty()) {
+			return load_err;
+		}
+		root = Object::cast_to<Node>(result[0]);
 	}
 
-	Node *root = Object::cast_to<Node>(result[0]);
 	Node *parent = _find_node(root, parent_node_path);
 	if (!parent) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Parent node not found: " + parent_node_path;
@@ -836,7 +853,9 @@ Dictionary JustAMCPSceneTools::add_node(const Dictionary &p_args) {
 		if (_new_node_obj) {
 			memdelete(_new_node_obj);
 		}
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Failed to instantiate nodeType: " + node_type;
@@ -845,12 +864,22 @@ Dictionary JustAMCPSceneTools::add_node(const Dictionary &p_args) {
 
 	new_node->set_name(node_name);
 	_set_node_properties(new_node, properties);
-	parent->add_child(new_node);
-	_set_owner_recursive(new_node, root);
 
-	err = _save_scene(root, scene_path);
-	if (!err.is_empty()) {
-		return err;
+	if (is_active) {
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("AI Local: Add Node"), UndoRedo::MERGE_DISABLE, parent);
+		ur->add_do_method(parent, "add_child", new_node, true);
+		ur->add_do_method(new_node, "set_owner", root);
+		ur->add_do_reference(new_node);
+		ur->add_undo_method(parent, "remove_child", new_node);
+		ur->commit_action(true);
+	} else {
+		parent->add_child(new_node);
+		_set_owner_recursive(new_node, root);
+		Dictionary save_err = _save_scene(root, scene_path);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	}
 
 	Dictionary ret;
@@ -881,16 +910,24 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 		return ret;
 	}
 
-	Array result = _load_scene(target_scene_path);
-	Dictionary err = result[1];
-	if (!err.is_empty()) {
-		return err;
+	bool is_active = _is_active_scene(target_scene_path);
+	Node *root = nullptr;
+	if (is_active) {
+		root = EditorInterface::get_singleton()->get_edited_scene_root();
+	} else {
+		Array result = _load_scene(target_scene_path);
+		Dictionary err = result[1];
+		if (!err.is_empty()) {
+			return err;
+		}
+		root = Object::cast_to<Node>(result[0]);
 	}
 
-	Node *root = Object::cast_to<Node>(result[0]);
 	Node *parent = _find_node(root, parent_node_path);
 	if (!parent) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Parent node not found: " + parent_node_path;
@@ -899,7 +936,9 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 
 	Node *new_node = packed->instantiate();
 	if (!new_node) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Failed to instantiate packed scene.";
@@ -916,12 +955,21 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 	Dictionary properties = _parse_properties_arg(p_args.get("properties", Dictionary()));
 	_set_node_properties(new_node, properties);
 
-	parent->add_child(new_node);
-	_set_owner_recursive(new_node, root);
-
-	err = _save_scene(root, target_scene_path);
-	if (!err.is_empty()) {
-		return err;
+	if (is_active) {
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("AI Local: Instance Scene"), UndoRedo::MERGE_DISABLE, parent);
+		ur->add_do_method(parent, "add_child", new_node, true);
+		ur->add_do_method(new_node, "set_owner", root);
+		ur->add_do_reference(new_node);
+		ur->add_undo_method(parent, "remove_child", new_node);
+		ur->commit_action(true);
+	} else {
+		parent->add_child(new_node);
+		_set_owner_recursive(new_node, root);
+		Dictionary save_err = _save_scene(root, target_scene_path);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	}
 
 	Dictionary ret;
@@ -942,16 +990,24 @@ Dictionary JustAMCPSceneTools::delete_node(const Dictionary &p_args) {
 		return ret;
 	}
 
-	Array result = _load_scene(scene_path);
-	Dictionary err = result[1];
-	if (!err.is_empty()) {
-		return err;
+	bool is_active = _is_active_scene(scene_path);
+	Node *root = nullptr;
+	if (is_active) {
+		root = EditorInterface::get_singleton()->get_edited_scene_root();
+	} else {
+		Array result = _load_scene(scene_path);
+		Dictionary err = result[1];
+		if (!err.is_empty()) {
+			return err;
+		}
+		root = Object::cast_to<Node>(result[0]);
 	}
 
-	Node *root = Object::cast_to<Node>(result[0]);
 	Node *node = _find_node(root, node_path);
 	if (!node) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Node not found: " + node_path;
@@ -960,19 +1016,30 @@ Dictionary JustAMCPSceneTools::delete_node(const Dictionary &p_args) {
 
 	Node *parent = node->get_parent();
 	if (!parent) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Cannot delete root node";
 		return ret;
 	}
 
-	parent->remove_child(node);
-	memdelete(node);
-
-	err = _save_scene(root, scene_path);
-	if (!err.is_empty()) {
-		return err;
+	if (is_active) {
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("AI Local: Delete Node"), UndoRedo::MERGE_DISABLE, node);
+		ur->add_do_method(parent, "remove_child", node);
+		ur->add_undo_method(parent, "add_child", node, true);
+		ur->add_undo_method(node, "set_owner", root);
+		ur->add_undo_reference(node);
+		ur->commit_action(true);
+	} else {
+		parent->remove_child(node);
+		memdelete(node);
+		Dictionary save_err = _save_scene(root, scene_path);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	}
 
 	Dictionary ret;
@@ -995,16 +1062,24 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 		return ret;
 	}
 
-	Array result = _load_scene(scene_path);
-	Dictionary err = result[1];
-	if (!err.is_empty()) {
-		return err;
+	bool is_active = _is_active_scene(scene_path);
+	Node *root = nullptr;
+	if (is_active) {
+		root = EditorInterface::get_singleton()->get_edited_scene_root();
+	} else {
+		Array result = _load_scene(scene_path);
+		Dictionary err = result[1];
+		if (!err.is_empty()) {
+			return err;
+		}
+		root = Object::cast_to<Node>(result[0]);
 	}
 
-	Node *root = Object::cast_to<Node>(result[0]);
 	Node *source = _find_node(root, node_path);
 	if (!source) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Node not found: " + node_path;
@@ -1016,7 +1091,9 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 		target_parent = _find_node(root, parent_path);
 	}
 	if (!target_parent) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Parent not found: " + parent_path;
@@ -1025,7 +1102,9 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 
 	Node *duplicated_node = source->duplicate();
 	if (!duplicated_node) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Failed to duplicate node: " + node_path;
@@ -1033,12 +1112,22 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 	}
 
 	duplicated_node->set_name(new_name);
-	target_parent->add_child(duplicated_node);
-	_set_owner_recursive(duplicated_node, root);
 
-	err = _save_scene(root, scene_path);
-	if (!err.is_empty()) {
-		return err;
+	if (is_active) {
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("AI Local: Duplicate Node"), UndoRedo::MERGE_DISABLE, duplicated_node);
+		ur->add_do_method(target_parent, "add_child", duplicated_node, true);
+		ur->add_do_method(duplicated_node, "set_owner", root);
+		ur->add_do_reference(duplicated_node);
+		ur->add_undo_method(target_parent, "remove_child", duplicated_node);
+		ur->commit_action(true);
+	} else {
+		target_parent->add_child(duplicated_node);
+		_set_owner_recursive(duplicated_node, root);
+		Dictionary save_err = _save_scene(root, scene_path);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	}
 
 	Dictionary ret;
@@ -1122,27 +1211,48 @@ Dictionary JustAMCPSceneTools::set_node_properties(const Dictionary &p_args) {
 	String node_path = p_args.get("nodePath", ".");
 	Dictionary properties = _parse_properties_arg(p_args.get("properties", Dictionary()));
 
-	Array result = _load_scene(scene_path);
-	Dictionary err = result[1];
-	if (!err.is_empty()) {
-		return err;
+	bool is_active = _is_active_scene(scene_path);
+	Node *root = nullptr;
+	if (is_active) {
+		root = EditorInterface::get_singleton()->get_edited_scene_root();
+	} else {
+		Array result = _load_scene(scene_path);
+		Dictionary err = result[1];
+		if (!err.is_empty()) {
+			return err;
+		}
+		root = Object::cast_to<Node>(result[0]);
 	}
 
-	Node *root = Object::cast_to<Node>(result[0]);
 	Node *node = _find_node(root, node_path);
 	if (!node) {
-		memdelete(root);
+		if (!is_active) {
+			memdelete(root);
+		}
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Node not found: " + node_path;
 		return ret;
 	}
 
-	_set_node_properties(node, properties);
-
-	err = _save_scene(root, scene_path);
-	if (!err.is_empty()) {
-		return err;
+	if (is_active) {
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("AI Local: Set Properties"), UndoRedo::MERGE_DISABLE, node);
+		Array keys = properties.keys();
+		for (int i = 0; i < keys.size(); i++) {
+			String prop_name = keys[i];
+			Variant new_val = _parse_value(properties[prop_name]);
+			Variant old_val = node->get(prop_name);
+			ur->add_do_property(node, prop_name, new_val);
+			ur->add_undo_property(node, prop_name, old_val);
+		}
+		ur->commit_action(true);
+	} else {
+		_set_node_properties(node, properties);
+		Dictionary save_err = _save_scene(root, scene_path);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	}
 
 	Dictionary ret;

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -460,6 +460,8 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 			if (EditorSettings::get_singleton()) {
 				EDITOR_DEF_BASIC(cat_path, is_core);
 				EDITOR_DEF_BASIC(tool_path, true);
+				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, cat_path));
+				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, tool_path));
 			}
 #endif
 			return;
@@ -2716,6 +2718,69 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 	}
 	if (p_tool_name.begins_with("project/")) {
 		return project_tools->execute_tool(internal_name, p_args);
+	}
+
+	if (internal_name.begins_with("editor_")) {
+		if (internal_name == "editor_play_scene") {
+			return editor_tools->editor_play_scene(p_args);
+		}
+		if (internal_name == "editor_play_main") {
+			return editor_tools->editor_play_main(p_args);
+		}
+		if (internal_name == "editor_stop_play") {
+			return editor_tools->editor_stop_play(p_args);
+		}
+		if (internal_name == "editor_is_playing") {
+			return editor_tools->editor_is_playing(p_args);
+		}
+		if (internal_name == "editor_select_node") {
+			return editor_tools->editor_select_node(p_args);
+		}
+		if (internal_name == "editor_get_selected") {
+			return editor_tools->editor_get_selected(p_args);
+		}
+		if (internal_name == "editor_undo") {
+			return editor_tools->editor_undo(p_args);
+		}
+		if (internal_name == "editor_redo") {
+			return editor_tools->editor_redo(p_args);
+		}
+		if (internal_name == "editor_take_screenshot") {
+			return editor_tools->editor_take_screenshot(p_args);
+		}
+		if (internal_name == "editor_set_main_screen") {
+			return editor_tools->editor_set_main_screen(p_args);
+		}
+		if (internal_name == "editor_open_scene") {
+			return editor_tools->editor_open_scene(p_args);
+		}
+		if (internal_name == "editor_get_settings") {
+			return editor_tools->editor_get_settings(p_args);
+		}
+		if (internal_name == "editor_set_settings") {
+			return editor_tools->editor_set_settings(p_args);
+		}
+		if (internal_name == "editor_clear_output") {
+			return editor_tools->editor_clear_output(p_args);
+		}
+		if (internal_name == "editor_screenshot_game") {
+			return editor_tools->editor_screenshot_game(p_args);
+		}
+		if (internal_name == "editor_get_output_log") {
+			return editor_tools->editor_get_output_log(p_args);
+		}
+		if (internal_name == "editor_get_errors") {
+			return editor_tools->editor_get_errors(p_args);
+		}
+		if (internal_name == "editor_reload_project") {
+			return editor_tools->editor_reload_project(p_args);
+		}
+		if (internal_name == "editor_save_all_scenes") {
+			return editor_tools->editor_save_all_scenes(p_args);
+		}
+		if (internal_name == "editor_get_signals") {
+			return editor_tools->editor_get_signals(p_args);
+		}
 	}
 
 	result["ok"] = false;


### PR DESCRIPTION
This change improves JustAMCP editor integration: EditorSettings entries get explicit property hints (with a null guard around \EDITOR_DEF_BASIC\), scene MCP tools use the active edited scene when applicable and route structural edits through \EditorUndoRedoManager\, and the tool executor registers BOOL hints for per-tool toggles plus dispatches \editor_*\ tools to editor tools. ProjectSettings class reference text is expanded for \Blazium/justamcp/disable_game_mcp\ and \Blazium/justamcp/game_control_enabled\.

Multiuser-editor-specific MCP tools and \MODULE_MULTIUSER_EDITOR\ wiring are intentionally omitted so this PR stays independent of the multiuser editor module.