### PR TITLE
Fix instance_scene nodeName use-after-free on inactive save

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -61,8 +61,10 @@ jobs:
             cache-name: windows-template
             target: template_release
             tests: true
-            sconsflags: debug_symbols=no tests=yes
-            bin: ./bin/blazium.windows.template_release.tests.x86_64.console.exe
+            # Build a console binary directly. The GUI + .console.exe wrapper can hang
+            # indefinitely on CI when running --test (MSVC and MinGW).
+            sconsflags: debug_symbols=no tests=yes windows_subsystem=console
+            bin: ./bin/blazium.windows.template_release.tests.x86_64.exe
             compiler: msvc
             artifact: true
             upload: true
@@ -74,7 +76,7 @@ jobs:
             target: template_release
             tests: true
             # Build a console binary directly. The GUI + .console.exe wrapper can hang
-            # indefinitely on CI when running --test with the MinGW toolchain.
+            # indefinitely on CI when running --test (MSVC and MinGW).
             sconsflags: debug_symbols=no use_mingw=yes windows_subsystem=console
             bin: ./bin/blazium.windows.template_release.tests.x86_64.exe
             compiler: gcc

--- a/modules/justamcp/tools/justamcp_scene_tools.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools.cpp
@@ -1081,12 +1081,13 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 
 	if (!requested_node_name.is_empty() && parent->has_node(requested_node_name)) {
 		Node *existing = parent->get_node(requested_node_name);
+		const String result_node_name = existing->get_name();
 		if (!is_active) {
 			memdelete(root);
 		}
 		Dictionary ret;
 		ret["ok"] = true;
-		ret["nodeName"] = existing->get_name();
+		ret["nodeName"] = result_node_name;
 		ret["instanceScenePath"] = instance_scene_path;
 		ret["parentNodePath"] = parent_node_path;
 		ret["alreadyExists"] = true;
@@ -1113,6 +1114,8 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 	Dictionary properties = _parse_properties_arg(p_args.get("properties", Dictionary()));
 	_set_node_properties(new_node, properties);
 
+	const String result_node_name = new_node->get_name();
+
 	if (is_active) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("AI Local: Instance Scene"), UndoRedo::MERGE_DISABLE, parent);
@@ -1136,7 +1139,7 @@ Dictionary JustAMCPSceneTools::instance_scene(const Dictionary &p_args) {
 
 	Dictionary ret;
 	ret["ok"] = true;
-	ret["nodeName"] = new_node->get_name();
+	ret["nodeName"] = result_node_name;
 	ret["instanceScenePath"] = instance_scene_path;
 	ret["parentNodePath"] = parent_node_path;
 	return ret;


### PR DESCRIPTION
## Summary
- Capture `nodeName` before `_save_scene` frees the inactive loaded scene tree in `instance_scene`
- Same fix on the `alreadyExists` early-return path (was calling `get_name()` after `memdelete(root)`)

