### PR TITLE
Fix JustaMCP input events schema and scene tool parsing

### DIFF
--- a/modules/justamcp/tools/justamcp_project_tools.cpp
+++ b/modules/justamcp/tools/justamcp_project_tools.cpp
@@ -35,6 +35,7 @@
 #include "core/input/input_map.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/json.h"
 #include "modules/regex/regex.h"
 
 void JustAMCPProjectTools::_bind_methods() {}
@@ -502,6 +503,94 @@ Dictionary JustAMCPProjectTools::get_input_actions(const Dictionary &p_args) {
 	return ret;
 }
 
+static Ref<InputEvent> _input_event_from_dictionary(const Dictionary &p_dict) {
+	String type = p_dict.get("type", "");
+	if (type.is_empty()) {
+		String device = p_dict.get("device", "");
+		if (device == "mouse" || p_dict.has("button_index")) {
+			type = "InputEventMouseButton";
+		} else if (p_dict.has("keycode") || p_dict.has("physical_keycode")) {
+			type = "InputEventKey";
+		}
+	}
+	if (type.contains("MouseButton") || type == "mouse_button") {
+		Ref<InputEventMouseButton> ev;
+		ev.instantiate();
+		if (p_dict.has("button_index")) {
+			ev->set_button_index((MouseButton)(int)p_dict["button_index"]);
+		}
+		if (p_dict.has("pressed")) {
+			ev->set_pressed(p_dict["pressed"]);
+		}
+		return ev;
+	}
+	if (type.contains("MouseMotion") || type == "mouse_motion") {
+		Ref<InputEventMouseMotion> ev;
+		ev.instantiate();
+		return ev;
+	}
+	if (type.contains("Key") || type == "key") {
+		Ref<InputEventKey> ev;
+		ev.instantiate();
+		if (p_dict.has("keycode")) {
+			ev->set_keycode((Key)(int)p_dict["keycode"]);
+		}
+		if (p_dict.has("physical_keycode")) {
+			ev->set_physical_keycode((Key)(int)p_dict["physical_keycode"]);
+		}
+		if (p_dict.has("pressed")) {
+			ev->set_pressed(p_dict["pressed"]);
+		}
+		return ev;
+	}
+	return Ref<InputEvent>();
+}
+
+static Array _parse_input_events_variant(const Variant &p_events) {
+	Array out;
+	Array source;
+	if (p_events.get_type() == Variant::STRING) {
+		String json_str = p_events;
+		Variant parsed = JSON::parse_string(json_str);
+		if (parsed.get_type() == Variant::ARRAY) {
+			source = parsed;
+		} else if (parsed.get_type() == Variant::DICTIONARY) {
+			source.push_back(parsed);
+		}
+	} else if (p_events.get_type() == Variant::ARRAY) {
+		source = p_events;
+	} else {
+		return out;
+	}
+	for (int i = 0; i < source.size(); i++) {
+		Variant item = source[i];
+		if (item.get_type() == Variant::OBJECT) {
+			Ref<InputEvent> ev = item;
+			if (ev.is_valid()) {
+				out.push_back(ev);
+			}
+			continue;
+		}
+		if (item.get_type() == Variant::DICTIONARY) {
+			Ref<InputEvent> ev = _input_event_from_dictionary(item);
+			if (ev.is_valid()) {
+				out.push_back(ev);
+			}
+			continue;
+		}
+		if (item.get_type() == Variant::STRING) {
+			Variant parsed = JSON::parse_string(item);
+			if (parsed.get_type() == Variant::DICTIONARY) {
+				Ref<InputEvent> ev = _input_event_from_dictionary(parsed);
+				if (ev.is_valid()) {
+					out.push_back(ev);
+				}
+			}
+		}
+	}
+	return out;
+}
+
 Dictionary JustAMCPProjectTools::set_input_action(const Dictionary &p_args) {
 	String action = p_args.get("action", "");
 	if (action.is_empty()) {
@@ -522,15 +611,27 @@ Dictionary JustAMCPProjectTools::set_input_action(const Dictionary &p_args) {
 		InputMap::get_singleton()->add_action(action, deadzone);
 	} else {
 		InputMap::get_singleton()->action_set_deadzone(action, deadzone);
-		if (p_args.get("replace_events", false)) {
-			InputMap::get_singleton()->action_erase_events(action);
+	}
+	if (p_args.get("replace_events", false)) {
+		InputMap::get_singleton()->action_erase_events(action);
+	}
+
+	Array parsed_events = _parse_input_events_variant(p_args.get("events", Array()));
+	for (int i = 0; i < parsed_events.size(); i++) {
+		Ref<InputEvent> ev = parsed_events[i];
+		if (ev.is_valid()) {
+			InputMap::get_singleton()->action_add_event(action, ev);
 		}
 	}
 
 	// Persist the caller-provided event descriptors so editor/project settings retain the intended binding data.
 	Dictionary setting;
 	setting["deadzone"] = deadzone;
-	setting["events"] = p_args.get("events", Array());
+	if (parsed_events.size() > 0) {
+		setting["events"] = parsed_events;
+	} else {
+		setting["events"] = p_args.get("events", Array());
+	}
 	ProjectSettings::get_singleton()->set_setting("input/" + action, setting);
 	ProjectSettings::get_singleton()->save();
 

--- a/modules/justamcp/tools/justamcp_scene_tools.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools.cpp
@@ -147,25 +147,35 @@ Array JustAMCPSceneTools::_load_scene(const String &p_scene_path) {
 	return ret;
 }
 
-Dictionary JustAMCPSceneTools::_save_scene(Node *p_scene_root, const String &p_scene_path) {
+Dictionary JustAMCPSceneTools::_pack_and_save_scene(Node *p_scene_root, const String &p_scene_path, bool p_free_root) {
 	Dictionary ret;
 	Ref<PackedScene> packed;
 	packed.instantiate();
 	if (packed->pack(p_scene_root) != OK) {
-		memdelete(p_scene_root);
+		if (p_free_root) {
+			memdelete(p_scene_root);
+		}
 		ret["ok"] = false;
 		ret["error"] = "Failed to pack scene";
 		return ret;
 	}
 	if (ResourceSaver::save(packed, p_scene_path) != OK) {
-		memdelete(p_scene_root);
+		if (p_free_root) {
+			memdelete(p_scene_root);
+		}
 		ret["ok"] = false;
 		ret["error"] = "Failed to save scene";
 		return ret;
 	}
-	memdelete(p_scene_root);
+	if (p_free_root) {
+		memdelete(p_scene_root);
+	}
 	_refresh_and_reload(p_scene_path);
-	return Dictionary(); // empty dict meaning okay
+	return Dictionary();
+}
+
+Dictionary JustAMCPSceneTools::_save_scene(Node *p_scene_root, const String &p_scene_path) {
+	return _pack_and_save_scene(p_scene_root, p_scene_path, true);
 }
 
 Node *JustAMCPSceneTools::_find_node(Node *p_root, const String &p_path) {
@@ -873,6 +883,10 @@ Dictionary JustAMCPSceneTools::add_node(const Dictionary &p_args) {
 		ur->add_do_reference(new_node);
 		ur->add_undo_method(parent, "remove_child", new_node);
 		ur->commit_action(true);
+		Dictionary save_err = _pack_and_save_scene(root, scene_path, false);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	} else {
 		parent->add_child(new_node);
 		_set_owner_recursive(new_node, root);

--- a/modules/justamcp/tools/justamcp_scene_tools.h
+++ b/modules/justamcp/tools/justamcp_scene_tools.h
@@ -95,6 +95,7 @@ private:
 
 	Array _load_scene(const String &p_scene_path);
 	Dictionary _save_scene(Node *p_scene_root, const String &p_scene_path);
+	Dictionary _pack_and_save_scene(Node *p_scene_root, const String &p_scene_path, bool p_free_root);
 	Node *_find_node(Node *p_root, const String &p_path);
 
 	Variant _parse_value(const Variant &p_value);

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -939,8 +939,8 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 			Vector<String>{ "name", "string" }, Vector<String>{ "name" });
 	add_schema("project_get_input_actions", "Retrieves the engine InputMap event bindings natively.",
 			Vector<String>{}, Vector<String>{});
-	add_schema("project_set_input_action", "Binds a custom InputMap action to an event mapping.",
-			Vector<String>{ "action", "string", "events", "string" }, Vector<String>{ "action", "events" });
+	add_schema("project_set_input_action", "Binds a custom InputMap action to an event mapping. events: array of InputEvent dictionaries (type, button_index, keycode, ...) or JSON string fallback.",
+			Vector<String>{ "action", "string", "events", "array", "deadzone", "number", "replace_events", "boolean" }, Vector<String>{ "action", "events" });
 	add_schema("project_remove_input_action", "Erases an InputMap action definition from project map.",
 			Vector<String>{ "action", "string" }, Vector<String>{ "action" });
 	add_schema("project_run", "Runs the project or a scene with optional save-all before launch.",


### PR DESCRIPTION
## Summary
- Accept `events` as array (or JSON string) in `project_set_input_action` and register `InputEvent` refs on InputMap
- Update MCP tool schema from string to array
- Scene tool parsing improvements for pipeline agents

## Test plan
- [x] Build editor with JustaMCP enabled
- [x] Call `blazium_project_set_input_action` with mouse button array payload
- [x] Verify input bindings persist in project.godot