### PR TITLE
Fix JustaMCP scaffold tools for pipeline stage2-scaffold

### DIFF
--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -1042,7 +1042,24 @@ void JustAMCPServer::send_tool_result(const Variant &p_request_id, bool p_succes
 		Dictionary result;
 		if (p_result.get_type() == Variant::DICTIONARY && Dictionary(p_result).has("content")) {
 			// The tool returned strict MCP "content" natively!
-			result["content"] = Dictionary(p_result)["content"];
+			Variant content_val = Dictionary(p_result)["content"];
+			if (content_val.get_type() == Variant::ARRAY) {
+				result["content"] = content_val;
+			} else if (content_val.get_type() == Variant::STRING) {
+				Array content;
+				Dictionary content_item;
+				content_item["type"] = "text";
+				content_item["text"] = content_val;
+				content.push_back(content_item);
+				result["content"] = content;
+			} else {
+				Array content;
+				Dictionary content_item;
+				content_item["type"] = "text";
+				content_item["text"] = JSON::stringify(content_val);
+				content.push_back(content_item);
+				result["content"] = content;
+			}
 			result["isError"] = Dictionary(p_result).get("isError", false);
 		} else {
 			// The tool returned a custom dictionary (e.g. {"result": ...})

--- a/modules/justamcp/tools/justamcp_project_tools.cpp
+++ b/modules/justamcp/tools/justamcp_project_tools.cpp
@@ -68,6 +68,15 @@ Dictionary JustAMCPProjectTools::execute_tool(const String &p_tool_name, const D
 	if (p_tool_name == "project_remove_input_action") {
 		return remove_input_action(p_args);
 	}
+	if (p_tool_name == "get_project_info") {
+		return get_project_info(p_args);
+	}
+	if (p_tool_name == "set_project_setting") {
+		return set_project_setting(p_args);
+	}
+	if (p_tool_name == "get_filesystem_tree") {
+		return get_filesystem_tree(p_args);
+	}
 
 	Dictionary ret;
 	ret["ok"] = false;
@@ -669,6 +678,130 @@ Dictionary JustAMCPProjectTools::remove_input_action(const Dictionary &p_args) {
 	ret["action"] = action;
 	ret["removed"] = existed;
 	return ret;
+}
+
+Dictionary JustAMCPProjectTools::get_project_info(const Dictionary &p_args) {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	ERR_FAIL_COND_V(!ps, Dictionary());
+
+	Dictionary autoload_args;
+	autoload_args["operation"] = "list";
+	Dictionary autoload_res = manage_autoloads(autoload_args);
+
+	Dictionary renderer;
+	renderer["rendering_method"] = ps->get_setting("rendering/renderer/rendering_method", "forward_plus");
+	renderer["anti_aliasing"] = ps->get_setting("rendering/anti_aliasing/quality/msaa_2d", 0);
+
+	Dictionary viewport;
+	viewport["viewport_width"] = ps->get_setting("display/window/size/viewport_width", 1152);
+	viewport["viewport_height"] = ps->get_setting("display/window/size/viewport_height", 648);
+	viewport["window_width_override"] = ps->get_setting("display/window/size/window_width_override", 0);
+	viewport["window_height_override"] = ps->get_setting("display/window/size/window_height_override", 0);
+	viewport["stretch_mode"] = ps->get_setting("display/window/stretch/mode", "canvas_items");
+
+	Dictionary result;
+	result["ok"] = true;
+	result["project_name"] = ps->get_setting("application/config/name", "Untitled");
+	result["main_scene"] = ps->get_setting("application/run/main_scene", "");
+	result["config_version"] = ps->get_setting("config_version", 5);
+	result["renderer"] = renderer;
+	result["viewport"] = viewport;
+	result["autoloads"] = autoload_res.get("autoloads", Array());
+	return result;
+}
+
+Dictionary JustAMCPProjectTools::set_project_setting(const Dictionary &p_args) {
+	String key = p_args.get("key", "");
+	if (key.is_empty()) {
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "key is required.";
+		return ret;
+	}
+
+	Variant value = p_args.get("value", Variant());
+	if (value.get_type() == Variant::STRING) {
+		String s = value;
+		Variant parsed = JSON::parse_string(s);
+		if (parsed.get_type() != Variant::NIL) {
+			value = parsed;
+		}
+	}
+
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	ERR_FAIL_COND_V(!ps, Dictionary());
+	ps->set_setting(key, value);
+	Error err = ps->save();
+
+	Dictionary ret;
+	ret["ok"] = err == OK;
+	ret["key"] = key;
+	ret["value"] = _serialize_value(value);
+	if (err != OK) {
+		ret["error"] = "Failed to save project settings.";
+	}
+	return ret;
+}
+
+Dictionary JustAMCPProjectTools::_build_filesystem_tree(const String &p_path, const String &p_filter, int p_max_depth, int p_depth) {
+	Dictionary node;
+	node["path"] = p_path;
+	node["name"] = p_path == "res://" ? "res://" : p_path.get_file();
+
+	Ref<DirAccess> dir = DirAccess::open(p_path);
+	if (dir.is_null()) {
+		node["type"] = "missing";
+		return node;
+	}
+
+	if (p_max_depth >= 0 && p_depth >= p_max_depth) {
+		node["type"] = "dir";
+		return node;
+	}
+
+	node["type"] = "dir";
+	Array children;
+	dir->list_dir_begin();
+	String name = dir->get_next();
+	while (!name.is_empty()) {
+		if (name.begins_with(".")) {
+			name = dir->get_next();
+			continue;
+		}
+		String full_path = p_path.path_join(name);
+		if (dir->current_is_dir()) {
+			children.push_back(_build_filesystem_tree(full_path, p_filter, p_max_depth, p_depth + 1));
+		} else {
+			if (!p_filter.is_empty() && !name.ends_with(p_filter) && !name.contains(p_filter)) {
+				name = dir->get_next();
+				continue;
+			}
+			Dictionary file_node;
+			file_node["path"] = full_path;
+			file_node["name"] = name;
+			file_node["type"] = "file";
+			children.push_back(file_node);
+		}
+		name = dir->get_next();
+	}
+	dir->list_dir_end();
+	node["children"] = children;
+	return node;
+}
+
+Dictionary JustAMCPProjectTools::get_filesystem_tree(const Dictionary &p_args) {
+	String path = p_args.get("path", "res://");
+	String filter = p_args.get("filter", "");
+	int max_depth = p_args.get("max_depth", -1);
+
+	if (!path.begins_with("res://")) {
+		path = "res://" + path;
+	}
+
+	Dictionary result;
+	result["ok"] = true;
+	result["root"] = _build_filesystem_tree(path, filter, max_depth, 0);
+	return result;
 }
 
 String JustAMCPProjectTools::_type_to_string(int p_type_id) {

--- a/modules/justamcp/tools/justamcp_project_tools.h
+++ b/modules/justamcp/tools/justamcp_project_tools.h
@@ -55,6 +55,9 @@ public:
 	Dictionary get_input_actions(const Dictionary &p_args);
 	Dictionary set_input_action(const Dictionary &p_args);
 	Dictionary remove_input_action(const Dictionary &p_args);
+	Dictionary get_project_info(const Dictionary &p_args);
+	Dictionary set_project_setting(const Dictionary &p_args);
+	Dictionary get_filesystem_tree(const Dictionary &p_args);
 
 private:
 	void _collect_scripts(const String &p_path, Array &r_results, bool p_include_addons);
@@ -63,6 +66,7 @@ private:
 	Dictionary _parse_scene(const String &p_path);
 	String _type_to_string(int p_type_id);
 	Variant _serialize_value(const Variant &p_value);
+	Dictionary _build_filesystem_tree(const String &p_path, const String &p_filter, int p_max_depth, int p_depth);
 
 public:
 	JustAMCPProjectTools();

--- a/modules/justamcp/tools/justamcp_scene_tools.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools.cpp
@@ -38,6 +38,7 @@
 #include "core/io/json.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/object/script_language.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
@@ -384,6 +385,15 @@ void JustAMCPSceneTools::_set_node_properties(Node *p_node, const Dictionary &p_
 	for (int i = 0; i < keys.size(); i++) {
 		String prop_name = keys[i];
 		Variant val = _parse_value(p_properties[prop_name]);
+		if (prop_name == "script" && val.get_type() == Variant::STRING) {
+			String script_path = val;
+			if (script_path.begins_with("res://")) {
+				Ref<Script> script_res = ResourceLoader::load(script_path);
+				if (script_res.is_valid()) {
+					val = script_res;
+				}
+			}
+		}
 		p_node->set(prop_name, val);
 	}
 }
@@ -514,7 +524,24 @@ Dictionary JustAMCPSceneTools::create_scene(const Dictionary &p_args) {
 		ret["error"] = "Failed to instantiate root node: " + root_node_type;
 		return ret;
 	}
-	root->set_name(root_node_type);
+	String root_node_name = p_args.get("rootNodeName", p_args.get("root_node_name", ""));
+	if (root_node_name.is_empty()) {
+		String file_stem = scene_path.get_file().get_basename();
+		if (!file_stem.is_empty()) {
+			PackedStringArray parts = file_stem.split("_");
+			for (int i = 0; i < parts.size(); i++) {
+				String part = parts[i];
+				if (part.is_empty()) {
+					continue;
+				}
+				root_node_name += part.substr(0, 1).to_upper() + part.substr(1);
+			}
+		}
+	}
+	if (root_node_name.is_empty()) {
+		root_node_name = root_node_type;
+	}
+	root->set_name(root_node_name);
 
 	if (!script_path.is_empty()) {
 		String full_script_path = _to_scene_res_path(project_path, script_path);
@@ -591,7 +618,7 @@ Dictionary JustAMCPSceneTools::get_scene_file_content(const Dictionary &p_args) 
 	Dictionary ret;
 	ret["ok"] = true;
 	ret["path"] = scene_path;
-	ret["content"] = content;
+	ret["sceneContent"] = content;
 	ret["size"] = content.length();
 	return ret;
 }
@@ -905,9 +932,10 @@ Dictionary JustAMCPSceneTools::add_node(const Dictionary &p_args) {
 
 Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 	String project_path = p_args.get("projectPath", "");
-	String target_scene_path = _to_scene_res_path(project_path, p_args.get("scenePath", ""));
-	String instance_scene_path = _to_scene_res_path(project_path, p_args.get("instanceScenePath", ""));
-	String parent_node_path = p_args.get("parentNodePath", ".");
+	String target_scene_path = _to_scene_res_path(project_path, p_args.get("scenePath", p_args.get("scene_path", "")));
+	String instance_scene_path = _to_scene_res_path(project_path, p_args.get("instanceScenePath", p_args.get("instance_scene_path", "")));
+	String parent_node_path = p_args.get("parentNodePath", p_args.get("parent_path", p_args.get("parent_node_path", ".")));
+	String requested_node_name = p_args.get("nodeName", p_args.get("node_name", ""));
 
 	if (instance_scene_path == "res://") {
 		Dictionary ret;
@@ -948,7 +976,21 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 		return ret;
 	}
 
-	Node *new_node = packed->instantiate();
+	if (!requested_node_name.is_empty() && parent->has_node(requested_node_name)) {
+		Node *existing = parent->get_node(requested_node_name);
+		if (!is_active) {
+			memdelete(root);
+		}
+		Dictionary ret;
+		ret["ok"] = true;
+		ret["nodeName"] = existing->get_name();
+		ret["instanceScenePath"] = instance_scene_path;
+		ret["parentNodePath"] = parent_node_path;
+		ret["alreadyExists"] = true;
+		return ret;
+	}
+
+	Node *new_node = packed->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
 	if (!new_node) {
 		if (!is_active) {
 			memdelete(root);
@@ -959,11 +1001,10 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 		return ret;
 	}
 
-	if (p_args.has("nodeName")) {
-		String node_name = p_args.get("nodeName", "");
-		if (!node_name.is_empty()) {
-			new_node->set_name(node_name);
-		}
+	new_node->set_scene_file_path(instance_scene_path);
+
+	if (!requested_node_name.is_empty()) {
+		new_node->set_name(requested_node_name);
 	}
 
 	Dictionary properties = _parse_properties_arg(p_args.get("properties", Dictionary()));
@@ -977,8 +1018,12 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 		ur->add_do_reference(new_node);
 		ur->add_undo_method(parent, "remove_child", new_node);
 		ur->commit_action(true);
+		Dictionary save_err = _pack_and_save_scene(root, target_scene_path, false);
+		if (!save_err.is_empty()) {
+			return save_err;
+		}
 	} else {
-		parent->add_child(new_node);
+		parent->add_child(new_node, true);
 		_set_owner_recursive(new_node, root);
 		Dictionary save_err = _save_scene(root, target_scene_path);
 		if (!save_err.is_empty()) {
@@ -989,6 +1034,8 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 	Dictionary ret;
 	ret["ok"] = true;
 	ret["nodeName"] = new_node->get_name();
+	ret["instanceScenePath"] = instance_scene_path;
+	ret["parentNodePath"] = parent_node_path;
 	return ret;
 }
 
@@ -1222,7 +1269,7 @@ Dictionary JustAMCPSceneTools::reparent_node(const Dictionary &p_args) {
 Dictionary JustAMCPSceneTools::set_node_properties(const Dictionary &p_args) {
 	String project_path = p_args.get("projectPath", "");
 	String scene_path = _to_scene_res_path(project_path, p_args.get("scenePath", p_args.get("scene_path", "")));
-	String node_path = p_args.get("nodePath", ".");
+	String node_path = p_args.get("nodePath", p_args.get("node_path", "."));
 	Dictionary properties = _parse_properties_arg(p_args.get("properties", Dictionary()));
 
 	bool is_active = _is_active_scene(scene_path);

--- a/modules/justamcp/tools/justamcp_script_tools.cpp
+++ b/modules/justamcp/tools/justamcp_script_tools.cpp
@@ -41,8 +41,10 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
 #include "core/object/script_language.h"
 #include "modules/regex/regex.h"
+#include "scene/resources/packed_scene.h"
 
 static inline Dictionary _MCP_SUCCESS(const Variant &data) {
 	Dictionary r;
@@ -433,26 +435,18 @@ void JustAMCPScriptTools::_reload_script(const String &p_path) {
 }
 
 Dictionary JustAMCPScriptTools::_attach_script(const Dictionary &p_params) {
-	if (!p_params.has("node_path")) {
+	String node_path = p_params.get("node_path", p_params.get("nodePath", ""));
+	if (node_path.is_empty()) {
 		return MCP_INVALID_PARAMS("Missing param: node_path");
 	}
-	if (!p_params.has("script_path")) {
+	String script_path = p_params.get("script_path", p_params.get("scriptPath", ""));
+	if (script_path.is_empty()) {
 		return MCP_INVALID_PARAMS("Missing param: script_path");
 	}
-	String node_path = p_params["node_path"];
-	String script_path = p_params["script_path"];
 
-	Node *root = _get_edited_root();
-	if (!root) {
-		return MCP_ERROR(-32000, "No scene is currently open");
-	}
-
-	Node *node = _find_node_by_path(node_path);
-	if (!node) {
-		return MCP_NOT_FOUND("Node '" + node_path + "'");
-	}
-
-	if (!FileAccess::exists(script_path)) {
+	if (!script_path.begins_with("res://") && FileAccess::exists(script_path)) {
+		// Keep absolute paths as-is for existence check.
+	} else if (!ResourceLoader::exists(script_path)) {
 		return MCP_NOT_FOUND("Script '" + script_path + "'");
 	}
 
@@ -461,11 +455,71 @@ Dictionary JustAMCPScriptTools::_attach_script(const Dictionary &p_params) {
 		return MCP_INTERNAL("Failed to load script: " + script_path);
 	}
 
+	String scene_path = p_params.get("scenePath", p_params.get("scene_path", ""));
+
+	Node *root = _get_edited_root();
+	if (root && (scene_path.is_empty() || root->get_scene_file_path() == scene_path)) {
+		Node *node = _find_node_by_path(node_path);
+		if (!node) {
+			return MCP_NOT_FOUND("Node '" + node_path + "'");
+		}
+		node->set_script(loaded_script);
+		Dictionary res;
+		res["node_path"] = root->get_path_to(node);
+		res["script_path"] = script_path;
+		res["attached"] = true;
+		return MCP_SUCCESS(res);
+	}
+
+	if (scene_path.is_empty()) {
+		return MCP_ERROR(-32000, "No scene is currently open");
+	}
+
+	if (!scene_path.ends_with(".tscn")) {
+		scene_path += ".tscn";
+	}
+	if (!ResourceLoader::exists(scene_path)) {
+		return MCP_NOT_FOUND("Scene '" + scene_path + "'");
+	}
+
+	Ref<PackedScene> packed_scene = ResourceLoader::load(scene_path);
+	if (packed_scene.is_null()) {
+		return MCP_INTERNAL("Failed to load scene: " + scene_path);
+	}
+
+	Node *scene_root = packed_scene->instantiate();
+	if (!scene_root) {
+		return MCP_INTERNAL("Failed to instantiate scene: " + scene_path);
+	}
+
+	Node *node = scene_root;
+	if (node_path != "." && !node_path.is_empty()) {
+		if (scene_root->has_node(node_path)) {
+			node = scene_root->get_node(node_path);
+		} else {
+			memdelete(scene_root);
+			return MCP_NOT_FOUND("Node '" + node_path + "'");
+		}
+	}
+
 	node->set_script(loaded_script);
 
+	Ref<PackedScene> out_packed;
+	out_packed.instantiate();
+	if (out_packed->pack(scene_root) != OK) {
+		memdelete(scene_root);
+		return MCP_INTERNAL("Failed to pack scene after attach: " + scene_path);
+	}
+	if (ResourceSaver::save(out_packed, scene_path) != OK) {
+		memdelete(scene_root);
+		return MCP_INTERNAL("Failed to save scene after attach: " + scene_path);
+	}
+	memdelete(scene_root);
+
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = node_path;
 	res["script_path"] = script_path;
+	res["scene_path"] = scene_path;
 	res["attached"] = true;
 	return MCP_SUCCESS(res);
 }

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -1436,7 +1436,6 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		if (!contents.is_empty()) {
 			Dictionary first = contents[0];
 			result["text"] = first.get("text", "");
-			result["content"] = result["text"];
 			result["mime_type"] = first.get("mimeType", "text/markdown");
 		}
 		return result;


### PR DESCRIPTION
## Summary
- Implement missing project MCP tools: get_project_info, set_project_setting, get_filesystem_tree
- Harden instance_scene: GEN_EDIT_STATE_INSTANCE, set_scene_file_path, arg aliases, idempotent alreadyExists guard
- Fix attach_script when no editor scene is open (scenePath + save)
- Fix MCP tool result content shape for Cursor schema; get_scene_file_content returns sceneContent
- Add RegEx include to justamcp_script_tools.cpp (Linux build fix)