### PR TITLE
JustAMCP: MCP tasks, progress, and cancellation

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -459,11 +459,11 @@
 		<member name="blazium/justamcp/enable_debug_logging" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], JustAMCP sends JSON-RPC method names, validation failures, and HTTP payload traces to connected MCP clients as [code]debug[/code] log notifications ([code]logger: justamcp[/code]).
 		</member>
-		<member name="blazium/justamcp/forward_engine_logs" type="bool" setter="" getter="" default="true">
-			If [code]true[/code] and the JustAMCP server is running, engine [code]print[/code] output is forwarded to MCP clients via [code]notifications/message[/code] ([code]logger: engine[/code]). Respects the client's [code]logging/setLevel[/code] minimum severity.
-		</member>
 		<member name="blazium/justamcp/game_control_enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows AI interacting via JustAMCP to natively trigger in-game commands and inputs over the pipeline, granting them orchestration control over gameplay mechanics.
+		</member>
+		<member name="blazium/justamcp/forward_engine_logs" type="bool" setter="" getter="" default="true">
+			If [code]true[/code] and the JustAMCP server is running, engine [code]print[/code] output is forwarded to MCP clients via [code]notifications/message[/code] ([code]logger: engine[/code]). Respects the client's [code]logging/setLevel[/code] minimum severity.
 		</member>
 		<member name="blazium/justamcp/list_page_size" type="int" setter="" getter="" default="50">
 			Maximum items per page for MCP list operations and paginated log reads ([code]tools/list[/code], [code]resources/list[/code], [code]blazium://logs/...[/code], etc.).
@@ -623,6 +623,15 @@
 		</member>
 		<member name="blazium/justamcp/server_port" type="int" setter="" getter="" default="6506">
 			TCP port for the JustAMCP MCP HTTP endpoint ([code]POST /mcp[/code]). Override at launch with [code]--mcp-port[/code].
+		</member>
+		<member name="blazium/justamcp/task_default_ttl_ms" type="int" setter="" getter="" default="600000">
+			Default time-to-live in milliseconds for MCP tasks created without an explicit [code]task.ttl[/code].
+		</member>
+		<member name="blazium/justamcp/task_max_concurrent" type="int" setter="" getter="" default="16">
+			Maximum number of concurrent in-flight MCP tasks.
+		</member>
+		<member name="blazium/justamcp/task_poll_interval_ms" type="int" setter="" getter="" default="1000">
+			Default suggested poll interval in milliseconds for MCP tasks.
 		</member>
 		<member name="blazium/justamcp/tools/analysis_tools" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables the Analysis Tools tool family for JustAMCP MCP clients. Individual tools under [code]blazium/justamcp/tools/analysis_tools/[/code] can be toggled separately.
@@ -915,8 +924,17 @@
 		<member name="blazium/justamcp/tools/export_tools/blazium_deploy_to_android" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], exposes the [code]blazium_deploy_to_android[/code] tool from the Export Tools family to MCP clients. Exports, installs, and optionally launches an Android build through adb.
 		</member>
+		<member name="blazium/justamcp/tools/export_tools/blazium_export_custom" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], exposes the [code]blazium_export_custom[/code] tool from the Export Tools family to MCP clients. Exports the project with explicit debug/release selection.
+		</member>
+		<member name="blazium/justamcp/tools/export_tools/blazium_export_debug" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], exposes the [code]blazium_export_debug[/code] tool from the Export Tools family to MCP clients. Exports the project using the debug preset.
+		</member>
 		<member name="blazium/justamcp/tools/export_tools/blazium_export_project" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], exposes the [code]blazium_export_project[/code] tool from the Export Tools family to MCP clients. Triggers a headless Godot export operation.
+		</member>
+		<member name="blazium/justamcp/tools/export_tools/blazium_export_release" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], exposes the [code]blazium_export_release[/code] tool from the Export Tools family to MCP clients. Exports the project using the release preset.
 		</member>
 		<member name="blazium/justamcp/tools/export_tools/blazium_get_android_preset_info" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], exposes the [code]blazium_get_android_preset_info[/code] tool from the Export Tools family to MCP clients. Reads Android export preset metadata.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -459,11 +459,11 @@
 		<member name="blazium/justamcp/enable_debug_logging" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], JustAMCP sends JSON-RPC method names, validation failures, and HTTP payload traces to connected MCP clients as [code]debug[/code] log notifications ([code]logger: justamcp[/code]).
 		</member>
-		<member name="blazium/justamcp/game_control_enabled" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows AI interacting via JustAMCP to natively trigger in-game commands and inputs over the pipeline, granting them orchestration control over gameplay mechanics.
-		</member>
 		<member name="blazium/justamcp/forward_engine_logs" type="bool" setter="" getter="" default="true">
 			If [code]true[/code] and the JustAMCP server is running, engine [code]print[/code] output is forwarded to MCP clients via [code]notifications/message[/code] ([code]logger: engine[/code]). Respects the client's [code]logging/setLevel[/code] minimum severity.
+		</member>
+		<member name="blazium/justamcp/game_control_enabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], allows AI interacting via JustAMCP to natively trigger in-game commands and inputs over the pipeline, granting them orchestration control over gameplay mechanics.
 		</member>
 		<member name="blazium/justamcp/list_page_size" type="int" setter="" getter="" default="50">
 			Maximum items per page for MCP list operations and paginated log reads ([code]tools/list[/code], [code]resources/list[/code], [code]blazium://logs/...[/code], etc.).

--- a/modules/justamcp/doc_classes/JustAMCPServer.xml
+++ b/modules/justamcp/doc_classes/JustAMCPServer.xml
@@ -7,6 +7,7 @@
 		[JustAMCPServer] owns the editor-facing MCP transport and emits signals for JSON-RPC tool requests, server lifecycle changes, elicitation responses, and cancellation notices. Most projects use it through the JustAMCP editor plugin or [JustAMCPRuntime] rather than instantiating it manually.
 		Implements the MCP [url=https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging]Logging[/url] utility: declares [code]logging[/code] capability, handles [code]logging/setLevel[/code], and pushes [code]notifications/message[/code] to SSE clients. Engine output and JustAMCP debug traces can be forwarded when [member ProjectSettings.blazium/justamcp/forward_engine_logs] and [member ProjectSettings.blazium/justamcp/enable_debug_logging] are enabled.
 		Implements MCP [url=https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination]pagination[/url] for [code]tools/list[/code], [code]prompts/list[/code], [code]resources/list[/code], and [code]resources/templates/list[/code] using opaque cursors. Buffers recent [code]notifications/message[/code] payloads for replay when clients missed SSE; see [member ProjectSettings.blazium/justamcp/mcp_log_buffer_size] and [code]blazium://logs/mcp/{cursor}[/code].
+		Supports task-augmented [code]tools/call[/code] for long-running tools ([url=https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks]Tasks[/url]), [code]notifications/progress[/code] via [code]_meta.progressToken[/code] ([url=https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress]Progress[/url]), and cooperative cancellation ([url=https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation]Cancellation[/url]). Sync requests honor [code]notifications/cancelled[/code]; task-augmented work uses [code]tasks/cancel[/code].
 		[codeblock]
 		var server = JustAMCPServer.new()
 		server.tool_requested.connect(func(request_id, tool_name, args):
@@ -18,6 +19,16 @@
 		<link title="Model Context Protocol (MCP)">https://modelcontextprotocol.io/</link>
 	</tutorials>
 	<methods>
+		<method name="report_tool_progress">
+			<return type="void" />
+			<param index="0" name="token" type="String" />
+			<param index="1" name="progress" type="float" />
+			<param index="2" name="total" type="float" />
+			<param index="3" name="message" type="String" />
+			<description>
+				Emits an MCP [code]notifications/progress[/code] notification for the active [code]progressToken[/code].
+			</description>
+		</method>
 		<method name="send_log_message">
 			<return type="void" />
 			<param index="0" name="level" type="String" />

--- a/modules/justamcp/doc_classes/JustAMCPTaskManager.xml
+++ b/modules/justamcp/doc_classes/JustAMCPTaskManager.xml
@@ -4,50 +4,19 @@
 		Tracks long-running MCP tasks and their results.
 	</brief_description>
 	<description>
-		[JustAMCPTaskManager] stores task metadata for MCP operations that complete asynchronously. It creates task handles, reports status, stores completed result content, and records cancellation or failure state.
-		[codeblock]
-		var manager = JustAMCPTaskManager.new()
-		var created = manager.create_task("task_001", 60000)
-		print(created["task"]["status"])
-
-		manager.complete_task("task_001", {
-		    "content": [{"type": "text", "text": "Task completed"}],
-		})
-		print(manager.get_task_result("task_001"))
-		[/codeblock]
+		[JustAMCPTaskManager] stores task metadata for MCP operations that complete asynchronously. It generates task UUIDs, reports status transitions (including [code]notifications/tasks/status[/code] via [JustAMCPServer]), blocks [code]tasks/result[/code] until a terminal state, and records cancellation or failure.
+		Configure defaults with [member ProjectSettings.blazium/justamcp/task_default_ttl_ms], [member ProjectSettings.blazium/justamcp/task_poll_interval_ms], and [member ProjectSettings.blazium/justamcp/task_max_concurrent].
+		See the MCP [url=https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks]Tasks[/url] utility.
 	</description>
 	<tutorials>
+		<link title="MCP Tasks">https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks</link>
 	</tutorials>
 	<methods>
 		<method name="cancel_task">
 			<return type="Dictionary" />
 			<param index="0" name="task_id" type="String" />
 			<description>
-				Marks an active task as cancelled unless it has already completed or failed, then returns the updated task dictionary.
-			</description>
-		</method>
-		<method name="complete_task">
-			<return type="void" />
-			<param index="0" name="task_id" type="String" />
-			<param index="1" name="result" type="Dictionary" />
-			<description>
-				Marks an existing task as completed and stores the [code]content[/code] array from [param result] for [method get_task_result].
-			</description>
-		</method>
-		<method name="create_task">
-			<return type="Dictionary" />
-			<param index="0" name="task_id" type="String" />
-			<param index="1" name="ttl" type="int" default="60000" />
-			<description>
-				Creates a task entry with status [code]working[/code], a time-to-live in milliseconds, and default polling metadata. Returns an error if the task id already exists.
-			</description>
-		</method>
-		<method name="fail_task">
-			<return type="void" />
-			<param index="0" name="task_id" type="String" />
-			<param index="1" name="error" type="String" />
-			<description>
-				Marks an existing task as failed and stores [param error] as the task status message.
+				Marks an active task as [code]cancelled[/code] unless it is already terminal. Returns an error if the task is unknown or already finished.
 			</description>
 		</method>
 		<method name="get_task">
@@ -61,14 +30,14 @@
 			<return type="Dictionary" />
 			<param index="0" name="task_id" type="String" />
 			<description>
-				Returns the stored result content for a completed task. Unknown, working, cancelled, or failed tasks return an error dictionary.
+				Blocks until the task reaches a terminal state, then returns the stored MCP tool result (including [code]_meta[/code] related-task metadata). Unknown tasks return [code]-32602[/code].
 			</description>
 		</method>
 		<method name="list_tasks">
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
 			<description>
-				Returns all tracked task dictionaries. [param cursor] is accepted for protocol compatibility.
+				Returns a paginated list of tracked tasks using opaque cursors.
 			</description>
 		</method>
 	</methods>

--- a/modules/justamcp/doc_classes/JustAMCPToolExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPToolExecutor.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[JustAMCPToolExecutor] builds the available tool schema list and dispatches validated tool calls to specialized tool groups such as [JustAMCPSceneTools], [JustAMCPResourceTools], [JustAMCPScriptTools], and [JustAMCPDocumentationTools]. Use it when code needs the same tool surface exposed to MCP clients.
+		Long-running tools expose [code]execution.taskSupport: optional[/code] in schemas (autowork, export, batch, editor play/reload) for MCP task-augmented [code]tools/call[/code].
 		[codeblock]
 		var schemas = JustAMCPToolExecutor.get_tool_schemas()
 		var executor = JustAMCPToolExecutor.new()

--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -260,6 +260,7 @@ void JustAMCPEditorPlugin::_notification(int p_what) {
 			tool_executor->set_editor_plugin(this);
 
 			mcp_server->connect("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested));
+			mcp_server->connect("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled));
 			mcp_server->connect("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed));
 
 			_setup_status_indicator();
@@ -355,7 +356,21 @@ void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const
 		return;
 	}
 
+	if (mcp_server->is_current_tool_cancel_requested()) {
+		Dictionary cancelled;
+		cancelled["ok"] = false;
+		cancelled["error"] = "cancelled";
+		mcp_server->send_tool_result(p_request_id, false, cancelled, "cancelled");
+		return;
+	}
+
 	Dictionary result = tool_executor->execute_tool(p_tool_name, p_args);
+
+	if (mcp_server->is_current_tool_cancel_requested() && String(result.get("error", "")) != "cancelled") {
+		result["ok"] = false;
+		result["error"] = "cancelled";
+	}
+
 	bool success = result.get("ok", false);
 
 	if (success) {

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -63,6 +63,45 @@ static String _justamcp_extract_list_cursor(const Dictionary &p_payload) {
 	return String(params["cursor"]);
 }
 
+static Dictionary _justamcp_extract_request_meta(const Dictionary &p_params) {
+	if (p_params.has("_meta") && p_params["_meta"].get_type() == Variant::DICTIONARY) {
+		return p_params["_meta"];
+	}
+	return Dictionary();
+}
+
+static String _justamcp_progress_token_from_meta(const Dictionary &p_meta) {
+	if (!p_meta.has("progressToken")) {
+		return String();
+	}
+	const Variant token_var = p_meta["progressToken"];
+	if (token_var.get_type() == Variant::STRING) {
+		return token_var;
+	}
+	if (token_var.get_type() == Variant::INT || token_var.get_type() == Variant::FLOAT) {
+		return String(token_var);
+	}
+	return String();
+}
+
+#ifdef TOOLS_ENABLED
+static String _justamcp_get_tool_task_support(const String &p_tool_name) {
+	Array schemas = JustAMCPToolExecutor::get_tool_schemas(false, true);
+	for (int i = 0; i < schemas.size(); i++) {
+		const Dictionary schema = schemas[i];
+		if (String(schema.get("name", "")) != p_tool_name) {
+			continue;
+		}
+		if (schema.has("execution") && schema["execution"].get_type() == Variant::DICTIONARY) {
+			const Dictionary execution = schema["execution"];
+			return String(execution.get("taskSupport", "forbidden"));
+		}
+		return "forbidden";
+	}
+	return "forbidden";
+}
+#endif
+
 static Dictionary _justamcp_finalize_list_result(const Dictionary &p_result, const Variant &p_req_id) {
 	if (p_result.has("ok") && !bool(p_result.get("ok", true))) {
 		Dictionary err;
@@ -88,6 +127,8 @@ void JustAMCPServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_process_pending_tools"), &JustAMCPServer::_process_pending_tools);
 	ClassDB::bind_method(D_METHOD("_emit_log_notification_deferred", "level", "logger", "data"), &JustAMCPServer::_emit_log_notification_deferred);
 	ClassDB::bind_method(D_METHOD("send_log_message", "level", "logger", "data"), &JustAMCPServer::send_log_message, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("_on_request_cancelled", "request_id", "reason"), &JustAMCPServer::_on_request_cancelled);
+	ClassDB::bind_method(D_METHOD("report_tool_progress", "token", "progress", "total", "message"), &JustAMCPServer::report_tool_progress);
 	ADD_SIGNAL(MethodInfo("tool_requested", PropertyInfo(Variant::NIL, "request_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::STRING, "tool_name"), PropertyInfo(Variant::DICTIONARY, "args")));
 	ADD_SIGNAL(MethodInfo("server_status_changed", PropertyInfo(Variant::BOOL, "started")));
 	ADD_SIGNAL(MethodInfo("elicitation_completed", PropertyInfo(Variant::NIL, "request_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::DICTIONARY, "result")));
@@ -142,6 +183,7 @@ JustAMCPServer::JustAMCPServer() {
 	prompt_executor = memnew(JustAMCPPromptExecutor);
 	resource_executor = memnew(JustAMCPResourceExecutor);
 	task_manager = memnew(JustAMCPTaskManager);
+	task_manager->set_server(this);
 #endif
 }
 
@@ -249,6 +291,15 @@ void JustAMCPServer::_setup_settings() {
 		EDITOR_DEF_BASIC("blazium/justamcp/mcp_log_buffer_size", 500);
 		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/mcp_log_buffer_size", PROPERTY_HINT_RANGE, "1,5000,1"));
 
+		EDITOR_DEF_BASIC("blazium/justamcp/task_default_ttl_ms", 600000);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/task_default_ttl_ms", PROPERTY_HINT_RANGE, "1000,3600000,1000"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/task_poll_interval_ms", 1000);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/task_poll_interval_ms", PROPERTY_HINT_RANGE, "100,60000,100"));
+
+		EDITOR_DEF_BASIC("blazium/justamcp/task_max_concurrent", 16);
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/task_max_concurrent", PROPERTY_HINT_RANGE, "1,128,1"));
+
 		EDITOR_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
 		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/bind_to_localhost_only"));
 	}
@@ -266,6 +317,9 @@ void JustAMCPServer::_setup_settings() {
 	GLOBAL_DEF_BASIC("blazium/justamcp/forward_engine_logs", true);
 	GLOBAL_DEF_BASIC("blazium/justamcp/list_page_size", 50);
 	GLOBAL_DEF_BASIC("blazium/justamcp/mcp_log_buffer_size", 500);
+	GLOBAL_DEF_BASIC("blazium/justamcp/task_default_ttl_ms", 600000);
+	GLOBAL_DEF_BASIC("blazium/justamcp/task_poll_interval_ms", 1000);
+	GLOBAL_DEF_BASIC("blazium/justamcp/task_max_concurrent", 16);
 	GLOBAL_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
 
 #ifdef TOOLS_ENABLED
@@ -952,6 +1006,9 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 #ifdef TOOLS_ENABLED
 		if (task_manager) {
 			result = task_manager->cancel_task(task_id);
+			if (result.get("ok", false)) {
+				request_task_queue_cancel(task_id);
+			}
 		}
 #endif
 		Dictionary rpc_result;
@@ -1028,10 +1085,114 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 		String tool_name = params["name"];
 		Dictionary args = params.has("arguments") && params["arguments"].get_type() == Variant::DICTIONARY ? Dictionary(params["arguments"]) : Dictionary();
 
+#ifdef TOOLS_ENABLED
+		const String task_support = _justamcp_get_tool_task_support(tool_name);
+		const bool has_task_param = params.has("task") && params["task"].get_type() == Variant::DICTIONARY;
+		if (task_support == "forbidden" && has_task_param) {
+			Dictionary err;
+			err["jsonrpc"] = "2.0";
+			err["id"] = req_id_var;
+			Dictionary error_dict;
+			error_dict["code"] = -32601;
+			error_dict["message"] = vformat("Tool '%s' does not support task-augmented execution.", tool_name);
+			err["error"] = error_dict;
+			return err;
+		}
+		if (task_support == "required" && !has_task_param) {
+			Dictionary err;
+			err["jsonrpc"] = "2.0";
+			err["id"] = req_id_var;
+			Dictionary error_dict;
+			error_dict["code"] = -32601;
+			error_dict["message"] = vformat("Tool '%s' requires task-augmented execution.", tool_name);
+			err["error"] = error_dict;
+			return err;
+		}
+#endif
+
+		Dictionary enqueue_options;
+		String progress_token = _justamcp_progress_token_from_meta(_justamcp_extract_request_meta(params));
+		if (!progress_token.is_empty()) {
+			enqueue_options["progress_token"] = progress_token;
+		}
+
+#ifdef TOOLS_ENABLED
+		if (has_task_param) {
+			int default_ttl = 600000;
+			int default_poll = 1000;
+			if (ProjectSettings::get_singleton()) {
+				if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_default_ttl_ms")) {
+					default_ttl = int(GLOBAL_GET("blazium/justamcp/task_default_ttl_ms"));
+				}
+				if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_poll_interval_ms")) {
+					default_poll = int(GLOBAL_GET("blazium/justamcp/task_poll_interval_ms"));
+				}
+			}
+			const Dictionary task_params = params["task"];
+			const int ttl_ms = task_params.has("ttl") ? int(task_params["ttl"]) : default_ttl;
+			const int poll_ms = task_params.has("pollInterval") ? int(task_params["pollInterval"]) : default_poll;
+
+			if (!task_manager) {
+				return invalid_params("Task manager unavailable.");
+			}
+			const String task_id = task_manager->create_task(ttl_ms, poll_ms, progress_token);
+			if (task_id.is_empty()) {
+				Dictionary err;
+				err["jsonrpc"] = "2.0";
+				err["id"] = req_id_var;
+				Dictionary error_dict;
+				error_dict["code"] = -32003;
+				error_dict["message"] = "Maximum concurrent MCP tasks reached.";
+				err["error"] = error_dict;
+				return err;
+			}
+
+			enqueue_options["is_task_augmented"] = true;
+			enqueue_options["task_id"] = task_id;
+			if (!progress_token.is_empty()) {
+				_register_progress_token(progress_token, task_id, req_id_var);
+			}
+
+			Dictionary queue_full_error;
+			MCPToolQueueEntry *entry = _enqueue_tool_request(req_id_var, tool_name, args, p_response, queue_full_error, enqueue_options);
+			if (!entry) {
+				task_manager->fail_task(task_id, "Failed to enqueue tool request.");
+				if (!progress_token.is_empty()) {
+					_unregister_progress_token(progress_token);
+				}
+				return queue_full_error;
+			}
+
+			call_deferred(SNAME("_process_pending_tools"));
+
+			const Dictionary create_task_result = _build_create_task_result(task_id);
+			if (entry->has_stateless_response) {
+				Dictionary rpc_result;
+				rpc_result["jsonrpc"] = "2.0";
+				rpc_result["id"] = req_id_var;
+				rpc_result["result"] = create_task_result;
+				entry->rpc_result = rpc_result;
+				entry->done_semaphore.post();
+				return rpc_result;
+			}
+
+			Dictionary rpc_result;
+			rpc_result["jsonrpc"] = "2.0";
+			rpc_result["id"] = req_id_var;
+			rpc_result["result"] = create_task_result;
+			_send_sse_message(JSON::stringify(rpc_result));
+			return Dictionary();
+		}
+#endif
+
 		Dictionary queue_full_error;
-		MCPToolQueueEntry *entry = _enqueue_tool_request(req_id_var, tool_name, args, p_response, queue_full_error);
+		MCPToolQueueEntry *entry = _enqueue_tool_request(req_id_var, tool_name, args, p_response, queue_full_error, enqueue_options);
 		if (!entry) {
 			return queue_full_error;
+		}
+
+		if (!progress_token.is_empty()) {
+			_register_progress_token(progress_token, String(), req_id_var);
 		}
 
 		call_deferred(SNAME("_process_pending_tools"));
@@ -1039,6 +1200,9 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 		if (entry->has_stateless_response) {
 			entry->done_semaphore.wait();
 			Dictionary res = entry->rpc_result;
+			if (!progress_token.is_empty()) {
+				_unregister_progress_token(progress_token);
+			}
 			memdelete(entry);
 			return res;
 		}
@@ -1075,91 +1239,21 @@ void JustAMCPServer::_send_sse_message(const String &p_json_string) {
 
 void JustAMCPServer::send_tool_result(const Variant &p_request_id, bool p_success, const Variant &p_result, const String &p_error) {
 #if defined(MODULE_HTTPSERVER_ENABLED)
-	Dictionary rpc_result;
-	rpc_result["jsonrpc"] = "2.0";
-
-	// request_id is correctly typed as a Variant (Integer or String)
-	rpc_result["id"] = p_request_id;
-
-	if (p_success) {
-		Dictionary result;
-		if (p_result.get_type() == Variant::DICTIONARY && Dictionary(p_result).has("content")) {
-			// The tool returned strict MCP "content" natively!
-			Variant content_val = Dictionary(p_result)["content"];
-			if (content_val.get_type() == Variant::ARRAY) {
-				result["content"] = content_val;
-			} else if (content_val.get_type() == Variant::STRING) {
-				Array content;
-				Dictionary content_item;
-				content_item["type"] = "text";
-				content_item["text"] = content_val;
-				content.push_back(content_item);
-				result["content"] = content;
-			} else {
-				Array content;
-				Dictionary content_item;
-				content_item["type"] = "text";
-				content_item["text"] = JSON::stringify(content_val);
-				content.push_back(content_item);
-				result["content"] = content;
-			}
-			result["isError"] = Dictionary(p_result).get("isError", false);
-		} else {
-			// The tool returned a custom dictionary (e.g. {"result": ...})
-			// We format it as a single TextContent block.
-			Array content;
-			Dictionary content_item;
-			content_item["type"] = "text";
-
-			String text_val;
-			if (p_result.get_type() == Variant::DICTIONARY && Dictionary(p_result).has("result") && Dictionary(p_result).size() == 1) {
-				Variant inner_result = Dictionary(p_result)["result"];
-				if (inner_result.get_type() == Variant::STRING) {
-					text_val = inner_result;
-				} else {
-					text_val = JSON::stringify(inner_result);
-				}
-			} else if (p_result.get_type() == Variant::STRING) {
-				text_val = p_result;
-			} else {
-				text_val = JSON::stringify(p_result);
-			}
-
-			content_item["text"] = text_val;
-			content.push_back(content_item);
-
-			result["content"] = content;
-			result["isError"] = false;
-		}
-
-		rpc_result["result"] = result;
-	} else {
-		// Differentiate Protocol Errors dynamically
-		Dictionary error_dict = p_result.get_type() == Variant::DICTIONARY ? Dictionary(p_result) : Dictionary();
-		if (!error_dict.is_empty() && error_dict.has("code")) {
-			// Pure JSON-RPC Protocol Error (-32xxx)
-			Dictionary error;
-			error["code"] = error_dict["code"];
-			error["message"] = error_dict.get("message", p_error);
-			rpc_result["error"] = error;
-		} else {
-			// Native Runtime Tool Execution error
-			Dictionary result;
-			Array content;
-			Dictionary content_item;
-			content_item["type"] = "text";
-			content_item["text"] = p_error;
-			content.push_back(content_item);
-
-			result["content"] = content;
-			result["isError"] = true;
-
-			rpc_result["result"] = result;
-		}
+	MCPToolQueueEntry *entry = nullptr;
+	{
+		MutexLock lock(tool_queue_mutex);
+		entry = current_tool_entry;
 	}
 
-	// Output to the active queued tool request.
-	_complete_current_tool_request(rpc_result);
+	if (entry && entry->is_task_augmented) {
+		_complete_task_tool_entry(entry, p_success, p_result, p_error);
+		return;
+	}
+
+	const Dictionary rpc_result = _format_tool_result_dict(p_success, p_result, p_error);
+	Dictionary rpc_with_id = rpc_result.duplicate();
+	rpc_with_id["id"] = p_request_id;
+	_complete_current_tool_request(rpc_with_id);
 #else
 	(void)p_request_id;
 	(void)p_success;
@@ -1170,7 +1264,7 @@ void JustAMCPServer::send_tool_result(const Variant &p_request_id, bool p_succes
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 
-MCPToolQueueEntry *JustAMCPServer::_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Ref<HTTPResponse> p_response, Dictionary &r_queue_full_error) {
+MCPToolQueueEntry *JustAMCPServer::_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Ref<HTTPResponse> p_response, Dictionary &r_queue_full_error, const Dictionary &p_options) {
 	MutexLock lock(tool_queue_mutex);
 	if (tool_queue.size() >= TOOL_QUEUE_MAX) {
 		r_queue_full_error["jsonrpc"] = "2.0";
@@ -1188,6 +1282,13 @@ MCPToolQueueEntry *JustAMCPServer::_enqueue_tool_request(const Variant &p_reques
 	entry->args = p_args;
 	entry->stateless_response = p_response;
 	entry->has_stateless_response = p_response.is_valid();
+	if (p_options.has("task_id")) {
+		entry->task_id = p_options["task_id"];
+	}
+	if (p_options.has("progress_token")) {
+		entry->progress_token = p_options["progress_token"];
+	}
+	entry->is_task_augmented = p_options.get("is_task_augmented", false);
 	tool_queue.push_back(entry);
 	return entry;
 }
@@ -1236,6 +1337,10 @@ void JustAMCPServer::_complete_current_tool_request(const Dictionary &p_rpc_resu
 		return;
 	}
 
+	if (!completed_entry->progress_token.is_empty()) {
+		_unregister_progress_token(completed_entry->progress_token);
+	}
+
 	if (has_stateless) {
 		completed_entry->done_semaphore.post();
 	} else {
@@ -1250,6 +1355,9 @@ void JustAMCPServer::_clear_tool_queue() {
 	for (int i = 0; i < tool_queue.size(); i++) {
 		MCPToolQueueEntry *entry = tool_queue[i];
 		if (entry) {
+			if (!entry->progress_token.is_empty()) {
+				_unregister_progress_token(entry->progress_token);
+			}
 			entry->done_semaphore.post();
 			memdelete(entry);
 		}
@@ -1257,6 +1365,278 @@ void JustAMCPServer::_clear_tool_queue() {
 	tool_queue.clear();
 	current_tool_entry = nullptr;
 	tool_queue_processing = false;
+}
+
+Dictionary JustAMCPServer::_format_tool_result_dict(bool p_success, const Variant &p_result, const String &p_error) const {
+	Dictionary rpc_result;
+	rpc_result["jsonrpc"] = "2.0";
+
+	if (p_success) {
+		Dictionary result;
+		if (p_result.get_type() == Variant::DICTIONARY && Dictionary(p_result).has("content")) {
+			Variant content_val = Dictionary(p_result)["content"];
+			if (content_val.get_type() == Variant::ARRAY) {
+				result["content"] = content_val;
+			} else if (content_val.get_type() == Variant::STRING) {
+				Array content;
+				Dictionary content_item;
+				content_item["type"] = "text";
+				content_item["text"] = content_val;
+				content.push_back(content_item);
+				result["content"] = content;
+			} else {
+				Array content;
+				Dictionary content_item;
+				content_item["type"] = "text";
+				content_item["text"] = JSON::stringify(content_val);
+				content.push_back(content_item);
+				result["content"] = content;
+			}
+			result["isError"] = Dictionary(p_result).get("isError", false);
+		} else {
+			Array content;
+			Dictionary content_item;
+			content_item["type"] = "text";
+
+			String text_val;
+			if (p_result.get_type() == Variant::DICTIONARY && Dictionary(p_result).has("result") && Dictionary(p_result).size() == 1) {
+				Variant inner_result = Dictionary(p_result)["result"];
+				if (inner_result.get_type() == Variant::STRING) {
+					text_val = inner_result;
+				} else {
+					text_val = JSON::stringify(inner_result);
+				}
+			} else if (p_result.get_type() == Variant::STRING) {
+				text_val = p_result;
+			} else {
+				text_val = JSON::stringify(p_result);
+			}
+
+			content_item["text"] = text_val;
+			content.push_back(content_item);
+
+			result["content"] = content;
+			result["isError"] = false;
+		}
+
+		rpc_result["result"] = result;
+	} else {
+		Dictionary error_dict = p_result.get_type() == Variant::DICTIONARY ? Dictionary(p_result) : Dictionary();
+		if (!error_dict.is_empty() && error_dict.has("code")) {
+			Dictionary error;
+			error["code"] = error_dict["code"];
+			error["message"] = error_dict.get("message", p_error);
+			rpc_result["error"] = error;
+		} else {
+			Dictionary result;
+			Array content;
+			Dictionary content_item;
+			content_item["type"] = "text";
+			content_item["text"] = p_error;
+			content.push_back(content_item);
+
+			result["content"] = content;
+			result["isError"] = true;
+
+			rpc_result["result"] = result;
+		}
+	}
+
+	return rpc_result;
+}
+
+Dictionary JustAMCPServer::_build_create_task_result(const String &p_task_id) const {
+	Dictionary result;
+#ifdef TOOLS_ENABLED
+	if (task_manager) {
+		Dictionary task_dict = task_manager->get_task(p_task_id);
+		if (task_dict.get("ok", false)) {
+			task_dict.erase("ok");
+			result["task"] = task_dict;
+			return result;
+		}
+	}
+#endif
+	Dictionary task;
+	task["taskId"] = p_task_id;
+	task["status"] = "working";
+	result["task"] = task;
+	return result;
+}
+
+void JustAMCPServer::_register_progress_token(const String &p_token, const String &p_task_id, const Variant &p_request_id) {
+	if (p_token.is_empty()) {
+		return;
+	}
+	MutexLock lock(progress_mutex);
+	JustAMCPActiveProgressContext ctx;
+	ctx.task_id = p_task_id;
+	ctx.request_id = p_request_id;
+	active_progress_tokens[p_token] = ctx;
+}
+
+void JustAMCPServer::_unregister_progress_token(const String &p_token) {
+	if (p_token.is_empty()) {
+		return;
+	}
+	MutexLock lock(progress_mutex);
+	active_progress_tokens.erase(p_token);
+}
+
+void JustAMCPServer::_complete_task_tool_entry(MCPToolQueueEntry *p_entry, bool p_success, const Variant &p_result, const String &p_error) {
+	if (!p_entry) {
+		return;
+	}
+
+	const String progress_token = p_entry->progress_token;
+	const String task_id = p_entry->task_id;
+	const bool was_cancelled = p_entry->cancel_requested || String(p_error) == "cancelled" || (p_result.get_type() == Variant::DICTIONARY && String(Dictionary(p_result).get("error", "")) == "cancelled");
+
+#ifdef TOOLS_ENABLED
+	if (task_manager && !task_id.is_empty()) {
+		if (was_cancelled) {
+			task_manager->cancel_task_execution(task_id);
+		} else {
+			const Dictionary formatted = _format_tool_result_dict(p_success, p_result, p_error);
+			Dictionary stored;
+			if (formatted.has("result")) {
+				stored = formatted["result"];
+			} else if (formatted.has("error")) {
+				task_manager->fail_task(task_id, String(formatted["error"].operator Dictionary().get("message", p_error)));
+			} else {
+				stored = formatted;
+			}
+			if (!was_cancelled && !formatted.has("error")) {
+				const bool is_error = stored.get("isError", false);
+				task_manager->complete_task(task_id, stored, is_error);
+			}
+		}
+	}
+#endif
+
+	if (!progress_token.is_empty()) {
+		_unregister_progress_token(progress_token);
+	}
+
+	MCPToolQueueEntry *completed_entry = p_entry;
+	{
+		MutexLock lock(tool_queue_mutex);
+		if (tool_queue.size() > 0 && tool_queue[0] == completed_entry) {
+			tool_queue.remove_at(0);
+		}
+		if (current_tool_entry == completed_entry) {
+			current_tool_entry = nullptr;
+		}
+		tool_queue_processing = false;
+	}
+
+	memdelete(completed_entry);
+	call_deferred(SNAME("_process_pending_tools"));
+}
+
+void JustAMCPServer::_on_request_cancelled(const Variant &p_request_id, const String &p_reason) {
+	(void)p_reason;
+#if defined(MODULE_HTTPSERVER_ENABLED)
+	MCPToolQueueEntry *target = nullptr;
+	{
+		MutexLock lock(tool_queue_mutex);
+		if (current_tool_entry && current_tool_entry->request_id == p_request_id && !current_tool_entry->is_task_augmented) {
+			current_tool_entry->cancel_requested = true;
+			target = current_tool_entry;
+		} else {
+			for (int i = 0; i < tool_queue.size(); i++) {
+				MCPToolQueueEntry *entry = tool_queue[i];
+				if (entry && entry->request_id == p_request_id && !entry->is_task_augmented) {
+					entry->cancel_requested = true;
+					target = entry;
+					break;
+				}
+			}
+		}
+	}
+
+	if (target && target == current_tool_entry && !target->cancel_requested) {
+		target->cancel_requested = true;
+		Dictionary cancelled;
+		cancelled["ok"] = false;
+		cancelled["error"] = "cancelled";
+		send_tool_result(p_request_id, false, cancelled, "cancelled");
+	}
+#endif
+}
+
+bool JustAMCPServer::is_current_tool_cancel_requested() const {
+	MutexLock lock(tool_queue_mutex);
+	if (!current_tool_entry) {
+		return false;
+	}
+	if (current_tool_entry->cancel_requested) {
+		return true;
+	}
+#ifdef TOOLS_ENABLED
+	if (!current_tool_entry->task_id.is_empty() && task_manager) {
+		return task_manager->is_cancel_requested(current_tool_entry->task_id);
+	}
+#endif
+	return false;
+}
+
+String JustAMCPServer::get_current_progress_token() const {
+	MutexLock lock(tool_queue_mutex);
+	return current_tool_entry ? current_tool_entry->progress_token : String();
+}
+
+String JustAMCPServer::get_current_task_id() const {
+	MutexLock lock(tool_queue_mutex);
+	return current_tool_entry ? current_tool_entry->task_id : String();
+}
+
+bool JustAMCPServer::is_task_cancel_requested(const String &p_task_id) const {
+#ifdef TOOLS_ENABLED
+	return task_manager && task_manager->is_cancel_requested(p_task_id);
+#else
+	(void)p_task_id;
+	return false;
+#endif
+}
+
+void JustAMCPServer::request_task_queue_cancel(const String &p_task_id) {
+#if defined(MODULE_HTTPSERVER_ENABLED)
+	MutexLock lock(tool_queue_mutex);
+	for (int i = 0; i < tool_queue.size(); i++) {
+		MCPToolQueueEntry *entry = tool_queue[i];
+		if (entry && entry->task_id == p_task_id) {
+			entry->cancel_requested = true;
+		}
+	}
+	if (current_tool_entry && current_tool_entry->task_id == p_task_id) {
+		current_tool_entry->cancel_requested = true;
+	}
+#endif
+}
+
+void JustAMCPServer::report_tool_progress(const String &p_token, double p_progress, double p_total, const String &p_message) {
+	if (p_token.is_empty()) {
+		return;
+	}
+
+	bool should_emit = false;
+	{
+		MutexLock lock(progress_mutex);
+		if (!active_progress_tokens.has(p_token)) {
+			return;
+		}
+		JustAMCPActiveProgressContext &ctx = active_progress_tokens[p_token];
+		const uint64_t now = Time::get_singleton()->get_ticks_usec();
+		if (ctx.last_emit_usec == 0 || now - ctx.last_emit_usec >= 100000) {
+			ctx.last_emit_usec = now;
+			should_emit = true;
+		}
+	}
+
+	if (should_emit) {
+		send_progress_notification(p_token, p_progress, p_total, p_message);
+	}
 }
 
 #endif // MODULE_HTTPSERVER_ENABLED

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -33,6 +33,7 @@
 #include "scene/main/node.h"
 
 #include "core/os/mutex.h"
+#include "core/templates/hash_map.h"
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 #include "core/os/semaphore.h"
@@ -51,6 +52,16 @@ struct MCPToolQueueEntry {
 	Dictionary rpc_result;
 	Semaphore done_semaphore;
 	bool has_stateless_response = false;
+	String task_id;
+	String progress_token;
+	bool is_task_augmented = false;
+	bool cancel_requested = false;
+};
+
+struct JustAMCPActiveProgressContext {
+	String task_id;
+	Variant request_id;
+	uint64_t last_emit_usec = 0;
 };
 
 class JustAMCPServer : public Node {
@@ -62,6 +73,9 @@ private:
 	MCPToolQueueEntry *current_tool_entry = nullptr;
 	bool tool_queue_processing = false;
 	static const int TOOL_QUEUE_MAX = 32;
+
+	Mutex progress_mutex;
+	HashMap<String, JustAMCPActiveProgressContext> active_progress_tokens;
 
 	int current_sse_connection_id = -1;
 	bool server_started = false;
@@ -98,9 +112,14 @@ private:
 	Dictionary _handle_json_rpc(const String &p_body, Ref<HTTPResponse> p_response);
 	void _send_sse_message(const String &p_json_string);
 	void _on_sse_connection_opened(int p_connection_id, const String &p_path, const Dictionary &p_headers);
-	MCPToolQueueEntry *_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Ref<HTTPResponse> p_response, Dictionary &r_queue_full_error);
+	MCPToolQueueEntry *_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Ref<HTTPResponse> p_response, Dictionary &r_queue_full_error, const Dictionary &p_options = Dictionary());
 	void _process_pending_tools();
 	void _complete_current_tool_request(const Dictionary &p_rpc_result);
+	void _complete_task_tool_entry(MCPToolQueueEntry *p_entry, bool p_success, const Variant &p_result, const String &p_error);
+	Dictionary _format_tool_result_dict(bool p_success, const Variant &p_result, const String &p_error) const;
+	Dictionary _build_create_task_result(const String &p_task_id) const;
+	void _register_progress_token(const String &p_token, const String &p_task_id, const Variant &p_request_id);
+	void _unregister_progress_token(const String &p_token);
 	void _clear_tool_queue();
 #endif
 
@@ -124,7 +143,14 @@ public:
 	void broadcast_resource_updated(const String &p_uri);
 	void send_log_message(const String &p_level, const String &p_logger, const Variant &p_data = Variant());
 	void send_progress_notification(const String &p_token, double p_progress, double p_total, const String &p_message);
+	void report_tool_progress(const String &p_token, double p_progress, double p_total, const String &p_message);
 	void broadcast_task_status(const String &p_task_id);
+	void _on_request_cancelled(const Variant &p_request_id, const String &p_reason);
+	bool is_current_tool_cancel_requested() const;
+	String get_current_progress_token() const;
+	String get_current_task_id() const;
+	bool is_task_cancel_requested(const String &p_task_id) const;
+	void request_task_queue_cancel(const String &p_task_id);
 
 	static JustAMCPServer *get_singleton();
 	Vector<String> get_engine_logs();

--- a/modules/justamcp/justamcp_tool_context.cpp
+++ b/modules/justamcp/justamcp_tool_context.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_task_manager.h                                               */
+/*  justamcp_tool_context.cpp                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -27,71 +27,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
 #ifdef TOOLS_ENABLED
 
-#include "core/object/class_db.h"
-#include "core/object/object.h"
-#include "core/os/mutex.h"
-#include "core/os/semaphore.h"
-#include "core/templates/hash_map.h"
+#include "justamcp_tool_context.h"
+#include "justamcp_server.h"
 
-class JustAMCPServer;
+bool justamcp_is_cancel_requested() {
+	JustAMCPServer *server = JustAMCPServer::get_singleton();
+	return server && server->is_current_tool_cancel_requested();
+}
 
-struct JustAMCPTaskRecord {
-	String task_id;
-	String status = "working";
-	String status_message;
-	String created_at;
-	String last_updated_at;
-	uint64_t created_at_usec = 0;
-	int ttl_ms = 60000;
-	int poll_interval_ms = 1000;
-	String progress_token;
-	bool cancel_requested = false;
-	bool is_terminal = false;
-	Dictionary stored_result;
-	Dictionary stored_error;
-	bool has_stored_error = false;
-	Semaphore result_ready;
-};
+void justamcp_report_progress(double p_progress, double p_total, const String &p_message) {
+	JustAMCPServer *server = JustAMCPServer::get_singleton();
+	if (!server) {
+		return;
+	}
+	const String token = server->get_current_progress_token();
+	if (token.is_empty()) {
+		return;
+	}
+	server->report_tool_progress(token, p_progress, p_total, p_message);
+}
 
-class JustAMCPTaskManager : public Object {
-	GDCLASS(JustAMCPTaskManager, Object);
-
-	HashMap<String, JustAMCPTaskRecord *> tasks;
-	Mutex tasks_mutex;
-	JustAMCPServer *server = nullptr;
-
-	String _iso_timestamp_now() const;
-	String _generate_task_id() const;
-	bool _is_terminal_status(const String &p_status) const;
-	Dictionary _task_to_dict(const JustAMCPTaskRecord &p_task) const;
-	void _purge_expired_tasks();
-	void _notify_status(const String &p_task_id);
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_server(JustAMCPServer *p_server);
-
-	String create_task(int p_ttl_ms, int p_poll_interval_ms, const String &p_progress_token = String());
-	Dictionary list_tasks(const String &p_cursor = "");
-	Dictionary get_task(const String &p_task_id);
-	Dictionary get_task_result(const String &p_task_id);
-	Dictionary cancel_task(const String &p_task_id);
-
-	void complete_task(const String &p_task_id, const Dictionary &p_result, bool p_is_error = false);
-	void fail_task(const String &p_task_id, const String &p_error);
-	void cancel_task_execution(const String &p_task_id, const String &p_message = "The task was cancelled by request.");
-
-	bool is_cancel_requested(const String &p_task_id) const;
-	String get_progress_token(const String &p_task_id) const;
-
-	JustAMCPTaskManager();
-	~JustAMCPTaskManager();
-};
+String justamcp_get_active_progress_token() {
+	JustAMCPServer *server = JustAMCPServer::get_singleton();
+	return server ? server->get_current_progress_token() : String();
+}
 
 #endif // TOOLS_ENABLED

--- a/modules/justamcp/justamcp_tool_context.h
+++ b/modules/justamcp/justamcp_tool_context.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_task_manager.h                                               */
+/*  justamcp_tool_context.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,69 +29,12 @@
 
 #pragma once
 
+#include "core/string/ustring.h"
+
 #ifdef TOOLS_ENABLED
 
-#include "core/object/class_db.h"
-#include "core/object/object.h"
-#include "core/os/mutex.h"
-#include "core/os/semaphore.h"
-#include "core/templates/hash_map.h"
-
-class JustAMCPServer;
-
-struct JustAMCPTaskRecord {
-	String task_id;
-	String status = "working";
-	String status_message;
-	String created_at;
-	String last_updated_at;
-	uint64_t created_at_usec = 0;
-	int ttl_ms = 60000;
-	int poll_interval_ms = 1000;
-	String progress_token;
-	bool cancel_requested = false;
-	bool is_terminal = false;
-	Dictionary stored_result;
-	Dictionary stored_error;
-	bool has_stored_error = false;
-	Semaphore result_ready;
-};
-
-class JustAMCPTaskManager : public Object {
-	GDCLASS(JustAMCPTaskManager, Object);
-
-	HashMap<String, JustAMCPTaskRecord *> tasks;
-	Mutex tasks_mutex;
-	JustAMCPServer *server = nullptr;
-
-	String _iso_timestamp_now() const;
-	String _generate_task_id() const;
-	bool _is_terminal_status(const String &p_status) const;
-	Dictionary _task_to_dict(const JustAMCPTaskRecord &p_task) const;
-	void _purge_expired_tasks();
-	void _notify_status(const String &p_task_id);
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_server(JustAMCPServer *p_server);
-
-	String create_task(int p_ttl_ms, int p_poll_interval_ms, const String &p_progress_token = String());
-	Dictionary list_tasks(const String &p_cursor = "");
-	Dictionary get_task(const String &p_task_id);
-	Dictionary get_task_result(const String &p_task_id);
-	Dictionary cancel_task(const String &p_task_id);
-
-	void complete_task(const String &p_task_id, const Dictionary &p_result, bool p_is_error = false);
-	void fail_task(const String &p_task_id, const String &p_error);
-	void cancel_task_execution(const String &p_task_id, const String &p_message = "The task was cancelled by request.");
-
-	bool is_cancel_requested(const String &p_task_id) const;
-	String get_progress_token(const String &p_task_id) const;
-
-	JustAMCPTaskManager();
-	~JustAMCPTaskManager();
-};
+bool justamcp_is_cancel_requested();
+void justamcp_report_progress(double p_progress, double p_total, const String &p_message);
+String justamcp_get_active_progress_token();
 
 #endif // TOOLS_ENABLED

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -134,6 +134,9 @@ static void _register_justamcp_project_settings() {
 	GLOBAL_DEF_BASIC("blazium/justamcp/forward_engine_logs", true);
 	GLOBAL_DEF_BASIC("blazium/justamcp/list_page_size", 50);
 	GLOBAL_DEF_BASIC("blazium/justamcp/mcp_log_buffer_size", 500);
+	GLOBAL_DEF_BASIC("blazium/justamcp/task_default_ttl_ms", 600000);
+	GLOBAL_DEF_BASIC("blazium/justamcp/task_poll_interval_ms", 1000);
+	GLOBAL_DEF_BASIC("blazium/justamcp/task_max_concurrent", 16);
 	GLOBAL_DEF_BASIC("blazium/justamcp/bind_to_localhost_only", true);
 
 	JustAMCPToolExecutor::register_tool_settings();

--- a/modules/justamcp/tools/justamcp_autowork_tools.cpp
+++ b/modules/justamcp/tools/justamcp_autowork_tools.cpp
@@ -32,6 +32,7 @@
 #ifdef TOOLS_ENABLED
 #ifdef MODULE_AUTOWORK_ENABLED
 
+#include "../justamcp_tool_context.h"
 #include "justamcp_autowork_tools.h"
 #include "modules/autowork/autowork_main.h"
 #include "modules/justamcp/justamcp_editor_plugin.h"
@@ -50,6 +51,12 @@ JustAMCPAutoworkTools::~JustAMCPAutoworkTools() {
 
 static Dictionary _execute_autowork(Autowork *p_autowork) {
 	Dictionary result;
+	if (justamcp_is_cancel_requested()) {
+		result["ok"] = false;
+		result["error"] = "cancelled";
+		return result;
+	}
+	justamcp_report_progress(0, 1, "Running autowork tests");
 
 	SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 	if (tree) {
@@ -94,6 +101,7 @@ static Dictionary _execute_autowork(Autowork *p_autowork) {
 	}
 	p_autowork->queue_free();
 
+	justamcp_report_progress(1, 1, "Autowork tests finished");
 	return result;
 }
 

--- a/modules/justamcp/tools/justamcp_editor_tools.cpp
+++ b/modules/justamcp/tools/justamcp_editor_tools.cpp
@@ -33,6 +33,7 @@
 #include "../justamcp_editor_plugin.h"
 #include "../justamcp_pagination.h"
 #include "../justamcp_server.h"
+#include "../justamcp_tool_context.h"
 #include "core/io/file_access.h"
 #include "editor/editor_command_palette.h"
 #include "editor/editor_data.h"
@@ -52,6 +53,12 @@ void JustAMCPEditorTools::set_editor_plugin(JustAMCPEditorPlugin *p_plugin) {
 
 Dictionary JustAMCPEditorTools::editor_play_scene(const Dictionary &p_args) {
 	Dictionary result;
+	if (justamcp_is_cancel_requested()) {
+		result["ok"] = false;
+		result["error"] = "cancelled";
+		return result;
+	}
+	justamcp_report_progress(0, 1, "Starting editor play");
 	String scene_path = p_args.get("scene_path", "");
 
 	if (scene_path.is_empty()) {
@@ -456,6 +463,12 @@ Dictionary JustAMCPEditorTools::editor_get_errors(const Dictionary &p_args) {
 
 Dictionary JustAMCPEditorTools::editor_reload_project(const Dictionary &p_args) {
 	Dictionary result;
+	if (justamcp_is_cancel_requested()) {
+		result["ok"] = false;
+		result["error"] = "cancelled";
+		return result;
+	}
+	justamcp_report_progress(0, 1, "Requesting project reload");
 	bool save = p_args.get("save", true);
 	if (DisplayServer::get_singleton() && DisplayServer::get_singleton()->get_name() == "headless") {
 		result["ok"] = false;

--- a/modules/justamcp/tools/justamcp_export_tools.cpp
+++ b/modules/justamcp/tools/justamcp_export_tools.cpp
@@ -28,6 +28,7 @@
 /**************************************************************************/
 
 #include "justamcp_export_tools.h"
+#include "../justamcp_tool_context.h"
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
@@ -211,6 +212,13 @@ Dictionary JustAMCPExportTools::_list_export_presets(const Dictionary &p_params)
 }
 
 Dictionary JustAMCPExportTools::_export_project(const Dictionary &p_params) {
+	if (justamcp_is_cancel_requested()) {
+		Dictionary err;
+		err["ok"] = false;
+		err["error"] = "cancelled";
+		return err;
+	}
+	justamcp_report_progress(0, 2, "Preparing export");
 	int preset_index = p_params.has("preset_index") ? int(p_params["preset_index"]) : -1;
 	String preset_name = p_params.has("preset_name") ? String(p_params["preset_name"]) : "";
 	bool debug = p_params.has("debug") ? bool(p_params["debug"]) : true;
@@ -276,6 +284,7 @@ Dictionary JustAMCPExportTools::_export_project(const Dictionary &p_params) {
 	res["debug"] = debug;
 	res["command"] = command;
 	res["message"] = "Run the command above to export. Direct export from editor plugin is not supported in Godot 4 via simple MCP calls yet.";
+	justamcp_report_progress(2, 2, "Export command prepared");
 	return MCP_SUCCESS(res);
 }
 

--- a/modules/justamcp/tools/justamcp_task_manager.cpp
+++ b/modules/justamcp/tools/justamcp_task_manager.cpp
@@ -31,137 +31,324 @@
 
 #include "justamcp_task_manager.h"
 #include "../justamcp_pagination.h"
+#include "../justamcp_server.h"
+#include "core/config/project_settings.h"
+#include "core/crypto/crypto_core.h"
 #include "core/os/time.h"
 
 void JustAMCPTaskManager::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("create_task", "task_id", "ttl"), &JustAMCPTaskManager::create_task, DEFVAL(60000));
 	ClassDB::bind_method(D_METHOD("list_tasks", "cursor"), &JustAMCPTaskManager::list_tasks, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_task", "task_id"), &JustAMCPTaskManager::get_task);
 	ClassDB::bind_method(D_METHOD("get_task_result", "task_id"), &JustAMCPTaskManager::get_task_result);
 	ClassDB::bind_method(D_METHOD("cancel_task", "task_id"), &JustAMCPTaskManager::cancel_task);
-	ClassDB::bind_method(D_METHOD("complete_task", "task_id", "result"), &JustAMCPTaskManager::complete_task);
-	ClassDB::bind_method(D_METHOD("fail_task", "task_id", "error"), &JustAMCPTaskManager::fail_task);
 }
 
 JustAMCPTaskManager::JustAMCPTaskManager() {}
-JustAMCPTaskManager::~JustAMCPTaskManager() {}
-
-Dictionary JustAMCPTaskManager::create_task(const String &p_task_id, int p_ttl) {
-	Dictionary result;
-	if (active_tasks.has(p_task_id)) {
-		result["ok"] = false;
-		result["error"] = "Task already exists";
-		return result;
+JustAMCPTaskManager::~JustAMCPTaskManager() {
+	MutexLock lock(tasks_mutex);
+	for (const KeyValue<String, JustAMCPTaskRecord *> &kv : tasks) {
+		memdelete(kv.value);
 	}
-
-	Dictionary task_info;
-	task_info["taskId"] = p_task_id;
-	task_info["status"] = "working";
-	task_info["createdAt"] = Time::get_singleton()->get_datetime_string_from_system();
-	task_info["ttl"] = p_ttl;
-	task_info["pollInterval"] = 1000;
-
-	active_tasks[p_task_id] = task_info;
-
-	result["task"] = task_info;
-	result["ok"] = true;
-	return result;
+	tasks.clear();
 }
 
-Dictionary JustAMCPTaskManager::list_tasks(const String &cursor) {
-	Array tasks_array;
-	Array keys = active_tasks.keys();
-	for (int i = 0; i < keys.size(); i++) {
-		Dictionary task_info = active_tasks[keys[i]];
-		tasks_array.push_back(task_info);
+void JustAMCPTaskManager::set_server(JustAMCPServer *p_server) {
+	server = p_server;
+}
+
+String JustAMCPTaskManager::_iso_timestamp_now() const {
+	return Time::get_singleton()->get_datetime_string_from_system(true);
+}
+
+String JustAMCPTaskManager::_generate_task_id() const {
+	uint8_t bytes[16];
+	CryptoCore::RandomGenerator rng;
+	if (rng.get_random_bytes(bytes, 16) != OK) {
+		return vformat("task-%d", Time::get_singleton()->get_ticks_usec());
 	}
-	return justamcp_pagination_slice_array(tasks_array, cursor, "tasks");
+	String hex;
+	for (int i = 0; i < 16; i++) {
+		hex += vformat("%02x", bytes[i]);
+	}
+	return hex;
+}
+
+bool JustAMCPTaskManager::_is_terminal_status(const String &p_status) const {
+	return p_status == "completed" || p_status == "failed" || p_status == "cancelled";
+}
+
+Dictionary JustAMCPTaskManager::_task_to_dict(const JustAMCPTaskRecord &p_task) const {
+	Dictionary d;
+	d["taskId"] = p_task.task_id;
+	d["status"] = p_task.status;
+	if (!p_task.status_message.is_empty()) {
+		d["statusMessage"] = p_task.status_message;
+	}
+	d["createdAt"] = p_task.created_at;
+	d["lastUpdatedAt"] = p_task.last_updated_at;
+	d["ttl"] = p_task.ttl_ms;
+	d["pollInterval"] = p_task.poll_interval_ms;
+	return d;
+}
+
+void JustAMCPTaskManager::_notify_status(const String &p_task_id) {
+	if (server) {
+		server->broadcast_task_status(p_task_id);
+	}
+}
+
+void JustAMCPTaskManager::_purge_expired_tasks() {
+	const uint64_t now_usec = Time::get_singleton()->get_ticks_usec();
+	Vector<String> to_remove;
+	for (const KeyValue<String, JustAMCPTaskRecord *> &kv : tasks) {
+		const JustAMCPTaskRecord *task = kv.value;
+		if (!task || task->ttl_ms <= 0 || task->created_at_usec == 0) {
+			continue;
+		}
+		const uint64_t age_ms = (now_usec - task->created_at_usec) / 1000;
+		if (age_ms > (uint64_t)task->ttl_ms) {
+			to_remove.push_back(kv.key);
+		}
+	}
+	for (int i = 0; i < to_remove.size(); i++) {
+		if (tasks.has(to_remove[i])) {
+			memdelete(tasks[to_remove[i]]);
+			tasks.erase(to_remove[i]);
+		}
+	}
+}
+
+String JustAMCPTaskManager::create_task(int p_ttl_ms, int p_poll_interval_ms, const String &p_progress_token) {
+	MutexLock lock(tasks_mutex);
+	_purge_expired_tasks();
+
+	int max_tasks = 16;
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_max_concurrent")) {
+		max_tasks = int(GLOBAL_GET("blazium/justamcp/task_max_concurrent"));
+	}
+	if (tasks.size() >= (uint32_t)max_tasks) {
+		return String();
+	}
+
+	JustAMCPTaskRecord *task = memnew(JustAMCPTaskRecord);
+	task->task_id = _generate_task_id();
+	task->status = "working";
+	task->status_message = "The operation is now in progress.";
+	task->created_at = _iso_timestamp_now();
+	task->last_updated_at = task->created_at;
+	task->created_at_usec = Time::get_singleton()->get_ticks_usec();
+	task->ttl_ms = p_ttl_ms;
+	task->poll_interval_ms = p_poll_interval_ms;
+	task->progress_token = p_progress_token;
+	tasks.insert(task->task_id, task);
+	return task->task_id;
+}
+
+Dictionary JustAMCPTaskManager::list_tasks(const String &p_cursor) {
+	MutexLock lock(tasks_mutex);
+	_purge_expired_tasks();
+	Array arr;
+	for (const KeyValue<String, JustAMCPTaskRecord *> &kv : tasks) {
+		if (kv.value) {
+			arr.push_back(_task_to_dict(*kv.value));
+		}
+	}
+	return justamcp_pagination_slice_array(arr, p_cursor, "tasks");
 }
 
 Dictionary JustAMCPTaskManager::get_task(const String &p_task_id) {
-	Dictionary result;
-	if (!active_tasks.has(p_task_id)) {
-		result["ok"] = false;
-		result["error_code"] = -32602;
-		result["error"] = "Task ID unknown";
-		return result;
+	MutexLock lock(tasks_mutex);
+	_purge_expired_tasks();
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		Dictionary err;
+		err["ok"] = false;
+		err["error_code"] = -32602;
+		err["error"] = "Failed to retrieve task: Task not found";
+		return err;
 	}
-	Dictionary task_info = active_tasks[p_task_id];
+	Dictionary result;
 	result["ok"] = true;
-	for (int i = 0; i < task_info.size(); i++) {
-		result[task_info.keys()[i]] = task_info.values()[i];
+	Dictionary task_dict = _task_to_dict(*tasks[p_task_id]);
+	for (int i = 0; i < task_dict.size(); i++) {
+		result[task_dict.keys()[i]] = task_dict.values()[i];
 	}
 	return result;
 }
 
 Dictionary JustAMCPTaskManager::get_task_result(const String &p_task_id) {
-	Dictionary result;
-	if (!active_tasks.has(p_task_id)) {
-		result["ok"] = false;
-		result["error_code"] = -32602;
-		result["error"] = "Task ID unknown";
-		return result;
+	bool wait_for_terminal = false;
+	{
+		MutexLock lock(tasks_mutex);
+		_purge_expired_tasks();
+		if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error_code"] = -32602;
+			err["error"] = "Failed to retrieve task: Task not found";
+			return err;
+		}
+		if (!_is_terminal_status(tasks[p_task_id]->status)) {
+			wait_for_terminal = true;
+		}
 	}
 
-	Dictionary task_info = active_tasks[p_task_id];
-	if (task_info.get("status", "") != "completed") {
-		result["ok"] = false;
-		result["error_code"] = -32602;
-		result["error"] = "Task not completed yet or failed.";
-		return result;
+	if (wait_for_terminal) {
+		Semaphore *ready = nullptr;
+		{
+			MutexLock lock(tasks_mutex);
+			if (tasks.has(p_task_id) && tasks[p_task_id]) {
+				ready = &tasks[p_task_id]->result_ready;
+			}
+		}
+		if (ready) {
+			ready->wait();
+		}
 	}
 
+	MutexLock lock(tasks_mutex);
+	_purge_expired_tasks();
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		Dictionary err;
+		err["ok"] = false;
+		err["error_code"] = -32602;
+		err["error"] = "Failed to retrieve task: Task not found";
+		return err;
+	}
+
+	const JustAMCPTaskRecord *task = tasks[p_task_id];
+	if (task->has_stored_error) {
+		Dictionary err;
+		err["ok"] = false;
+		err["error_code"] = task->stored_error.get("code", -32603);
+		err["error"] = task->stored_error.get("message", "Task failed.");
+		return err;
+	}
+
+	Dictionary result = task->stored_result.duplicate();
 	result["ok"] = true;
-	result["content"] = task_info.get("stored_result_content", Array());
-	result["isError"] = false;
-
 	Dictionary meta;
-	Dictionary related_task;
-	related_task["taskId"] = p_task_id;
-	meta["io.modelcontextprotocol/related-task"] = related_task;
+	Dictionary related;
+	related["taskId"] = p_task_id;
+	meta["io.modelcontextprotocol/related-task"] = related;
 	result["_meta"] = meta;
 	return result;
 }
 
 Dictionary JustAMCPTaskManager::cancel_task(const String &p_task_id) {
-	Dictionary result;
-	if (!active_tasks.has(p_task_id)) {
-		result["ok"] = false;
-		result["error_code"] = -32602;
-		result["error"] = "Task ID unknown";
-		return result;
+	{
+		MutexLock lock(tasks_mutex);
+		_purge_expired_tasks();
+		if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error_code"] = -32602;
+			err["error"] = "Failed to retrieve task: Task not found";
+			return err;
+		}
+		if (_is_terminal_status(tasks[p_task_id]->status)) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error_code"] = -32602;
+			err["message"] = vformat("Cannot cancel task: already in terminal status '%s'", tasks[p_task_id]->status);
+			err["error"] = err["message"];
+			return err;
+		}
 	}
-
-	Dictionary task_info = active_tasks[p_task_id];
-	if (task_info.get("status", "") != "completed" && task_info.get("status", "") != "failed") {
-		task_info["status"] = "cancelled";
-		task_info["statusMessage"] = "Cancelled normally";
-		active_tasks[p_task_id] = task_info;
-	}
-
-	result["ok"] = true;
-	for (int i = 0; i < task_info.size(); i++) {
-		result[task_info.keys()[i]] = task_info.values()[i];
-	}
-	return result;
+	cancel_task_execution(p_task_id, "The task was cancelled by request.");
+	return get_task(p_task_id);
 }
 
-void JustAMCPTaskManager::complete_task(const String &p_task_id, const Dictionary &p_result) {
-	if (active_tasks.has(p_task_id)) {
-		Dictionary task_info = active_tasks[p_task_id];
-		task_info["status"] = "completed";
-		task_info["stored_result_content"] = p_result.get("content", Array());
-		active_tasks[p_task_id] = task_info;
+void JustAMCPTaskManager::complete_task(const String &p_task_id, const Dictionary &p_result, bool p_is_error) {
+	MutexLock lock(tasks_mutex);
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		return;
 	}
+	JustAMCPTaskRecord *task = tasks[p_task_id];
+	if (_is_terminal_status(task->status)) {
+		return;
+	}
+	task->stored_result = p_result.duplicate();
+	task->has_stored_error = false;
+	if (p_is_error) {
+		task->status = "failed";
+		task->status_message = "Tool execution returned an error result.";
+	} else {
+		task->status = "completed";
+		task->status_message = "Task completed successfully.";
+	}
+	task->last_updated_at = _iso_timestamp_now();
+	task->is_terminal = true;
+	task->result_ready.post();
+	lock.temp_unlock();
+	_notify_status(p_task_id);
 }
 
 void JustAMCPTaskManager::fail_task(const String &p_task_id, const String &p_error) {
-	if (active_tasks.has(p_task_id)) {
-		Dictionary task_info = active_tasks[p_task_id];
-		task_info["status"] = "failed";
-		task_info["statusMessage"] = p_error;
-		active_tasks[p_task_id] = task_info;
+	MutexLock lock(tasks_mutex);
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		return;
 	}
+	JustAMCPTaskRecord *task = tasks[p_task_id];
+	if (_is_terminal_status(task->status)) {
+		return;
+	}
+	task->status = "failed";
+	task->status_message = p_error;
+	task->last_updated_at = _iso_timestamp_now();
+	task->is_terminal = true;
+	task->has_stored_error = true;
+	Dictionary err;
+	err["code"] = -32603;
+	err["message"] = p_error;
+	task->stored_error = err;
+	task->result_ready.post();
+	lock.temp_unlock();
+	_notify_status(p_task_id);
+}
+
+void JustAMCPTaskManager::cancel_task_execution(const String &p_task_id, const String &p_message) {
+	MutexLock lock(tasks_mutex);
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		return;
+	}
+	JustAMCPTaskRecord *task = tasks[p_task_id];
+	if (_is_terminal_status(task->status)) {
+		return;
+	}
+	task->cancel_requested = true;
+	task->status = "cancelled";
+	task->status_message = p_message;
+	task->last_updated_at = _iso_timestamp_now();
+	task->is_terminal = true;
+	task->has_stored_error = false;
+	Array content;
+	Dictionary content_item;
+	content_item["type"] = "text";
+	content_item["text"] = p_message;
+	content.push_back(content_item);
+	Dictionary stored;
+	stored["content"] = content;
+	stored["isError"] = true;
+	task->stored_result = stored;
+	task->result_ready.post();
+	lock.temp_unlock();
+	_notify_status(p_task_id);
+}
+
+bool JustAMCPTaskManager::is_cancel_requested(const String &p_task_id) const {
+	MutexLock lock(tasks_mutex);
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		return false;
+	}
+	return tasks[p_task_id]->cancel_requested;
+}
+
+String JustAMCPTaskManager::get_progress_token(const String &p_task_id) const {
+	MutexLock lock(tasks_mutex);
+	if (!tasks.has(p_task_id) || !tasks[p_task_id]) {
+		return String();
+	}
+	return tasks[p_task_id]->progress_token;
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -31,6 +31,7 @@
 #include "../justamcp_pagination.h"
 #include "../justamcp_runtime.h"
 #include "../justamcp_server.h"
+#include "../justamcp_tool_context.h"
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
@@ -461,7 +462,7 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	String current_category = "";
 	bool is_core = false;
 
-	auto add_schema = [&](const String &p_name, const String &p_desc, const Vector<String> &p_props, const Vector<String> &p_req) {
+	auto add_schema = [&](const String &p_name, const String &p_desc, const Vector<String> &p_props, const Vector<String> &p_req, const String &p_task_support = "forbidden") {
 		String full_name = "blazium_" + p_name;
 
 		if (p_register_only) {
@@ -553,6 +554,11 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 			schema["required"] = req;
 		}
 		t["inputSchema"] = schema;
+		if (p_task_support != "forbidden") {
+			Dictionary execution;
+			execution["taskSupport"] = p_task_support;
+			t["execution"] = execution;
+		}
 		tools.push_back(t);
 	};
 
@@ -568,7 +574,7 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	current_category = "editor_tools";
 	is_core = false;
 	add_schema("editor_play_scene", "Runs the currently active or specified scene.",
-			Vector<String>{ "scene_path", "string" }, Vector<String>{});
+			Vector<String>{ "scene_path", "string" }, Vector<String>{}, "optional");
 	add_schema("editor_play_main", "Runs the project's main scene.",
 			Vector<String>{}, Vector<String>{});
 	add_schema("editor_stop_play", "Terminates an active play session.",
@@ -604,7 +610,7 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	add_schema("logs_read", "Reads recent JustAMCP/editor log lines with optional filtering and MCP notification replay.",
 			Vector<String>{ "limit", "number", "since_index", "number", "source", "string", "cursor", "string" }, Vector<String>{});
 	add_schema("editor_reload_project", "Requests an editor restart to reload the project.",
-			Vector<String>{ "save", "boolean" }, Vector<String>{});
+			Vector<String>{ "save", "boolean" }, Vector<String>{}, "optional");
 	add_schema("editor_save_all_scenes", "Saves all open editor scenes.",
 			Vector<String>{}, Vector<String>{});
 	add_schema("editor_get_signals", "Lists signals for a class or node in the edited scene.",
@@ -974,7 +980,13 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	add_schema("list_export_presets", "Reads and returns all export presets from export_presets.cfg.",
 			Vector<String>{}, Vector<String>{});
 	add_schema("export_project", "Triggers a headless Godot export operation.",
-			Vector<String>{ "preset_index", "number", "preset_name", "string", "debug", "boolean" }, Vector<String>{});
+			Vector<String>{ "preset_index", "number", "preset_name", "string", "debug", "boolean" }, Vector<String>{}, "optional");
+	add_schema("export_release", "Exports the project using the release preset.",
+			Vector<String>{ "preset_name", "string", "preset_index", "number" }, Vector<String>{}, "optional");
+	add_schema("export_debug", "Exports the project using the debug preset.",
+			Vector<String>{ "preset_name", "string", "preset_index", "number" }, Vector<String>{}, "optional");
+	add_schema("export_custom", "Exports the project with explicit debug/release selection.",
+			Vector<String>{ "preset_name", "string", "preset_index", "number", "debug", "boolean" }, Vector<String>{}, "optional");
 	add_schema("get_export_info", "Returns metadata regarding absolute template directions and binary configurations.",
 			Vector<String>{}, Vector<String>{});
 	add_schema("list_android_devices", "Lists Android devices visible to adb.",
@@ -982,7 +994,7 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	add_schema("get_android_preset_info", "Reads Android export preset metadata.",
 			Vector<String>{ "preset_name", "string", "preset_index", "number" }, Vector<String>{});
 	add_schema("deploy_to_android", "Exports, installs, and optionally launches an Android build through adb.",
-			Vector<String>{ "preset_name", "string", "preset_index", "number", "device_serial", "string", "debug", "boolean", "skip_export", "boolean", "launch", "boolean" }, Vector<String>{});
+			Vector<String>{ "preset_name", "string", "preset_index", "number", "device_serial", "string", "debug", "boolean", "skip_export", "boolean", "launch", "boolean" }, Vector<String>{}, "optional");
 
 	// Batch Tools
 	current_category = "batch_tools";
@@ -996,7 +1008,7 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	add_schema("batch_add_nodes", "Adds multiple nodes to the currently edited scene in one call.",
 			Vector<String>{ "nodes", "array" }, Vector<String>{ "nodes" });
 	add_schema("batch_execute", "Executes multiple JustAMCP tools sequentially with optional undo on failure.",
-			Vector<String>{ "steps", "array", "stop_on_error", "boolean", "undo_on_error", "boolean" }, Vector<String>{ "steps" });
+			Vector<String>{ "steps", "array", "stop_on_error", "boolean", "undo_on_error", "boolean" }, Vector<String>{ "steps" }, "optional");
 	add_schema("find_node_references", "Searches file system recursively for reference nodes by string pattern.",
 			Vector<String>{ "pattern", "string" }, Vector<String>{ "pattern" });
 	add_schema("cross_scene_set_property", "Modifies properties identically across ALL scene files matching parameters saving changes into file system.",
@@ -1284,13 +1296,13 @@ Array JustAMCPToolExecutor::get_tool_schemas(bool p_register_only, bool p_ignore
 	current_category = "autowork_tools";
 	is_core = false;
 	add_schema("autowork_run_all_tests", "Recursively traverses and executes all autowork test suites natively returning structured passing/failure statistics.",
-			Vector<String>{}, Vector<String>{});
+			Vector<String>{}, Vector<String>{}, "optional");
 	add_schema("autowork_run_tests_in_directory", "Recursively finds and executes all Godot autowork unit tests inside a given directory, returning formatted results.",
-			Vector<String>{ "directory_path", "string" }, Vector<String>{ "directory_path" });
+			Vector<String>{ "directory_path", "string" }, Vector<String>{ "directory_path" }, "optional");
 	add_schema("autowork_run_test_script", "Executes an exact test script natively against the runtime test suite framework evaluating state.",
-			Vector<String>{ "script_path", "string" }, Vector<String>{ "script_path" });
+			Vector<String>{ "script_path", "string" }, Vector<String>{ "script_path" }, "optional");
 	add_schema("autowork_run_test_by_name", "Performs regex lookup isolating explicit test pattern function names universally across suites for debugging single logic instances.",
-			Vector<String>{ "test_name", "string" }, Vector<String>{ "test_name" });
+			Vector<String>{ "test_name", "string" }, Vector<String>{ "test_name" }, "optional");
 #endif
 
 	return tools;
@@ -1335,6 +1347,13 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		result["ok"] = false;
 		result["error"] = err;
 		return result;
+	}
+
+	if (justamcp_is_cancel_requested()) {
+		Dictionary err;
+		err["ok"] = false;
+		err["error"] = "cancelled";
+		return err;
 	}
 
 	if (target_schema.has("inputSchema")) {
@@ -1751,7 +1770,28 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		return export_tools->execute_tool(internal_name, p_args);
 	}
 	if (internal_name == "export_project") {
-		return export_tools->execute_tool(internal_name, p_args);
+		justamcp_report_progress(0, 2, "Starting export_project");
+		if (justamcp_is_cancel_requested()) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error"] = "cancelled";
+			return err;
+		}
+		Dictionary export_result = export_tools->execute_tool(internal_name, p_args);
+		justamcp_report_progress(2, 2, "export_project finished");
+		return export_result;
+	}
+	if (internal_name == "deploy_to_android") {
+		justamcp_report_progress(0, 3, "Starting deploy_to_android");
+		if (justamcp_is_cancel_requested()) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error"] = "cancelled";
+			return err;
+		}
+		Dictionary deploy_result = export_tools->execute_tool(internal_name, p_args);
+		justamcp_report_progress(3, 3, "deploy_to_android finished");
+		return deploy_result;
 	}
 	if (internal_name == "get_export_info") {
 		return export_tools->execute_tool(internal_name, p_args);
@@ -1760,9 +1800,6 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		return export_tools->execute_tool(internal_name, p_args);
 	}
 	if (internal_name == "get_android_preset_info") {
-		return export_tools->execute_tool(internal_name, p_args);
-	}
-	if (internal_name == "deploy_to_android") {
 		return export_tools->execute_tool(internal_name, p_args);
 	}
 
@@ -1904,7 +1941,17 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		bool undo_on_error = p_args.get("undo_on_error", false);
 		Array results;
 		int completed = 0;
+		const int total_steps = steps.size();
+		justamcp_report_progress(0, total_steps > 0 ? total_steps : 1, "Starting batch_execute");
 		for (int i = 0; i < steps.size(); i++) {
+			if (justamcp_is_cancel_requested()) {
+				Dictionary err;
+				err["ok"] = false;
+				err["error"] = "cancelled";
+				results.push_back(err);
+				break;
+			}
+			justamcp_report_progress(i, total_steps > 0 ? total_steps : 1, vformat("batch step %d", i + 1));
 			if (steps[i].get_type() != Variant::DICTIONARY) {
 				Dictionary step_error;
 				step_error["ok"] = false;
@@ -1944,12 +1991,32 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 				completed++;
 			}
 		}
+		justamcp_report_progress(total_steps > 0 ? total_steps : 1, total_steps > 0 ? total_steps : 1, "batch_execute finished");
 		Dictionary ret;
 		ret["ok"] = true;
 		ret["results"] = results;
 		ret["completed"] = completed;
 		ret["count"] = results.size();
 		return ret;
+	}
+
+	if (internal_name == "export_release" || internal_name == "export_debug" || internal_name == "export_custom") {
+		Dictionary export_args = p_args.duplicate();
+		if (internal_name == "export_release") {
+			export_args["debug"] = false;
+		} else if (internal_name == "export_debug") {
+			export_args["debug"] = true;
+		}
+		justamcp_report_progress(0, 1, vformat("Starting %s", internal_name));
+		if (justamcp_is_cancel_requested()) {
+			Dictionary err;
+			err["ok"] = false;
+			err["error"] = "cancelled";
+			return err;
+		}
+		Dictionary export_result = export_tools->execute_tool("export_project", export_args);
+		justamcp_report_progress(1, 1, vformat("Finished %s", internal_name));
+		return export_result;
 	}
 
 #ifdef MODULE_AUTOWORK_ENABLED


### PR DESCRIPTION
## Summary
- Add task-augmented `tools/call` with immediate CreateTaskResult, blocking `tasks/result`, `tasks/cancel`, and `notifications/tasks/status` for long-running tools.
- Track `_meta.progressToken` and emit `notifications/progress` with rate limiting via `report_tool_progress`.
- Wire `notifications/cancelled` for sync tool calls; cooperative cancel checks in autowork, export, batch, and editor play/reload tools.

## Test plan
- [ ] `tools/list` shows `execution.taskSupport: optional` only on whitelisted tools
- [ ] `tools/call` with `task` on autowork returns CreateTaskResult; poll `tasks/get` / `tasks/result`
- [ ] Sync `tools/call` without `task` on optional tools still works
- [ ] `tools/call` with `task` on fast/forbidden tools returns -32601
- [ ] `_meta.progressToken` emits monotonic `notifications/progress` during autowork
- [ ] `notifications/cancelled` stops sync in-flight tool call
- [ ] `tasks/cancel` during task run sets status cancelled
- [ ] `tasks/cancel` on completed task returns -32602
- [ ] Invalid taskId on get/result/cancel returns -32602
