### PR TITLE
JustAMCP: MCP pagination and buffered log replay

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -462,6 +462,12 @@
 		<member name="blazium/justamcp/game_control_enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows AI interacting via JustAMCP to natively trigger in-game commands and inputs over the pipeline, granting them orchestration control over gameplay mechanics.
 		</member>
+		<member name="blazium/justamcp/list_page_size" type="int" setter="" getter="" default="50">
+			Maximum items per page for MCP list operations and paginated log reads ([code]tools/list[/code], [code]resources/list[/code], [code]blazium://logs/...[/code], etc.).
+		</member>
+		<member name="blazium/justamcp/mcp_log_buffer_size" type="int" setter="" getter="" default="500">
+			Maximum buffered MCP [code]notifications/message[/code] entries retained for replay when clients missed SSE.
+		</member>
 		<member name="blazium/justamcp/oauth_enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], MCP clients must authenticate with OAuth credentials before calling JustAMCP tools.
 		</member>
@@ -546,6 +552,9 @@
 		<member name="blazium/justamcp/resources/Input Map" type="String" setter="" getter="">
 			Read-only MCP resource metadata for [code]Input Map[/code]. Description: Project input actions and their configured events.
 		</member>
+		<member name="blazium/justamcp/resources/MCP Log Notifications" type="String" setter="" getter="">
+			Read-only MCP resource metadata for [code]MCP Log Notifications[/code]. Description: Paginated buffered MCP notifications/message history. Use blazium://logs/mcp/start for the first page.
+		</member>
 		<member name="blazium/justamcp/resources/Materials" type="String" setter="" getter="">
 			Read-only MCP resource metadata for [code]Materials[/code]. Description: Material resources found under res://.
 		</member>
@@ -570,6 +579,9 @@
 		<member name="blazium/justamcp/resources/Project Settings" type="String" setter="" getter="">
 			Read-only MCP resource metadata for [code]Project Settings[/code]. Description: Common project settings subset.
 		</member>
+		<member name="blazium/justamcp/resources/Recent Engine Logs" type="String" setter="" getter="">
+			Read-only MCP resource metadata for [code]Recent Engine Logs[/code]. Description: Paginated recent engine log lines captured by JustAMCP. Use blazium://logs/recent/start for the first page.
+		</member>
 		<member name="blazium/justamcp/resources/Recent Logs" type="String" setter="" getter="">
 			Read-only MCP resource metadata for [code]Recent Logs[/code]. Description: Recent JustAMCP engine log lines.
 		</member>
@@ -584,6 +596,9 @@
 		</member>
 		<member name="blazium/justamcp/resources/System Logs" type="String" setter="" getter="">
 			Read-only MCP resource metadata for [code]System Logs[/code]. Description: Recent engine log lines captured by JustAMCP.
+		</member>
+		<member name="blazium/justamcp/resources/System Logs (Paginated)" type="String" setter="" getter="">
+			Read-only MCP resource metadata for [code]System Logs (Paginated)[/code]. Description: Paginated engine log lines as JSON. Use blazium://system/logs/start for the first page.
 		</member>
 		<member name="blazium/justamcp/resources/Test Results" type="String" setter="" getter="">
 			Read-only MCP resource metadata for [code]Test Results[/code]. Description: Latest Autowork test results when available.

--- a/modules/justamcp/doc_classes/JustAMCPPromptExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPPromptExecutor.xml
@@ -43,7 +43,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
 			<description>
-				Returns an MCP-compatible dictionary containing the schemas for all registered prompts. [param cursor] is accepted for protocol compatibility.
+				Returns a paginated MCP [code]prompts/list[/code] dictionary with [code]prompts[/code] and optional [code]nextCursor[/code]. Invalid [param cursor] values return an error dictionary with code [code]-32602[/code].
 			</description>
 		</method>
 	</methods>

--- a/modules/justamcp/doc_classes/JustAMCPResourceExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPResourceExecutor.xml
@@ -27,14 +27,14 @@
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
 			<description>
-				Returns the MCP resource templates registered with the executor. [param cursor] is accepted for protocol compatibility.
+				Returns a paginated MCP [code]resources/templates/list[/code] dictionary with [code]resourceTemplates[/code] and optional [code]nextCursor[/code].
 			</description>
 		</method>
 		<method name="list_resources">
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
 			<description>
-				Returns fixed MCP resources registered with the executor, including names, descriptions, URIs, and MIME types. [param cursor] is accepted for protocol compatibility.
+				Returns a paginated MCP [code]resources/list[/code] dictionary with [code]resources[/code] and optional [code]nextCursor[/code].
 			</description>
 		</method>
 		<method name="read_resource">

--- a/modules/justamcp/doc_classes/JustAMCPServer.xml
+++ b/modules/justamcp/doc_classes/JustAMCPServer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[JustAMCPServer] owns the editor-facing MCP transport and emits signals for JSON-RPC tool requests, server lifecycle changes, elicitation responses, and cancellation notices. Most projects use it through the JustAMCP editor plugin or [JustAMCPRuntime] rather than instantiating it manually.
+		Implements MCP [url=https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination]pagination[/url] for [code]tools/list[/code], [code]prompts/list[/code], [code]resources/list[/code], and [code]resources/templates/list[/code] using opaque cursors. Buffers recent [code]notifications/message[/code] payloads for replay when clients missed SSE; see [member ProjectSettings.blazium/justamcp/mcp_log_buffer_size] and [code]blazium://logs/mcp/{cursor}[/code].
 		[codeblock]
 		var server = JustAMCPServer.new()
 		server.tool_requested.connect(func(request_id, tool_name, args):

--- a/modules/justamcp/doc_classes/JustAMCPToolExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPToolExecutor.xml
@@ -31,6 +31,13 @@
 				Returns MCP JSON schema dictionaries for the available tools. Set [param register_only] to return registration metadata only, or [param ignore_settings] to bypass editor filtering.
 			</description>
 		</method>
+		<method name="list_tools" qualifiers="static">
+			<return type="Dictionary" />
+			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
+			<description>
+				Returns a paginated MCP [code]tools/list[/code] result dictionary with [code]tools[/code] and optional [code]nextCursor[/code]. [param cursor] is an opaque token from a previous page.
+			</description>
+		</method>
 		<method name="set_test_scene_root" qualifiers="static">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />

--- a/modules/justamcp/justamcp_pagination.cpp
+++ b/modules/justamcp/justamcp_pagination.cpp
@@ -1,0 +1,156 @@
+/**************************************************************************/
+/*  justamcp_pagination.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "justamcp_pagination.h"
+
+#include "core/config/project_settings.h"
+#include "core/crypto/crypto_core.h"
+#include "core/io/marshalls.h"
+
+static const uint8_t CURSOR_MAGIC_0 = 'J';
+static const uint8_t CURSOR_MAGIC_1 = 'M';
+static const uint8_t CURSOR_VERSION = 1;
+static const int CURSOR_PAYLOAD_SIZE = 7;
+
+int justamcp_pagination_page_size() {
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/list_page_size")) {
+		const int size = int(GLOBAL_GET("blazium/justamcp/list_page_size"));
+		return MAX(1, size);
+	}
+	return 50;
+}
+
+int justamcp_mcp_log_buffer_size() {
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/mcp_log_buffer_size")) {
+		const int size = int(GLOBAL_GET("blazium/justamcp/mcp_log_buffer_size"));
+		return MAX(1, size);
+	}
+	return 500;
+}
+
+String justamcp_pagination_cursor_from_uri_suffix(const String &p_suffix) {
+	const String trimmed = p_suffix.strip_edges();
+	if (trimmed.is_empty() || trimmed == "start") {
+		return String();
+	}
+	return trimmed;
+}
+
+bool justamcp_pagination_decode_cursor(const String &p_cursor, int &r_offset) {
+	r_offset = 0;
+	const String trimmed = p_cursor.strip_edges();
+	if (trimmed.is_empty() || trimmed == "start") {
+		return true;
+	}
+
+	PackedByteArray raw = trimmed.to_utf8_buffer();
+	if (raw.is_empty()) {
+		return false;
+	}
+
+	size_t out_len = 0;
+	const size_t max_len = (raw.size() * 3) / 4 + 4;
+	PackedByteArray decoded;
+	decoded.resize(max_len);
+	const Error err = CryptoCore::b64_decode(decoded.ptrw(), max_len, &out_len, raw.ptr(), raw.size());
+	if (err != OK || out_len != CURSOR_PAYLOAD_SIZE) {
+		return false;
+	}
+
+	if (decoded[0] != CURSOR_MAGIC_0 || decoded[1] != CURSOR_MAGIC_1 || decoded[2] != CURSOR_VERSION) {
+		return false;
+	}
+
+	const uint32_t offset = decode_uint32(&decoded[3]);
+	if (offset > INT_MAX) {
+		return false;
+	}
+	r_offset = int(offset);
+	return true;
+}
+
+String justamcp_pagination_encode_cursor(int p_offset) {
+	if (p_offset < 0) {
+		p_offset = 0;
+	}
+
+	uint8_t payload[CURSOR_PAYLOAD_SIZE];
+	payload[0] = CURSOR_MAGIC_0;
+	payload[1] = CURSOR_MAGIC_1;
+	payload[2] = CURSOR_VERSION;
+	encode_uint32((uint32_t)p_offset, &payload[3]);
+	return CryptoCore::b64_encode_str(payload, CURSOR_PAYLOAD_SIZE);
+}
+
+static Dictionary _pagination_error_invalid_cursor() {
+	Dictionary err;
+	err["ok"] = false;
+	err["error_code"] = -32602;
+	err["error"] = "Invalid pagination cursor.";
+	return err;
+}
+
+static Dictionary _pagination_slice_at_offset(const Array &p_page_items, int p_offset, int p_total, const String &p_result_key) {
+	Dictionary result;
+	result["ok"] = true;
+	result[p_result_key] = p_page_items;
+	if (p_offset + p_page_items.size() < p_total) {
+		result["nextCursor"] = justamcp_pagination_encode_cursor(p_offset + p_page_items.size());
+	}
+	return result;
+}
+
+Dictionary justamcp_pagination_slice_array(const Array &p_items, const String &p_cursor, const String &p_result_key) {
+	int offset = 0;
+	if (!justamcp_pagination_decode_cursor(p_cursor, offset)) {
+		return _pagination_error_invalid_cursor();
+	}
+	if (offset < 0) {
+		return _pagination_error_invalid_cursor();
+	}
+	if (offset >= p_items.size()) {
+		return _pagination_slice_at_offset(Array(), offset, p_items.size(), p_result_key);
+	}
+
+	const int page_size = justamcp_pagination_page_size();
+	Array page;
+	for (int i = offset; i < p_items.size() && page.size() < page_size; i++) {
+		page.push_back(p_items[i]);
+	}
+	return _pagination_slice_at_offset(page, offset, p_items.size(), p_result_key);
+}
+
+Dictionary justamcp_pagination_slice_strings(const Vector<String> &p_items, const String &p_cursor, const String &p_result_key) {
+	Array arr;
+	arr.resize(p_items.size());
+	for (int i = 0; i < p_items.size(); i++) {
+		arr[i] = p_items[i];
+	}
+	return justamcp_pagination_slice_array(arr, p_cursor, p_result_key);
+}

--- a/modules/justamcp/justamcp_pagination.h
+++ b/modules/justamcp/justamcp_pagination.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  justamcp_pagination.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/variant/variant.h"
+
+int justamcp_pagination_page_size();
+int justamcp_mcp_log_buffer_size();
+
+bool justamcp_pagination_decode_cursor(const String &p_cursor, int &r_offset);
+String justamcp_pagination_encode_cursor(int p_offset);
+
+Dictionary justamcp_pagination_slice_array(const Array &p_items, const String &p_cursor, const String &p_result_key);
+Dictionary justamcp_pagination_slice_strings(const Vector<String> &p_items, const String &p_cursor, const String &p_result_key);
+
+String justamcp_pagination_cursor_from_uri_suffix(const String &p_suffix);

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -31,7 +31,9 @@
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "core/os/os.h"
+#include "core/os/time.h"
 #include "editor/editor_settings.h"
+#include "justamcp_pagination.h"
 #include "modules/modules_enabled.gen.h"
 #include "servers/display_server.h"
 #include "tools/justamcp_prompt_executor.h"
@@ -47,6 +49,38 @@ static bool _is_headless() {
 		return true;
 	}
 	return false;
+}
+
+static String _justamcp_extract_list_cursor(const Dictionary &p_payload) {
+	if (!p_payload.has("params") || p_payload["params"].get_type() != Variant::DICTIONARY) {
+		return String();
+	}
+	const Dictionary params = p_payload["params"];
+	if (!params.has("cursor")) {
+		return String();
+	}
+	return String(params["cursor"]);
+}
+
+static Dictionary _justamcp_finalize_list_result(const Dictionary &p_result, const Variant &p_req_id) {
+	if (p_result.has("ok") && !bool(p_result.get("ok", true))) {
+		Dictionary err;
+		err["jsonrpc"] = "2.0";
+		err["id"] = p_req_id;
+		Dictionary error_dict;
+		error_dict["code"] = p_result.get("error_code", -32602);
+		error_dict["message"] = p_result.get("error", "Invalid params.");
+		err["error"] = error_dict;
+		return err;
+	}
+
+	Dictionary out = p_result.duplicate();
+	out.erase("ok");
+	Dictionary rpc_result;
+	rpc_result["jsonrpc"] = "2.0";
+	rpc_result["id"] = p_req_id;
+	rpc_result["result"] = out;
+	return rpc_result;
 }
 
 void JustAMCPServer::_bind_methods() {
@@ -191,6 +225,12 @@ void JustAMCPServer::_setup_settings() {
 		EDITOR_DEF_BASIC("blazium/justamcp/enable_debug_logging", true);
 		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/enable_debug_logging"));
 
+		EDITOR_DEF_BASIC("blazium/justamcp/list_page_size", 50);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/list_page_size", PROPERTY_HINT_RANGE, "1,500,1"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/mcp_log_buffer_size", 500);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/mcp_log_buffer_size", PROPERTY_HINT_RANGE, "1,5000,1"));
+
 		EDITOR_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
 		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/bind_to_localhost_only"));
 	}
@@ -205,6 +245,8 @@ void JustAMCPServer::_setup_settings() {
 	GLOBAL_DEF_BASIC("blazium/justamcp/client_secret", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/z_mcp_config", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/enable_debug_logging", true);
+	GLOBAL_DEF_BASIC("blazium/justamcp/list_page_size", 50);
+	GLOBAL_DEF_BASIC("blazium/justamcp/mcp_log_buffer_size", 500);
 	GLOBAL_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
 
 #ifdef TOOLS_ENABLED
@@ -668,39 +710,28 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 	}
 
 	if (method == "tools/list") {
-		Dictionary result;
+		const String cursor = _justamcp_extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		result["tools"] = JustAMCPToolExecutor::get_tool_schemas();
+		return _justamcp_finalize_list_result(JustAMCPToolExecutor::list_tools(cursor), req_id_var);
 #else
-		result["tools"] = Array();
+		Dictionary empty;
+		empty["ok"] = true;
+		empty["tools"] = Array();
+		return _justamcp_finalize_list_result(empty, req_id_var);
 #endif
-
-		Dictionary rpc_result;
-		rpc_result["jsonrpc"] = "2.0";
-		rpc_result["id"] = req_id_var;
-		rpc_result["result"] = result;
-
-		return rpc_result;
 	}
 
 	if (method == "prompts/list") {
-		Dictionary result;
+		const String cursor = _justamcp_extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		String cursor = "";
-		if (payload.has("params") && Dictionary(payload["params"]).has("cursor")) {
-			cursor = String(Variant(Dictionary(payload["params"])["cursor"]));
-		}
 		if (prompt_executor) {
-			result = prompt_executor->list_prompts(cursor);
+			return _justamcp_finalize_list_result(prompt_executor->list_prompts(cursor), req_id_var);
 		}
-#else
-		result["prompts"] = Array();
 #endif
-		Dictionary rpc_result;
-		rpc_result["jsonrpc"] = "2.0";
-		rpc_result["id"] = req_id_var;
-		rpc_result["result"] = result;
-		return rpc_result;
+		Dictionary empty;
+		empty["ok"] = true;
+		empty["prompts"] = Array();
+		return _justamcp_finalize_list_result(empty, req_id_var);
 	}
 
 	if (method == "prompts/get") {
@@ -736,37 +767,29 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 	}
 
 	if (method == "resources/list") {
-		Dictionary result;
+		const String cursor = _justamcp_extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		String cursor = payload.has("params") && Dictionary(payload["params"]).has("cursor") ? String(Variant(Dictionary(payload["params"])["cursor"])) : "";
 		if (resource_executor) {
-			result = resource_executor->list_resources(cursor);
+			return _justamcp_finalize_list_result(resource_executor->list_resources(cursor), req_id_var);
 		}
-#else
-		result["resources"] = Array();
 #endif
-		Dictionary rpc_result;
-		rpc_result["jsonrpc"] = "2.0";
-		rpc_result["id"] = req_id_var;
-		rpc_result["result"] = result;
-		return rpc_result;
+		Dictionary empty;
+		empty["ok"] = true;
+		empty["resources"] = Array();
+		return _justamcp_finalize_list_result(empty, req_id_var);
 	}
 
 	if (method == "resources/templates/list") {
-		Dictionary result;
+		const String cursor = _justamcp_extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		String cursor = payload.has("params") && Dictionary(payload["params"]).has("cursor") ? String(Variant(Dictionary(payload["params"])["cursor"])) : "";
 		if (resource_executor) {
-			result = resource_executor->list_resource_templates(cursor);
+			return _justamcp_finalize_list_result(resource_executor->list_resource_templates(cursor), req_id_var);
 		}
-#else
-		result["resourceTemplates"] = Array();
 #endif
-		Dictionary rpc_result;
-		rpc_result["jsonrpc"] = "2.0";
-		rpc_result["id"] = req_id_var;
-		rpc_result["result"] = result;
-		return rpc_result;
+		Dictionary empty;
+		empty["ok"] = true;
+		empty["resourceTemplates"] = Array();
+		return _justamcp_finalize_list_result(empty, req_id_var);
 	}
 
 	if (method == "resources/read") {
@@ -826,20 +849,16 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 	}
 
 	if (method == "tasks/list") {
-		Dictionary result;
+		const String cursor = _justamcp_extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		String cursor = payload.has("params") && Dictionary(payload["params"]).has("cursor") ? String(Variant(Dictionary(payload["params"])["cursor"])) : "";
 		if (task_manager) {
-			result = task_manager->list_tasks(cursor);
+			return _justamcp_finalize_list_result(task_manager->list_tasks(cursor), req_id_var);
 		}
-#else
-		result["tasks"] = Array();
 #endif
-		Dictionary rpc_result;
-		rpc_result["jsonrpc"] = "2.0";
-		rpc_result["id"] = req_id_var;
-		rpc_result["result"] = result;
-		return rpc_result;
+		Dictionary empty;
+		empty["ok"] = true;
+		empty["tasks"] = Array();
+		return _justamcp_finalize_list_result(empty, req_id_var);
 	}
 
 	if (method == "tasks/get") {
@@ -1286,7 +1305,44 @@ void JustAMCPServer::broadcast_tools_list_changed() {
 #endif
 }
 
+void JustAMCPServer::_append_mcp_notification_log(const String &p_level, const String &p_logger, const Dictionary &p_data) {
+	Dictionary entry;
+	entry["level"] = p_level;
+	if (!p_logger.is_empty()) {
+		entry["logger"] = p_logger;
+	}
+	entry["data"] = p_data;
+	entry["timestamp_usec"] = Time::get_singleton()->get_ticks_usec();
+
+	MutexLock lock(mcp_notification_log_mutex);
+	mcp_notification_log.push_back(entry);
+	const int max_entries = justamcp_mcp_log_buffer_size();
+	while (mcp_notification_log.size() > max_entries) {
+		mcp_notification_log.remove_at(0);
+	}
+}
+
+Dictionary JustAMCPServer::get_mcp_notification_log_page(const String &p_cursor) {
+	Array notifications;
+	{
+		MutexLock lock(mcp_notification_log_mutex);
+		notifications.resize(mcp_notification_log.size());
+		for (int i = 0; i < mcp_notification_log.size(); i++) {
+			notifications[i] = mcp_notification_log[i];
+		}
+	}
+	return justamcp_pagination_slice_array(notifications, p_cursor, "notifications");
+}
+
 void JustAMCPServer::send_log_message(const String &p_level, const String &p_logger, const Variant &p_data) {
+	Dictionary log_data;
+	if (p_data.get_type() == Variant::DICTIONARY) {
+		log_data = Dictionary(p_data);
+	} else if (p_data.get_type() != Variant::NIL) {
+		log_data["message"] = String(p_data);
+	}
+	_append_mcp_notification_log(p_level, p_logger, log_data);
+
 #if defined(MODULE_HTTPSERVER_ENABLED)
 	Dictionary notification;
 	notification["jsonrpc"] = "2.0";
@@ -1297,7 +1353,7 @@ void JustAMCPServer::send_log_message(const String &p_level, const String &p_log
 	if (!p_logger.is_empty()) {
 		params["logger"] = p_logger;
 	}
-	params["data"] = p_data;
+	params["data"] = log_data;
 
 	notification["params"] = params;
 	_send_sse_message(JSON::stringify(notification));

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -32,8 +32,9 @@
 #include "modules/modules_enabled.gen.h"
 #include "scene/main/node.h"
 
-#if defined(MODULE_HTTPSERVER_ENABLED)
 #include "core/os/mutex.h"
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
 #include "core/os/semaphore.h"
 #include "modules/httpserver/http_request_context.h"
 #include "modules/httpserver/http_response.h"
@@ -78,6 +79,8 @@ private:
 	static JustAMCPServer *singleton;
 	Vector<String> engine_logs;
 	Mutex engine_logs_mutex;
+	Vector<Dictionary> mcp_notification_log;
+	Mutex mcp_notification_log_mutex;
 	PrintHandlerList print_handler;
 	static void _print_handler_callback(void *p_user_data, const String &p_string, bool p_error, bool p_rich);
 
@@ -94,6 +97,8 @@ private:
 	void _complete_current_tool_request(const Dictionary &p_rpc_result);
 	void _clear_tool_queue();
 #endif
+
+	void _append_mcp_notification_log(const String &p_level, const String &p_logger, const Dictionary &p_data);
 
 protected:
 	static void _bind_methods();
@@ -113,6 +118,7 @@ public:
 
 	static JustAMCPServer *get_singleton();
 	Vector<String> get_engine_logs();
+	Dictionary get_mcp_notification_log_page(const String &p_cursor);
 
 	bool is_server_started() const { return server_started; }
 

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -131,6 +131,8 @@ static void _register_justamcp_project_settings() {
 	GLOBAL_DEF_BASIC("blazium/justamcp/client_secret", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/z_mcp_config", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/enable_debug_logging", true);
+	GLOBAL_DEF_BASIC("blazium/justamcp/list_page_size", 50);
+	GLOBAL_DEF_BASIC("blazium/justamcp/mcp_log_buffer_size", 500);
 	GLOBAL_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
 
 	JustAMCPToolExecutor::register_tool_settings();

--- a/modules/justamcp/tools/justamcp_editor_tools.cpp
+++ b/modules/justamcp/tools/justamcp_editor_tools.cpp
@@ -31,6 +31,7 @@
 
 #include "justamcp_editor_tools.h"
 #include "../justamcp_editor_plugin.h"
+#include "../justamcp_pagination.h"
 #include "../justamcp_server.h"
 #include "core/io/file_access.h"
 #include "editor/editor_command_palette.h"
@@ -389,6 +390,34 @@ Dictionary JustAMCPEditorTools::editor_screenshot_game(const Dictionary &p_args)
 }
 
 Dictionary JustAMCPEditorTools::editor_get_output_log(const Dictionary &p_args) {
+	if (p_args.has("cursor")) {
+		Array all_lines;
+		if (JustAMCPServer::get_singleton()) {
+			Vector<String> engine_logs = JustAMCPServer::get_singleton()->get_engine_logs();
+			all_lines.resize(engine_logs.size());
+			for (int i = 0; i < engine_logs.size(); i++) {
+				all_lines[i] = engine_logs[i];
+			}
+		}
+		const String cursor = String(p_args["cursor"]);
+		Dictionary page = justamcp_pagination_slice_array(all_lines, cursor, "logs");
+		if (page.has("ok") && !bool(page.get("ok", true))) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error"] = page.get("error", "Invalid pagination cursor.");
+			err["error_code"] = page.get("error_code", -32602);
+			return err;
+		}
+		Dictionary result;
+		result["ok"] = true;
+		result["logs"] = page.get("logs", Array());
+		result["count"] = Array(result["logs"]).size();
+		if (page.has("nextCursor")) {
+			result["nextCursor"] = page["nextCursor"];
+		}
+		return result;
+	}
+
 	Dictionary result;
 	Array logs;
 	int limit = p_args.get("limit", 200);

--- a/modules/justamcp/tools/justamcp_prompt_executor.cpp
+++ b/modules/justamcp/tools/justamcp_prompt_executor.cpp
@@ -30,6 +30,7 @@
 #ifdef TOOLS_ENABLED
 
 #include "justamcp_prompt_executor.h"
+#include "../justamcp_pagination.h"
 #include "core/config/project_settings.h"
 #include "editor/editor_settings.h"
 #include "prompts/justamcp_prompt_autowork_failure_analyzer.h"
@@ -101,31 +102,13 @@ void JustAMCPPromptExecutor::add_prompt(const Ref<JustAMCPPrompt> &p_prompt) {
 }
 
 Dictionary JustAMCPPromptExecutor::list_prompts(const String &cursor) {
-	Dictionary result;
 	Array prompts;
-	int offset = cursor.is_valid_int() ? cursor.to_int() : 0;
-	if (offset < 0) {
-		offset = 0;
-	}
-	const int page_size = 50;
-	int emitted = 0;
-
 	for (int i = 0; i < registered_prompts.size(); i++) {
 		if (registered_prompts[i].is_valid()) {
-			if (i < offset) {
-				continue;
-			}
-			if (emitted >= page_size) {
-				result["nextCursor"] = itos(i);
-				break;
-			}
 			prompts.push_back(registered_prompts[i]->get_prompt());
-			emitted++;
 		}
 	}
-
-	result["prompts"] = prompts;
-	return result;
+	return justamcp_pagination_slice_array(prompts, cursor, "prompts");
 }
 
 Dictionary JustAMCPPromptExecutor::get_prompt(const String &p_name, const Dictionary &p_args) {

--- a/modules/justamcp/tools/justamcp_resource_executor.cpp
+++ b/modules/justamcp/tools/justamcp_resource_executor.cpp
@@ -30,6 +30,7 @@
 #ifdef TOOLS_ENABLED
 
 #include "justamcp_resource_executor.h"
+#include "../justamcp_pagination.h"
 #include "../justamcp_server.h"
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
@@ -173,6 +174,19 @@ String JustAMCPResourceExecutor::_canonicalize_resource_uri(const String &p_uri)
 	return p_uri;
 }
 
+static bool _justamcp_try_extract_log_cursor(const String &p_uri, const String &p_prefix, String &r_cursor) {
+	if (p_uri == p_prefix) {
+		r_cursor = String();
+		return true;
+	}
+	const String prefix_slash = p_prefix + "/";
+	if (p_uri.begins_with(prefix_slash)) {
+		r_cursor = justamcp_pagination_cursor_from_uri_suffix(p_uri.substr(prefix_slash.length()));
+		return true;
+	}
+	return false;
+}
+
 Node *JustAMCPResourceExecutor::_get_edited_root() const {
 	if (EditorNode::get_singleton() && EditorInterface::get_singleton()) {
 		return EditorInterface::get_singleton()->get_edited_scene_root();
@@ -278,7 +292,6 @@ void JustAMCPResourceExecutor::_collect_materials(const String &p_path, Array &r
 }
 
 Dictionary JustAMCPResourceExecutor::list_resources(const String &cursor) {
-	Dictionary result;
 	Array resources;
 
 	for (int i = 0; i < registered_resources.size(); i++) {
@@ -306,8 +319,7 @@ Dictionary JustAMCPResourceExecutor::list_resources(const String &cursor) {
 	resources.push_back(_make_resource_schema("blazium://editor/state", "Editor State", "Current editor play mode, active scene, and selection summary."));
 	resources.push_back(_make_resource_schema("blazium://test/results", "Test Results", "Latest Autowork test results when available."));
 
-	result["resources"] = resources;
-	return result;
+	return justamcp_pagination_slice_array(resources, cursor, "resources");
 }
 
 Dictionary JustAMCPResourceExecutor::list_resource_templates(const String &cursor) {
@@ -327,9 +339,11 @@ Dictionary JustAMCPResourceExecutor::list_resource_templates(const String &curso
 	templates.push_back(_make_resource_template_schema("blazium://docs/search/{query}", "Documentation Search", "Search internal Blazium class and member documentation."));
 	templates.push_back(_make_resource_template_schema("blazium://docs/class/{class_name}", "Class Documentation", "Read internal documentation for one Blazium class."));
 	templates.push_back(_make_resource_template_schema("blazium://docs/member/{class_name}/{member_type}/{member_name}", "Member Documentation", "Read internal documentation for one method, property, signal, constant, enum, annotation, or theme property."));
+	templates.push_back(_make_resource_template_schema("blazium://logs/mcp/{cursor}", "MCP Log Notifications", "Paginated buffered MCP notifications/message history. Use blazium://logs/mcp/start for the first page."));
+	templates.push_back(_make_resource_template_schema("blazium://logs/recent/{cursor}", "Recent Engine Logs", "Paginated recent engine log lines captured by JustAMCP. Use blazium://logs/recent/start for the first page."));
+	templates.push_back(_make_resource_template_schema("blazium://system/logs/{cursor}", "System Logs (Paginated)", "Paginated engine log lines as JSON. Use blazium://system/logs/start for the first page."));
 
-	result["resourceTemplates"] = templates;
-	return result;
+	return justamcp_pagination_slice_array(templates, cursor, "resourceTemplates");
 }
 
 Dictionary JustAMCPResourceExecutor::read_resource(const String &p_uri) {
@@ -595,33 +609,86 @@ Dictionary JustAMCPResourceExecutor::_read_blazium_resource(const String &p_uri)
 		return _make_json_contents(p_uri, payload);
 	}
 
-	if (canonical_uri == "blazium://logs/recent") {
-		Array lines;
-		if (JustAMCPServer::get_singleton()) {
-			Vector<String> logs = JustAMCPServer::get_singleton()->get_engine_logs();
-			int start = MAX(0, logs.size() - 100);
-			for (int i = start; i < logs.size(); i++) {
-				lines.push_back(logs[i]);
+	{
+		String log_cursor;
+		if (_justamcp_try_extract_log_cursor(canonical_uri, "blazium://logs/mcp", log_cursor)) {
+			if (!JustAMCPServer::get_singleton()) {
+				Dictionary payload;
+				payload["notifications"] = Array();
+				payload["count"] = 0;
+				return _make_json_contents(p_uri, payload);
 			}
+			Dictionary page = JustAMCPServer::get_singleton()->get_mcp_notification_log_page(log_cursor);
+			if (page.has("ok") && !bool(page.get("ok", true))) {
+				Dictionary payload;
+				payload["error"] = page.get("error", "Invalid pagination cursor.");
+				return _make_json_contents(p_uri, payload);
+			}
+			Dictionary payload;
+			payload["notifications"] = page.get("notifications", Array());
+			payload["count"] = Array(payload["notifications"]).size();
+			if (page.has("nextCursor")) {
+				payload["nextCursor"] = page["nextCursor"];
+				payload["nextUri"] = "blazium://logs/mcp/" + String(page["nextCursor"]);
+			}
+			return _make_json_contents(p_uri, payload);
 		}
-		Dictionary payload;
-		payload["lines"] = lines;
-		payload["count"] = lines.size();
-		return _make_json_contents(p_uri, payload);
 	}
 
-	if (canonical_uri == "blazium://system/logs") {
-		String full_log;
-		if (JustAMCPServer::get_singleton()) {
-			Vector<String> logs = JustAMCPServer::get_singleton()->get_engine_logs();
-			for (int i = 0; i < logs.size(); i++) {
-				full_log += logs[i] + "\n";
+	{
+		String log_cursor;
+		if (_justamcp_try_extract_log_cursor(canonical_uri, "blazium://logs/recent", log_cursor)) {
+			Array all_lines;
+			if (JustAMCPServer::get_singleton()) {
+				Vector<String> logs = JustAMCPServer::get_singleton()->get_engine_logs();
+				all_lines.resize(logs.size());
+				for (int i = 0; i < logs.size(); i++) {
+					all_lines[i] = logs[i];
+				}
 			}
+			Dictionary page = justamcp_pagination_slice_array(all_lines, log_cursor, "lines");
+			if (page.has("ok") && !bool(page.get("ok", true))) {
+				Dictionary payload;
+				payload["error"] = page.get("error", "Invalid pagination cursor.");
+				return _make_json_contents(p_uri, payload);
+			}
+			Dictionary payload;
+			payload["lines"] = page.get("lines", Array());
+			payload["count"] = Array(payload["lines"]).size();
+			if (page.has("nextCursor")) {
+				payload["nextCursor"] = page["nextCursor"];
+				payload["nextUri"] = "blazium://logs/recent/" + String(page["nextCursor"]);
+			}
+			return _make_json_contents(p_uri, payload);
 		}
-		if (full_log.is_empty()) {
-			full_log = "Log is empty or hasn't started capturing yet.";
+	}
+
+	{
+		String log_cursor;
+		if (_justamcp_try_extract_log_cursor(canonical_uri, "blazium://system/logs", log_cursor)) {
+			Array all_lines;
+			if (JustAMCPServer::get_singleton()) {
+				Vector<String> logs = JustAMCPServer::get_singleton()->get_engine_logs();
+				all_lines.resize(logs.size());
+				for (int i = 0; i < logs.size(); i++) {
+					all_lines[i] = logs[i];
+				}
+			}
+			Dictionary page = justamcp_pagination_slice_array(all_lines, log_cursor, "lines");
+			if (page.has("ok") && !bool(page.get("ok", true))) {
+				Dictionary payload;
+				payload["error"] = page.get("error", "Invalid pagination cursor.");
+				return _make_json_contents(p_uri, payload);
+			}
+			Dictionary payload;
+			payload["lines"] = page.get("lines", Array());
+			payload["count"] = Array(payload["lines"]).size();
+			if (page.has("nextCursor")) {
+				payload["nextCursor"] = page["nextCursor"];
+				payload["nextUri"] = "blazium://system/logs/" + String(page["nextCursor"]);
+			}
+			return _make_json_contents(p_uri, payload);
 		}
-		return _make_text_contents(p_uri, full_log, "text/plain");
 	}
 
 	if (canonical_uri == "blazium://editor/state") {

--- a/modules/justamcp/tools/justamcp_task_manager.cpp
+++ b/modules/justamcp/tools/justamcp_task_manager.cpp
@@ -30,6 +30,7 @@
 #ifdef TOOLS_ENABLED
 
 #include "justamcp_task_manager.h"
+#include "../justamcp_pagination.h"
 #include "core/os/time.h"
 
 void JustAMCPTaskManager::_bind_methods() {
@@ -68,17 +69,13 @@ Dictionary JustAMCPTaskManager::create_task(const String &p_task_id, int p_ttl) 
 }
 
 Dictionary JustAMCPTaskManager::list_tasks(const String &cursor) {
-	Dictionary result;
 	Array tasks_array;
-
 	Array keys = active_tasks.keys();
 	for (int i = 0; i < keys.size(); i++) {
 		Dictionary task_info = active_tasks[keys[i]];
 		tasks_array.push_back(task_info);
 	}
-
-	result["tasks"] = tasks_array;
-	return result;
+	return justamcp_pagination_slice_array(tasks_array, cursor, "tasks");
 }
 
 Dictionary JustAMCPTaskManager::get_task(const String &p_task_id) {

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -28,6 +28,7 @@
 /**************************************************************************/
 
 #include "justamcp_tool_executor.h"
+#include "../justamcp_pagination.h"
 #include "../justamcp_runtime.h"
 #include "../justamcp_server.h"
 #include "core/config/project_settings.h"
@@ -82,6 +83,7 @@
 void JustAMCPToolExecutor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("execute_tool", "tool_name", "args"), &JustAMCPToolExecutor::execute_tool);
 	ClassDB::bind_static_method("JustAMCPToolExecutor", D_METHOD("get_tool_schemas", "register_only", "ignore_settings"), &JustAMCPToolExecutor::get_tool_schemas, DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_static_method("JustAMCPToolExecutor", D_METHOD("list_tools", "cursor"), &JustAMCPToolExecutor::list_tools, DEFVAL(""));
 	ClassDB::bind_static_method("JustAMCPToolExecutor", D_METHOD("set_test_scene_root", "node"), &JustAMCPToolExecutor::set_test_scene_root);
 }
 
@@ -596,11 +598,11 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	add_schema("editor_screenshot_game", "Captures the visible game display to a PNG file.",
 			Vector<String>{}, Vector<String>{});
 	add_schema("editor_get_output_log", "Returns recent output lines captured by the JustAMCP engine log hook.",
-			Vector<String>{ "limit", "number" }, Vector<String>{});
+			Vector<String>{ "limit", "number", "cursor", "string" }, Vector<String>{});
 	add_schema("editor_get_errors", "Returns recent error and warning lines captured by the JustAMCP engine log hook.",
 			Vector<String>{ "limit", "number" }, Vector<String>{});
-	add_schema("logs_read", "Reads recent JustAMCP/editor log lines with optional filtering.",
-			Vector<String>{ "limit", "number", "since_index", "number", "source", "string" }, Vector<String>{});
+	add_schema("logs_read", "Reads recent JustAMCP/editor log lines with optional filtering and MCP notification replay.",
+			Vector<String>{ "limit", "number", "since_index", "number", "source", "string", "cursor", "string" }, Vector<String>{});
 	add_schema("editor_reload_project", "Requests an editor restart to reload the project.",
 			Vector<String>{ "save", "boolean" }, Vector<String>{});
 	add_schema("editor_save_all_scenes", "Saves all open editor scenes.",
@@ -1294,6 +1296,10 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	return tools;
 }
 
+Dictionary JustAMCPToolExecutor::list_tools(const String &p_cursor) {
+	return justamcp_pagination_slice_array(get_tool_schemas(false, false), p_cursor, "tools");
+}
+
 Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const Dictionary &p_args) {
 	Dictionary result;
 
@@ -1494,10 +1500,36 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		return editor_tools->editor_get_errors(p_args);
 	}
 	if (internal_name == "logs_read") {
+		const String source = String(p_args.get("source", "editor"));
+		const String cursor = String(p_args.get("cursor", ""));
+		if (source == "mcp" && JustAMCPServer::get_singleton()) {
+			Dictionary page = JustAMCPServer::get_singleton()->get_mcp_notification_log_page(cursor);
+			if (page.has("ok") && !bool(page.get("ok", true))) {
+				Dictionary ret;
+				ret["ok"] = false;
+				ret["error"] = page.get("error", "Invalid pagination cursor.");
+				ret["error_code"] = page.get("error_code", -32602);
+				return ret;
+			}
+			Dictionary ret;
+			ret["ok"] = true;
+			ret["source"] = "mcp";
+			ret["notifications"] = page.get("notifications", Array());
+			ret["count"] = Array(ret["notifications"]).size();
+			if (page.has("nextCursor")) {
+				ret["nextCursor"] = page["nextCursor"];
+			}
+			return ret;
+		}
+
 		Dictionary ret;
 		Dictionary log_args;
 		log_args["limit"] = p_args.get("limit", 200);
+		log_args["cursor"] = cursor;
 		Dictionary logs = editor_tools->editor_get_output_log(log_args);
+		if (!bool(logs.get("ok", true))) {
+			return logs;
+		}
 		Array lines = logs.get("logs", Array());
 		int since_index = p_args.get("since_index", 0);
 		Array sliced;
@@ -1505,10 +1537,13 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 			sliced.push_back(lines[i]);
 		}
 		ret["ok"] = true;
-		ret["source"] = p_args.get("source", "editor");
+		ret["source"] = source;
 		ret["logs"] = sliced;
 		ret["count"] = sliced.size();
 		ret["next_index"] = lines.size();
+		if (logs.has("nextCursor")) {
+			ret["nextCursor"] = logs["nextCursor"];
+		}
 		return ret;
 	}
 	if (internal_name == "editor_reload_project") {

--- a/modules/justamcp/tools/justamcp_tool_executor.h
+++ b/modules/justamcp/tools/justamcp_tool_executor.h
@@ -125,6 +125,7 @@ public:
 
 	static void register_tool_settings();
 	static Array get_tool_schemas(bool p_register_only = false, bool p_ignore_settings = false);
+	static Dictionary list_tools(const String &p_cursor = "");
 
 	static Node *test_scene_root;
 	static void set_test_scene_root(Node *p_node);


### PR DESCRIPTION
## Summary

- Adds shared opaque cursor pagination ([MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination)) for `tools/list`, `prompts/list`, `resources/list`, and `resources/templates/list` via `justamcp_pagination`.
- Buffers `notifications/message` payloads for replay when clients miss SSE; readable through `blazium://logs/mcp/{cursor}` and `logs_read` with `source: mcp`.
- Paginates engine log reads via `blazium://logs/recent/{cursor}`, `blazium://system/logs/{cursor}`, and optional `cursor` on `editor_get_output_log` / `logs_read`.
- New settings: `blazium/justamcp/list_page_size` (default 50), `blazium/justamcp/mcp_log_buffer_size` (default 500).

## Test plan

- [ ] `tools/list` returns `nextCursor` until exhausted; invalid cursor → `-32602`
- [ ] Same for `prompts/list`, `resources/list`, `resources/templates/list`
- [ ] `send_log_message` with no SSE client; `resources/read` `blazium://logs/mcp/start` returns buffered notifications
- [ ] `logs_read` with `source: mcp` and cursor pages through buffer
- [ ] Live SSE still receives `notifications/message` when connected