### PR TITLE
Add native xbox_module with GDK PC integration and Autowork tests

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -7,7 +7,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   BLAZIUM_BASE_BRANCH: blazium-dev
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{ github.workspace }}/"
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes module_xbox_module_enabled=no "angle_libs=${{ github.workspace }}/"
   SCONS_CACHE_MSVC_CONFIG: true
 
 concurrency:
@@ -82,6 +82,26 @@ jobs:
             compiler: gcc
             cache-limit: 1
 
+          - name: Editor w/ Xbox Module (target=editor, tests=yes, module_xbox_module_enabled=yes)
+            cache-name: windows-editor-xbox-module
+            target: editor
+            tests: true
+            sconsflags: debug_symbols=no windows_subsystem=console module_xbox_module_enabled=yes
+            bin: ./bin/blazium.windows.editor.tests.x86_64.exe
+            compiler: msvc
+            xbox-module-test: true
+            cache-limit: 1
+
+          - name: Template w/ Xbox Module (target=template_release, tests=yes, module_xbox_module_enabled=yes)
+            cache-name: windows-template-xbox-module
+            target: template_release
+            tests: true
+            sconsflags: debug_symbols=no tests=yes windows_subsystem=console module_xbox_module_enabled=yes
+            bin: ./bin/blazium.windows.template_release.tests.x86_64.exe
+            compiler: msvc
+            xbox-module-test: true
+            cache-limit: 1
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -96,6 +116,39 @@ jobs:
 
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
+
+      - name: Install Microsoft Gaming GDK and resolve path
+        if: matrix.xbox-module-test
+        shell: pwsh
+        run: |
+          winget install --id Microsoft.Gaming.GDK --accept-package-agreements --accept-source-agreements
+
+          function Get-GdkEditionRoot {
+            foreach ($name in @('GameDKCoreLatest','GameDKLatest','GRDKLatest')) {
+              foreach ($target in @('Process','Machine','User')) {
+                $value = [Environment]::GetEnvironmentVariable($name, $target)
+                if ($value -and (Test-Path $value)) { return $value.TrimEnd('\') }
+              }
+            }
+            $root = Join-Path ${env:ProgramFiles(x86)} 'Microsoft GDK'
+            if (-not (Test-Path $root)) { return $null }
+            $best = $null; $bestNum = -1
+            Get-ChildItem $root -Directory | ForEach-Object {
+              if ($_.Name -match '^\d+$' -and (Test-Path (Join-Path $_.FullName 'windows\include\XGameRuntime.h'))) {
+                $num = [int]$_.Name
+                if ($num -gt $bestNum) { $bestNum = $num; $best = $_.FullName }
+              }
+            }
+            return $best
+          }
+
+          $editionRoot = Get-GdkEditionRoot
+          if (-not $editionRoot) {
+            Write-Error 'GDK not found after winget install (no env marker and no Microsoft GDK edition under Program Files (x86)).'
+            exit 1
+          }
+          Write-Host "GDK edition root: $editionRoot"
+          "gdk_path=$editionRoot" >> $env:GITHUB_ENV
 
       - name: Download Direct3D 12 SDK components
         run: python ./misc/scripts/install_d3d12_sdk_windows.py
@@ -146,9 +199,16 @@ jobs:
           name: ${{ matrix.cache-name }}
 
       - name: Unit tests
-        if: matrix.tests
+        if: matrix.tests && !matrix.xbox-module-test
         timeout-minutes: 45
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
           ${{ matrix.bin }} --headless --test --force-colors
+
+      - name: Xbox module unit tests
+        if: matrix.xbox-module-test
+        timeout-minutes: 15
+        run: |
+          ${{ matrix.bin }} --version
+          ${{ matrix.bin }} --headless --test --force-colors --test-case="*[XboxModule]*"

--- a/modules/xbox_module/SCsub
+++ b/modules/xbox_module/SCsub
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_xbox_module = env_modules.Clone()
+
+if env.get("xbox_module_gdk", False):
+    env_xbox_module.Append(CPPDEFINES=["XBOX_MODULE_GDK_ENABLED", "_GAMING_DESKTOP"])
+
+env_xbox_module.add_source_files(env.modules_sources, "register_types.cpp")
+env_xbox_module.add_source_files(env.modules_sources, "gdk/*.cpp")
+
+if env.editor_build:
+    env_xbox_module.add_source_files(env.modules_sources, "editor/*.cpp")
+    env_xbox_module.add_source_files(env.modules_sources, "editor/export/*.cpp")
+elif env["tests"]:
+    # Unit tests cover export helpers without pulling in full editor/export code.
+    env_xbox_module.add_source_files(env.modules_sources, "editor/gdk_toolchain.cpp")
+    env_xbox_module.add_source_files(env.modules_sources, "editor/microsoft_game_config.cpp")
+
+if env["tests"]:
+    env_xbox_module.Append(CPPDEFINES=["TESTS_ENABLED"])

--- a/modules/xbox_module/config.py
+++ b/modules/xbox_module/config.py
@@ -1,0 +1,231 @@
+import os
+
+
+def is_enabled():
+    # Disabled by default. Enable with: module_xbox_module_enabled=yes
+    return False
+
+
+def get_opts(platform):
+    from SCons.Variables import PathVariable
+
+    return [
+        PathVariable(
+            "gdk_path",
+            "Path to Microsoft GDK installation (edition or windows layout)",
+            "",
+            PathVariable.PathAccept,
+        ),
+    ]
+
+
+def can_build(env, platform):
+    return platform == "windows"
+
+
+def _normalize_gdk_windows_path(path):
+    if not path:
+        return None
+
+    path = os.path.normpath(path)
+
+    if os.path.isfile(os.path.join(path, "include", "XGameRuntime.h")):
+        return path
+
+    windows_subdir = os.path.join(path, "windows")
+    if os.path.isfile(os.path.join(windows_subdir, "include", "XGameRuntime.h")):
+        return windows_subdir
+
+    grdk_sibling = os.path.join(os.path.dirname(path), "windows")
+    if os.path.isfile(os.path.join(grdk_sibling, "include", "XGameRuntime.h")):
+        return grdk_sibling
+
+    return None
+
+
+def _pick_latest_version_dir(root):
+    if not root or not os.path.isdir(root):
+        return None
+
+    best = None
+    best_num = -1
+    for entry in os.listdir(root):
+        full = os.path.join(root, entry)
+        if not os.path.isdir(full):
+            continue
+        if not entry.isdigit():
+            continue
+        version_num = int(entry)
+        if version_num > best_num:
+            candidate = _normalize_gdk_windows_path(full)
+            if candidate:
+                best = candidate
+                best_num = version_num
+
+    return best
+
+
+def _discover_default_gdk_install():
+    program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    default_root = os.path.join(program_files_x86, "Microsoft GDK")
+    if not os.path.isdir(default_root):
+        return None
+    return _pick_latest_version_dir(default_root)
+
+
+def _discover_gdk_path(env):
+    explicit = str(env.get("gdk_path", "")).strip()
+    if not explicit:
+        explicit = os.environ.get("gdk_path", "").strip()
+    if explicit:
+        normalized = _normalize_gdk_windows_path(explicit)
+        if normalized:
+            return normalized
+        latest = _pick_latest_version_dir(explicit)
+        if latest:
+            return latest
+
+    for env_name in ("GameDKCoreLatest", "GameDKLatest", "GRDKLatest"):
+        env_value = os.environ.get(env_name, "").strip()
+        if not env_value:
+            continue
+        normalized = _normalize_gdk_windows_path(env_value)
+        if normalized:
+            return normalized
+
+    for env_name in ("GameDK", "GRDK"):
+        env_value = os.environ.get(env_name, "").strip()
+        if not env_value:
+            continue
+        latest = _pick_latest_version_dir(env_value)
+        if latest:
+            return latest
+
+    return _discover_default_gdk_install()
+
+
+def _copy_gdk_runtime_dlls(env, gdk_windows):
+    bin_dir = os.path.join(gdk_windows, "bin", "x64")
+    if not os.path.isdir(bin_dir):
+        return
+
+    dll_names = [
+        "libHttpClient.dll",
+        "XCurl.dll",
+        "Microsoft.Xbox.Services.C.Thunks.dll",
+    ]
+    if env["target"] in ("editor", "template_debug"):
+        dll_names.append("Microsoft.Xbox.Services.C.Thunks.Debug.dll")
+
+    output_dir = os.path.join(env.Dir("#").abspath, "bin")
+    os.makedirs(output_dir, exist_ok=True)
+
+    for dll_name in dll_names:
+        src = os.path.join(bin_dir, dll_name)
+        if not os.path.isfile(src):
+            continue
+        dst = os.path.join(output_dir, dll_name)
+        if os.path.isfile(dst) and os.path.getmtime(dst) >= os.path.getmtime(src):
+            continue
+        try:
+            import shutil
+
+            shutil.copy2(src, dst)
+        except OSError as exc:
+            print(f"xbox_module: failed to copy GDK runtime DLL {dll_name}: {exc}")
+            return
+
+    print(f"xbox_module: staged GDK runtime DLLs in {output_dir}")
+
+
+def configure(env):
+    gdk_windows = _discover_gdk_path(env)
+    env["xbox_module_gdk"] = gdk_windows is not None
+
+    if not gdk_windows:
+        print(
+            "xbox_module: Microsoft GDK not found (set gdk_path or GameDKCoreLatest/GameDKLatest). "
+            "Building stub implementation without XBOX_MODULE_GDK_ENABLED."
+        )
+        return
+
+    include_dir = os.path.join(gdk_windows, "include")
+    lib_dir = os.path.join(gdk_windows, "lib", "x64")
+
+    if not os.path.isdir(include_dir):
+        print(f"xbox_module: GDK include directory not found at {include_dir}")
+        env["xbox_module_gdk"] = False
+        return
+
+    if not os.path.isdir(lib_dir):
+        print(f"xbox_module: GDK lib directory not found at {lib_dir}")
+        env["xbox_module_gdk"] = False
+        return
+
+    env.Append(
+        CPPDEFINES=[
+            "XBOX_MODULE_GDK_ENABLED",
+            "_GAMING_DESKTOP",
+            ("WINAPI_FAMILY", "WINAPI_FAMILY_DESKTOP_APP"),
+        ]
+    )
+    env.Append(CPPPATH=[include_dir])
+    env.Append(LIBPATH=[lib_dir])
+
+    # Custom-engine PC integration: GRTS via xgameruntime.lib; XSAPI via Thunks
+    # import lib + runtime DLL (see Microsoft GDK custom-engine get-started guide).
+    gdk_libs = [
+        "xgameruntime",
+        "Microsoft.Xbox.Services.C.Thunks",
+        "libHttpClient",
+        "XCurl",
+        "GameChat2",
+    ]
+    for lib_name in gdk_libs:
+        lib_file = os.path.join(lib_dir, lib_name + ".lib")
+        if os.path.isfile(lib_file):
+            env.Append(LIBS=[env.File(lib_file)])
+        else:
+            print(f"xbox_module: GDK library not found: {lib_file}")
+            env["xbox_module_gdk"] = False
+            return
+
+    _copy_gdk_runtime_dlls(env, gdk_windows)
+
+    print(f"xbox_module: Microsoft GDK enabled from {gdk_windows} (XSAPI via Thunks.dll)")
+
+
+def get_doc_classes():
+    return [
+        "GDK",
+        "GDKResult",
+        "GDKPendingSignal",
+        "GDKUser",
+        "GDKUsers",
+        "GDKGameUI",
+        "GDKAccessibility",
+        "GDKAchievement",
+        "GDKAchievements",
+        "GDKPackage",
+        "GDKStats",
+        "GDKLeaderboards",
+        "GDKPrivacy",
+        "GDKPresence",
+        "GDKSocial",
+        "GDKStore",
+        "GDKProfile",
+        "GDKStringVerify",
+        "GDKTitleStorage",
+        "GDKErrorReporting",
+        "GDKLauncher",
+        "GDKMultiplayerActivity",
+        "GDKCapture",
+        "GDKSystem",
+        "GDKDisplay",
+        "GDKActivation",
+        "XboxEditorPlugin",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/xbox_module/doc_classes/GDK.xml
+++ b/modules/xbox_module/doc_classes/GDK.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDK" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Native Xbox GDK runtime singleton for Xbox on PC.
+	</brief_description>
+	<description>
+		Access via [code]Engine.get_singleton("GDK")[/code]. Provides Xbox Game Runtime initialization, task-queue dispatch, and Xbox Live service namespaces.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="initialize">
+			<return type="GDKResult" />
+			<param index="0" name="config" type="Variant" default="null" />
+			<description>
+				Initializes the GDK runtime and shared task queue.
+			</description>
+		</method>
+		<method name="shutdown">
+			<return type="void" />
+			<description>
+				Shuts down the active GDK session (process-lifetime runtime remains until exit).
+			</description>
+		</method>
+		<method name="is_available">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when this build was compiled with GDK support.
+			</description>
+		</method>
+		<method name="is_initialized">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] after a successful [method initialize] call.
+			</description>
+		</method>
+		<method name="dispatch">
+			<return type="int" />
+			<description>
+				Pumps the GDK completion port; call each frame or enable [code]gdk/runtime/embed_dispatch[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/xbox_module/doc_classes/GDKResult.xml
+++ b/modules/xbox_module/doc_classes/GDKResult.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDKResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Normalized result object for GDK async operations.
+	</brief_description>
+	<description>
+		Contains [code]ok[/code], [code]hresult[/code], [code]code[/code], [code]message[/code], and optional [code]data[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_ok">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the operation completed successfully.
+			</description>
+		</method>
+		<method name="get_hresult">
+			<return type="int" />
+			<description>
+				Returns the underlying Win32 [code]HRESULT[/code] value for the result.
+			</description>
+		</method>
+		<method name="get_code">
+			<return type="String" />
+			<description>
+				Returns the stable machine-readable error code (for example [code]already_initialized[/code]).
+			</description>
+		</method>
+		<method name="get_message">
+			<return type="String" />
+			<description>
+				Returns the human-readable result message.
+			</description>
+		</method>
+		<method name="get_data">
+			<return type="Variant" />
+			<description>
+				Returns optional payload data attached to the result.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/xbox_module/doc_classes/XboxEditorPlugin.xml
+++ b/modules/xbox_module/doc_classes/XboxEditorPlugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="XboxEditorPlugin" inherits="EditorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Editor integration for the Xbox on PC export platform and MicrosoftGame.config tooling.
+	</brief_description>
+	<description>
+		[XboxEditorPlugin] registers the Xbox on PC export platform, exposes menu actions for creating and validating [code]MicrosoftGame.config[/code], and surfaces GDK toolchain status in the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/xbox_module/editor/export/xbox_export_platform.cpp
+++ b/modules/xbox_module/editor/export/xbox_export_platform.cpp
@@ -1,0 +1,323 @@
+/**************************************************************************/
+/*  xbox_export_platform.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "xbox_export_platform.h"
+
+#include "../gdk_toolchain.h"
+#include "../microsoft_game_config.h"
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/os/os.h"
+#include "core/templates/list.h"
+#include "scene/resources/image_texture.h"
+
+EditorExportPlatformXbox::EditorExportPlatformXbox() {
+	set_name("Xbox on PC");
+	set_os_name("Windows");
+
+	Ref<Image> logo_image = Image::create_empty(16, 16, false, Image::FORMAT_RGBA8);
+	logo_image->fill(Color(0.0, 0.5, 0.0));
+	Ref<ImageTexture> logo_tex = ImageTexture::create_from_image(logo_image);
+	set_logo(logo_tex);
+
+	toolchain = GDKToolchain::create();
+}
+
+void EditorExportPlatformXbox::set_export_target(XboxExportTarget p_target) {
+	export_target = p_target;
+}
+
+XboxExportTarget EditorExportPlatformXbox::get_export_target() const {
+	return export_target;
+}
+
+String EditorExportPlatformXbox::get_target_device_family(XboxExportTarget p_target) const {
+	switch (p_target) {
+		case XBOX_EXPORT_TARGET_XBOX_ONE:
+			return "XboxOne";
+		case XBOX_EXPORT_TARGET_XBOX_SERIES:
+			return "XboxSeries";
+		case XBOX_EXPORT_TARGET_GDK_DESKTOP:
+		default:
+			return "PC";
+	}
+}
+
+String EditorExportPlatformXbox::get_template_file_name_for_target(XboxExportTarget p_target, bool p_debug) const {
+	switch (p_target) {
+		case XBOX_EXPORT_TARGET_XBOX_ONE:
+			return vformat("xbox_durango_%s.exe", p_debug ? "debug" : "release");
+		case XBOX_EXPORT_TARGET_XBOX_SERIES:
+			return vformat("xbox_scarlett_%s.exe", p_debug ? "debug" : "release");
+		case XBOX_EXPORT_TARGET_GDK_DESKTOP:
+		default:
+			return vformat("windows_%s_x86_64.exe", p_debug ? "debug" : "release");
+	}
+}
+
+String EditorExportPlatformXbox::get_template_file_name(const String &p_target, const String &p_arch) const {
+	bool debug = p_target.contains("debug");
+	return get_template_file_name_for_target(export_target, debug);
+}
+
+List<String> EditorExportPlatformXbox::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> extensions;
+	extensions.push_back("msixvc");
+	return extensions;
+}
+
+void EditorExportPlatformXbox::get_platform_features(List<String> *r_features) const {
+	r_features->push_back("pc");
+	r_features->push_back("windows");
+	r_features->push_back("gdk");
+	r_features->push_back("xbox");
+	r_features->push_back("d3d12");
+	r_features->push_back("x86_64");
+}
+
+void EditorExportPlatformXbox::get_export_options(List<ExportOption> *r_options) const {
+	EditorExportPlatformPC::get_export_options(r_options);
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64"), "x86_64"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "packaging/ekb_file", PROPERTY_HINT_GLOBAL_FILE, "*.ekb"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "dev/register_loose"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "dev/sandbox_id"), "RETAIL"));
+}
+
+bool EditorExportPlatformXbox::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
+	if (p_option == "packaging/ekb_file") {
+		return !p_preset->get("dev/register_loose");
+	}
+	if (p_option == "dev/sandbox_id") {
+		return p_preset->get("dev/register_loose");
+	}
+	return true;
+}
+
+String EditorExportPlatformXbox::get_windows_template_path(bool p_debug) const {
+	String template_name = get_template_file_name_for_target(XBOX_EXPORT_TARGET_GDK_DESKTOP, p_debug);
+	String found = find_export_template(template_name);
+	if (!found.is_empty()) {
+		return found;
+	}
+	return OS::get_singleton()->get_executable_path();
+}
+
+bool EditorExportPlatformXbox::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
+	if (!toolchain.is_valid() || !toolchain->is_gdk_available()) {
+		r_error = "Microsoft GDK not found. Install via: winget install Microsoft.Gaming.GDK";
+		return false;
+	}
+	r_error = String();
+	return true;
+}
+
+bool EditorExportPlatformXbox::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+	r_missing_templates = false;
+
+	if (export_target == XBOX_EXPORT_TARGET_XBOX_ONE || export_target == XBOX_EXPORT_TARGET_XBOX_SERIES) {
+		r_error = "Xbox console export requires GDKX and console export templates (not available in public GDK).";
+		return false;
+	}
+
+	if (!has_valid_project_configuration(p_preset, r_error)) {
+		return false;
+	}
+
+	String config_error;
+	if (MicrosoftGameConfig::validate_project_config(&config_error).is_empty()) {
+		r_error = config_error;
+		return false;
+	}
+
+	String template_path = get_windows_template_path(p_debug);
+	if (template_path.is_empty()) {
+		r_error = "Windows export template not found.";
+		r_missing_templates = true;
+		return false;
+	}
+
+	r_error = String();
+	return true;
+}
+
+void EditorExportPlatformXbox::_remove_dir_recursive(const String &p_path) {
+	Ref<DirAccess> da = DirAccess::open(p_path);
+	if (da.is_null()) {
+		return;
+	}
+	da->list_dir_begin();
+	String entry = da->get_next();
+	while (!entry.is_empty()) {
+		if (da->current_is_dir()) {
+			_remove_dir_recursive(p_path.path_join(entry));
+		} else {
+			da->remove(entry);
+		}
+		entry = da->get_next();
+	}
+	da->list_dir_end();
+	DirAccess::remove_absolute(p_path);
+}
+
+Error EditorExportPlatformXbox::_stage_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_abs_output_path, BitField<DebugFlags> p_flags, String &r_staging_dir) {
+	ProjectSettings *settings = ProjectSettings::get_singleton();
+	ERR_FAIL_NULL_V(settings, ERR_UNAVAILABLE);
+
+	String out_dir = p_abs_output_path.get_base_dir();
+	Error mk_err = DirAccess::make_dir_recursive_absolute(out_dir);
+	ERR_FAIL_COND_V(mk_err != OK, mk_err);
+
+	r_staging_dir = out_dir.path_join("_xbox_staging");
+	if (DirAccess::exists(r_staging_dir)) {
+		_remove_dir_recursive(r_staging_dir);
+	}
+	mk_err = DirAccess::make_dir_recursive_absolute(r_staging_dir);
+	ERR_FAIL_COND_V(mk_err != OK, mk_err);
+
+	Ref<FileAccess> gdignore = FileAccess::open(r_staging_dir.path_join(".gdignore"), FileAccess::WRITE);
+	if (gdignore.is_valid()) {
+		gdignore->close();
+	}
+
+	const String exe_name = MicrosoftGameConfig::validate_project_config();
+	ERR_FAIL_COND_V(exe_name.is_empty(), ERR_FILE_NOT_FOUND);
+
+	const String exe_path = r_staging_dir.path_join(exe_name);
+	const String pck_path = r_staging_dir.path_join(exe_name.get_basename() + ".pck");
+
+	const String template_path = get_windows_template_path(p_debug);
+	Error copy_err = DirAccess::copy_absolute(template_path, exe_path);
+	ERR_FAIL_COND_V(copy_err != OK, copy_err);
+
+	Error pck_err = export_pack(p_preset, p_debug, pck_path, p_flags);
+	ERR_FAIL_COND_V(pck_err != OK, pck_err);
+
+	if (toolchain.is_valid()) {
+		copy_err = toolchain->copy_runtime_dlls(r_staging_dir, p_debug);
+		ERR_FAIL_COND_V(copy_err != OK, copy_err);
+	}
+
+	copy_err = MicrosoftGameConfig::copy_to_staging(r_staging_dir, get_target_device_family(export_target));
+	ERR_FAIL_COND_V(copy_err != OK, copy_err);
+
+	MicrosoftGameConfig::stage_logos(r_staging_dir);
+	return OK;
+}
+
+Error EditorExportPlatformXbox::_wdapp_register(const String &p_staging_dir) {
+	if (!toolchain.is_valid() || toolchain->get_wdapp_path().is_empty()) {
+		return ERR_UNAVAILABLE;
+	}
+
+	List<String> args;
+	args.push_back("register");
+	args.push_back(ProjectSettings::get_singleton()->globalize_path(p_staging_dir));
+
+	int exit_code = 0;
+	String output;
+	Error err = OS::get_singleton()->execute(toolchain->get_wdapp_path(), args, &output, &exit_code, true);
+	if (err != OK || exit_code != 0) {
+		add_message(EXPORT_MESSAGE_ERROR, "XboxExport", vformat("wdapp register failed (exit %d): %s", exit_code, output));
+		return ERR_BUG;
+	}
+	add_message(EXPORT_MESSAGE_INFO, "XboxExport", "Registered loose package via wdapp.");
+	return OK;
+}
+
+Error EditorExportPlatformXbox::_makepkg_pack(const Ref<EditorExportPreset> &p_preset, const String &p_staging_dir, const String &p_output_path) {
+	if (!toolchain.is_valid() || toolchain->get_makepkg_path().is_empty()) {
+		return ERR_UNAVAILABLE;
+	}
+
+	const String global_staging = ProjectSettings::get_singleton()->globalize_path(p_staging_dir);
+	const String global_output = ProjectSettings::get_singleton()->globalize_path(p_output_path);
+	const String layout_path = global_staging + "\\layout.xml";
+
+	List<String> genmap_args;
+	genmap_args.push_back("genmap");
+	genmap_args.push_back("/f");
+	genmap_args.push_back(layout_path);
+	genmap_args.push_back("/d");
+	genmap_args.push_back(global_staging);
+
+	int exit_code = 0;
+	String output;
+	Error err = OS::get_singleton()->execute(toolchain->get_makepkg_path(), genmap_args, &output, &exit_code, true);
+	if (err != OK || exit_code != 0) {
+		add_message(EXPORT_MESSAGE_ERROR, "XboxExport", vformat("makepkg genmap failed: %s", output));
+		return ERR_BUG;
+	}
+
+	List<String> pack_args;
+	pack_args.push_back("pack");
+	pack_args.push_back("/f");
+	pack_args.push_back(layout_path);
+	pack_args.push_back("/d");
+	pack_args.push_back(global_staging);
+	pack_args.push_back("/pd");
+	pack_args.push_back(global_output.get_base_dir());
+
+	String ekb = p_preset->get("packaging/ekb_file");
+	if (!ekb.is_empty()) {
+		pack_args.push_back("/lk");
+		pack_args.push_back(ProjectSettings::get_singleton()->globalize_path(ekb));
+	}
+
+	err = OS::get_singleton()->execute(toolchain->get_makepkg_path(), pack_args, &output, &exit_code, true);
+	if (err != OK || exit_code != 0) {
+		add_message(EXPORT_MESSAGE_ERROR, "XboxExport", vformat("makepkg pack failed: %s", output));
+		return ERR_BUG;
+	}
+
+	add_message(EXPORT_MESSAGE_INFO, "XboxExport", vformat("Package created: %s", global_output));
+	return OK;
+}
+
+Error EditorExportPlatformXbox::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<DebugFlags> p_flags) {
+	String abs_path = ProjectSettings::get_singleton()->globalize_path(p_path);
+	if (!abs_path.is_absolute_path()) {
+		abs_path = ProjectSettings::get_singleton()->globalize_path("res://").path_join(abs_path);
+	}
+	abs_path = abs_path.simplify_path();
+
+	String staging_dir;
+	Error err = _stage_project(p_preset, p_debug, abs_path, p_flags, staging_dir);
+	if (err != OK) {
+		return err;
+	}
+
+	if (p_preset->get("dev/register_loose")) {
+		return _wdapp_register(staging_dir);
+	}
+
+	return _makepkg_pack(p_preset, staging_dir, abs_path);
+}

--- a/modules/xbox_module/editor/export/xbox_export_platform.h
+++ b/modules/xbox_module/editor/export/xbox_export_platform.h
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  xbox_export_platform.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/export/editor_export_platform_pc.h"
+#include "modules/xbox_module/xbox_module_constants.h"
+
+class GDKToolchain;
+
+class EditorExportPlatformXbox : public EditorExportPlatformPC {
+	GDCLASS(EditorExportPlatformXbox, EditorExportPlatformPC);
+
+	Ref<GDKToolchain> toolchain;
+	XboxExportTarget export_target = XBOX_EXPORT_TARGET_GDK_DESKTOP;
+
+	String get_template_file_name_for_target(XboxExportTarget p_target, bool p_debug) const;
+	String get_target_device_family(XboxExportTarget p_target) const;
+	String get_windows_template_path(bool p_debug) const;
+
+	Error _stage_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_abs_output_path, BitField<DebugFlags> p_flags, String &r_staging_dir);
+	Error _wdapp_register(const String &p_staging_dir);
+	Error _makepkg_pack(const Ref<EditorExportPreset> &p_preset, const String &p_staging_dir, const String &p_output_path);
+	void _remove_dir_recursive(const String &p_path);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	EditorExportPlatformXbox();
+
+	void set_export_target(XboxExportTarget p_target);
+	XboxExportTarget get_export_target() const;
+
+	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
+	virtual void get_platform_features(List<String> *r_features) const override;
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual void get_export_options(List<ExportOption> *r_options) const override;
+	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
+	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
+	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<DebugFlags> p_flags = 0) override;
+};

--- a/modules/xbox_module/editor/gdk_toolchain.cpp
+++ b/modules/xbox_module/editor/gdk_toolchain.cpp
@@ -1,0 +1,244 @@
+/**************************************************************************/
+/*  gdk_toolchain.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_toolchain.h"
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/os/os.h"
+
+namespace {
+
+String _trim_trailing_slash(const String &p_path) {
+	String path = p_path;
+	while (path.ends_with("/") || path.ends_with("\\")) {
+		path = path.substr(0, path.length() - 1);
+	}
+	return path;
+}
+
+bool _dir_has_xgame_runtime(const String &p_path) {
+	return FileAccess::exists(p_path.path_join("include").path_join("XGameRuntime.h"));
+}
+
+String _normalize_windows_layout(const String &p_root) {
+	if (p_root.is_empty()) {
+		return String();
+	}
+	String root = _trim_trailing_slash(p_root);
+	if (_dir_has_xgame_runtime(root)) {
+		return root;
+	}
+	String windows = root.path_join("windows");
+	if (_dir_has_xgame_runtime(windows)) {
+		return windows;
+	}
+	return String();
+}
+
+String _extract_version_from_path(const String &p_path) {
+	PackedStringArray parts = p_path.replace("\\", "/").split("/");
+	for (int i = parts.size() - 1; i >= 0; --i) {
+		const String &part = parts[i];
+		if (part.length() == 6 && part.is_valid_int()) {
+			return part;
+		}
+	}
+	return String();
+}
+
+} //namespace
+
+GDKToolchain::GDKToolchain() {
+	_detect_gdk();
+}
+
+void GDKToolchain::_detect_gdk() {
+	Vector<String> edition_roots;
+
+	for (const String &env_name : { "GameDKCoreLatest", "GameDKLatest", "GRDKLatest" }) {
+		String env_value = OS::get_singleton()->get_environment(env_name);
+		if (env_value.is_empty()) {
+			continue;
+		}
+		String normalized = _normalize_windows_layout(env_value);
+		if (!normalized.is_empty() && !edition_roots.has(normalized)) {
+			edition_roots.push_back(normalized);
+		}
+	}
+
+	const String default_root = "C:/Program Files (x86)/Microsoft GDK";
+	if (DirAccess::exists(default_root)) {
+		Ref<DirAccess> da = DirAccess::open(default_root);
+		if (da.is_valid()) {
+			da->list_dir_begin();
+			String entry = da->get_next();
+			int best_num = -1;
+			String best_root;
+			while (!entry.is_empty()) {
+				if (da->current_is_dir() && entry.is_valid_int()) {
+					int version_num = entry.to_int();
+					String candidate = _normalize_windows_layout(default_root.path_join(entry));
+					if (!candidate.is_empty() && version_num > best_num) {
+						best_num = version_num;
+						best_root = candidate;
+					}
+				}
+				entry = da->get_next();
+			}
+			da->list_dir_end();
+			if (!best_root.is_empty() && !edition_roots.has(best_root)) {
+				edition_roots.push_back(best_root);
+			}
+		}
+	}
+
+	String env_bin = OS::get_singleton()->get_environment("GDK_BIN");
+	if (!env_bin.is_empty() && DirAccess::exists(env_bin)) {
+		bin_dir = env_bin;
+	}
+
+	for (const String &root : edition_roots) {
+		gdk_windows_root = root;
+		edition_root = _trim_trailing_slash(root.get_base_dir());
+		gdk_version = _extract_version_from_path(edition_root);
+
+		if (bin_dir.is_empty()) {
+			const String candidate = edition_root.path_join("bin");
+			if (DirAccess::exists(candidate)) {
+				bin_dir = candidate;
+			}
+		}
+
+		if (!bin_dir.is_empty()) {
+			makepkg_path = bin_dir.path_join("makepkg.exe");
+			wdapp_path = bin_dir.path_join("wdapp.exe");
+			sandbox_path = bin_dir.path_join("XblPCSandbox.exe");
+			game_config_editor_path = bin_dir.path_join("GameConfigEditor.exe");
+		}
+
+		if (FileAccess::exists(makepkg_path) && FileAccess::exists(wdapp_path)) {
+			available = true;
+			return;
+		}
+	}
+
+	available = false;
+	gdk_windows_root = String();
+	edition_root = String();
+}
+
+bool GDKToolchain::is_gdk_available() const {
+	return available;
+}
+
+String GDKToolchain::get_gdk_version() const {
+	return gdk_version;
+}
+
+String GDKToolchain::get_gdk_windows_root() const {
+	return gdk_windows_root;
+}
+
+String GDKToolchain::get_edition_root() const {
+	return edition_root;
+}
+
+String GDKToolchain::get_bin_dir() const {
+	return bin_dir;
+}
+
+String GDKToolchain::get_makepkg_path() const {
+	return makepkg_path;
+}
+
+String GDKToolchain::get_wdapp_path() const {
+	return wdapp_path;
+}
+
+String GDKToolchain::get_sandbox_path() const {
+	return sandbox_path;
+}
+
+String GDKToolchain::get_game_config_editor_path() const {
+	return game_config_editor_path;
+}
+
+Vector<String> GDKToolchain::get_runtime_dll_names(bool p_debug) const {
+	Vector<String> names;
+	names.push_back("libHttpClient.dll");
+	names.push_back("XCurl.dll");
+	if (p_debug) {
+		names.push_back("Microsoft.Xbox.Services.C.Thunks.Debug.dll");
+	} else {
+		names.push_back("Microsoft.Xbox.Services.C.Thunks.dll");
+	}
+	return names;
+}
+
+Error GDKToolchain::copy_runtime_dlls(const String &p_staging_dir, bool p_debug) const {
+	if (gdk_windows_root.is_empty()) {
+		return ERR_UNAVAILABLE;
+	}
+
+	Vector<String> search_dirs;
+	search_dirs.push_back(gdk_windows_root.path_join("bin").path_join("x64"));
+	if (!bin_dir.is_empty()) {
+		search_dirs.push_back(bin_dir);
+	}
+	search_dirs.push_back(gdk_windows_root.path_join("bin"));
+
+	for (const String &dll_name : get_runtime_dll_names(p_debug)) {
+		bool copied = false;
+		for (const String &dir : search_dirs) {
+			const String src = dir.path_join(dll_name);
+			if (!FileAccess::exists(src)) {
+				continue;
+			}
+			const String dst = p_staging_dir.path_join(dll_name);
+			Error err = DirAccess::copy_absolute(src, dst);
+			if (err != OK) {
+				return err;
+			}
+			copied = true;
+			break;
+		}
+		if (!copied) {
+			WARN_PRINT(vformat("xbox_module: GDK runtime DLL not found: %s", dll_name));
+		}
+	}
+
+	return OK;
+}
+
+Ref<GDKToolchain> GDKToolchain::create() {
+	Ref<GDKToolchain> toolchain;
+	toolchain.instantiate();
+	return toolchain;
+}

--- a/modules/xbox_module/editor/gdk_toolchain.h
+++ b/modules/xbox_module/editor/gdk_toolchain.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  gdk_toolchain.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "core/templates/vector.h"
+
+class GDKToolchain : public RefCounted {
+	GDCLASS(GDKToolchain, RefCounted);
+
+	String gdk_windows_root;
+	String edition_root;
+	String bin_dir;
+	String makepkg_path;
+	String wdapp_path;
+	String sandbox_path;
+	String game_config_editor_path;
+	String gdk_version;
+	bool available = false;
+
+	void _detect_gdk();
+
+public:
+	GDKToolchain();
+
+	bool is_gdk_available() const;
+	String get_gdk_version() const;
+	String get_gdk_windows_root() const;
+	String get_edition_root() const;
+	String get_bin_dir() const;
+	String get_makepkg_path() const;
+	String get_wdapp_path() const;
+	String get_sandbox_path() const;
+	String get_game_config_editor_path() const;
+
+	Vector<String> get_runtime_dll_names(bool p_debug) const;
+	Error copy_runtime_dlls(const String &p_staging_dir, bool p_debug) const;
+
+	static Ref<GDKToolchain> create();
+};

--- a/modules/xbox_module/editor/microsoft_game_config.cpp
+++ b/modules/xbox_module/editor/microsoft_game_config.cpp
@@ -1,0 +1,272 @@
+/**************************************************************************/
+/*  microsoft_game_config.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "microsoft_game_config.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+
+namespace {
+
+const char *CONFIG_FILENAME = "MicrosoftGame.config";
+
+PackedStringArray _logo_attributes() {
+	PackedStringArray attrs;
+	attrs.push_back("StoreLogo");
+	attrs.push_back("Square150x150Logo");
+	attrs.push_back("Square44x44Logo");
+	attrs.push_back("Square480x480Logo");
+	attrs.push_back("SplashScreenImage");
+	return attrs;
+}
+
+String _read_attr_value(const String &p_content, const String &p_attr) {
+	const String pattern = vformat("%s=\"", p_attr);
+	int pos = p_content.find(pattern);
+	if (pos == -1) {
+		return String();
+	}
+	pos += pattern.length();
+	int end = p_content.find("\"", pos);
+	if (end == -1) {
+		return String();
+	}
+	return p_content.substr(pos, end - pos);
+}
+
+} //namespace
+
+String MicrosoftGameConfig::get_project_config_path() {
+	ProjectSettings *settings = ProjectSettings::get_singleton();
+	ERR_FAIL_NULL_V(settings, String());
+	return settings->globalize_path("res://").path_join(CONFIG_FILENAME);
+}
+
+bool MicrosoftGameConfig::project_config_exists() {
+	return FileAccess::exists(get_project_config_path());
+}
+
+String MicrosoftGameConfig::read_executable_name_from_content(const String &p_content) {
+	int pos = p_content.find("<Executable");
+	if (pos == -1) {
+		return String();
+	}
+	int name_pos = p_content.find("Name=\"", pos);
+	if (name_pos == -1) {
+		return String();
+	}
+	name_pos += 6;
+	int end = p_content.find("\"", name_pos);
+	if (end == -1) {
+		return String();
+	}
+	return p_content.substr(name_pos, end - name_pos);
+}
+
+String MicrosoftGameConfig::read_executable_name(const String &p_config_path) {
+	String path = p_config_path.is_empty() ? get_project_config_path() : p_config_path;
+	if (!FileAccess::exists(path)) {
+		return String();
+	}
+	Ref<FileAccess> file = FileAccess::open(path, FileAccess::READ);
+	ERR_FAIL_COND_V(file.is_null(), String());
+	return read_executable_name_from_content(file->get_as_text());
+}
+
+String MicrosoftGameConfig::inject_target_device_family(const String &p_content, const String &p_family) {
+	if (p_content.find("TargetDeviceFamily=") != -1) {
+		return p_content;
+	}
+
+	int pos = p_content.find("<Executable");
+	if (pos == -1) {
+		return p_content;
+	}
+	int end = p_content.find("/>", pos);
+	bool self_closing = end != -1;
+	if (!self_closing) {
+		end = p_content.find(">", pos);
+	}
+	if (end == -1) {
+		return p_content;
+	}
+
+	String tag = p_content.substr(pos, end - pos + (self_closing ? 2 : 1));
+	String patched = tag;
+	if (self_closing) {
+		patched = tag.substr(0, tag.length() - 2) + vformat(" TargetDeviceFamily=\"%s\" />", p_family);
+	} else {
+		patched = tag.substr(0, tag.length() - 1) + vformat(" TargetDeviceFamily=\"%s\">", p_family);
+	}
+
+	return p_content.substr(0, pos) + patched + p_content.substr(end + (self_closing ? 2 : 1));
+}
+
+Error MicrosoftGameConfig::copy_to_staging(const String &p_staging_dir, const String &p_family) {
+	const String src = get_project_config_path();
+	if (!FileAccess::exists(src)) {
+		return ERR_FILE_NOT_FOUND;
+	}
+
+	Ref<FileAccess> in = FileAccess::open(src, FileAccess::READ);
+	ERR_FAIL_COND_V(in.is_null(), ERR_FILE_CANT_READ);
+
+	String content = inject_target_device_family(in->get_as_text(), p_family);
+	const String dst = p_staging_dir.path_join(CONFIG_FILENAME);
+	Ref<FileAccess> out = FileAccess::open(dst, FileAccess::WRITE);
+	ERR_FAIL_COND_V(out.is_null(), ERR_FILE_CANT_WRITE);
+	out->store_string(content);
+	return OK;
+}
+
+Error MicrosoftGameConfig::stage_logos(const String &p_staging_dir) {
+	const String config_path = p_staging_dir.path_join(CONFIG_FILENAME);
+	if (!FileAccess::exists(config_path)) {
+		return ERR_FILE_NOT_FOUND;
+	}
+
+	Ref<FileAccess> file = FileAccess::open(config_path, FileAccess::READ);
+	ERR_FAIL_COND_V(file.is_null(), ERR_FILE_CANT_READ);
+	const String content = file->get_as_text();
+
+	ProjectSettings *settings = ProjectSettings::get_singleton();
+	ERR_FAIL_NULL_V(settings, ERR_UNAVAILABLE);
+	const String project_dir = settings->globalize_path("res://");
+
+	for (const String &attr : _logo_attributes()) {
+		const String rel = _read_attr_value(content, attr);
+		if (rel.is_empty()) {
+			continue;
+		}
+
+		const String filename = rel.get_file();
+		Vector<String> candidates;
+		candidates.push_back(project_dir.path_join(rel));
+		candidates.push_back(project_dir.path_join("storelogos").path_join(filename));
+		candidates.push_back(project_dir.path_join(filename));
+
+		String src;
+		for (const String &candidate : candidates) {
+			if (FileAccess::exists(candidate)) {
+				src = candidate;
+				break;
+			}
+		}
+		if (src.is_empty()) {
+			WARN_PRINT(vformat("xbox_module: %s logo not found for %s", attr, rel));
+			continue;
+		}
+
+		const String dst = p_staging_dir.path_join(rel);
+		Error mk_err = DirAccess::make_dir_recursive_absolute(dst.get_base_dir());
+		if (mk_err != OK) {
+			return mk_err;
+		}
+		Error copy_err = DirAccess::copy_absolute(src, dst);
+		if (copy_err != OK) {
+			WARN_PRINT(vformat("xbox_module: failed to copy logo %s", src));
+		}
+	}
+
+	return OK;
+}
+
+String MicrosoftGameConfig::get_template_xml(const String &p_executable_name) {
+	return vformat(
+			"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+			"<Game configVersion=\"1\">\n"
+			"  <Identity Name=\"PublisherToken.YourGameTitle\"\n"
+			"            Publisher=\"CN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX\"\n"
+			"            Version=\"1.0.0.0\" />\n"
+			"  <TitleId>FFFFFFFF</TitleId>\n"
+			"  <MSAAppId>00000000-0000-0000-0000-000000000000</MSAAppId>\n"
+			"  <StoreId>9NXXXXXXXXXX</StoreId>\n"
+			"  <ExecutableList>\n"
+			"    <Executable Name=\"%s\"\n"
+			"                TargetDeviceFamily=\"PC\"\n"
+			"                Id=\"Game\"\n"
+			"                IsDevOnly=\"false\" />\n"
+			"  </ExecutableList>\n"
+			"  <ShellVisuals DefaultDisplayName=\"Your Game Title\"\n"
+			"                PublisherDisplayName=\"Your Publisher\"\n"
+			"                StoreLogo=\"StoreLogo.png\"\n"
+			"                Square150x150Logo=\"Logo150.png\"\n"
+			"                Square44x44Logo=\"Logo44.png\"\n"
+			"                Square480x480Logo=\"Logo480.png\"\n"
+			"                SplashScreenImage=\"SplashScreen.png\"\n"
+			"                ForegroundText=\"light\"\n"
+			"                BackgroundColor=\"#1a1a2e\" />\n"
+			"  <DesktopRegistration>\n"
+			"    <DependencyList>\n"
+			"      <KnownDependency Name=\"VC14\" />\n"
+			"    </DependencyList>\n"
+			"  </DesktopRegistration>\n"
+			"</Game>\n",
+			p_executable_name);
+}
+
+Error MicrosoftGameConfig::write_template_to_project(const String &p_executable_name) {
+	String exe_name = p_executable_name;
+	if (exe_name.is_empty()) {
+		exe_name = "blazium.windows.template_release.x86_64.exe";
+	}
+
+	const String path = get_project_config_path();
+	if (FileAccess::exists(path)) {
+		return ERR_ALREADY_EXISTS;
+	}
+
+	Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE);
+	ERR_FAIL_COND_V(file.is_null(), ERR_FILE_CANT_WRITE);
+	file->store_string(get_template_xml(exe_name));
+	return OK;
+}
+
+String MicrosoftGameConfig::validate_project_config(String *r_error) {
+	if (!project_config_exists()) {
+		if (r_error) {
+			*r_error = "MicrosoftGame.config not found at project root.";
+		}
+		return String();
+	}
+
+	const String exe_name = read_executable_name();
+	if (exe_name.is_empty()) {
+		if (r_error) {
+			*r_error = "MicrosoftGame.config is missing <Executable Name=\"...\">.";
+		}
+		return String();
+	}
+
+	if (r_error) {
+		r_error->clear();
+	}
+	return exe_name;
+}

--- a/modules/xbox_module/editor/microsoft_game_config.h
+++ b/modules/xbox_module/editor/microsoft_game_config.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  microsoft_game_config.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+
+class MicrosoftGameConfig : public RefCounted {
+	GDCLASS(MicrosoftGameConfig, RefCounted);
+
+public:
+	static String get_project_config_path();
+	static bool project_config_exists();
+
+	static String read_executable_name(const String &p_config_path = String());
+	static String read_executable_name_from_content(const String &p_content);
+	static String inject_target_device_family(const String &p_content, const String &p_family = "PC");
+
+	static Error copy_to_staging(const String &p_staging_dir, const String &p_family = "PC");
+	static Error stage_logos(const String &p_staging_dir);
+
+	static String get_template_xml(const String &p_executable_name = "blazium.windows.template_release.x86_64.exe");
+	static Error write_template_to_project(const String &p_executable_name = String());
+
+	static String validate_project_config(String *r_error = nullptr);
+};

--- a/modules/xbox_module/editor/xbox_editor_plugin.cpp
+++ b/modules/xbox_module/editor/xbox_editor_plugin.cpp
@@ -1,0 +1,103 @@
+/**************************************************************************/
+/*  xbox_editor_plugin.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "xbox_editor_plugin.h"
+
+#include "export/xbox_export_platform.h"
+#include "gdk_toolchain.h"
+#include "microsoft_game_config.h"
+
+#include "core/config/engine.h"
+#include "editor/editor_node.h"
+#include "editor/export/editor_export.h"
+#include "modules/xbox_module/gdk/gdk.h"
+
+void XboxEditorPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_create_game_config"), &XboxEditorPlugin::_create_game_config);
+	ClassDB::bind_method(D_METHOD("_validate_configuration"), &XboxEditorPlugin::_validate_configuration);
+	ClassDB::bind_method(D_METHOD("_open_gdk_docs"), &XboxEditorPlugin::_open_gdk_docs);
+}
+
+void XboxEditorPlugin::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		export_platform = Ref<EditorExportPlatform>(memnew(EditorExportPlatformXbox));
+		EditorExport::get_singleton()->add_export_platform(export_platform);
+
+		add_tool_menu_item("Xbox: Create Game Config", callable_mp(this, &XboxEditorPlugin::_create_game_config));
+		add_tool_menu_item("Xbox: Validate Configuration", callable_mp(this, &XboxEditorPlugin::_validate_configuration));
+		add_tool_menu_item("Xbox: Open GDK Documentation", callable_mp(this, &XboxEditorPlugin::_open_gdk_docs));
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
+		if (export_platform.is_valid()) {
+			EditorExport::get_singleton()->remove_export_platform(export_platform);
+			export_platform.unref();
+		}
+	}
+}
+
+void XboxEditorPlugin::_create_game_config() {
+	Error err = MicrosoftGameConfig::write_template_to_project();
+	if (err == ERR_ALREADY_EXISTS) {
+		EditorNode::get_singleton()->show_warning("MicrosoftGame.config already exists at the project root.");
+		return;
+	}
+	if (err != OK) {
+		EditorNode::get_singleton()->show_warning(vformat("Failed to create MicrosoftGame.config (error %d).", err));
+		return;
+	}
+	EditorNode::get_singleton()->show_warning("Created MicrosoftGame.config template at project root. Edit Partner Center values before exporting.");
+}
+
+void XboxEditorPlugin::_validate_configuration() {
+	Ref<GDKToolchain> toolchain = GDKToolchain::create();
+	String message;
+	if (!toolchain->is_gdk_available()) {
+		message = "GDK tools not found. Install via: winget install Microsoft.Gaming.GDK";
+	} else {
+		message = vformat("GDK tools found (version %s).", toolchain->get_gdk_version().is_empty() ? "unknown" : toolchain->get_gdk_version());
+	}
+
+	String config_error;
+	const String exe_name = MicrosoftGameConfig::validate_project_config(&config_error);
+	if (exe_name.is_empty()) {
+		message += "\n" + config_error;
+	} else {
+		message += vformat("\nMicrosoftGame.config OK (executable: %s).", exe_name);
+	}
+
+	GDK *gdk = GDK::get_singleton();
+	if (gdk) {
+		message += vformat("\nGDK runtime available: %s", gdk->is_available() ? "yes" : "no (stub build or GDK not linked)");
+	}
+
+	EditorNode::get_singleton()->show_warning(message);
+}
+
+void XboxEditorPlugin::_open_gdk_docs() {
+	OS::get_singleton()->shell_open("https://learn.microsoft.com/gaming/gdk/");
+}

--- a/modules/xbox_module/editor/xbox_editor_plugin.h
+++ b/modules/xbox_module/editor/xbox_editor_plugin.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  xbox_editor_plugin.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_plugin.h"
+
+#include "editor/export/editor_export_platform.h"
+#include "editor/plugins/editor_plugin.h"
+
+class EditorExportPlatformXbox;
+
+class XboxEditorPlugin : public EditorPlugin {
+	GDCLASS(XboxEditorPlugin, EditorPlugin);
+
+	Ref<EditorExportPlatform> export_platform;
+
+	void _create_game_config();
+	void _validate_configuration();
+	void _open_gdk_docs();
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void _notification(int p_what);
+	virtual String get_plugin_name() const override { return "Xbox"; }
+};

--- a/modules/xbox_module/gdk/gdk.cpp
+++ b/modules/xbox_module/gdk/gdk.cpp
@@ -1,0 +1,601 @@
+/**************************************************************************/
+/*  gdk.cpp                                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk.h"
+
+#include "gdk_accessibility.h"
+#include "gdk_achievement.h"
+#include "gdk_activation.h"
+#include "gdk_capture.h"
+#include "gdk_display.h"
+#include "gdk_error_reporting.h"
+#include "gdk_game_ui.h"
+#include "gdk_launcher.h"
+#include "gdk_leaderboards.h"
+#include "gdk_multiplayer_activity.h"
+#include "gdk_package.h"
+#include "gdk_presence.h"
+#include "gdk_privacy.h"
+#include "gdk_profile.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_social.h"
+#include "gdk_stats.h"
+#include "gdk_store.h"
+#include "gdk_string_verify.h"
+#include "gdk_system.h"
+#include "gdk_title_storage.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#include <iterator>
+#include <vector>
+
+GDK *GDK::singleton = nullptr;
+
+GDK *GDK::get_singleton() {
+	return singleton;
+}
+
+GDK::GDK() {
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+
+	m_runtime = new GDKRuntime();
+	m_xbox_services = new GDKXboxServices();
+	m_users.instantiate();
+	m_users->set_owner(this);
+	m_game_ui.instantiate();
+	m_game_ui->set_owner(this);
+	m_accessibility.instantiate();
+	m_accessibility->set_owner(this);
+	m_achievements.instantiate();
+	m_achievements->set_owner(this);
+	m_package.instantiate();
+	m_package->set_owner(this);
+	m_stats.instantiate();
+	m_stats->set_owner(this);
+	m_leaderboards.instantiate();
+	m_leaderboards->set_owner(this);
+	m_privacy.instantiate();
+	m_privacy->set_owner(this);
+	m_presence.instantiate();
+	m_presence->set_owner(this);
+	m_social.instantiate();
+	m_social->set_owner(this);
+	m_store.instantiate();
+	m_store->set_owner(this);
+	m_profile.instantiate();
+	m_profile->set_owner(this);
+	m_string_verify.instantiate();
+	m_string_verify->set_owner(this);
+	m_title_storage.instantiate();
+	m_title_storage->set_owner(this);
+	m_error_reporting.instantiate();
+	m_error_reporting->set_owner(this);
+	m_launcher.instantiate();
+	m_launcher->set_owner(this);
+	m_multiplayer_activity.instantiate();
+	m_multiplayer_activity->set_owner(this);
+	m_capture.instantiate();
+	m_capture->set_owner(this);
+	m_system.instantiate();
+	m_system->set_owner(this);
+	m_display.instantiate();
+	m_display->set_owner(this);
+	m_activation.instantiate();
+	m_activation->set_owner(this);
+}
+
+GDK::~GDK() {
+	shutdown();
+
+	if (m_xbox_services != nullptr) {
+		delete m_xbox_services;
+		m_xbox_services = nullptr;
+	}
+
+	if (m_runtime != nullptr) {
+		delete m_runtime;
+		m_runtime = nullptr;
+	}
+
+	m_users.unref();
+	m_game_ui.unref();
+	m_accessibility.unref();
+	m_achievements.unref();
+	m_package.unref();
+	m_stats.unref();
+	m_leaderboards.unref();
+	m_privacy.unref();
+	m_presence.unref();
+	m_social.unref();
+	m_store.unref();
+	m_profile.unref();
+	m_string_verify.unref();
+	m_title_storage.unref();
+	m_error_reporting.unref();
+	m_launcher.unref();
+	m_multiplayer_activity.unref();
+	m_capture.unref();
+	m_system.unref();
+	m_display.unref();
+	m_activation.unref();
+	singleton = nullptr;
+}
+
+void GDK::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("initialize", "config"), &GDK::initialize, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("shutdown"), &GDK::shutdown);
+	ClassDB::bind_method(D_METHOD("is_available"), &GDK::is_available);
+	ClassDB::bind_method(D_METHOD("is_initialized"), &GDK::is_initialized);
+	ClassDB::bind_method(D_METHOD("dispatch"), &GDK::dispatch);
+	ClassDB::bind_method(D_METHOD("get_users"), &GDK::get_users);
+	ClassDB::bind_method(D_METHOD("get_game_ui"), &GDK::get_game_ui);
+	ClassDB::bind_method(D_METHOD("get_accessibility"), &GDK::get_accessibility);
+	ClassDB::bind_method(D_METHOD("get_achievements"), &GDK::get_achievements);
+	ClassDB::bind_method(D_METHOD("get_package"), &GDK::get_package);
+	ClassDB::bind_method(D_METHOD("get_stats"), &GDK::get_stats);
+	ClassDB::bind_method(D_METHOD("get_leaderboards"), &GDK::get_leaderboards);
+	ClassDB::bind_method(D_METHOD("get_privacy"), &GDK::get_privacy);
+	ClassDB::bind_method(D_METHOD("get_presence"), &GDK::get_presence);
+	ClassDB::bind_method(D_METHOD("get_social"), &GDK::get_social);
+	ClassDB::bind_method(D_METHOD("get_store"), &GDK::get_store);
+	ClassDB::bind_method(D_METHOD("get_profile"), &GDK::get_profile);
+	ClassDB::bind_method(D_METHOD("get_string_verify"), &GDK::get_string_verify);
+	ClassDB::bind_method(D_METHOD("get_title_storage"), &GDK::get_title_storage);
+	ClassDB::bind_method(D_METHOD("get_error_reporting"), &GDK::get_error_reporting);
+	ClassDB::bind_method(D_METHOD("get_launcher"), &GDK::get_launcher);
+	ClassDB::bind_method(D_METHOD("get_multiplayer_activity"), &GDK::get_multiplayer_activity);
+	ClassDB::bind_method(D_METHOD("get_capture"), &GDK::get_capture);
+	ClassDB::bind_method(D_METHOD("get_system"), &GDK::get_system);
+	ClassDB::bind_method(D_METHOD("get_display"), &GDK::get_display);
+	ClassDB::bind_method(D_METHOD("get_activation"), &GDK::get_activation);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "users", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKUsers"), "", "get_users");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_ui", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameUI"), "", "get_game_ui");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "accessibility", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKAccessibility"), "", "get_accessibility");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "achievements", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKAchievements"), "", "get_achievements");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "package", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKPackage"), "", "get_package");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stats", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKStats"), "", "get_stats");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "leaderboards", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKLeaderboards"), "", "get_leaderboards");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "privacy", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKPrivacy"), "", "get_privacy");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "presence", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKPresence"), "", "get_presence");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "social", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSocial"), "", "get_social");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "store", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKStore"), "", "get_store");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "profile", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKProfile"), "", "get_profile");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "string_verify", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKStringVerify"), "", "get_string_verify");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "title_storage", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKTitleStorage"), "", "get_title_storage");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "error_reporting", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKErrorReporting"), "", "get_error_reporting");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "launcher", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKLauncher"), "", "get_launcher");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multiplayer_activity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKMultiplayerActivity"), "", "get_multiplayer_activity");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "capture", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKCapture"), "", "get_capture");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "system", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSystem"), "", "get_system");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "display", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKDisplay"), "", "get_display");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "activation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKActivation"), "", "get_activation");
+
+	ADD_SIGNAL(MethodInfo("initialized"));
+	ADD_SIGNAL(MethodInfo("shutdown_completed"));
+	ADD_SIGNAL(MethodInfo("runtime_error", PropertyInfo(Variant::OBJECT, "result")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+namespace {
+
+struct GDKInitStep {
+	Ref<GDKResult> (*init)(GDK *);
+	void (*shutdown)(GDK *);
+};
+
+const GDKInitStep INIT_STEPS[] = {
+	{ [](GDK *g) { return g->get_users()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_users()->shutdown(); } },
+	{ [](GDK *g) { return g->get_game_ui()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_game_ui()->shutdown(); } },
+	{ [](GDK *g) { return g->get_achievements()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_achievements()->shutdown(); } },
+	{ [](GDK *g) { return g->get_package()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_package()->shutdown(); } },
+	{ [](GDK *g) { return g->get_stats()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_stats()->shutdown(); } },
+	{ [](GDK *g) { return g->get_leaderboards()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_leaderboards()->shutdown(); } },
+	{ [](GDK *g) { return g->get_privacy()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_privacy()->shutdown(); } },
+	{ [](GDK *g) { return g->get_presence()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_presence()->shutdown(); } },
+	{ [](GDK *g) { return g->get_social()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_social()->shutdown(); } },
+	{ [](GDK *g) { return g->get_store()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_store()->shutdown(); } },
+	{ [](GDK *g) { return g->get_profile()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_profile()->shutdown(); } },
+	{ [](GDK *g) { return g->get_string_verify()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_string_verify()->shutdown(); } },
+	{ [](GDK *g) { return g->get_title_storage()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_title_storage()->shutdown(); } },
+	{ [](GDK *g) { return g->get_error_reporting()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_error_reporting()->shutdown(); } },
+	{ [](GDK *g) { return g->get_launcher()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_launcher()->shutdown(); } },
+	{ [](GDK *g) { return g->get_activation()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_activation()->shutdown(); } },
+	{ [](GDK *g) { return g->get_multiplayer_activity()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_multiplayer_activity()->shutdown(); } },
+	{ [](GDK *g) { return g->get_capture()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_capture()->shutdown(); } },
+	{ [](GDK *g) { return g->get_display()->on_runtime_initialized(); },
+			[](GDK *g) { g->get_display()->shutdown(); } },
+};
+
+struct GDKDispatchStep {
+	int (*dispatch)(GDK *);
+};
+
+const GDKDispatchStep DISPATCH_STEPS[] = {
+	{ [](GDK *g) { return g->get_runtime()->dispatch(); } },
+	{ [](GDK *g) { return g->get_achievements()->dispatch(); } },
+	{ [](GDK *g) { return g->get_stats()->dispatch(); } },
+	{ [](GDK *g) { return g->get_privacy()->dispatch(); } },
+	{ [](GDK *g) { return g->get_presence()->dispatch(); } },
+	{ [](GDK *g) { return g->get_social()->dispatch(); } },
+	{ [](GDK *g) { return g->get_error_reporting()->dispatch(); } },
+};
+
+class GDKShutdownGuard {
+public:
+	explicit GDKShutdownGuard(GDK *p_gdk) :
+			m_gdk(p_gdk) {}
+
+	~GDKShutdownGuard() {
+		if (m_committed || m_gdk == nullptr) {
+			return;
+		}
+		for (auto it = m_shutdowns.rbegin(); it != m_shutdowns.rend(); ++it) {
+			(*it)(m_gdk);
+		}
+	}
+
+	void push(void (*p_shutdown)(GDK *)) {
+		m_shutdowns.push_back(p_shutdown);
+	}
+
+	void commit() {
+		m_committed = true;
+	}
+
+private:
+	GDK *m_gdk = nullptr;
+	std::vector<void (*)(GDK *)> m_shutdowns;
+	bool m_committed = false;
+};
+
+} //namespace
+
+Ref<GDKResult> GDK::initialize(const Variant &p_config) {
+	Ref<GDKResult> runtime_result = m_runtime->initialize();
+	if (!runtime_result->is_ok()) {
+		return runtime_result;
+	}
+
+	GDKShutdownGuard guard(this);
+	guard.push([](GDK *g) { g->get_runtime()->shutdown(); });
+
+	Ref<GDKResult> xbox_services_result = m_xbox_services->initialize(m_runtime->get_task_queue(), p_config);
+	if (!xbox_services_result->is_ok()) {
+		if (xbox_services_result->get_code() != "xbox_title_id_unavailable") {
+			return xbox_services_result;
+		}
+	}
+	guard.push([](GDK *g) { g->get_xbox_services()->shutdown(); });
+
+	for (const auto &step : INIT_STEPS) {
+		Ref<GDKResult> result = step.init(this);
+		if (!result->is_ok()) {
+			return result;
+		}
+		guard.push(step.shutdown);
+	}
+
+	guard.commit();
+	emit_signal("initialized");
+	return GDKResult::ok_result();
+}
+
+void GDK::shutdown() {
+	if (!m_runtime->is_initialized()) {
+		return;
+	}
+
+	for (auto it = std::rbegin(INIT_STEPS); it != std::rend(INIT_STEPS); ++it) {
+		it->shutdown(this);
+	}
+	m_xbox_services->shutdown();
+	m_runtime->shutdown();
+
+	emit_signal("shutdown_completed");
+}
+
+bool GDK::is_available() const {
+	return m_runtime->is_available();
+}
+
+bool GDK::is_initialized() const {
+	return m_runtime->is_initialized();
+}
+
+int64_t GDK::dispatch() {
+	int64_t total = 0;
+	for (const auto &step : DISPATCH_STEPS) {
+		total += static_cast<int64_t>(step.dispatch(this));
+	}
+	return total;
+}
+
+Ref<GDKUsers> GDK::get_users() const {
+	return m_users;
+}
+
+Ref<GDKGameUI> GDK::get_game_ui() const {
+	return m_game_ui;
+}
+
+Ref<GDKAccessibility> GDK::get_accessibility() const {
+	return m_accessibility;
+}
+
+Ref<GDKAchievements> GDK::get_achievements() const {
+	return m_achievements;
+}
+
+Ref<GDKPackage> GDK::get_package() const {
+	return m_package;
+}
+
+Ref<GDKStats> GDK::get_stats() const {
+	return m_stats;
+}
+
+Ref<GDKLeaderboards> GDK::get_leaderboards() const {
+	return m_leaderboards;
+}
+
+Ref<GDKPrivacy> GDK::get_privacy() const {
+	return m_privacy;
+}
+
+Ref<GDKPresence> GDK::get_presence() const {
+	return m_presence;
+}
+
+Ref<GDKSocial> GDK::get_social() const {
+	return m_social;
+}
+
+Ref<GDKStore> GDK::get_store() const {
+	return m_store;
+}
+
+Ref<GDKProfile> GDK::get_profile() const {
+	return m_profile;
+}
+
+Ref<GDKStringVerify> GDK::get_string_verify() const {
+	return m_string_verify;
+}
+
+Ref<GDKTitleStorage> GDK::get_title_storage() const {
+	return m_title_storage;
+}
+
+Ref<GDKErrorReporting> GDK::get_error_reporting() const {
+	return m_error_reporting;
+}
+
+Ref<GDKLauncher> GDK::get_launcher() const {
+	return m_launcher;
+}
+
+Ref<GDKMultiplayerActivity> GDK::get_multiplayer_activity() const {
+	return m_multiplayer_activity;
+}
+
+Ref<GDKCapture> GDK::get_capture() const {
+	return m_capture;
+}
+
+Ref<GDKSystem> GDK::get_system() const {
+	return m_system;
+}
+
+Ref<GDKDisplay> GDK::get_display() const {
+	return m_display;
+}
+
+Ref<GDKActivation> GDK::get_activation() const {
+	return m_activation;
+}
+
+GDKRuntime *GDK::get_runtime() const {
+	return m_runtime;
+}
+
+GDKXboxServices *GDK::get_xbox_services() const {
+	return m_xbox_services;
+}
+
+void GDK::emit_runtime_error(const Ref<GDKResult> &p_result) {
+	emit_signal("runtime_error", p_result);
+}
+
+void GDK::notify_user_removed(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	if (m_achievements.is_valid()) {
+		m_achievements->on_user_removed(p_user);
+	}
+	if (m_stats.is_valid()) {
+		m_stats->on_user_removed(p_user);
+	}
+	if (m_leaderboards.is_valid()) {
+		m_leaderboards->on_user_removed(p_user);
+	}
+	if (m_privacy.is_valid()) {
+		m_privacy->on_user_removed(p_user);
+	}
+	if (m_presence.is_valid()) {
+		m_presence->on_user_removed(p_user);
+	}
+	if (m_social.is_valid()) {
+		m_social->on_user_removed(p_user);
+	}
+	if (m_store.is_valid()) {
+		m_store->on_user_removed(p_user);
+	}
+	if (m_profile.is_valid()) {
+		m_profile->on_user_removed(p_user);
+	}
+	if (m_string_verify.is_valid()) {
+		m_string_verify->on_user_removed(p_user);
+	}
+	if (m_title_storage.is_valid()) {
+		m_title_storage->on_user_removed(p_user);
+	}
+	if (m_multiplayer_activity.is_valid()) {
+		m_multiplayer_activity->on_user_removed(p_user);
+	}
+	if (m_xbox_services != nullptr) {
+		XUserLocalId local_id = {};
+		local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+		m_xbox_services->forget_user(local_id);
+	}
+}
+
+#else
+
+Ref<GDKResult> GDK::initialize(const Variant &p_config) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDK::shutdown() {
+}
+
+bool GDK::is_available() const {
+	return false;
+}
+
+bool GDK::is_initialized() const {
+	return false;
+}
+
+int64_t GDK::dispatch() {
+	return 0;
+}
+
+Ref<GDKUsers> GDK::get_users() const {
+	return m_users;
+}
+Ref<GDKGameUI> GDK::get_game_ui() const {
+	return m_game_ui;
+}
+Ref<GDKAccessibility> GDK::get_accessibility() const {
+	return m_accessibility;
+}
+Ref<GDKAchievements> GDK::get_achievements() const {
+	return m_achievements;
+}
+Ref<GDKPackage> GDK::get_package() const {
+	return m_package;
+}
+Ref<GDKStats> GDK::get_stats() const {
+	return m_stats;
+}
+Ref<GDKLeaderboards> GDK::get_leaderboards() const {
+	return m_leaderboards;
+}
+Ref<GDKPrivacy> GDK::get_privacy() const {
+	return m_privacy;
+}
+Ref<GDKPresence> GDK::get_presence() const {
+	return m_presence;
+}
+Ref<GDKSocial> GDK::get_social() const {
+	return m_social;
+}
+Ref<GDKStore> GDK::get_store() const {
+	return m_store;
+}
+Ref<GDKProfile> GDK::get_profile() const {
+	return m_profile;
+}
+Ref<GDKStringVerify> GDK::get_string_verify() const {
+	return m_string_verify;
+}
+Ref<GDKTitleStorage> GDK::get_title_storage() const {
+	return m_title_storage;
+}
+Ref<GDKErrorReporting> GDK::get_error_reporting() const {
+	return m_error_reporting;
+}
+Ref<GDKLauncher> GDK::get_launcher() const {
+	return m_launcher;
+}
+Ref<GDKMultiplayerActivity> GDK::get_multiplayer_activity() const {
+	return m_multiplayer_activity;
+}
+Ref<GDKCapture> GDK::get_capture() const {
+	return m_capture;
+}
+Ref<GDKSystem> GDK::get_system() const {
+	return m_system;
+}
+Ref<GDKDisplay> GDK::get_display() const {
+	return m_display;
+}
+Ref<GDKActivation> GDK::get_activation() const {
+	return m_activation;
+}
+
+GDKRuntime *GDK::get_runtime() const {
+	return m_runtime;
+}
+
+GDKXboxServices *GDK::get_xbox_services() const {
+	return m_xbox_services;
+}
+
+void GDK::emit_runtime_error(const Ref<GDKResult> &p_result) {
+}
+
+void GDK::notify_user_removed(const Ref<GDKUser> &p_user) {
+}
+
+#endif

--- a/modules/xbox_module/gdk/gdk.h
+++ b/modules/xbox_module/gdk/gdk.h
@@ -1,0 +1,139 @@
+/**************************************************************************/
+/*  gdk.h                                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/object/ref_counted.h"
+#include "core/variant/variant.h"
+
+class GDKAccessibility;
+class GDKAchievements;
+class GDKActivation;
+class GDKCapture;
+class GDKDisplay;
+class GDKErrorReporting;
+class GDKGameUI;
+class GDKLauncher;
+class GDKLeaderboards;
+class GDKMultiplayerActivity;
+class GDKPackage;
+class GDKPresence;
+class GDKPrivacy;
+class GDKProfile;
+class GDKResult;
+class GDKRuntime;
+class GDKSocial;
+class GDKStats;
+class GDKStore;
+class GDKStringVerify;
+class GDKSystem;
+class GDKTitleStorage;
+class GDKUser;
+class GDKUsers;
+class GDKXboxServices;
+
+class GDK : public Object {
+	GDCLASS(GDK, Object);
+
+	static GDK *singleton;
+
+	GDKRuntime *m_runtime = nullptr;
+	GDKXboxServices *m_xbox_services = nullptr;
+	Ref<GDKUsers> m_users;
+	Ref<GDKGameUI> m_game_ui;
+	Ref<GDKAccessibility> m_accessibility;
+	Ref<GDKAchievements> m_achievements;
+	Ref<GDKPackage> m_package;
+	Ref<GDKStats> m_stats;
+	Ref<GDKLeaderboards> m_leaderboards;
+	Ref<GDKPrivacy> m_privacy;
+	Ref<GDKPresence> m_presence;
+	Ref<GDKSocial> m_social;
+	Ref<GDKStore> m_store;
+	Ref<GDKProfile> m_profile;
+	Ref<GDKStringVerify> m_string_verify;
+	Ref<GDKTitleStorage> m_title_storage;
+	Ref<GDKErrorReporting> m_error_reporting;
+	Ref<GDKLauncher> m_launcher;
+	Ref<GDKMultiplayerActivity> m_multiplayer_activity;
+	Ref<GDKCapture> m_capture;
+	Ref<GDKSystem> m_system;
+	Ref<GDKDisplay> m_display;
+	Ref<GDKActivation> m_activation;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static GDK *get_singleton();
+
+	GDK();
+	~GDK();
+
+	Ref<GDKResult> initialize(const Variant &p_config = Variant());
+	void shutdown();
+	bool is_available() const;
+	bool is_initialized() const;
+	int64_t dispatch();
+	Ref<GDKUsers> get_users() const;
+	Ref<GDKGameUI> get_game_ui() const;
+	Ref<GDKAccessibility> get_accessibility() const;
+	Ref<GDKAchievements> get_achievements() const;
+	Ref<GDKPackage> get_package() const;
+	Ref<GDKStats> get_stats() const;
+	Ref<GDKLeaderboards> get_leaderboards() const;
+	Ref<GDKPrivacy> get_privacy() const;
+	Ref<GDKPresence> get_presence() const;
+	Ref<GDKSocial> get_social() const;
+	Ref<GDKStore> get_store() const;
+	Ref<GDKProfile> get_profile() const;
+	Ref<GDKStringVerify> get_string_verify() const;
+	Ref<GDKTitleStorage> get_title_storage() const;
+	Ref<GDKErrorReporting> get_error_reporting() const;
+	Ref<GDKLauncher> get_launcher() const;
+	Ref<GDKMultiplayerActivity> get_multiplayer_activity() const;
+	Ref<GDKCapture> get_capture() const;
+	Ref<GDKSystem> get_system() const;
+	Ref<GDKDisplay> get_display() const;
+	Ref<GDKActivation> get_activation() const;
+
+	GDKRuntime *get_runtime() const;
+	GDKXboxServices *get_xbox_services() const;
+	void emit_runtime_error(const Ref<GDKResult> &p_result);
+	void notify_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_accessibility.cpp
+++ b/modules/xbox_module/gdk/gdk_accessibility.cpp
@@ -1,0 +1,360 @@
+/**************************************************************************/
+/*  gdk_accessibility.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_accessibility.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+
+namespace {
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+Color _xcolor_to_color(const XColor &p_color) {
+	const uint8_t *channels = reinterpret_cast<const uint8_t *>(&p_color.Value);
+	return Color(
+			static_cast<float>(channels[1]) / 255.0f,
+			static_cast<float>(channels[2]) / 255.0f,
+			static_cast<float>(channels[3]) / 255.0f,
+			static_cast<float>(channels[0]) / 255.0f);
+}
+
+GDKClosedCaptionProperties::FontEdgeAttribute _to_font_edge_attribute(XClosedCaptionFontEdgeAttribute p_value) {
+	switch (p_value) {
+		case XClosedCaptionFontEdgeAttribute::NoEdgeAttribute:
+			return GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_NONE;
+		case XClosedCaptionFontEdgeAttribute::RaisedEdges:
+			return GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_RAISED;
+		case XClosedCaptionFontEdgeAttribute::DepressedEdges:
+			return GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_DEPRESSED;
+		case XClosedCaptionFontEdgeAttribute::UniformedEdges:
+			return GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_UNIFORM;
+		case XClosedCaptionFontEdgeAttribute::DropShadowedEdges:
+			return GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_DROP_SHADOW;
+		case XClosedCaptionFontEdgeAttribute::Default:
+		default:
+			return GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_DEFAULT;
+	}
+}
+
+GDKClosedCaptionProperties::FontStyle _to_font_style(XClosedCaptionFontStyle p_value) {
+	switch (p_value) {
+		case XClosedCaptionFontStyle::MonospacedWithSerifs:
+			return GDKClosedCaptionProperties::FONT_STYLE_MONOSPACED_SERIF;
+		case XClosedCaptionFontStyle::ProportionalWithSerifs:
+			return GDKClosedCaptionProperties::FONT_STYLE_PROPORTIONAL_SERIF;
+		case XClosedCaptionFontStyle::MonospacedWithoutSerifs:
+			return GDKClosedCaptionProperties::FONT_STYLE_MONOSPACED_SANS_SERIF;
+		case XClosedCaptionFontStyle::ProportionalWithoutSerifs:
+			return GDKClosedCaptionProperties::FONT_STYLE_PROPORTIONAL_SANS_SERIF;
+		case XClosedCaptionFontStyle::Casual:
+			return GDKClosedCaptionProperties::FONT_STYLE_CASUAL;
+		case XClosedCaptionFontStyle::Cursive:
+			return GDKClosedCaptionProperties::FONT_STYLE_CURSIVE;
+		case XClosedCaptionFontStyle::SmallCapitals:
+			return GDKClosedCaptionProperties::FONT_STYLE_SMALL_CAPITALS;
+		case XClosedCaptionFontStyle::Default:
+		default:
+			return GDKClosedCaptionProperties::FONT_STYLE_DEFAULT;
+	}
+}
+#endif
+
+String _font_edge_attribute_to_name(GDKClosedCaptionProperties::FontEdgeAttribute p_value) {
+	switch (p_value) {
+		case GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_NONE:
+			return "none";
+		case GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_RAISED:
+			return "raised";
+		case GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_DEPRESSED:
+			return "depressed";
+		case GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_UNIFORM:
+			return "uniform";
+		case GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_DROP_SHADOW:
+			return "drop_shadow";
+		case GDKClosedCaptionProperties::FONT_EDGE_ATTRIBUTE_DEFAULT:
+		default:
+			return "default";
+	}
+}
+
+String _font_style_to_name(GDKClosedCaptionProperties::FontStyle p_value) {
+	switch (p_value) {
+		case GDKClosedCaptionProperties::FONT_STYLE_MONOSPACED_SERIF:
+			return "monospaced_serif";
+		case GDKClosedCaptionProperties::FONT_STYLE_PROPORTIONAL_SERIF:
+			return "proportional_serif";
+		case GDKClosedCaptionProperties::FONT_STYLE_MONOSPACED_SANS_SERIF:
+			return "monospaced_sans_serif";
+		case GDKClosedCaptionProperties::FONT_STYLE_PROPORTIONAL_SANS_SERIF:
+			return "proportional_sans_serif";
+		case GDKClosedCaptionProperties::FONT_STYLE_CASUAL:
+			return "casual";
+		case GDKClosedCaptionProperties::FONT_STYLE_CURSIVE:
+			return "cursive";
+		case GDKClosedCaptionProperties::FONT_STYLE_SMALL_CAPITALS:
+			return "small_capitals";
+		case GDKClosedCaptionProperties::FONT_STYLE_DEFAULT:
+		default:
+			return "default";
+	}
+}
+
+} //namespace
+
+void GDKClosedCaptionProperties::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_background_color"), &GDKClosedCaptionProperties::get_background_color);
+	ClassDB::bind_method(D_METHOD("get_font_color"), &GDKClosedCaptionProperties::get_font_color);
+	ClassDB::bind_method(D_METHOD("get_window_color"), &GDKClosedCaptionProperties::get_window_color);
+	ClassDB::bind_method(D_METHOD("get_font_edge_attribute"), &GDKClosedCaptionProperties::get_font_edge_attribute);
+	ClassDB::bind_method(D_METHOD("get_font_edge_attribute_name"), &GDKClosedCaptionProperties::get_font_edge_attribute_name);
+	ClassDB::bind_method(D_METHOD("get_font_style"), &GDKClosedCaptionProperties::get_font_style);
+	ClassDB::bind_method(D_METHOD("get_font_style_name"), &GDKClosedCaptionProperties::get_font_style_name);
+	ClassDB::bind_method(D_METHOD("get_font_scale"), &GDKClosedCaptionProperties::get_font_scale);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &GDKClosedCaptionProperties::is_enabled);
+
+	BIND_ENUM_CONSTANT(FONT_EDGE_ATTRIBUTE_DEFAULT);
+	BIND_ENUM_CONSTANT(FONT_EDGE_ATTRIBUTE_NONE);
+	BIND_ENUM_CONSTANT(FONT_EDGE_ATTRIBUTE_RAISED);
+	BIND_ENUM_CONSTANT(FONT_EDGE_ATTRIBUTE_DEPRESSED);
+	BIND_ENUM_CONSTANT(FONT_EDGE_ATTRIBUTE_UNIFORM);
+	BIND_ENUM_CONSTANT(FONT_EDGE_ATTRIBUTE_DROP_SHADOW);
+
+	BIND_ENUM_CONSTANT(FONT_STYLE_DEFAULT);
+	BIND_ENUM_CONSTANT(FONT_STYLE_MONOSPACED_SERIF);
+	BIND_ENUM_CONSTANT(FONT_STYLE_PROPORTIONAL_SERIF);
+	BIND_ENUM_CONSTANT(FONT_STYLE_MONOSPACED_SANS_SERIF);
+	BIND_ENUM_CONSTANT(FONT_STYLE_PROPORTIONAL_SANS_SERIF);
+	BIND_ENUM_CONSTANT(FONT_STYLE_CASUAL);
+	BIND_ENUM_CONSTANT(FONT_STYLE_CURSIVE);
+	BIND_ENUM_CONSTANT(FONT_STYLE_SMALL_CAPITALS);
+
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "background_color"), "", "get_background_color");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "font_color"), "", "get_font_color");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "window_color"), "", "get_window_color");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "font_edge_attribute", PROPERTY_HINT_ENUM, "Default,None,Raised,Depressed,Uniform,Drop Shadow"), "", "get_font_edge_attribute");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "font_style", PROPERTY_HINT_ENUM, "Default,Monospaced Serif,Proportional Serif,Monospaced Sans Serif,Proportional Sans Serif,Casual,Cursive,Small Capitals"), "", "get_font_style");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "font_scale"), "", "get_font_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "", "is_enabled");
+}
+
+Color GDKClosedCaptionProperties::get_background_color() const {
+	return m_background_color;
+}
+
+Color GDKClosedCaptionProperties::get_font_color() const {
+	return m_font_color;
+}
+
+Color GDKClosedCaptionProperties::get_window_color() const {
+	return m_window_color;
+}
+
+GDKClosedCaptionProperties::FontEdgeAttribute GDKClosedCaptionProperties::get_font_edge_attribute() const {
+	return m_font_edge_attribute;
+}
+
+String GDKClosedCaptionProperties::get_font_edge_attribute_name() const {
+	return _font_edge_attribute_to_name(m_font_edge_attribute);
+}
+
+GDKClosedCaptionProperties::FontStyle GDKClosedCaptionProperties::get_font_style() const {
+	return m_font_style;
+}
+
+String GDKClosedCaptionProperties::get_font_style_name() const {
+	return _font_style_to_name(m_font_style);
+}
+
+double GDKClosedCaptionProperties::get_font_scale() const {
+	return m_font_scale;
+}
+
+bool GDKClosedCaptionProperties::is_enabled() const {
+	return m_enabled;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKClosedCaptionProperties::set_from_native(const XClosedCaptionProperties &p_properties) {
+	m_background_color = _xcolor_to_color(p_properties.BackgroundColor);
+	m_font_color = _xcolor_to_color(p_properties.FontColor);
+	m_window_color = _xcolor_to_color(p_properties.WindowColor);
+	m_font_edge_attribute = _to_font_edge_attribute(p_properties.FontEdgeAttribute);
+	m_font_style = _to_font_style(p_properties.FontStyle);
+	m_font_scale = static_cast<double>(p_properties.FontScale);
+	m_enabled = p_properties.Enabled;
+}
+#else
+void GDKClosedCaptionProperties::set_from_native(const XClosedCaptionProperties &p_properties) {
+}
+#endif
+
+void GDKAccessibility::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("query_closed_caption_properties"), &GDKAccessibility::query_closed_caption_properties);
+	ClassDB::bind_method(D_METHOD("set_closed_caption_enabled", "enabled"), &GDKAccessibility::set_closed_caption_enabled);
+	ClassDB::bind_method(D_METHOD("query_high_contrast_mode"), &GDKAccessibility::query_high_contrast_mode);
+	ClassDB::bind_method(D_METHOD("get_high_contrast_mode_name", "mode"), &GDKAccessibility::get_high_contrast_mode_name);
+
+	BIND_ENUM_CONSTANT(HIGH_CONTRAST_MODE_OFF);
+	BIND_ENUM_CONSTANT(HIGH_CONTRAST_MODE_DARK);
+	BIND_ENUM_CONSTANT(HIGH_CONTRAST_MODE_LIGHT);
+	BIND_ENUM_CONSTANT(HIGH_CONTRAST_MODE_OTHER);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKAccessibility::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKAccessibility::_get_runtime() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+
+	return m_owner->get_runtime();
+}
+
+GDKAccessibility::HighContrastMode GDKAccessibility::_to_high_contrast_mode(XHighContrastMode p_mode) {
+	switch (p_mode) {
+		case XHighContrastMode::Dark:
+			return HIGH_CONTRAST_MODE_DARK;
+		case XHighContrastMode::Light:
+			return HIGH_CONTRAST_MODE_LIGHT;
+		case XHighContrastMode::Other:
+			return HIGH_CONTRAST_MODE_OTHER;
+		case XHighContrastMode::Off:
+		default:
+			return HIGH_CONTRAST_MODE_OFF;
+	}
+}
+
+String GDKAccessibility::_high_contrast_mode_to_name(HighContrastMode p_mode) {
+	switch (p_mode) {
+		case HIGH_CONTRAST_MODE_DARK:
+			return "dark";
+		case HIGH_CONTRAST_MODE_LIGHT:
+			return "light";
+		case HIGH_CONTRAST_MODE_OTHER:
+			return "other";
+		case HIGH_CONTRAST_MODE_OFF:
+		default:
+			return "off";
+	}
+}
+
+Ref<GDKResult> GDKAccessibility::query_closed_caption_properties() const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+
+	XClosedCaptionProperties native_properties = {};
+	HRESULT hr = XClosedCaptionGetProperties(&native_properties);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to query closed caption properties.", "closed_caption_get_failed");
+		return result;
+	}
+
+	Ref<GDKClosedCaptionProperties> properties;
+	properties.instantiate();
+	properties->set_from_native(native_properties);
+
+	return GDKResult::ok_result(properties);
+}
+
+Ref<GDKResult> GDKAccessibility::set_closed_caption_enabled(bool p_enabled) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+
+	HRESULT hr = XClosedCaptionSetEnabled(p_enabled);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to update closed caption enabled state.", "closed_caption_set_failed");
+		return result;
+	}
+
+	Dictionary data;
+	data["enabled"] = p_enabled;
+	return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKAccessibility::query_high_contrast_mode() const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+
+	XHighContrastMode native_mode = XHighContrastMode::Off;
+	HRESULT hr = XHighContrastGetMode(&native_mode);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to query high contrast mode.", "high_contrast_get_failed");
+		return result;
+	}
+
+	const HighContrastMode mode = _to_high_contrast_mode(native_mode);
+	Dictionary data;
+	data["mode"] = static_cast<int64_t>(mode);
+	data["mode_name"] = _high_contrast_mode_to_name(mode);
+
+	return GDKResult::ok_result(data);
+}
+
+String GDKAccessibility::get_high_contrast_mode_name(HighContrastMode p_mode) const {
+	return _high_contrast_mode_to_name(p_mode);
+}
+
+#else
+void GDKAccessibility::set_owner(GDK *p_owner) {}
+
+String GDKAccessibility::_high_contrast_mode_to_name(HighContrastMode p_mode) {
+	return String();
+}
+
+Ref<GDKResult> GDKAccessibility::query_closed_caption_properties() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKAccessibility::set_closed_caption_enabled(bool p_enabled) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKAccessibility::query_high_contrast_mode() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+String GDKAccessibility::get_high_contrast_mode_name(HighContrastMode p_mode) const {
+	return String();
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_accessibility.h
+++ b/modules/xbox_module/gdk/gdk_accessibility.h
@@ -1,0 +1,136 @@
+/**************************************************************************/
+/*  gdk_accessibility.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/math/color.h"
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XAccessibility.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+
+class GDKClosedCaptionProperties : public RefCounted {
+	GDCLASS(GDKClosedCaptionProperties, RefCounted);
+
+public:
+	enum FontEdgeAttribute {
+		FONT_EDGE_ATTRIBUTE_DEFAULT = 0,
+		FONT_EDGE_ATTRIBUTE_NONE,
+		FONT_EDGE_ATTRIBUTE_RAISED,
+		FONT_EDGE_ATTRIBUTE_DEPRESSED,
+		FONT_EDGE_ATTRIBUTE_UNIFORM,
+		FONT_EDGE_ATTRIBUTE_DROP_SHADOW,
+	};
+
+	enum FontStyle {
+		FONT_STYLE_DEFAULT = 0,
+		FONT_STYLE_MONOSPACED_SERIF,
+		FONT_STYLE_PROPORTIONAL_SERIF,
+		FONT_STYLE_MONOSPACED_SANS_SERIF,
+		FONT_STYLE_PROPORTIONAL_SANS_SERIF,
+		FONT_STYLE_CASUAL,
+		FONT_STYLE_CURSIVE,
+		FONT_STYLE_SMALL_CAPITALS,
+	};
+
+private:
+	Color m_background_color = Color(0, 0, 0, 1);
+	Color m_font_color = Color(1, 1, 1, 1);
+	Color m_window_color = Color(0, 0, 0, 1);
+	FontEdgeAttribute m_font_edge_attribute = FONT_EDGE_ATTRIBUTE_DEFAULT;
+	FontStyle m_font_style = FONT_STYLE_DEFAULT;
+	double m_font_scale = 1.0;
+	bool m_enabled = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Color get_background_color() const;
+	Color get_font_color() const;
+	Color get_window_color() const;
+	FontEdgeAttribute get_font_edge_attribute() const;
+	String get_font_edge_attribute_name() const;
+	FontStyle get_font_style() const;
+	String get_font_style_name() const;
+	double get_font_scale() const;
+	bool is_enabled() const;
+
+	void set_from_native(const XClosedCaptionProperties &p_properties);
+};
+
+class GDKAccessibility : public RefCounted {
+	GDCLASS(GDKAccessibility, RefCounted);
+
+public:
+	enum HighContrastMode {
+		HIGH_CONTRAST_MODE_OFF = 0,
+		HIGH_CONTRAST_MODE_DARK,
+		HIGH_CONTRAST_MODE_LIGHT,
+		HIGH_CONTRAST_MODE_OTHER,
+	};
+
+private:
+	GDK *m_owner = nullptr;
+
+	GDKRuntime *_get_runtime() const;
+	static HighContrastMode _to_high_contrast_mode(XHighContrastMode p_mode);
+	static String _high_contrast_mode_to_name(HighContrastMode p_mode);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> query_closed_caption_properties() const;
+	Ref<GDKResult> set_closed_caption_enabled(bool p_enabled) const;
+	Ref<GDKResult> query_high_contrast_mode() const;
+	String get_high_contrast_mode_name(HighContrastMode p_mode) const;
+};
+
+VARIANT_ENUM_CAST(GDKClosedCaptionProperties::FontEdgeAttribute);
+VARIANT_ENUM_CAST(GDKClosedCaptionProperties::FontStyle);
+VARIANT_ENUM_CAST(GDKAccessibility::HighContrastMode);

--- a/modules/xbox_module/gdk/gdk_achievement.cpp
+++ b/modules/xbox_module/gdk/gdk_achievement.cpp
@@ -1,0 +1,927 @@
+/**************************************************************************/
+/*  gdk_achievement.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_achievement.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	return p_value != nullptr ? String::utf8(p_value) : String();
+}
+
+String _progress_state_to_string(XblAchievementProgressState p_state) {
+	switch (p_state) {
+		case XblAchievementProgressState::Achieved:
+			return "Achieved";
+		case XblAchievementProgressState::NotStarted:
+			return "NotStarted";
+		case XblAchievementProgressState::InProgress:
+			return "InProgress";
+		case XblAchievementProgressState::Unknown:
+		default:
+			return "Unknown";
+	}
+}
+
+bool _try_parse_progress_value(const char *p_value, double &r_parsed_value) {
+	if (p_value == nullptr || *p_value == '\0') {
+		return false;
+	}
+
+	char *end = nullptr;
+	double parsed_value = std::strtod(p_value, &end);
+	if (end == p_value || (end != nullptr && *end != '\0')) {
+		return false;
+	}
+
+	r_parsed_value = parsed_value;
+	return true;
+}
+
+int64_t _compute_progress_percent(const XblAchievement &p_achievement) {
+	if (p_achievement.progressState == XblAchievementProgressState::Achieved) {
+		return 100;
+	}
+
+	if (p_achievement.progression.requirements == nullptr || p_achievement.progression.requirementsCount == 0) {
+		return p_achievement.progressState == XblAchievementProgressState::InProgress ? 1 : 0;
+	}
+
+	double total_ratio = 0.0;
+	size_t parsed_requirements = 0;
+	for (size_t i = 0; i < p_achievement.progression.requirementsCount; ++i) {
+		const XblAchievementRequirement &requirement = p_achievement.progression.requirements[i];
+
+		double current_value = 0.0;
+		double target_value = 0.0;
+		if (!_try_parse_progress_value(requirement.currentProgressValue, current_value) ||
+				!_try_parse_progress_value(requirement.targetProgressValue, target_value) ||
+				target_value <= 0.0) {
+			continue;
+		}
+
+		total_ratio += std::clamp(current_value / target_value, 0.0, 1.0);
+		++parsed_requirements;
+	}
+
+	if (parsed_requirements == 0) {
+		return p_achievement.progressState == XblAchievementProgressState::InProgress ? 1 : 0;
+	}
+
+	return static_cast<int64_t>(std::round((total_ratio / static_cast<double>(parsed_requirements)) * 100.0));
+}
+
+} //namespace
+#endif
+
+void GDKAchievement::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_id"), &GDKAchievement::get_id);
+	ClassDB::bind_method(D_METHOD("get_name"), &GDKAchievement::get_name);
+	ClassDB::bind_method(D_METHOD("get_service_configuration_id"), &GDKAchievement::get_service_configuration_id);
+	ClassDB::bind_method(D_METHOD("get_progress_state"), &GDKAchievement::get_progress_state);
+	ClassDB::bind_method(D_METHOD("get_progress_percent"), &GDKAchievement::get_progress_percent);
+	ClassDB::bind_method(D_METHOD("is_unlocked"), &GDKAchievement::is_unlocked);
+	ClassDB::bind_method(D_METHOD("is_secret"), &GDKAchievement::is_secret);
+	ClassDB::bind_method(D_METHOD("get_locked_description"), &GDKAchievement::get_locked_description);
+	ClassDB::bind_method(D_METHOD("get_unlocked_description"), &GDKAchievement::get_unlocked_description);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "id"), "", "get_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name"), "", "get_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "service_configuration_id"), "", "get_service_configuration_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "progress_state"), "", "get_progress_state");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "progress_percent"), "", "get_progress_percent");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "unlocked"), "", "is_unlocked");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "secret"), "", "is_secret");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "locked_description"), "", "get_locked_description");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "unlocked_description"), "", "get_unlocked_description");
+}
+
+String GDKAchievement::get_id() const {
+	return m_id;
+}
+
+String GDKAchievement::get_name() const {
+	return m_name;
+}
+
+String GDKAchievement::get_service_configuration_id() const {
+	return m_service_configuration_id;
+}
+
+String GDKAchievement::get_progress_state() const {
+	return m_progress_state;
+}
+
+int64_t GDKAchievement::get_progress_percent() const {
+	return m_progress_percent;
+}
+
+bool GDKAchievement::is_unlocked() const {
+	return m_unlocked;
+}
+
+bool GDKAchievement::is_secret() const {
+	return m_secret;
+}
+
+String GDKAchievement::get_locked_description() const {
+	return m_locked_description;
+}
+
+String GDKAchievement::get_unlocked_description() const {
+	return m_unlocked_description;
+}
+
+bool GDKAchievement::matches_id(const String &p_id) const {
+	return m_id == p_id;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKAchievement::populate_from_native(const XblAchievement &p_native_achievement) {
+	m_id = _utf8_or_empty(p_native_achievement.id);
+	m_name = _utf8_or_empty(p_native_achievement.name);
+	m_service_configuration_id = _utf8_or_empty(p_native_achievement.serviceConfigurationId);
+	m_progress_state = _progress_state_to_string(p_native_achievement.progressState);
+	m_progress_percent = _compute_progress_percent(p_native_achievement);
+	m_unlocked = p_native_achievement.progressState == XblAchievementProgressState::Achieved;
+	m_secret = p_native_achievement.isSecret;
+	m_locked_description = _utf8_or_empty(p_native_achievement.lockedDescription);
+	m_unlocked_description = _utf8_or_empty(p_native_achievement.unlockedDescription);
+}
+#else
+void GDKAchievement::populate_from_native(const XblAchievement &p_native_achievement) {
+}
+#endif
+
+void GDKAchievements::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("query_player_achievements_async", "user"), &GDKAchievements::query_player_achievements_async);
+	ClassDB::bind_method(D_METHOD("update_achievement_async", "user", "achievement_id", "percent_complete"), &GDKAchievements::update_achievement_async);
+	ClassDB::bind_method(D_METHOD("get_cached_achievements", "user"), &GDKAchievements::get_cached_achievements);
+
+	ADD_SIGNAL(MethodInfo("achievement_unlocked",
+			PropertyInfo(Variant::OBJECT, "user"),
+			PropertyInfo(Variant::STRING, "achievement_id")));
+	ADD_SIGNAL(MethodInfo("achievements_updated", PropertyInfo(Variant::OBJECT, "user")));
+	ADD_SIGNAL(MethodInfo("runtime_error", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKResult")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+GDKRuntime *GDKAchievements::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+GDKXboxServices *GDKAchievements::_get_xbox_services() const {
+	return m_owner != nullptr ? m_owner->get_xbox_services() : nullptr;
+}
+
+Signal GDKAchievements::_make_completed_signal(const Ref<GDKResult> &p_result) const {
+	GDKRuntime *runtime = _get_runtime();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	if (pending_signal.is_null()) {
+		pending_signal.instantiate();
+	}
+	pending_signal->complete_deferred(p_result);
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKAchievements::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+		return runtime->make_error_signal(p_hresult, p_code, p_message);
+	}
+
+	Ref<GDKPendingSignal> pending_signal;
+	pending_signal.instantiate();
+	pending_signal->complete_deferred(GDKResult::error_result(p_hresult, p_code, p_message));
+	return pending_signal->get_completed_signal();
+}
+
+GDKAchievements::UserState *GDKAchievements::_find_user_state_by_xuid(uint64_t p_xbox_user_id) {
+	for (UserState &state : m_user_states) {
+		if (state.xbox_user_id == p_xbox_user_id) {
+			return &state;
+		}
+	}
+
+	return nullptr;
+}
+
+GDKAchievements::UserState *GDKAchievements::_find_user_state_by_local_id(XUserLocalId p_local_id) {
+	for (UserState &state : m_user_states) {
+		if (state.user.is_valid() && state.user->matches_local_id(p_local_id)) {
+			return &state;
+		}
+	}
+
+	return nullptr;
+}
+
+Ref<GDKAchievement> GDKAchievements::_find_cached_achievement(const UserState &p_state, const String &p_achievement_id) const {
+	for (const Ref<GDKAchievement> &achievement : p_state.achievements) {
+		if (achievement.is_valid() && achievement->matches_id(p_achievement_id)) {
+			return achievement;
+		}
+	}
+
+	return Ref<GDKAchievement>();
+}
+
+Array GDKAchievements::_get_cached_achievements_array(const UserState &p_state) const {
+	Array achievements;
+	for (const Ref<GDKAchievement> &achievement : p_state.achievements) {
+		achievements.push_back(achievement);
+	}
+	return achievements;
+}
+
+Ref<GDKResult> GDKAchievements::_ensure_user_state(const Ref<GDKUser> &p_user, UserState **r_state) {
+	ERR_FAIL_COND_V(r_state == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing achievements user-state output."));
+
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"xbox_services_not_initialized",
+				"Xbox services are unavailable. Ensure the title has a TitleId before using achievements.");
+	}
+
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for achievements.");
+	}
+
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->get_xbox_user_id(p_user, &xbox_user_id);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to resolve the Xbox services context for the user.", "xbox_services_context_failed");
+	}
+
+	UserState *state = _find_user_state_by_xuid(xbox_user_id);
+	if (state == nullptr) {
+		UserState new_state;
+		new_state.user = p_user;
+		new_state.xbox_user_id = xbox_user_id;
+		m_user_states.push_back(new_state);
+		state = &m_user_states.back();
+	} else {
+		state->user = p_user;
+	}
+
+	if (!state->manager_added) {
+		hr = XblAchievementsManagerAddLocalUser(p_user->get_handle(), runtime->get_task_queue());
+		if (FAILED(hr)) {
+			return GDKResult::hresult_error(hr, "Failed to register the user with Achievements Manager.", "achievement_manager_add_user_failed");
+		}
+
+		state->manager_added = true;
+		state->initialized = SUCCEEDED(XblAchievementsManagerIsUserInitialized(state->xbox_user_id));
+	}
+
+	*r_state = state;
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKAchievements::_refresh_user_cache(UserState &p_state) {
+	XblAchievementsManagerResultHandle result_handle = nullptr;
+	HRESULT hr = XblAchievementsManagerGetAchievements(
+			p_state.xbox_user_id,
+			XblAchievementOrderBy::DefaultOrder,
+			XblAchievementsManagerSortOrder::Unsorted,
+			&result_handle);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to read the achievements cache for the user.", "achievement_cache_read_failed");
+	}
+
+	const XblAchievement *achievements = nullptr;
+	uint64_t achievements_count = 0;
+	hr = XblAchievementsManagerResultGetAchievements(result_handle, &achievements, &achievements_count);
+	if (FAILED(hr)) {
+		XblAchievementsManagerResultCloseHandle(result_handle);
+		return GDKResult::hresult_error(hr, "Failed to translate the achievements cache.", "achievement_cache_translate_failed");
+	}
+
+	p_state.achievements.clear();
+	for (uint64_t i = 0; i < achievements_count; ++i) {
+		Ref<GDKAchievement> achievement;
+		achievement.instantiate();
+		achievement->populate_from_native(achievements[i]);
+		p_state.achievements.push_back(achievement);
+	}
+
+	XblAchievementsManagerResultCloseHandle(result_handle);
+	return GDKResult::ok_result(_get_cached_achievements_array(p_state));
+}
+
+Ref<GDKResult> GDKAchievements::_refresh_single_achievement(UserState &p_state, const String &p_achievement_id) {
+	CharString achievement_id_utf8 = p_achievement_id.utf8();
+
+	XblAchievementsManagerResultHandle result_handle = nullptr;
+	HRESULT hr = XblAchievementsManagerGetAchievement(
+			p_state.xbox_user_id,
+			achievement_id_utf8.get_data(),
+			&result_handle);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to read the cached achievement state.", "achievement_read_failed");
+	}
+
+	const XblAchievement *achievements = nullptr;
+	uint64_t achievements_count = 0;
+	hr = XblAchievementsManagerResultGetAchievements(result_handle, &achievements, &achievements_count);
+	if (FAILED(hr)) {
+		XblAchievementsManagerResultCloseHandle(result_handle);
+		return GDKResult::hresult_error(hr, "Failed to translate the cached achievement state.", "achievement_translate_failed");
+	}
+
+	if (achievements_count == 0) {
+		XblAchievementsManagerResultCloseHandle(result_handle);
+		return GDKResult::error_result(E_FAIL, "achievement_not_found", "The cached achievement state was empty.");
+	}
+
+	Ref<GDKAchievement> achievement;
+	achievement.instantiate();
+	achievement->populate_from_native(achievements[0]);
+
+	bool updated = false;
+	for (Ref<GDKAchievement> &existing : p_state.achievements) {
+		if (existing.is_valid() && existing->matches_id(p_achievement_id)) {
+			existing = achievement;
+			updated = true;
+			break;
+		}
+	}
+	if (!updated) {
+		p_state.achievements.push_back(achievement);
+	}
+
+	XblAchievementsManagerResultCloseHandle(result_handle);
+	return GDKResult::ok_result(achievement);
+}
+
+Ref<GDKResult> GDKAchievements::_submit_update(PendingUpdateOp &p_pending_update) {
+	HRESULT hr = XblAchievementsManagerUpdateAchievement(
+			p_pending_update.xbox_user_id,
+			p_pending_update.achievement_id.utf8().get_data(),
+			static_cast<uint8_t>(p_pending_update.percent_complete));
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to submit the achievement update.", "achievement_update_submit_failed");
+	}
+
+	p_pending_update.submitted = true;
+	return GDKResult::ok_result();
+}
+
+void GDKAchievements::_complete_pending_queries(UserState &p_state) {
+	Ref<GDKResult> result = GDKResult::ok_result(_get_cached_achievements_array(p_state));
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+	}
+
+	m_pending_query_ops.erase(
+			std::remove_if(
+					m_pending_query_ops.begin(),
+					m_pending_query_ops.end(),
+					[&p_state, &result](PendingQueryOp &pending_query) {
+						if (pending_query.xbox_user_id != p_state.xbox_user_id) {
+							return false;
+						}
+
+						if (pending_query.request.is_valid()) {
+							pending_query.request->complete(result);
+						}
+						return true;
+					}),
+			m_pending_query_ops.end());
+}
+
+void GDKAchievements::_fail_pending_queries(uint64_t p_xbox_user_id, const Ref<GDKResult> &p_result) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+	}
+
+	m_pending_query_ops.erase(
+			std::remove_if(
+					m_pending_query_ops.begin(),
+					m_pending_query_ops.end(),
+					[p_xbox_user_id, &p_result](PendingQueryOp &pending_query) {
+						if (p_xbox_user_id != UINT64_MAX && pending_query.xbox_user_id != p_xbox_user_id) {
+							return false;
+						}
+
+						if (pending_query.request.is_valid()) {
+							pending_query.request->complete(p_result);
+						}
+						return true;
+					}),
+			m_pending_query_ops.end());
+}
+
+void GDKAchievements::_complete_pending_updates(UserState &p_state, const String &p_achievement_id) {
+	Ref<GDKAchievement> achievement = _find_cached_achievement(p_state, p_achievement_id);
+	if (!achievement.is_valid()) {
+		return;
+	}
+
+	Ref<GDKResult> result = GDKResult::ok_result(achievement);
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+	}
+
+	m_pending_update_ops.erase(
+			std::remove_if(
+					m_pending_update_ops.begin(),
+					m_pending_update_ops.end(),
+					[&p_state, &p_achievement_id, &achievement, &result](PendingUpdateOp &pending_update) {
+						if (pending_update.xbox_user_id != p_state.xbox_user_id ||
+								pending_update.achievement_id != p_achievement_id ||
+								!pending_update.submitted) {
+							return false;
+						}
+
+						if (!achievement->is_unlocked() &&
+								achievement->get_progress_percent() < static_cast<int64_t>(pending_update.percent_complete)) {
+							return false;
+						}
+
+						if (pending_update.request.is_valid()) {
+							pending_update.request->complete(result);
+						}
+						return true;
+					}),
+			m_pending_update_ops.end());
+}
+
+void GDKAchievements::_fail_pending_updates(uint64_t p_xbox_user_id, const Ref<GDKResult> &p_result) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+	}
+
+	m_pending_update_ops.erase(
+			std::remove_if(
+					m_pending_update_ops.begin(),
+					m_pending_update_ops.end(),
+					[p_xbox_user_id, &p_result](PendingUpdateOp &pending_update) {
+						if (p_xbox_user_id != UINT64_MAX && pending_update.xbox_user_id != p_xbox_user_id) {
+							return false;
+						}
+
+						if (pending_update.request.is_valid()) {
+							pending_update.request->complete(p_result);
+						}
+						return true;
+					}),
+			m_pending_update_ops.end());
+}
+
+void GDKAchievements::_cancel_pending_query_signal(GDKPendingSignal *p_request) {
+	if (p_request == nullptr) {
+		return;
+	}
+
+	for (auto it = m_pending_query_ops.begin(); it != m_pending_query_ops.end(); ++it) {
+		if (it->request.is_null() || it->request.ptr() != p_request) {
+			continue;
+		}
+
+		Ref<GDKPendingSignal> pending_signal = it->request;
+		m_pending_query_ops.erase(it);
+		if (pending_signal.is_valid()) {
+			pending_signal->clear_cancel_handler();
+			pending_signal->complete(GDKResult::cancelled("Achievement query cancelled."));
+		}
+		return;
+	}
+}
+
+void GDKAchievements::_cancel_pending_update_signal(GDKPendingSignal *p_request) {
+	if (p_request == nullptr) {
+		return;
+	}
+
+	for (auto it = m_pending_update_ops.begin(); it != m_pending_update_ops.end(); ++it) {
+		if (it->request.is_null() || it->request.ptr() != p_request) {
+			continue;
+		}
+
+		Ref<GDKPendingSignal> pending_signal = it->request;
+		m_pending_update_ops.erase(it);
+		if (pending_signal.is_valid()) {
+			pending_signal->clear_cancel_handler();
+			pending_signal->complete(GDKResult::cancelled("Achievement update cancelled."));
+		}
+		return;
+	}
+}
+
+void GDKAchievements::_submit_waiting_updates(UserState &p_state) {
+	GDKRuntime *runtime = _get_runtime();
+
+	for (PendingUpdateOp &pending_update : m_pending_update_ops) {
+		if (pending_update.xbox_user_id != p_state.xbox_user_id || pending_update.submitted || !pending_update.request.is_valid()) {
+			continue;
+		}
+
+		Ref<GDKResult> submit_result = _submit_update(pending_update);
+		if (!submit_result->is_ok()) {
+			if (runtime != nullptr) {
+			}
+			pending_update.request->complete(submit_result);
+		}
+	}
+
+	_erase_completed_updates();
+}
+
+void GDKAchievements::_erase_completed_updates() {
+	m_pending_update_ops.erase(
+			std::remove_if(
+					m_pending_update_ops.begin(),
+					m_pending_update_ops.end(),
+					[](const PendingUpdateOp &pending_update) {
+						return pending_update.request.is_null() || pending_update.request->is_done();
+					}),
+			m_pending_update_ops.end());
+}
+
+void GDKAchievements::_erase_user_state(uint64_t p_xbox_user_id) {
+	m_user_states.erase(
+			std::remove_if(
+					m_user_states.begin(),
+					m_user_states.end(),
+					[p_xbox_user_id](const UserState &state) {
+						return state.xbox_user_id == p_xbox_user_id;
+					}),
+			m_user_states.end());
+}
+
+void GDKAchievements::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKAchievements::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKAchievements::shutdown() {
+	m_runtime_ready = false;
+
+	Ref<GDKResult> cancelled = GDKResult::cancelled("Achievements operation cancelled during shutdown.");
+	_fail_pending_queries(UINT64_MAX, cancelled);
+	_fail_pending_updates(UINT64_MAX, cancelled);
+
+	for (UserState &state : m_user_states) {
+		if (state.manager_added && state.user.is_valid() && state.user->get_handle() != nullptr) {
+			XblAchievementsManagerRemoveLocalUser(state.user->get_handle());
+		}
+	}
+
+	m_pending_query_ops.clear();
+	m_pending_update_ops.clear();
+	m_user_states.clear();
+}
+
+int GDKAchievements::dispatch() {
+	if (!m_runtime_ready) {
+		return 0;
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return 0;
+	}
+
+	const XblAchievementsManagerEvent *events = nullptr;
+	size_t event_count = 0;
+	HRESULT hr = XblAchievementsManagerDoWork(&events, &event_count);
+	if (FAILED(hr)) {
+		emit_signal("runtime_error", GDKResult::hresult_error(hr, "Failed to dispatch Achievements Manager state.", "achievement_manager_dispatch_failed"));
+		return 0;
+	}
+
+	int handled_events = 0;
+	for (size_t i = 0; i < event_count; ++i) {
+		const XblAchievementsManagerEvent &event = events[i];
+		UserState *state = _find_user_state_by_xuid(event.xboxUserId);
+		if (state == nullptr || !state->user.is_valid()) {
+			continue;
+		}
+
+		++handled_events;
+
+		switch (event.eventType) {
+			case XblAchievementsManagerEventType::LocalUserInitialStateSynced: {
+				state->initialized = true;
+
+				Ref<GDKResult> refresh_result = _refresh_user_cache(*state);
+				if (!refresh_result->is_ok()) {
+					_fail_pending_queries(state->xbox_user_id, refresh_result);
+					_fail_pending_updates(state->xbox_user_id, refresh_result);
+					continue;
+				}
+
+				emit_signal("achievements_updated", state->user);
+				if (!m_runtime_ready) {
+					return handled_events;
+				}
+				_complete_pending_queries(*state);
+				_submit_waiting_updates(*state);
+			} break;
+			case XblAchievementsManagerEventType::AchievementProgressUpdated: {
+				String achievement_id = _utf8_or_empty(event.progressInfo.achievementId);
+				Ref<GDKResult> refresh_result = _refresh_single_achievement(*state, achievement_id);
+				if (!refresh_result->is_ok()) {
+					_fail_pending_updates(state->xbox_user_id, refresh_result);
+					continue;
+				}
+
+				emit_signal("achievements_updated", state->user);
+				if (!m_runtime_ready) {
+					return handled_events;
+				}
+				_complete_pending_updates(*state, achievement_id);
+			} break;
+			case XblAchievementsManagerEventType::AchievementUnlocked: {
+				String achievement_id = _utf8_or_empty(event.progressInfo.achievementId);
+				Ref<GDKResult> refresh_result = _refresh_single_achievement(*state, achievement_id);
+				if (!refresh_result->is_ok()) {
+					_fail_pending_updates(state->xbox_user_id, refresh_result);
+					continue;
+				}
+
+				emit_signal("achievements_updated", state->user);
+				if (!m_runtime_ready) {
+					return handled_events;
+				}
+				emit_signal("achievement_unlocked", state->user, achievement_id);
+				if (!m_runtime_ready) {
+					return handled_events;
+				}
+				_complete_pending_updates(*state, achievement_id);
+			} break;
+			default:
+				break;
+		}
+	}
+
+	return handled_events;
+}
+
+Signal GDKAchievements::query_player_achievements_async(const Ref<GDKUser> &p_user) {
+	UserState *state = nullptr;
+	Ref<GDKResult> ensure_result = _ensure_user_state(p_user, &state);
+	if (!ensure_result->is_ok()) {
+		return _make_error_signal(
+				static_cast<HRESULT>(ensure_result->get_hresult()),
+				ensure_result->get_code(),
+				ensure_result->get_message());
+	}
+
+	if (state->initialized) {
+		Ref<GDKResult> refresh_result = _refresh_user_cache(*state);
+		if (!refresh_result->is_ok()) {
+			return _make_error_signal(
+					static_cast<HRESULT>(refresh_result->get_hresult()),
+					refresh_result->get_code(),
+					refresh_result->get_message());
+		}
+		return _make_completed_signal(refresh_result);
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	PendingQueryOp pending_query;
+	pending_query.xbox_user_id = state->xbox_user_id;
+	pending_query.request = pending_signal;
+	m_pending_query_ops.push_back(pending_query);
+	GDKPendingSignal *pending_signal_ptr = pending_signal.ptr();
+	pending_signal->set_cancel_handler([this, pending_signal_ptr]() {
+		_cancel_pending_query_signal(pending_signal_ptr);
+	});
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKAchievements::update_achievement_async(const Ref<GDKUser> &p_user, const String &p_achievement_id, int64_t p_percent_complete) {
+	UserState *state = nullptr;
+	Ref<GDKResult> ensure_result = _ensure_user_state(p_user, &state);
+	if (!ensure_result->is_ok()) {
+		return _make_error_signal(
+				static_cast<HRESULT>(ensure_result->get_hresult()),
+				ensure_result->get_code(),
+				ensure_result->get_message());
+	}
+
+	if (p_achievement_id.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_achievement_id", "Achievement updates require a non-empty achievement id.");
+	}
+	if (p_percent_complete < 1 || p_percent_complete > 100) {
+		return _make_error_signal(E_INVALIDARG, "invalid_achievement_progress", "Achievement progress must be between 1 and 100.");
+	}
+
+	PendingUpdateOp pending_update;
+	pending_update.xbox_user_id = state->xbox_user_id;
+	pending_update.achievement_id = p_achievement_id;
+	pending_update.percent_complete = static_cast<uint32_t>(p_percent_complete);
+
+	if (state->initialized) {
+		Ref<GDKResult> submit_result = _submit_update(pending_update);
+		if (!submit_result->is_ok()) {
+			return _make_error_signal(
+					static_cast<HRESULT>(submit_result->get_hresult()),
+					submit_result->get_code(),
+					submit_result->get_message());
+		}
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+	pending_update.request = pending_signal;
+
+	m_pending_update_ops.push_back(pending_update);
+	GDKPendingSignal *pending_signal_ptr = pending_signal.ptr();
+	pending_signal->set_cancel_handler([this, pending_signal_ptr]() {
+		_cancel_pending_update_signal(pending_signal_ptr);
+	});
+	return pending_signal->get_completed_signal();
+}
+
+Array GDKAchievements::get_cached_achievements(const Ref<GDKUser> &p_user) const {
+	if (!p_user.is_valid()) {
+		return Array();
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+
+	for (const UserState &state : m_user_states) {
+		if (state.user.is_valid() && state.user->matches_local_id(local_id)) {
+			return _get_cached_achievements_array(state);
+		}
+	}
+
+	return Array();
+}
+
+void GDKAchievements::on_user_removed(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+
+	UserState *state = _find_user_state_by_local_id(local_id);
+	if (state == nullptr) {
+		return;
+	}
+
+	Ref<GDKResult> cancelled = GDKResult::cancelled("Achievement operation cancelled because the user signed out.");
+	_fail_pending_queries(state->xbox_user_id, cancelled);
+	_fail_pending_updates(state->xbox_user_id, cancelled);
+
+	if (state->manager_added && p_user->get_handle() != nullptr) {
+		XblAchievementsManagerRemoveLocalUser(p_user->get_handle());
+	}
+
+	_erase_user_state(state->xbox_user_id);
+}
+
+#else
+Signal GDKAchievements::_make_completed_signal(const Ref<GDKResult> &p_result) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKAchievements::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKAchievement> GDKAchievements::_find_cached_achievement(const UserState &p_state, const String &p_achievement_id) const {
+	return Ref<GDKAchievement>();
+}
+
+Array GDKAchievements::_get_cached_achievements_array(const UserState &p_state) const {
+	return Array();
+}
+
+Ref<GDKResult> GDKAchievements::_ensure_user_state(const Ref<GDKUser> &p_user, UserState **r_state) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKAchievements::_refresh_user_cache(UserState &p_state) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKAchievements::_refresh_single_achievement(UserState &p_state, const String &p_achievement_id) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKAchievements::_submit_update(PendingUpdateOp &p_pending_update) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKAchievements::_complete_pending_queries(UserState &p_state) {}
+
+void GDKAchievements::_fail_pending_queries(uint64_t p_xbox_user_id, const Ref<GDKResult> &p_result) {}
+
+void GDKAchievements::_complete_pending_updates(UserState &p_state, const String &p_achievement_id) {}
+
+void GDKAchievements::_fail_pending_updates(uint64_t p_xbox_user_id, const Ref<GDKResult> &p_result) {}
+
+void GDKAchievements::_cancel_pending_query_signal(GDKPendingSignal *p_request) {}
+
+void GDKAchievements::_cancel_pending_update_signal(GDKPendingSignal *p_request) {}
+
+void GDKAchievements::_submit_waiting_updates(UserState &p_state) {}
+
+void GDKAchievements::_erase_completed_updates() {}
+
+void GDKAchievements::_erase_user_state(uint64_t p_xbox_user_id) {}
+
+void GDKAchievements::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKAchievements::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKAchievements::shutdown() {}
+
+int GDKAchievements::dispatch() {
+	return 0;
+}
+
+Signal GDKAchievements::query_player_achievements_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKAchievements::update_achievement_async(const Ref<GDKUser> &p_user, const String &p_achievement_id, int64_t p_percent_complete) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Array GDKAchievements::get_cached_achievements(const Ref<GDKUser> &p_user) const {
+	return Array();
+}
+
+void GDKAchievements::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_achievement.h
+++ b/modules/xbox_module/gdk/gdk_achievement.h
@@ -1,0 +1,160 @@
+/**************************************************************************/
+/*  gdk_achievement.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/variant/callable.h"
+#include "gdk_gdk_stubs.h"
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+#include "gdk_pending_signal.h"
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKAchievement : public RefCounted {
+	GDCLASS(GDKAchievement, RefCounted);
+
+	String m_id;
+	String m_name;
+	String m_service_configuration_id;
+	String m_progress_state;
+	int64_t m_progress_percent = 0;
+	bool m_unlocked = false;
+	bool m_secret = false;
+	String m_locked_description;
+	String m_unlocked_description;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_id() const;
+	String get_name() const;
+	String get_service_configuration_id() const;
+	String get_progress_state() const;
+	int64_t get_progress_percent() const;
+	bool is_unlocked() const;
+	bool is_secret() const;
+	String get_locked_description() const;
+	String get_unlocked_description() const;
+
+	bool matches_id(const String &p_id) const;
+	void populate_from_native(const XblAchievement &p_native_achievement);
+};
+
+class GDKAchievements : public RefCounted {
+	GDCLASS(GDKAchievements, RefCounted);
+
+	struct UserState {
+		Ref<GDKUser> user;
+		uint64_t xbox_user_id = 0;
+		bool manager_added = false;
+		bool initialized = false;
+		std::vector<Ref<GDKAchievement>> achievements;
+	};
+
+	struct PendingQueryOp {
+		uint64_t xbox_user_id = 0;
+		Ref<GDKPendingSignal> request;
+	};
+
+	struct PendingUpdateOp {
+		uint64_t xbox_user_id = 0;
+		String achievement_id;
+		uint32_t percent_complete = 0;
+		bool submitted = false;
+		Ref<GDKPendingSignal> request;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	std::vector<UserState> m_user_states;
+	std::vector<PendingQueryOp> m_pending_query_ops;
+	std::vector<PendingUpdateOp> m_pending_update_ops;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_completed_signal(const Ref<GDKResult> &p_result) const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const;
+	UserState *_find_user_state_by_xuid(uint64_t p_xbox_user_id);
+	UserState *_find_user_state_by_local_id(XUserLocalId p_local_id);
+	Ref<GDKAchievement> _find_cached_achievement(const UserState &p_state, const String &p_achievement_id) const;
+	Array _get_cached_achievements_array(const UserState &p_state) const;
+	Ref<GDKResult> _ensure_user_state(const Ref<GDKUser> &p_user, UserState **r_state);
+	Ref<GDKResult> _refresh_user_cache(UserState &p_state);
+	Ref<GDKResult> _refresh_single_achievement(UserState &p_state, const String &p_achievement_id);
+	Ref<GDKResult> _submit_update(PendingUpdateOp &p_pending_update);
+	void _complete_pending_queries(UserState &p_state);
+	void _fail_pending_queries(uint64_t p_xbox_user_id, const Ref<GDKResult> &p_result);
+	void _complete_pending_updates(UserState &p_state, const String &p_achievement_id);
+	void _fail_pending_updates(uint64_t p_xbox_user_id, const Ref<GDKResult> &p_result);
+	void _cancel_pending_query_signal(GDKPendingSignal *p_request);
+	void _cancel_pending_update_signal(GDKPendingSignal *p_request);
+	void _submit_waiting_updates(UserState &p_state);
+	void _erase_completed_updates();
+	void _erase_user_state(uint64_t p_xbox_user_id);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	int dispatch();
+
+	Signal query_player_achievements_async(const Ref<GDKUser> &p_user);
+	Signal update_achievement_async(const Ref<GDKUser> &p_user, const String &p_achievement_id, int64_t p_percent_complete);
+	Array get_cached_achievements(const Ref<GDKUser> &p_user) const;
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_activation.cpp
+++ b/modules/xbox_module/gdk/gdk_activation.cpp
@@ -1,0 +1,360 @@
+/**************************************************************************/
+/*  gdk_activation.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_activation.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <utility>
+
+#include "core/error/error_macros.h"
+#include "core/variant/variant.h"
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	if (p_value == nullptr) {
+		return String();
+	}
+	return String::utf8(p_value);
+}
+
+String _normalize_invite_action(const String &p_action) {
+	if (p_action == "inviteHandleAccept") {
+		return "invite_handle_accept";
+	}
+	if (p_action == "activityHandleJoin") {
+		return "activity_handle_join";
+	}
+	return p_action.to_lower();
+}
+
+String _normalize_invite_key(const String &p_key) {
+	if (p_key == "invitedXuid") {
+		return "invited_xuid";
+	}
+	if (p_key == "senderXuid") {
+		return "sender_xuid";
+	}
+	if (p_key == "joinerXuid") {
+		return "joiner_xuid";
+	}
+	if (p_key == "joineeXuid") {
+		return "joinee_xuid";
+	}
+	return p_key.to_lower();
+}
+
+} //namespace
+
+void GDKActivation::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("accept_pending_invite", "invite_uri"), &GDKActivation::accept_pending_invite);
+
+	ADD_SIGNAL(MethodInfo("protocol_activated", PropertyInfo(Variant::STRING, "uri")));
+	ADD_SIGNAL(MethodInfo("file_activated", PropertyInfo(Variant::STRING, "file")));
+	ADD_SIGNAL(MethodInfo("pending_invite_received", PropertyInfo(Variant::DICTIONARY, "invite")));
+	ADD_SIGNAL(MethodInfo("invite_accepted", PropertyInfo(Variant::DICTIONARY, "invite")));
+	ADD_SIGNAL(MethodInfo("activated", PropertyInfo(Variant::DICTIONARY, "info")));
+
+	BIND_ENUM_CONSTANT(ACTIVATION_TYPE_PROTOCOL);
+	BIND_ENUM_CONSTANT(ACTIVATION_TYPE_FILE);
+	BIND_ENUM_CONSTANT(ACTIVATION_TYPE_PENDING_GAME_INVITE);
+	BIND_ENUM_CONSTANT(ACTIVATION_TYPE_ACCEPTED_GAME_INVITE);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKActivation::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKActivation::on_runtime_initialized() {
+	GDKRuntime *runtime = m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"Cannot initialize the activation service before the GDK runtime.");
+	}
+
+	if (m_activation_registered) {
+		m_runtime_ready = true;
+		return GDKResult::ok_result();
+	}
+
+	HRESULT hr = XGameActivationRegisterForEvent(
+			runtime->get_task_queue(),
+			this,
+			_activation_callback,
+			&m_activation_token);
+	if (FAILED(hr)) {
+		char hr_buf[16];
+		std::snprintf(hr_buf, sizeof(hr_buf), "0x%08X", static_cast<unsigned int>(hr));
+		WARN_PRINT(String("[GDK] XGameActivationRegisterForEvent failed (HRESULT ") +
+				String(hr_buf) +
+				") — activation inbound events disabled, accept_pending_invite still available.");
+		m_activation_registered = false;
+		m_runtime_ready = true;
+		return GDKResult::ok_result();
+	}
+
+	m_runtime_ready = true;
+	m_activation_registered = true;
+	return GDKResult::ok_result();
+}
+
+void GDKActivation::shutdown() {
+	m_runtime_ready = false;
+
+	if (m_activation_registered) {
+		XGameActivationUnregisterForEvent(m_activation_token, true);
+		m_activation_registered = false;
+		m_activation_token = {};
+	}
+
+	m_activation_listeners.clear();
+}
+
+uint64_t GDKActivation::add_activation_listener(std::function<void(const Dictionary &)> p_callback) {
+	if (!p_callback) {
+		return 0;
+	}
+
+	ActivationListener listener;
+	listener.id = m_next_activation_listener_id++;
+	listener.callback = std::move(p_callback);
+	m_activation_listeners.push_back(std::move(listener));
+	return m_activation_listeners.back().id;
+}
+
+void GDKActivation::remove_activation_listener(uint64_t p_listener_id) {
+	if (p_listener_id == 0) {
+		return;
+	}
+
+	m_activation_listeners.erase(
+			std::remove_if(
+					m_activation_listeners.begin(),
+					m_activation_listeners.end(),
+					[p_listener_id](const ActivationListener &p_listener) {
+						return p_listener.id == p_listener_id;
+					}),
+			m_activation_listeners.end());
+}
+
+void GDKActivation::notify_activation_listeners_internal(const Dictionary &p_info) {
+	if (!m_runtime_ready) {
+		return;
+	}
+
+	std::vector<std::function<void(const Dictionary &)>> callbacks;
+	callbacks.reserve(m_activation_listeners.size());
+	for (const ActivationListener &listener : m_activation_listeners) {
+		if (listener.callback) {
+			callbacks.push_back(listener.callback);
+		}
+	}
+
+	for (const std::function<void(const Dictionary &)> &callback : callbacks) {
+		if (!m_runtime_ready) {
+			break;
+		}
+		callback(p_info);
+	}
+}
+
+Dictionary GDKActivation::make_invite_dictionary_internal(const String &p_uri, const String &p_activation_type) {
+	Dictionary data;
+	data["raw_uri"] = p_uri;
+	data["activation_type"] = p_activation_type;
+
+	const String uri = p_uri.strip_edges();
+	const int64_t scheme_separator = uri.find("://");
+	String remainder = uri;
+	if (scheme_separator >= 0) {
+		data["scheme"] = uri.substr(0, scheme_separator);
+		remainder = uri.substr(scheme_separator + 3);
+	} else {
+		data["scheme"] = String();
+	}
+
+	const int64_t query_separator = remainder.find("?");
+	String action = remainder;
+	String query;
+	if (query_separator >= 0) {
+		action = remainder.substr(0, query_separator);
+		query = remainder.substr(query_separator + 1);
+	}
+
+	data["action"] = _normalize_invite_action(action);
+
+	if (query.begins_with("&")) {
+		query = query.substr(1);
+	}
+
+	PackedStringArray query_parts = query.split("&", false);
+	for (int64_t i = 0; i < query_parts.size(); ++i) {
+		const String pair = query_parts[i];
+		if (pair.is_empty()) {
+			continue;
+		}
+
+		const int64_t equals_index = pair.find("=");
+		const String key = equals_index >= 0 ? pair.substr(0, equals_index) : pair;
+		const String value = equals_index >= 0 ? pair.substr(equals_index + 1) : String();
+		data[_normalize_invite_key(key)] = value.uri_decode();
+	}
+
+	return data;
+}
+
+Ref<GDKResult> GDKActivation::accept_pending_invite(const String &p_invite_uri) {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"not_initialized",
+				"GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	const String invite_uri = p_invite_uri.strip_edges();
+	if (invite_uri.is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_invite_uri",
+				"A non-empty invite URI is required.");
+	}
+
+	const CharString invite_uri_utf8 = invite_uri.utf8();
+	HRESULT hr = XGameActivationAcceptPendingInvite(invite_uri_utf8.get_data());
+	if (FAILED(hr)) {
+		Dictionary data;
+		data["invite_uri"] = invite_uri;
+		return GDKResult::hresult_error(
+				hr,
+				"Failed to accept pending invite.",
+				"accept_pending_invite_failed",
+				data);
+	}
+
+	Dictionary data;
+	data["invite_uri"] = invite_uri;
+	return GDKResult::ok_result(data);
+}
+
+void GDKActivation::handle_activation_internal(const XGameActivationInfo *p_activation_info) {
+	if (!m_runtime_ready || p_activation_info == nullptr) {
+		return;
+	}
+
+	Dictionary info;
+	info["type"] = static_cast<int64_t>(p_activation_info->type);
+
+	switch (p_activation_info->type) {
+		case XGameActivationType::Protocol: {
+			const String uri = _utf8_or_empty(p_activation_info->protocolUri);
+			info["uri"] = uri;
+			emit_signal("protocol_activated", uri);
+			break;
+		}
+		case XGameActivationType::File: {
+			const String file = _utf8_or_empty(p_activation_info->file);
+			info["file"] = file;
+			emit_signal("file_activated", file);
+			break;
+		}
+		case XGameActivationType::PendingGameInvite: {
+			const String invite_uri = _utf8_or_empty(p_activation_info->inviteUri);
+			Dictionary invite = make_invite_dictionary_internal(invite_uri, "pending_game_invite");
+			info["invite_uri"] = invite_uri;
+			info["invite"] = invite;
+			emit_signal("pending_invite_received", invite);
+			break;
+		}
+		case XGameActivationType::AcceptedGameInvite: {
+			const String invite_uri = _utf8_or_empty(p_activation_info->inviteUri);
+			Dictionary invite = make_invite_dictionary_internal(invite_uri, "accepted_game_invite");
+			info["invite_uri"] = invite_uri;
+			info["invite"] = invite;
+			emit_signal("invite_accepted", invite);
+			break;
+		}
+		default:
+			break;
+	}
+
+	if (!m_runtime_ready) {
+		return;
+	}
+
+	notify_activation_listeners_internal(info);
+	if (!m_runtime_ready) {
+		return;
+	}
+
+	emit_signal("activated", info);
+}
+
+void CALLBACK GDKActivation::_activation_callback(void *p_context, const XGameActivationInfo *p_activation_info) {
+	auto *service = static_cast<GDKActivation *>(p_context);
+	if (service != nullptr) {
+		service->handle_activation_internal(p_activation_info);
+	}
+}
+
+#else
+void GDKActivation::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKActivation::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKActivation::shutdown() {}
+
+void GDKActivation::remove_activation_listener(uint64_t p_listener_id) {}
+
+void GDKActivation::notify_activation_listeners_internal(const Dictionary &p_info) {}
+
+Dictionary GDKActivation::make_invite_dictionary_internal(const String &p_uri, const String &p_activation_type) {
+	return Dictionary();
+}
+
+Ref<GDKResult> GDKActivation::accept_pending_invite(const String &p_invite_uri) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKActivation::handle_activation_internal(const XGameActivationInfo *p_activation_info) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_activation.h
+++ b/modules/xbox_module/gdk/gdk_activation.h
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  gdk_activation.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XGameActivation.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+
+class GDKActivation : public RefCounted {
+	GDCLASS(GDKActivation, RefCounted);
+
+	struct ActivationListener {
+		uint64_t id = 0;
+		std::function<void(const Dictionary &)> callback;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	bool m_activation_registered = false;
+	uint64_t m_next_activation_listener_id = 1;
+	XTaskQueueRegistrationToken m_activation_token = {};
+	std::vector<ActivationListener> m_activation_listeners;
+
+	static void CALLBACK _activation_callback(void *p_context, const XGameActivationInfo *p_activation_info);
+	void notify_activation_listeners_internal(const Dictionary &p_info);
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum ActivationType {
+		ACTIVATION_TYPE_PROTOCOL = static_cast<uint32_t>(XGameActivationType::Protocol),
+		ACTIVATION_TYPE_FILE = static_cast<uint32_t>(XGameActivationType::File),
+		ACTIVATION_TYPE_PENDING_GAME_INVITE = static_cast<uint32_t>(XGameActivationType::PendingGameInvite),
+		ACTIVATION_TYPE_ACCEPTED_GAME_INVITE = static_cast<uint32_t>(XGameActivationType::AcceptedGameInvite),
+	};
+
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Ref<GDKResult> accept_pending_invite(const String &p_invite_uri);
+
+	void handle_activation_internal(const XGameActivationInfo *p_activation_info);
+	uint64_t add_activation_listener(std::function<void(const Dictionary &)> p_callback);
+	void remove_activation_listener(uint64_t p_listener_id);
+
+	static Dictionary make_invite_dictionary_internal(const String &p_uri, const String &p_activation_type);
+};
+
+VARIANT_ENUM_CAST(GDKActivation::ActivationType);

--- a/modules/xbox_module/gdk/gdk_capture.cpp
+++ b/modules/xbox_module/gdk/gdk_capture.cpp
@@ -1,0 +1,569 @@
+/**************************************************************************/
+/*  gdk_capture.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_capture.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cmath>
+#include <ctime>
+#include <limits>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+
+void GDKCaptureMetaData::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_valid"), &GDKCaptureMetaData::is_valid);
+	ClassDB::bind_method(D_METHOD("close"), &GDKCaptureMetaData::close);
+	ClassDB::bind_method(D_METHOD("stop_all_states"), &GDKCaptureMetaData::stop_all_states);
+	ClassDB::bind_method(D_METHOD("get_remaining_storage_bytes"), &GDKCaptureMetaData::get_remaining_storage_bytes);
+	ClassDB::bind_method(
+			D_METHOD("add_string_event", "name", "value", "priority"),
+			&GDKCaptureMetaData::add_string_event,
+			DEFVAL(PRIORITY_GAMEPLAY));
+	ClassDB::bind_method(
+			D_METHOD("add_double_event", "name", "value", "priority"),
+			&GDKCaptureMetaData::add_double_event,
+			DEFVAL(PRIORITY_GAMEPLAY));
+	ClassDB::bind_method(
+			D_METHOD("add_int32_event", "name", "value", "priority"),
+			&GDKCaptureMetaData::add_int32_event,
+			DEFVAL(PRIORITY_GAMEPLAY));
+	ClassDB::bind_method(
+			D_METHOD("start_string_state", "name", "value", "priority"),
+			&GDKCaptureMetaData::start_string_state,
+			DEFVAL(PRIORITY_GAMEPLAY));
+	ClassDB::bind_method(
+			D_METHOD("start_double_state", "name", "value", "priority"),
+			&GDKCaptureMetaData::start_double_state,
+			DEFVAL(PRIORITY_GAMEPLAY));
+	ClassDB::bind_method(
+			D_METHOD("start_int32_state", "name", "value", "priority"),
+			&GDKCaptureMetaData::start_int32_state,
+			DEFVAL(PRIORITY_GAMEPLAY));
+
+	BIND_ENUM_CONSTANT(PRIORITY_GAMEPLAY);
+	BIND_ENUM_CONSTANT(PRIORITY_IMPORTANT);
+}
+
+GDKCaptureMetaData::~GDKCaptureMetaData() {
+	close();
+}
+
+Ref<GDKResult> GDKCaptureMetaData::_check_valid() const {
+	if (!m_valid) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_handle",
+				"The capture metadata context is not valid. Call GDKCapture.create_metadata() first.");
+	}
+	return Ref<GDKResult>();
+}
+
+int32_t GDKCaptureMetaData::_clamp_to_int32(int64_t p_value) {
+	return static_cast<int32_t>(
+			std::max<int64_t>(std::numeric_limits<int32_t>::min(),
+					std::min<int64_t>(std::numeric_limits<int32_t>::max(), p_value)));
+}
+
+XAppCaptureMetadataPriority GDKCaptureMetaData::_to_native_priority(int64_t p_priority) {
+	if (p_priority == PRIORITY_IMPORTANT) {
+		return XAppCaptureMetadataPriority::Important;
+	}
+	return XAppCaptureMetadataPriority::Informational;
+}
+
+Ref<GDKResult> GDKCaptureMetaData::_wrap_hresult(HRESULT p_hr, const char *p_action, const char *p_code) {
+	if (SUCCEEDED(p_hr)) {
+		return GDKResult::ok_result();
+	}
+	return GDKResult::hresult_error(p_hr, p_action, p_code);
+}
+
+bool GDKCaptureMetaData::is_valid() const {
+	return m_valid;
+}
+
+void GDKCaptureMetaData::close() {
+	m_valid = false;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+Ref<GDKResult> GDKCaptureMetaData::stop_all_states() {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	HRESULT hr = XAppCaptureMetadataStopAllStates();
+	return _wrap_hresult(hr, "Failed to stop all metadata states.", "capture_metadata_stop_all_states_failed");
+}
+
+int64_t GDKCaptureMetaData::get_remaining_storage_bytes() const {
+	if (!m_valid) {
+		return -1;
+	}
+	uint64_t remaining = 0;
+	HRESULT hr = XAppCaptureMetadataRemainingStorageBytesAvailable(&remaining);
+	if (FAILED(hr)) {
+		return -1;
+	}
+	return static_cast<int64_t>(remaining);
+}
+
+Ref<GDKResult> GDKCaptureMetaData::add_string_event(
+		const String &p_name,
+		const String &p_value,
+		int64_t p_priority) {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	if (p_name.strip_edges().is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_name",
+				"Metadata event name must not be empty.");
+	}
+	CharString name_utf8 = p_name.utf8();
+	CharString value_utf8 = p_value.utf8();
+	HRESULT hr = XAppCaptureMetadataAddStringEvent(
+			name_utf8.get_data(),
+			value_utf8.get_data(),
+			_to_native_priority(p_priority));
+	return _wrap_hresult(hr, "Failed to add string event to capture metadata.", "capture_metadata_add_string_event_failed");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::add_double_event(
+		const String &p_name,
+		double p_value,
+		int64_t p_priority) {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	if (p_name.strip_edges().is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_name",
+				"Metadata event name must not be empty.");
+	}
+	CharString name_utf8 = p_name.utf8();
+	HRESULT hr = XAppCaptureMetadataAddDoubleEvent(
+			name_utf8.get_data(),
+			p_value,
+			_to_native_priority(p_priority));
+	return _wrap_hresult(hr, "Failed to add double event to capture metadata.", "capture_metadata_add_double_event_failed");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::add_int32_event(
+		const String &p_name,
+		int64_t p_value,
+		int64_t p_priority) {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	if (p_name.strip_edges().is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_name",
+				"Metadata event name must not be empty.");
+	}
+	const int32_t clamped = _clamp_to_int32(p_value);
+	CharString name_utf8 = p_name.utf8();
+	HRESULT hr = XAppCaptureMetadataAddInt32Event(
+			name_utf8.get_data(),
+			clamped,
+			_to_native_priority(p_priority));
+	return _wrap_hresult(hr, "Failed to add int32 event to capture metadata.", "capture_metadata_add_int32_event_failed");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::start_string_state(
+		const String &p_name,
+		const String &p_value,
+		int64_t p_priority) {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	if (p_name.strip_edges().is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_name",
+				"Metadata state name must not be empty.");
+	}
+	CharString name_utf8 = p_name.utf8();
+	CharString value_utf8 = p_value.utf8();
+	HRESULT hr = XAppCaptureMetadataStartStringState(
+			name_utf8.get_data(),
+			value_utf8.get_data(),
+			_to_native_priority(p_priority));
+	return _wrap_hresult(hr, "Failed to start string state in capture metadata.", "capture_metadata_start_string_state_failed");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::start_double_state(
+		const String &p_name,
+		double p_value,
+		int64_t p_priority) {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	if (p_name.strip_edges().is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_name",
+				"Metadata state name must not be empty.");
+	}
+	CharString name_utf8 = p_name.utf8();
+	HRESULT hr = XAppCaptureMetadataStartDoubleState(
+			name_utf8.get_data(),
+			p_value,
+			_to_native_priority(p_priority));
+	return _wrap_hresult(hr, "Failed to start double state in capture metadata.", "capture_metadata_start_double_state_failed");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::start_int32_state(
+		const String &p_name,
+		int64_t p_value,
+		int64_t p_priority) {
+	Ref<GDKResult> valid_check = _check_valid();
+	if (valid_check.is_valid()) {
+		return valid_check;
+	}
+	if (p_name.strip_edges().is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_metadata_name",
+				"Metadata state name must not be empty.");
+	}
+	const int32_t clamped = _clamp_to_int32(p_value);
+	CharString name_utf8 = p_name.utf8();
+	HRESULT hr = XAppCaptureMetadataStartInt32State(
+			name_utf8.get_data(),
+			clamped,
+			_to_native_priority(p_priority));
+	return _wrap_hresult(hr, "Failed to start int32 state in capture metadata.", "capture_metadata_start_int32_state_failed");
+}
+
+void GDKCaptureMetaData::activate_internal() {
+	m_valid = true;
+}
+
+#else
+
+Ref<GDKResult> GDKCaptureMetaData::stop_all_states() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+int64_t GDKCaptureMetaData::get_remaining_storage_bytes() const {
+	return -1;
+}
+
+Ref<GDKResult> GDKCaptureMetaData::add_string_event(const String &p_name, const String &p_value, int64_t p_priority) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::add_double_event(const String &p_name, double p_value, int64_t p_priority) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::add_int32_event(const String &p_name, int64_t p_value, int64_t p_priority) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::start_string_state(const String &p_name, const String &p_value, int64_t p_priority) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::start_double_state(const String &p_name, double p_value, int64_t p_priority) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKCaptureMetaData::start_int32_state(const String &p_name, int64_t p_value, int64_t p_priority) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKCaptureMetaData::activate_internal() {
+	m_valid = true;
+}
+
+#endif
+
+void GDKCapture::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("enable_capture"), &GDKCapture::enable_capture);
+	ClassDB::bind_method(D_METHOD("disable_capture"), &GDKCapture::disable_capture);
+	ClassDB::bind_method(
+			D_METHOD("record_diagnostic_clip_async", "duration"),
+			&GDKCapture::record_diagnostic_clip_async);
+	ClassDB::bind_method(
+			D_METHOD("take_diagnostic_screenshot_async", "path_hint"),
+			&GDKCapture::take_diagnostic_screenshot_async);
+	ClassDB::bind_method(
+			D_METHOD("create_metadata", "reserved_bytes"),
+			&GDKCapture::create_metadata,
+			DEFVAL(0));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+GDKRuntime *GDKCapture::_get_runtime() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+	return m_owner->get_runtime();
+}
+
+Signal GDKCapture::_make_error_signal(
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message) const {
+	GDKRuntime *runtime = _get_runtime();
+	return runtime != nullptr ? runtime->make_error_signal(p_hresult, p_code, p_message) : Signal();
+}
+
+void GDKCapture::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKCapture::on_runtime_initialized() {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"Cannot initialize the capture service before the GDK runtime.");
+	}
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKCapture::shutdown() {
+	m_runtime_ready = false;
+}
+
+Ref<GDKResult> GDKCapture::enable_capture() {
+	GDKRuntime *runtime = _get_runtime();
+	if (!m_runtime_ready) {
+		Ref<GDKResult> result = GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"The GDK runtime must be initialized before enabling capture.");
+		if (runtime != nullptr) {
+		}
+		return result;
+	}
+	HRESULT hr = XAppCaptureEnableRecord();
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to enable capture.", "capture_enable_failed");
+		if (runtime != nullptr) {
+		}
+		return result;
+	}
+	if (runtime != nullptr) {
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKCapture::disable_capture() {
+	GDKRuntime *runtime = _get_runtime();
+	if (!m_runtime_ready) {
+		Ref<GDKResult> result = GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"The GDK runtime must be initialized before disabling capture.");
+		if (runtime != nullptr) {
+		}
+		return result;
+	}
+	HRESULT hr = XAppCaptureDisableRecord();
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to disable capture.", "capture_disable_failed");
+		if (runtime != nullptr) {
+		}
+		return result;
+	}
+	if (runtime != nullptr) {
+	}
+	return GDKResult::ok_result();
+}
+
+Signal GDKCapture::record_diagnostic_clip_async(double p_duration) {
+	GDKRuntime *runtime = _get_runtime();
+
+	if (!std::isfinite(p_duration) || p_duration <= 0.0) {
+		return _make_error_signal(
+				E_INVALIDARG,
+				"invalid_capture_duration",
+				"Clip duration must be greater than zero.");
+	}
+
+	const double duration_seconds = std::ceil(p_duration);
+	const double duration_ms = duration_seconds * 1000.0;
+	if (duration_ms > static_cast<double>(std::numeric_limits<uint32_t>::max())) {
+		return _make_error_signal(
+				E_INVALIDARG,
+				"invalid_capture_duration",
+				"Clip duration is too large.");
+	}
+
+	if (!m_runtime_ready || runtime == nullptr) {
+		return _make_error_signal(
+				E_FAIL,
+				"runtime_not_initialized",
+				"The GDK runtime must be initialized before recording a diagnostic clip.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	XAppCaptureRecordClipResult clip_result = {};
+	const time_t now = std::time(nullptr);
+	const time_t start_time = now - static_cast<time_t>(duration_seconds);
+	HRESULT hr = XAppCaptureRecordDiagnosticClip(
+			start_time,
+			static_cast<uint32_t>(duration_ms),
+			nullptr,
+			&clip_result);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to record diagnostic clip.",
+				"capture_record_failed");
+		pending_signal->complete_deferred(result);
+		return pending_signal->get_completed_signal();
+	}
+
+	pending_signal->complete_deferred(GDKResult::ok_result());
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKCapture::take_diagnostic_screenshot_async(const String &p_path_hint) {
+	GDKRuntime *runtime = _get_runtime();
+
+	if (p_path_hint.strip_edges().is_empty()) {
+		return _make_error_signal(
+				E_INVALIDARG,
+				"invalid_screenshot_path_hint",
+				"Screenshot path hint must not be empty.");
+	}
+
+	if (!m_runtime_ready || runtime == nullptr) {
+		return _make_error_signal(
+				E_FAIL,
+				"runtime_not_initialized",
+				"The GDK runtime must be initialized before taking a diagnostic screenshot.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	CharString path_hint_utf8 = p_path_hint.utf8();
+	XAppCaptureDiagnosticScreenshotResult screenshot_result = {};
+	HRESULT hr = XAppCaptureTakeDiagnosticScreenshot(
+			true,
+			XAppCaptureScreenshotFormatFlag::SDR,
+			path_hint_utf8.get_data(),
+			&screenshot_result);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to take diagnostic screenshot.",
+				"capture_screenshot_failed");
+		pending_signal->complete_deferred(result);
+		return pending_signal->get_completed_signal();
+	}
+
+	pending_signal->complete_deferred(GDKResult::ok_result());
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKCaptureMetaData> GDKCapture::create_metadata(int64_t p_reserved_bytes) {
+	(void)p_reserved_bytes;
+
+	if (!m_runtime_ready) {
+		return Ref<GDKCaptureMetaData>();
+	}
+
+	Ref<GDKCaptureMetaData> capture_metadata;
+	capture_metadata.instantiate();
+	capture_metadata->activate_internal();
+	return capture_metadata;
+}
+
+#else
+Signal GDKCapture::_make_error_signal(
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKCapture::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKCapture::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKCapture::shutdown() {}
+
+Ref<GDKResult> GDKCapture::enable_capture() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKCapture::disable_capture() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKCapture::record_diagnostic_clip_async(double p_duration) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKCapture::take_diagnostic_screenshot_async(const String &p_path_hint) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKCaptureMetaData> GDKCapture::create_metadata(int64_t p_reserved_bytes) {
+	return Ref<GDKCaptureMetaData>();
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_capture.h
+++ b/modules/xbox_module/gdk/gdk_capture.h
@@ -1,0 +1,146 @@
+/**************************************************************************/
+/*  gdk_capture.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XAppCapture.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+
+class GDKCaptureMetaData : public RefCounted {
+	GDCLASS(GDKCaptureMetaData, RefCounted);
+
+	bool m_valid = false;
+
+	Ref<GDKResult> _check_valid() const;
+	static int32_t _clamp_to_int32(int64_t p_value);
+	static XAppCaptureMetadataPriority _to_native_priority(int64_t p_priority);
+	static Ref<GDKResult> _wrap_hresult(HRESULT p_hr, const char *p_action, const char *p_code);
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum Priority {
+		PRIORITY_GAMEPLAY = 0,
+		PRIORITY_IMPORTANT = 1,
+	};
+
+	~GDKCaptureMetaData();
+
+	bool is_valid() const;
+
+	void close();
+
+	Ref<GDKResult> stop_all_states();
+
+	int64_t get_remaining_storage_bytes() const;
+
+	Ref<GDKResult> add_string_event(
+			const String &p_name,
+			const String &p_value,
+			int64_t p_priority = PRIORITY_GAMEPLAY);
+
+	Ref<GDKResult> add_double_event(
+			const String &p_name,
+			double p_value,
+			int64_t p_priority = PRIORITY_GAMEPLAY);
+
+	Ref<GDKResult> add_int32_event(
+			const String &p_name,
+			int64_t p_value,
+			int64_t p_priority = PRIORITY_GAMEPLAY);
+
+	Ref<GDKResult> start_string_state(
+			const String &p_name,
+			const String &p_value,
+			int64_t p_priority = PRIORITY_GAMEPLAY);
+
+	Ref<GDKResult> start_double_state(
+			const String &p_name,
+			double p_value,
+			int64_t p_priority = PRIORITY_GAMEPLAY);
+
+	Ref<GDKResult> start_int32_state(
+			const String &p_name,
+			int64_t p_value,
+			int64_t p_priority = PRIORITY_GAMEPLAY);
+
+	void activate_internal();
+};
+
+class GDKCapture : public RefCounted {
+	GDCLASS(GDKCapture, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	GDKRuntime *_get_runtime() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Ref<GDKResult> enable_capture();
+
+	Ref<GDKResult> disable_capture();
+
+	Signal record_diagnostic_clip_async(double p_duration);
+
+	Signal take_diagnostic_screenshot_async(const String &p_path_hint);
+
+	Ref<GDKCaptureMetaData> create_metadata(int64_t p_reserved_bytes = 0);
+};
+
+VARIANT_ENUM_CAST(GDKCaptureMetaData::Priority);

--- a/modules/xbox_module/gdk/gdk_display.cpp
+++ b/modules/xbox_module/gdk/gdk_display.cpp
@@ -1,0 +1,194 @@
+/**************************************************************************/
+/*  gdk_display.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_display.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include "core/variant/dictionary.h"
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+
+void GDKDisplayTimeoutDeferral::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_valid"), &GDKDisplayTimeoutDeferral::is_valid);
+	ClassDB::bind_method(D_METHOD("release"), &GDKDisplayTimeoutDeferral::release);
+}
+
+GDKDisplayTimeoutDeferral::~GDKDisplayTimeoutDeferral() {
+	release();
+}
+
+bool GDKDisplayTimeoutDeferral::is_valid() const {
+	return m_handle != nullptr;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKDisplayTimeoutDeferral::release() {
+	if (m_handle != nullptr) {
+		XDisplayCloseTimeoutDeferralHandle(m_handle);
+		m_handle = nullptr;
+	}
+}
+#else
+void GDKDisplayTimeoutDeferral::release() {
+	m_handle = nullptr;
+}
+#endif
+
+void GDKDisplayTimeoutDeferral::set_handle_internal(XDisplayTimeoutDeferralHandle p_handle) {
+	if (m_handle == p_handle) {
+		return;
+	}
+	release();
+	m_handle = p_handle;
+}
+
+void GDKDisplay::_bind_methods() {
+	ClassDB::bind_method(
+			D_METHOD("try_enable_hdr_mode", "preference"),
+			&GDKDisplay::try_enable_hdr_mode,
+			DEFVAL(static_cast<int64_t>(HDR_MODE_PREFERENCE_PREFER_HDR)));
+	ClassDB::bind_method(D_METHOD("acquire_timeout_deferral"), &GDKDisplay::acquire_timeout_deferral);
+
+	BIND_ENUM_CONSTANT(HDR_MODE_UNKNOWN);
+	BIND_ENUM_CONSTANT(HDR_MODE_ENABLED);
+	BIND_ENUM_CONSTANT(HDR_MODE_DISABLED);
+
+	BIND_ENUM_CONSTANT(HDR_MODE_PREFERENCE_PREFER_HDR);
+	BIND_ENUM_CONSTANT(HDR_MODE_PREFERENCE_PREFER_REFRESH_RATE);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKDisplay::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKDisplay::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+Ref<GDKResult> GDKDisplay::on_runtime_initialized() {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"Cannot initialize the display service before the GDK runtime.");
+	}
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKDisplay::shutdown() {
+	m_runtime_ready = false;
+}
+
+Ref<GDKResult> GDKDisplay::try_enable_hdr_mode(int64_t p_preference) {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"not_initialized",
+				"GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	XDisplayHdrModePreference native_preference;
+	switch (p_preference) {
+		case HDR_MODE_PREFERENCE_PREFER_HDR:
+			native_preference = XDisplayHdrModePreference::PreferHdr;
+			break;
+		case HDR_MODE_PREFERENCE_PREFER_REFRESH_RATE:
+			native_preference = XDisplayHdrModePreference::PreferRefreshRate;
+			break;
+		default:
+			return GDKResult::error_result(
+					E_INVALIDARG,
+					"invalid_preference",
+					"Unknown HDR mode preference value.");
+	}
+
+	XDisplayHdrModeInfo info_native = {};
+	const XDisplayHdrModeResult mode_result = XDisplayTryEnableHdrMode(native_preference, &info_native);
+
+	Dictionary data;
+	data["mode"] = static_cast<int64_t>(mode_result);
+	if (mode_result == XDisplayHdrModeResult::Enabled) {
+		Dictionary info;
+		info["min_tone_map_luminance"] = static_cast<double>(info_native.minToneMapLuminance);
+		info["max_tone_map_luminance"] = static_cast<double>(info_native.maxToneMapLuminance);
+		info["max_full_frame_tone_map_luminance"] = static_cast<double>(info_native.maxFullFrameToneMapLuminance);
+		data["info"] = info;
+	}
+	return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKDisplay::acquire_timeout_deferral() {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"not_initialized",
+				"GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	XDisplayTimeoutDeferralHandle handle = nullptr;
+	HRESULT hr = XDisplayAcquireTimeoutDeferral(&handle);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Failed to acquire display timeout deferral.",
+				"acquire_timeout_deferral_failed");
+	}
+
+	Ref<GDKDisplayTimeoutDeferral> deferral;
+	deferral.instantiate();
+	deferral->set_handle_internal(handle);
+	return GDKResult::ok_result(deferral);
+}
+
+#else
+void GDKDisplay::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKDisplay::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKDisplay::shutdown() {}
+
+Ref<GDKResult> GDKDisplay::try_enable_hdr_mode(int64_t p_preference) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKDisplay::acquire_timeout_deferral() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_display.h
+++ b/modules/xbox_module/gdk/gdk_display.h
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*  gdk_display.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XDisplay.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+
+class GDKDisplayTimeoutDeferral : public RefCounted {
+	GDCLASS(GDKDisplayTimeoutDeferral, RefCounted);
+
+	XDisplayTimeoutDeferralHandle m_handle = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDKDisplayTimeoutDeferral() = default;
+	~GDKDisplayTimeoutDeferral();
+
+	bool is_valid() const;
+	void release();
+
+	void set_handle_internal(XDisplayTimeoutDeferralHandle p_handle);
+};
+
+class GDKDisplay : public RefCounted {
+	GDCLASS(GDKDisplay, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	GDKRuntime *_get_runtime() const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum HdrMode {
+		HDR_MODE_UNKNOWN = static_cast<uint32_t>(XDisplayHdrModeResult::Unknown),
+		HDR_MODE_ENABLED = static_cast<uint32_t>(XDisplayHdrModeResult::Enabled),
+		HDR_MODE_DISABLED = static_cast<uint32_t>(XDisplayHdrModeResult::Disabled),
+	};
+
+	enum HdrModePreference {
+		HDR_MODE_PREFERENCE_PREFER_HDR = static_cast<uint32_t>(XDisplayHdrModePreference::PreferHdr),
+		HDR_MODE_PREFERENCE_PREFER_REFRESH_RATE = static_cast<uint32_t>(XDisplayHdrModePreference::PreferRefreshRate),
+	};
+
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Ref<GDKResult> try_enable_hdr_mode(int64_t p_preference = HDR_MODE_PREFERENCE_PREFER_HDR);
+
+	Ref<GDKResult> acquire_timeout_deferral();
+};
+
+VARIANT_ENUM_CAST(GDKDisplay::HdrMode);
+VARIANT_ENUM_CAST(GDKDisplay::HdrModePreference);

--- a/modules/xbox_module/gdk/gdk_error_reporting.cpp
+++ b/modules/xbox_module/gdk/gdk_error_reporting.cpp
@@ -1,0 +1,304 @@
+/**************************************************************************/
+/*  gdk_error_reporting.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_error_reporting.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cstdint>
+
+#include "core/variant/dictionary.h"
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+
+namespace {
+constexpr const char *RUNTIME_NOT_INITIALIZED_ERROR_MESSAGE = "GDK runtime must be initialized before configuring error reporting.";
+constexpr const char *ERROR_OPTIONS_OUT_OF_RANGE_MESSAGE = "Error reporting options value is out of valid range.";
+constexpr const char *ERROR_OPTIONS_UNSUPPORTED_BITS_MESSAGE = "Error reporting options contain unsupported flag bits.";
+} //namespace
+
+void GDKErrorReporting::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("configure_options", "debugger_present_options", "debugger_not_present_options"), &GDKErrorReporting::configure_options, DEFVAL(static_cast<int64_t>(ERROR_OPTIONS_NONE)), DEFVAL(static_cast<int64_t>(ERROR_OPTIONS_NONE)));
+	ClassDB::bind_method(D_METHOD("set_callback_enabled", "enabled"), &GDKErrorReporting::set_callback_enabled);
+	ClassDB::bind_method(D_METHOD("is_callback_enabled"), &GDKErrorReporting::is_callback_enabled);
+
+	BIND_ENUM_CONSTANT(ERROR_OPTIONS_NONE);
+	BIND_ENUM_CONSTANT(ERROR_OPTIONS_OUTPUT_DEBUG_STRING_ON_ERROR);
+	BIND_ENUM_CONSTANT(ERROR_OPTIONS_DEBUG_BREAK_ON_ERROR);
+	BIND_ENUM_CONSTANT(ERROR_OPTIONS_FAIL_FAST_ON_ERROR);
+
+	ADD_SIGNAL(MethodInfo("error_reported", PropertyInfo(Variant::OBJECT, "result")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKErrorReporting::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKErrorReporting::on_runtime_initialized() {
+	XErrorSetCallback(nullptr, nullptr);
+	_clear_callback_context();
+
+	std::lock_guard<std::mutex> lock(m_pending_errors_mutex);
+	m_pending_errors.clear();
+	m_runtime_ready = true;
+	m_callback_enabled = false;
+	return GDKResult::ok_result();
+}
+
+void GDKErrorReporting::shutdown() {
+	if (m_runtime_ready) {
+		_set_callback(nullptr);
+	}
+
+	std::lock_guard<std::mutex> lock(m_pending_errors_mutex);
+	m_pending_errors.clear();
+	m_runtime_ready = false;
+	m_callback_enabled = false;
+}
+
+int GDKErrorReporting::dispatch() {
+	if (!m_runtime_ready) {
+		return 0;
+	}
+
+	std::vector<PendingError> pending_errors;
+	{
+		std::lock_guard<std::mutex> lock(m_pending_errors_mutex);
+		if (m_pending_errors.empty()) {
+			return 0;
+		}
+		pending_errors.swap(m_pending_errors);
+	}
+
+	int64_t handled = 0;
+	for (const PendingError &pending_error : pending_errors) {
+		const char *native_message_chars = pending_error.message.empty() ? nullptr : pending_error.message.c_str();
+		const String native_message = native_message_chars != nullptr ? String::utf8(native_message_chars) : String();
+		Dictionary data;
+		data["native_message"] = native_message;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				pending_error.hr,
+				"GDK runtime error callback invoked.",
+				"xerror_callback_error",
+				data);
+
+		if (m_owner != nullptr) {
+			m_owner->emit_runtime_error(result);
+		}
+		++handled;
+		if (!m_runtime_ready) {
+			break;
+		}
+		emit_signal("error_reported", result);
+		if (!m_runtime_ready) {
+			break;
+		}
+	}
+
+	return static_cast<int>(handled);
+}
+
+Ref<GDKResult> GDKErrorReporting::configure_options(
+		int64_t p_debugger_present_options,
+		int64_t p_debugger_not_present_options) {
+	XErrorOptions debugger_present_options = XErrorOptions::None;
+	Ref<GDKResult> debugger_present_parse_result = _parse_options(p_debugger_present_options, &debugger_present_options);
+	if (!debugger_present_parse_result->is_ok()) {
+		return debugger_present_parse_result;
+	}
+
+	XErrorOptions debugger_not_present_options = XErrorOptions::None;
+	Ref<GDKResult> debugger_not_present_parse_result = _parse_options(p_debugger_not_present_options, &debugger_not_present_options);
+	if (!debugger_not_present_parse_result->is_ok()) {
+		return debugger_not_present_parse_result;
+	}
+
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_not_initialized", RUNTIME_NOT_INITIALIZED_ERROR_MESSAGE);
+	}
+
+	XErrorSetOptions(debugger_present_options, debugger_not_present_options);
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime != nullptr) {
+	}
+
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKErrorReporting::set_callback_enabled(bool p_enabled) {
+	XErrorCallback *callback = p_enabled ? _error_callback : nullptr;
+	Ref<GDKResult> result = _set_callback(callback);
+	if (result->is_ok()) {
+		m_callback_enabled = p_enabled;
+	}
+	return result;
+}
+
+void GDKErrorReporting::_clear_callback_context() {
+	if (m_callback_context) {
+		std::lock_guard<std::mutex> lock(m_callback_context->mutex);
+		m_callback_context->active.store(false, std::memory_order_release);
+		m_callback_context->service = nullptr;
+	}
+
+	if (m_callback_token) {
+		constexpr size_t MAX_RETIRED_CALLBACK_TOKENS = 16;
+		m_retired_callback_tokens.push_back(m_callback_token);
+		if (m_retired_callback_tokens.size() > MAX_RETIRED_CALLBACK_TOKENS) {
+			m_retired_callback_tokens.erase(m_retired_callback_tokens.begin());
+		}
+		m_callback_token.reset();
+	}
+	m_callback_context.reset();
+}
+
+Ref<GDKResult> GDKErrorReporting::_set_callback(XErrorCallback *p_callback) {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_not_initialized", RUNTIME_NOT_INITIALIZED_ERROR_MESSAGE);
+	}
+
+	if (p_callback == nullptr) {
+		_clear_callback_context();
+		XErrorSetCallback(nullptr, nullptr);
+		return GDKResult::ok_result();
+	}
+
+	_clear_callback_context();
+	m_callback_context = std::make_shared<CallbackContext>();
+	m_callback_context->service = this;
+	m_callback_token = std::make_shared<CallbackToken>();
+	m_callback_token->context = m_callback_context;
+	XErrorSetCallback(p_callback, m_callback_token.get());
+
+	return GDKResult::ok_result();
+}
+
+bool GDKErrorReporting::is_callback_enabled() const {
+	return m_callback_enabled;
+}
+
+GDKRuntime *GDKErrorReporting::get_runtime_internal() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+	return m_owner->get_runtime();
+}
+
+void GDKErrorReporting::push_error_internal(HRESULT p_hr, const char *p_message) {
+	std::lock_guard<std::mutex> lock(m_pending_errors_mutex);
+	m_pending_errors.push_back({ p_hr, p_message != nullptr ? p_message : "" });
+}
+
+bool GDKErrorReporting::_error_callback(HRESULT p_hr, const char *p_message, void *p_context) {
+	CallbackToken *token = static_cast<CallbackToken *>(p_context);
+	std::shared_ptr<CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+	if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
+		return true;
+	}
+
+	std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+	GDKErrorReporting *service = callback_context->service;
+	if (!callback_context->active.load(std::memory_order_acquire) || service == nullptr) {
+		return true;
+	}
+
+	service->push_error_internal(p_hr, p_message);
+	return true;
+}
+
+Ref<GDKResult> GDKErrorReporting::_parse_options(int64_t p_options_value, XErrorOptions *r_options) {
+	ERR_FAIL_COND_V(r_options == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing XError options output buffer."));
+
+	if (p_options_value < 0 || p_options_value > static_cast<int64_t>(INT32_MAX)) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_error_reporting_options", ERROR_OPTIONS_OUT_OF_RANGE_MESSAGE);
+	}
+
+	const int32_t options_bits = static_cast<int32_t>(p_options_value);
+	const int32_t supported_mask =
+			static_cast<int32_t>(ERROR_OPTIONS_OUTPUT_DEBUG_STRING_ON_ERROR) |
+			static_cast<int32_t>(ERROR_OPTIONS_DEBUG_BREAK_ON_ERROR) |
+			static_cast<int32_t>(ERROR_OPTIONS_FAIL_FAST_ON_ERROR);
+	if ((options_bits & ~supported_mask) != 0) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_error_reporting_options", ERROR_OPTIONS_UNSUPPORTED_BITS_MESSAGE);
+	}
+
+	*r_options = static_cast<XErrorOptions>(options_bits);
+	return GDKResult::ok_result();
+}
+
+#else
+void GDKErrorReporting::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKErrorReporting::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKErrorReporting::shutdown() {}
+
+int GDKErrorReporting::dispatch() {
+	return 0;
+}
+
+Ref<GDKResult> GDKErrorReporting::configure_options(
+		int64_t p_debugger_present_options,
+		int64_t p_debugger_not_present_options) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKErrorReporting::set_callback_enabled(bool p_enabled) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKErrorReporting::_clear_callback_context() {}
+
+Ref<GDKResult> GDKErrorReporting::_set_callback(XErrorCallback *p_callback) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+bool GDKErrorReporting::is_callback_enabled() const {
+	return false;
+}
+
+void GDKErrorReporting::push_error_internal(HRESULT p_hr, const char *p_message) {}
+
+bool GDKErrorReporting::_error_callback(HRESULT p_hr, const char *p_message, void *p_context) {
+	return false;
+}
+
+Ref<GDKResult> GDKErrorReporting::_parse_options(int64_t p_options_value, XErrorOptions *r_options) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_error_reporting.h
+++ b/modules/xbox_module/gdk/gdk_error_reporting.h
@@ -1,0 +1,120 @@
+/**************************************************************************/
+/*  gdk_error_reporting.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "core/error/error_macros.h"
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XError.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+
+class GDKErrorReporting : public RefCounted {
+	GDCLASS(GDKErrorReporting, RefCounted);
+
+public:
+	enum ErrorOptions {
+		ERROR_OPTIONS_NONE = 0,
+		ERROR_OPTIONS_OUTPUT_DEBUG_STRING_ON_ERROR = static_cast<uint32_t>(XErrorOptions::OutputDebugStringOnError),
+		ERROR_OPTIONS_DEBUG_BREAK_ON_ERROR = static_cast<uint32_t>(XErrorOptions::DebugBreakOnError),
+		ERROR_OPTIONS_FAIL_FAST_ON_ERROR = static_cast<uint32_t>(XErrorOptions::FailFastOnError),
+	};
+
+private:
+	struct PendingError {
+		HRESULT hr = S_OK;
+		std::string message;
+	};
+
+	struct CallbackContext {
+		GDKErrorReporting *service = nullptr;
+		std::atomic_bool active = true;
+		std::mutex mutex;
+	};
+
+	struct CallbackToken {
+		std::weak_ptr<CallbackContext> context;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	bool m_callback_enabled = false;
+	std::mutex m_pending_errors_mutex;
+	std::vector<PendingError> m_pending_errors;
+	std::shared_ptr<CallbackContext> m_callback_context;
+	std::shared_ptr<CallbackToken> m_callback_token;
+	std::vector<std::shared_ptr<CallbackToken>> m_retired_callback_tokens;
+
+	static bool _error_callback(HRESULT p_hr, const char *p_message, void *p_context);
+	static Ref<GDKResult> _parse_options(int64_t p_options_value, XErrorOptions *r_options);
+	void _clear_callback_context();
+	Ref<GDKResult> _set_callback(XErrorCallback *p_callback);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	int dispatch();
+
+	Ref<GDKResult> configure_options(
+			int64_t p_debugger_present_options = ERROR_OPTIONS_NONE,
+			int64_t p_debugger_not_present_options = ERROR_OPTIONS_NONE);
+	Ref<GDKResult> set_callback_enabled(bool p_enabled);
+	bool is_callback_enabled() const;
+
+	GDKRuntime *get_runtime_internal() const;
+	void push_error_internal(HRESULT p_hr, const char *p_message);
+};
+
+VARIANT_ENUM_CAST(GDKErrorReporting::ErrorOptions);

--- a/modules/xbox_module/gdk/gdk_game_ui.cpp
+++ b/modules/xbox_module/gdk/gdk_game_ui.cpp
@@ -1,0 +1,790 @@
+/**************************************************************************/
+/*  gdk_game_ui.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_game_ui.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XGameUI.h>
+#endif
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String trimmed = p_xuid.strip_edges();
+	if (trimmed.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = trimmed.utf8();
+	if (utf8.get_data() == nullptr || utf8.get_data()[0] == '\0') {
+		return false;
+	}
+
+	char *end = nullptr;
+	errno = 0;
+	const uint64_t parsed = std::strtoull(utf8.get_data(), &end, 10);
+	if (errno != 0 || end == nullptr || *end != '\0' || parsed == 0) {
+		return false;
+	}
+
+	*r_xuid = parsed;
+	return true;
+}
+
+Ref<GDKResult> _parse_xuid_list(
+		const PackedStringArray &p_xuids,
+		std::vector<uint64_t> *r_xuids,
+		PackedStringArray *r_normalized_xuids,
+		const String &p_empty_code,
+		const String &p_invalid_code,
+		const String &p_empty_message,
+		const String &p_invalid_message) {
+	if (r_xuids == nullptr) {
+		return GDKResult::error_result(E_POINTER, "internal_error", "Missing XUID list output.");
+	}
+
+	if (p_xuids.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, p_empty_code, p_empty_message);
+	}
+
+	r_xuids->clear();
+	r_xuids->reserve(static_cast<size_t>(p_xuids.size()));
+
+	if (r_normalized_xuids != nullptr) {
+		r_normalized_xuids->clear();
+	}
+
+	for (int64_t i = 0; i < p_xuids.size(); ++i) {
+		uint64_t parsed = 0;
+		if (!_try_parse_xuid(p_xuids[i], &parsed)) {
+			return GDKResult::error_result(E_INVALIDARG, p_invalid_code, p_invalid_message);
+		}
+
+		r_xuids->push_back(parsed);
+		if (r_normalized_xuids != nullptr) {
+			r_normalized_xuids->push_back(String::num_uint64(parsed));
+		}
+	}
+
+	return GDKResult::ok_result();
+}
+
+bool _try_parse_message_dialog_button(const String &p_name, XGameUiMessageDialogButton *r_button, String *r_normalized_name = nullptr) {
+	if (r_button == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_name.strip_edges().to_lower();
+	if (normalized == "first" || normalized == "0") {
+		*r_button = XGameUiMessageDialogButton::First;
+		if (r_normalized_name != nullptr) {
+			*r_normalized_name = "first";
+		}
+		return true;
+	}
+	if (normalized == "second" || normalized == "1") {
+		*r_button = XGameUiMessageDialogButton::Second;
+		if (r_normalized_name != nullptr) {
+			*r_normalized_name = "second";
+		}
+		return true;
+	}
+	if (normalized == "third" || normalized == "2") {
+		*r_button = XGameUiMessageDialogButton::Third;
+		if (r_normalized_name != nullptr) {
+			*r_normalized_name = "third";
+		}
+		return true;
+	}
+
+	return false;
+}
+
+String _message_dialog_button_to_string(XGameUiMessageDialogButton p_button) {
+	if (p_button == XGameUiMessageDialogButton::Second) {
+		return "second";
+	}
+	if (p_button == XGameUiMessageDialogButton::Third) {
+		return "third";
+	}
+	return "first";
+}
+
+bool _try_parse_notification_position(
+		const String &p_position,
+		XGameUiNotificationPositionHint *r_hint,
+		String *r_normalized_position = nullptr) {
+	if (r_hint == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_position.strip_edges().to_lower();
+	if (normalized == "bottom_center") {
+		*r_hint = XGameUiNotificationPositionHint::BottomCenter;
+		if (r_normalized_position != nullptr) {
+			*r_normalized_position = normalized;
+		}
+		return true;
+	}
+	if (normalized == "bottom_left") {
+		*r_hint = XGameUiNotificationPositionHint::BottomLeft;
+		if (r_normalized_position != nullptr) {
+			*r_normalized_position = normalized;
+		}
+		return true;
+	}
+	if (normalized == "bottom_right") {
+		*r_hint = XGameUiNotificationPositionHint::BottomRight;
+		if (r_normalized_position != nullptr) {
+			*r_normalized_position = normalized;
+		}
+		return true;
+	}
+	if (normalized == "top_center") {
+		*r_hint = XGameUiNotificationPositionHint::TopCenter;
+		if (r_normalized_position != nullptr) {
+			*r_normalized_position = normalized;
+		}
+		return true;
+	}
+	if (normalized == "top_left") {
+		*r_hint = XGameUiNotificationPositionHint::TopLeft;
+		if (r_normalized_position != nullptr) {
+			*r_normalized_position = normalized;
+		}
+		return true;
+	}
+	if (normalized == "top_right") {
+		*r_hint = XGameUiNotificationPositionHint::TopRight;
+		if (r_normalized_position != nullptr) {
+			*r_normalized_position = normalized;
+		}
+		return true;
+	}
+
+	return false;
+}
+
+class MessageDialogAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Message dialog cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XGameUiMessageDialogButton selected_button = XGameUiMessageDialogButton::First;
+		HRESULT result_hr = XGameUiShowMessageDialogResult(p_async_block, &selected_button);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Message dialog cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to complete the message dialog flow.",
+					"game_ui_message_dialog_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary data;
+		data["selected_button"] = _message_dialog_button_to_string(selected_button);
+		data["selected_button_index"] = static_cast<int64_t>(selected_button);
+
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	MessageDialogAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+class PlayerProfileCardAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Player profile card UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XGameUiShowPlayerProfileCardResult(p_async_block);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Player profile card UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to complete the player profile card UI flow.",
+					"game_ui_player_profile_card_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result());
+	}
+
+public:
+	PlayerProfileCardAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+class PlayerPickerAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Player picker UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		uint32_t selected_count = 0;
+		HRESULT count_hr = XGameUiShowPlayerPickerResultCount(p_async_block, &selected_count);
+		if (count_hr == E_ABORT) {
+			result = GDKResult::cancelled("Player picker UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(count_hr)) {
+			result = GDKResult::hresult_error(
+					count_hr,
+					"Failed to get the player picker result count.",
+					"game_ui_player_picker_count_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint64_t> selected_players(selected_count);
+		uint32_t selected_used = 0;
+		HRESULT result_hr = XGameUiShowPlayerPickerResult(
+				p_async_block,
+				selected_count,
+				selected_players.data(),
+				&selected_used);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Player picker UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to complete the player picker UI flow.",
+					"game_ui_player_picker_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		PackedStringArray selected_xuids;
+		for (uint32_t i = 0; i < selected_used; ++i) {
+			selected_xuids.push_back(String::num_uint64(selected_players[i]));
+		}
+
+		Dictionary data;
+		data["selected_xuids"] = selected_xuids;
+		data["selection_count"] = static_cast<int64_t>(selected_xuids.size());
+
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	PlayerPickerAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+} //namespace
+
+#endif
+
+void GDKGameUI::_bind_methods() {
+	ClassDB::bind_method(
+			D_METHOD("show_message_dialog_async", "title", "message", "first_button", "second_button", "third_button", "default_button", "cancel_button"),
+			&GDKGameUI::show_message_dialog_async,
+			DEFVAL(String("OK")),
+			DEFVAL(String()),
+			DEFVAL(String()),
+			DEFVAL(String("first")),
+			DEFVAL(String("first")));
+	ClassDB::bind_method(D_METHOD("set_notification_position_hint", "position"), &GDKGameUI::set_notification_position_hint);
+	ClassDB::bind_method(D_METHOD("show_player_profile_card_async", "requesting_user", "target_xuid"), &GDKGameUI::show_player_profile_card_async);
+	ClassDB::bind_method(
+			D_METHOD("show_player_picker_async", "requesting_user", "prompt", "selectable_xuids", "preselected_xuids", "min_selection_count", "max_selection_count"),
+			&GDKGameUI::show_player_picker_async,
+			DEFVAL(PackedStringArray()),
+			DEFVAL(static_cast<int64_t>(1)),
+			DEFVAL(static_cast<int64_t>(1)));
+	ClassDB::bind_method(D_METHOD("resolve_privilege_with_ui_async", "user", "privilege"), &GDKGameUI::resolve_privilege_with_ui_async);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKGameUI::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKGameUI::on_runtime_initialized() {
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"Cannot initialize the game UI service before the GDK runtime.");
+	}
+
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKGameUI::shutdown() {
+	m_runtime_ready = false;
+}
+
+Signal GDKGameUI::show_message_dialog_async(
+		const String &p_title,
+		const String &p_message,
+		const String &p_first_button,
+		const String &p_second_button,
+		const String &p_third_button,
+		const String &p_default_button,
+		const String &p_cancel_button) {
+	const String title = p_title.strip_edges();
+	const String message = p_message.strip_edges();
+	if (title.is_empty()) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_title", "A non-empty dialog title is required.");
+	}
+	if (message.is_empty()) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_message", "A non-empty dialog message is required.");
+	}
+
+	const String first_button = p_first_button.strip_edges();
+	const String second_button = p_second_button.strip_edges();
+	const String third_button = p_third_button.strip_edges();
+	if (first_button.is_empty()) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_button_label", "The first dialog button label is required.");
+	}
+
+	XGameUiMessageDialogButton default_button = XGameUiMessageDialogButton::First;
+	String default_button_name;
+	if (!_try_parse_message_dialog_button(p_default_button, &default_button, &default_button_name)) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_default_button", "default_button must be 'first', 'second', or 'third'.");
+	}
+
+	XGameUiMessageDialogButton cancel_button = XGameUiMessageDialogButton::First;
+	String cancel_button_name;
+	if (!_try_parse_message_dialog_button(p_cancel_button, &cancel_button, &cancel_button_name)) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_cancel_button", "cancel_button must be 'first', 'second', or 'third'.");
+	}
+
+	const bool has_second_button = !second_button.is_empty();
+	const bool has_third_button = !third_button.is_empty();
+	if (!has_second_button && (default_button_name == "second" || default_button_name == "third" || cancel_button_name == "second" || cancel_button_name == "third")) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_button_layout", "A second button label is required when selecting second/third as default or cancel.");
+	}
+	if (!has_third_button && (default_button_name == "third" || cancel_button_name == "third")) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_button_layout", "A third button label is required when selecting third as default or cancel.");
+	}
+
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new MessageDialogAsyncContext(runtime, pending_signal);
+	context->bind_cancel_handler();
+
+	const CharString title_utf8 = title.utf8();
+	const CharString message_utf8 = message.utf8();
+	const CharString first_button_utf8 = first_button.utf8();
+	const CharString second_button_utf8 = second_button.utf8();
+	const CharString third_button_utf8 = third_button.utf8();
+
+	HRESULT hr = XGameUiShowMessageDialogAsync(
+			context->get_async_block(),
+			title_utf8.get_data(),
+			message_utf8.get_data(),
+			first_button_utf8.get_data(),
+			has_second_button ? second_button_utf8.get_data() : nullptr,
+			has_third_button ? third_button_utf8.get_data() : nullptr,
+			default_button,
+			cancel_button);
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the message dialog flow.",
+				"game_ui_message_dialog_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKGameUI::set_notification_position_hint(const String &p_position) {
+	XGameUiNotificationPositionHint position_hint = XGameUiNotificationPositionHint::BottomCenter;
+	String normalized_position;
+	if (!_try_parse_notification_position(p_position, &position_hint, &normalized_position)) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_notification_position",
+				"position must be one of: bottom_center, bottom_left, bottom_right, top_center, top_left, top_right.");
+	}
+
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	HRESULT hr = XGameUiSetNotificationPositionHint(position_hint);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to set the notification position hint.",
+				"game_ui_notification_position_failed");
+		return result;
+	}
+
+	Dictionary data;
+	data["position"] = normalized_position;
+
+	return GDKResult::ok_result(data);
+}
+
+Signal GDKGameUI::show_player_profile_card_async(const Ref<GDKUser> &p_requesting_user, const String &p_target_xuid) {
+	uint64_t target_xuid = 0;
+	if (!_try_parse_xuid(p_target_xuid, &target_xuid)) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_target_xuid", "target_xuid must be a non-empty, non-zero numeric string.");
+	}
+
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_requesting_user.is_valid() || p_requesting_user->get_handle() == nullptr) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to show profile card UI.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new PlayerProfileCardAsyncContext(runtime, pending_signal);
+	context->bind_cancel_handler();
+
+	HRESULT hr = XGameUiShowPlayerProfileCardAsync(
+			context->get_async_block(),
+			p_requesting_user->get_handle(),
+			target_xuid);
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the player profile card UI flow.",
+				"game_ui_player_profile_card_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKGameUI::show_player_picker_async(
+		const Ref<GDKUser> &p_requesting_user,
+		const String &p_prompt,
+		const PackedStringArray &p_selectable_xuids,
+		const PackedStringArray &p_preselected_xuids,
+		int64_t p_min_selection_count,
+		int64_t p_max_selection_count) {
+	const String prompt = p_prompt.strip_edges();
+	if (prompt.is_empty()) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_prompt", "A non-empty player picker prompt is required.");
+	}
+
+	std::vector<uint64_t> selectable_xuids;
+	Ref<GDKResult> selectable_parse_result = _parse_xuid_list(
+			p_selectable_xuids,
+			&selectable_xuids,
+			nullptr,
+			"missing_xuids",
+			"invalid_xuids",
+			"At least one selectable XUID is required.",
+			"Each selectable XUID must be a non-empty, non-zero numeric string.");
+	if (!selectable_parse_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(selectable_parse_result->get_hresult()),
+				selectable_parse_result->get_code(),
+				selectable_parse_result->get_message());
+	}
+
+	std::vector<uint64_t> preselected_xuids;
+	if (!p_preselected_xuids.is_empty()) {
+		Ref<GDKResult> preselected_parse_result = _parse_xuid_list(
+				p_preselected_xuids,
+				&preselected_xuids,
+				nullptr,
+				"invalid_preselected_xuids",
+				"invalid_preselected_xuids",
+				"Preselected XUIDs must be numeric strings.",
+				"Each preselected XUID must be a non-empty, non-zero numeric string.");
+		if (!preselected_parse_result->is_ok()) {
+			return make_error_signal_internal(
+					static_cast<HRESULT>(preselected_parse_result->get_hresult()),
+					preselected_parse_result->get_code(),
+					preselected_parse_result->get_message());
+		}
+	}
+
+	if (p_min_selection_count <= 0 || p_max_selection_count <= 0) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_selection_range", "min_selection_count and max_selection_count must be greater than zero.");
+	}
+	if (p_min_selection_count > p_max_selection_count) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_selection_range", "min_selection_count cannot be greater than max_selection_count.");
+	}
+	if (p_max_selection_count > static_cast<int64_t>(selectable_xuids.size())) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_selection_range", "max_selection_count cannot exceed the selectable_xuids count.");
+	}
+	if (preselected_xuids.size() > selectable_xuids.size()) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_preselected_xuids", "preselected_xuids cannot exceed selectable_xuids.");
+	}
+
+	std::unordered_set<uint64_t> selectable_xuids_set(selectable_xuids.begin(), selectable_xuids.end());
+	for (uint64_t preselected_xuid : preselected_xuids) {
+		if (selectable_xuids_set.find(preselected_xuid) == selectable_xuids_set.end()) {
+			return make_error_signal_internal(E_INVALIDARG, "invalid_preselected_xuids", "Each preselected_xuid must be present in selectable_xuids.");
+		}
+	}
+
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_requesting_user.is_valid() || p_requesting_user->get_handle() == nullptr) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to show player picker UI.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new PlayerPickerAsyncContext(runtime, pending_signal);
+	context->bind_cancel_handler();
+
+	const CharString prompt_utf8 = prompt.utf8();
+	const uint64_t *selectable_xuids_ptr = selectable_xuids.empty() ? nullptr : selectable_xuids.data();
+	const uint64_t *preselected_xuids_ptr = preselected_xuids.empty() ? nullptr : preselected_xuids.data();
+	HRESULT hr = XGameUiShowPlayerPickerAsync(
+			context->get_async_block(),
+			p_requesting_user->get_handle(),
+			prompt_utf8.get_data(),
+			static_cast<uint32_t>(selectable_xuids.size()),
+			selectable_xuids_ptr,
+			static_cast<uint32_t>(preselected_xuids.size()),
+			preselected_xuids_ptr,
+			static_cast<uint32_t>(p_min_selection_count),
+			static_cast<uint32_t>(p_max_selection_count));
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the player picker UI flow.",
+				"game_ui_player_picker_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKGameUI::resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege) {
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return make_error_signal_internal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to resolve privilege UI.");
+	}
+
+	GDKUsers *users = get_users_internal();
+	if (users == nullptr) {
+		return make_error_signal_internal(E_FAIL, "users_service_unavailable", "GDK users service is unavailable.");
+	}
+
+	return users->resolve_privilege_with_ui_async(p_user, p_privilege);
+}
+
+GDKRuntime *GDKGameUI::get_runtime_internal() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+
+	return m_owner->get_runtime();
+}
+
+GDKUsers *GDKGameUI::get_users_internal() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+
+	Ref<GDKUsers> users = m_owner->get_users();
+	return users.ptr();
+}
+
+Signal GDKGameUI::make_completed_signal_internal(const Ref<GDKResult> &p_result) const {
+	GDKRuntime *runtime = get_runtime_internal();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	if (pending_signal.is_null()) {
+		pending_signal.instantiate();
+	}
+	pending_signal->complete_deferred(p_result);
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKGameUI::make_error_signal_internal(
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message) const {
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime != nullptr) {
+		return runtime->make_error_signal(p_hresult, p_code, p_message);
+	}
+
+	Ref<GDKPendingSignal> pending_signal;
+	pending_signal.instantiate();
+	pending_signal->complete_deferred(GDKResult::error_result(p_hresult, p_code, p_message));
+	return pending_signal->get_completed_signal();
+}
+
+#else
+void GDKGameUI::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKGameUI::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKGameUI::shutdown() {}
+
+Signal GDKGameUI::show_message_dialog_async(
+		const String &p_title,
+		const String &p_message,
+		const String &p_first_button,
+		const String &p_second_button,
+		const String &p_third_button,
+		const String &p_default_button,
+		const String &p_cancel_button) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKGameUI::set_notification_position_hint(const String &p_position) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKGameUI::show_player_profile_card_async(const Ref<GDKUser> &p_requesting_user, const String &p_target_xuid) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKGameUI::show_player_picker_async(
+		const Ref<GDKUser> &p_requesting_user,
+		const String &p_prompt,
+		const PackedStringArray &p_selectable_xuids,
+		const PackedStringArray &p_preselected_xuids,
+		int64_t p_min_selection_count,
+		int64_t p_max_selection_count) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKGameUI::resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKGameUI::make_completed_signal_internal(const Ref<GDKResult> &p_result) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKGameUI::make_error_signal_internal(
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_game_ui.h
+++ b/modules/xbox_module/gdk/gdk_game_ui.h
@@ -1,0 +1,95 @@
+/**************************************************************************/
+/*  gdk_game_ui.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/variant/callable.h"
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKUsers;
+
+class GDKGameUI : public RefCounted {
+	GDCLASS(GDKGameUI, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Signal show_message_dialog_async(
+			const String &p_title,
+			const String &p_message,
+			const String &p_first_button = "OK",
+			const String &p_second_button = String(),
+			const String &p_third_button = String(),
+			const String &p_default_button = "first",
+			const String &p_cancel_button = "first");
+	Ref<GDKResult> set_notification_position_hint(const String &p_position);
+	Signal show_player_profile_card_async(const Ref<GDKUser> &p_requesting_user, const String &p_target_xuid);
+	Signal show_player_picker_async(
+			const Ref<GDKUser> &p_requesting_user,
+			const String &p_prompt,
+			const PackedStringArray &p_selectable_xuids,
+			const PackedStringArray &p_preselected_xuids = PackedStringArray(),
+			int64_t p_min_selection_count = 1,
+			int64_t p_max_selection_count = 1);
+	Signal resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege);
+
+	GDKRuntime *get_runtime_internal() const;
+	GDKUsers *get_users_internal() const;
+	Signal make_completed_signal_internal(const Ref<GDKResult> &p_result) const;
+	Signal make_error_signal_internal(
+			HRESULT p_hresult,
+			const String &p_code,
+			const String &p_message) const;
+};

--- a/modules/xbox_module/gdk/gdk_gdk_stubs.h
+++ b/modules/xbox_module/gdk/gdk_gdk_stubs.h
@@ -1,0 +1,210 @@
+/**************************************************************************/
+/*  gdk_gdk_stubs.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef XBOX_MODULE_GDK_ENABLED
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#ifdef _WIN32
+#undef min
+#undef max
+#undef ERROR
+#undef DELETE
+#undef MessageBox
+#undef Error
+#undef OK
+#undef CONNECT_DEFERRED
+#undef MemoryBarrier
+#undef MONO_FONT
+#endif
+
+#include <cstdint>
+
+struct XUserLocalId {
+	uint64_t value = 0;
+};
+
+using XUserHandle = void *;
+using XTaskQueueHandle = void *;
+using XblContextHandle = void *;
+using XblSocialManagerUserGroupHandle = void *;
+using XPackageMountHandle = void *;
+using XStoreContextHandle = void *;
+using XDisplayTimeoutDeferralHandle = void *;
+
+struct XAsyncBlock {
+	void *queue = nullptr;
+	void *context = nullptr;
+	void *callback = nullptr;
+};
+
+struct XTaskQueueRegistrationToken {};
+
+struct XClosedCaptionProperties {};
+
+enum class XHighContrastMode : uint32_t {
+	Off = 0,
+	Dark = 1,
+	Light = 2,
+	Other = 3,
+};
+
+enum class XGameActivationType : uint32_t {
+	Protocol = 0,
+	File = 1,
+	PendingGameInvite = 2,
+	AcceptedGameInvite = 3,
+};
+
+struct XGameActivationInfo {};
+
+enum class XAppCaptureMetadataPriority : int32_t {
+	Informational = 0,
+	Important = 1,
+};
+
+enum class XDisplayHdrModeResult : uint32_t {
+	Unknown = 0,
+	Enabled = 1,
+	Disabled = 2,
+};
+
+enum class XDisplayHdrModePreference : uint32_t {
+	PreferHdr = 0,
+	PreferRefreshRate = 1,
+};
+
+enum class XErrorOptions : uint32_t {
+	OutputDebugStringOnError = 1,
+	DebugBreakOnError = 2,
+	FailFastOnError = 4,
+};
+
+using XErrorCallback = bool (*)(HRESULT, const char *, void *);
+
+enum class XPackageKind : int {
+	Game = 0,
+	Content = 1,
+};
+
+enum class XPackageEnumerationScope : int {
+	ThisPublisher = 0,
+	ThisAndRelated = 1,
+};
+
+enum class XUserAddOptions : uint32_t {
+	None = 0,
+	AllowGuests = 1,
+	AddDefaultUserSilently = 2,
+};
+
+enum class XUserChangeEvent : uint32_t {
+	SignedInAgain = 0,
+	SignedOut = 1,
+	Gamertag = 2,
+	GamerPicture = 3,
+	Privileges = 4,
+	TrackingState = 5,
+};
+
+struct XblAchievement {};
+struct XblSocialManagerUser {};
+struct XblSocialManagerPresenceRecord {};
+struct XblUserProfile {};
+struct XblTitleStorageBlobMetadata {};
+struct XblLeaderboardColumn {};
+struct XblLeaderboardRow {};
+struct XblLeaderboardResult {};
+struct XblMultiplayerActivityInfo {};
+struct XblUserStatisticsResult {};
+struct XblStatisticChangeEventArgs {};
+
+using XblTitleStorageBlobMetadataResultHandle = void *;
+using XblPresenceRecordHandle = void *;
+struct XblFunctionContext {};
+
+enum class XblPresenceDeviceType : uint32_t {
+	Unknown = 0,
+};
+
+enum class XblPresenceTitleState : uint32_t {
+	Unknown = 0,
+};
+
+enum class XblPresenceBroadcastProvider : uint32_t {
+	Unknown = 0,
+	Twitch = 1,
+};
+
+struct XblPresenceTitleRecord {
+	uint32_t titleId = 0;
+	const char *titleName = nullptr;
+	uint64_t lastModified = 0;
+	bool titleActive = false;
+	const char *richPresenceString = nullptr;
+	uint32_t viewState = 0;
+	void *broadcastRecord = nullptr;
+};
+
+struct XblSocialManagerPresenceTitleRecord {
+	uint32_t titleId = 0;
+	const char *titleName = nullptr;
+	bool isTitleActive = false;
+	const char *presenceText = nullptr;
+	XblPresenceDeviceType deviceType = XblPresenceDeviceType::Unknown;
+	bool isBroadcasting = false;
+	bool isPrimary = false;
+};
+
+enum class XblMultiplayerActivityJoinRestriction : uint32_t {
+	None = 0,
+};
+
+enum class XblMultiplayerActivityPlatform : uint32_t {
+	Unknown = 0,
+};
+
+enum class XblMultiplayerActivityEncounterType : uint32_t {
+	None = 0,
+};
+
+enum class XblSocialGroupType : uint32_t {
+	None = 0,
+};
+
+enum class XblLeaderboardQueryType : uint32_t {
+	Global = 0,
+};
+
+#endif

--- a/modules/xbox_module/gdk/gdk_launcher.cpp
+++ b/modules/xbox_module/gdk/gdk_launcher.cpp
@@ -1,0 +1,196 @@
+/**************************************************************************/
+/*  gdk_launcher.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_launcher.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_user.h"
+
+void GDKLauncher::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("launch_uri", "uri", "user"), &GDKLauncher::launch_uri, DEFVAL(Ref<GDKUser>()));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKLauncher::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKLauncher::on_runtime_initialized() {
+	GDKRuntime *runtime = m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"Cannot initialize the launcher service before the GDK runtime.");
+	}
+
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKLauncher::shutdown() {
+	m_runtime_ready = false;
+}
+
+Ref<GDKResult> GDKLauncher::launch_uri(const String &p_uri, const Ref<GDKUser> &p_user) {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"not_initialized",
+				"GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	const String uri = p_uri.strip_edges();
+	String scheme;
+	if (!try_parse_uri_scheme_internal(uri, &scheme)) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_uri",
+				"A non-empty absolute URI with a valid scheme is required.");
+	}
+
+	if (is_disallowed_scheme_internal(scheme)) {
+		Dictionary data;
+		data["uri"] = uri;
+		data["scheme"] = scheme;
+		return GDKResult::error_result(
+				E_NOTIMPL,
+				"unsupported_launcher_destination",
+				"This URI destination is not supported by GDK.launcher on PC.",
+				data);
+	}
+
+	if (!is_supported_scheme_internal(scheme)) {
+		Dictionary data;
+		data["uri"] = uri;
+		data["scheme"] = scheme;
+		return GDKResult::error_result(
+				E_NOTIMPL,
+				"unsupported_launcher_destination",
+				"This URI destination is not supported by GDK.launcher on PC.",
+				data);
+	}
+
+	XUserHandle user_handle = nullptr;
+	if (p_user.is_valid()) {
+		user_handle = p_user->get_handle();
+		if (user_handle == nullptr) {
+			return GDKResult::error_result(
+					E_INVALIDARG,
+					"invalid_user",
+					"A signed-in GDKUser is required when a user is provided.");
+		}
+	}
+
+	const CharString uri_utf8 = uri.utf8();
+	HRESULT hr = XLaunchUri(user_handle, uri_utf8.get_data());
+	if (FAILED(hr)) {
+		Dictionary data;
+		data["uri"] = uri;
+		data["destination"] = "uri";
+		return GDKResult::hresult_error(hr, "Failed to launch the requested URI.", "launch_uri_failed", data);
+	}
+
+	Dictionary data;
+	data["uri"] = uri;
+	data["destination"] = "uri";
+	return GDKResult::ok_result(data);
+}
+
+bool GDKLauncher::try_parse_uri_scheme_internal(const String &p_uri, String *r_scheme) {
+	if (r_scheme == nullptr) {
+		return false;
+	}
+
+	*r_scheme = String();
+
+	const String uri = p_uri.strip_edges();
+	if (uri.is_empty() || uri.contains(" ")) {
+		return false;
+	}
+
+	const int64_t separator = uri.find(":");
+	if (separator <= 0) {
+		return false;
+	}
+
+	const String scheme = uri.substr(0, separator).to_lower();
+	if (scheme.is_empty()) {
+		return false;
+	}
+
+	*r_scheme = scheme;
+	return true;
+}
+
+bool GDKLauncher::is_supported_scheme_internal(const String &p_scheme) {
+	const String scheme = p_scheme.to_lower();
+	if (scheme.begins_with("ms-")) {
+		return scheme == "ms-settings" || scheme == "ms-windows-store";
+	}
+	return true;
+}
+
+bool GDKLauncher::is_disallowed_scheme_internal(const String &p_scheme) {
+	const String scheme = p_scheme.to_lower();
+	return scheme == "file" || scheme == "javascript" || scheme == "data" || scheme == "about";
+}
+
+#else
+void GDKLauncher::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKLauncher::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKLauncher::shutdown() {}
+
+Ref<GDKResult> GDKLauncher::launch_uri(const String &p_uri, const Ref<GDKUser> &p_user) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+bool GDKLauncher::try_parse_uri_scheme_internal(const String &p_uri, String *r_scheme) {
+	return false;
+}
+
+bool GDKLauncher::is_supported_scheme_internal(const String &p_scheme) {
+	return false;
+}
+
+bool GDKLauncher::is_disallowed_scheme_internal(const String &p_scheme) {
+	return false;
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_launcher.h
+++ b/modules/xbox_module/gdk/gdk_launcher.h
@@ -1,0 +1,73 @@
+/**************************************************************************/
+/*  gdk_launcher.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XLauncher.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKUser;
+
+class GDKLauncher : public RefCounted {
+	GDCLASS(GDKLauncher, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	static bool try_parse_uri_scheme_internal(const String &p_uri, String *r_scheme);
+	static bool is_supported_scheme_internal(const String &p_scheme);
+	static bool is_disallowed_scheme_internal(const String &p_scheme);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Ref<GDKResult> launch_uri(const String &p_uri, const Ref<GDKUser> &p_user = Ref<GDKUser>());
+};

--- a/modules/xbox_module/gdk/gdk_leaderboards.cpp
+++ b/modules/xbox_module/gdk/gdk_leaderboards.cpp
@@ -1,0 +1,818 @@
+/**************************************************************************/
+/*  gdk_leaderboards.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_leaderboards.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <utility>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	return p_value != nullptr && p_value[0] != '\0' ? String::utf8(p_value) : String();
+}
+
+String _stat_type_to_string(XblLeaderboardStatType p_type) {
+	switch (p_type) {
+		case XblLeaderboardStatType::Uint64:
+			return "uint64";
+		case XblLeaderboardStatType::Boolean:
+			return "boolean";
+		case XblLeaderboardStatType::Double:
+			return "double";
+		case XblLeaderboardStatType::String:
+			return "string";
+		case XblLeaderboardStatType::Other:
+		default:
+			return "other";
+	}
+}
+
+Ref<GDKResult> _parse_stat_name(const String &p_stat_name, String *r_stat_name) {
+	if (r_stat_name == nullptr) {
+		return GDKResult::error_result(E_POINTER, "invalid_output", "Statistic name output storage is unavailable.");
+	}
+
+	const String stat_name = p_stat_name.strip_edges();
+	if (stat_name.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_stat_name", "Statistic name must be a non-empty string.");
+	}
+
+	*r_stat_name = stat_name;
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> _parse_max_items(int64_t p_max_items, uint32_t *r_max_items) {
+	if (r_max_items == nullptr) {
+		return GDKResult::error_result(E_POINTER, "invalid_output", "Max item output storage is unavailable.");
+	}
+	if (p_max_items < 0 || p_max_items > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_max_items", "max_items must fit in a non-negative 32-bit unsigned integer.");
+	}
+
+	*r_max_items = static_cast<uint32_t>(p_max_items);
+	return GDKResult::ok_result();
+}
+
+String _query_type_to_string(XblLeaderboardQueryType p_query_type, bool p_around_user) {
+	if (p_around_user) {
+		return "around_user";
+	}
+
+	switch (p_query_type) {
+		case XblLeaderboardQueryType::TitleManagedStatBackedSocial:
+			return "social";
+		case XblLeaderboardQueryType::TitleManagedStatBackedGlobal:
+			return "global";
+		case XblLeaderboardQueryType::UserStatBacked:
+		default:
+			return "user_stat";
+	}
+}
+
+class LeaderboardAsyncContext : public GDKSignalXAsyncContext {
+	GDKLeaderboards *m_leaderboards = nullptr;
+	Ref<GDKUser> m_user;
+	XblContextHandle m_context = nullptr;
+	String m_stat_name;
+	String m_query_type;
+	bool m_next_page = false;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Leaderboard query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t result_size = 0;
+		HRESULT result_hr = m_next_page ? XblLeaderboardResultGetNextResultSize(p_async_block, &result_size) : XblLeaderboardGetLeaderboardResultSize(p_async_block, &result_size);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Leaderboard query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve leaderboard result size.", "leaderboard_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(result_size);
+		XblLeaderboardResult *native_result = nullptr;
+		size_t buffer_used = 0;
+		result_hr = m_next_page ? XblLeaderboardResultGetNextResult(
+										  p_async_block,
+										  buffer.size(),
+										  buffer.empty() ? nullptr : buffer.data(),
+										  &native_result,
+										  &buffer_used)
+								: XblLeaderboardGetLeaderboardResult(
+										  p_async_block,
+										  buffer.size(),
+										  buffer.empty() ? nullptr : buffer.data(),
+										  &native_result,
+										  &buffer_used);
+
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Leaderboard query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve leaderboard results.", "leaderboard_results_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Ref<GDKLeaderboard> leaderboard;
+		leaderboard.instantiate();
+		leaderboard->populate_from_native(m_stat_name, m_query_type, m_user, std::move(buffer), native_result);
+		m_leaderboards->cache_leaderboard_internal(leaderboard);
+
+		m_leaderboards->emit_signal("leaderboard_updated", m_stat_name, leaderboard);
+		get_pending_signal()->complete(GDKResult::ok_result(leaderboard));
+	}
+
+public:
+	LeaderboardAsyncContext(
+			GDKLeaderboards *p_leaderboards,
+			const Ref<GDKUser> &p_user,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const String &p_stat_name,
+			const String &p_query_type,
+			bool p_next_page) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_leaderboards(p_leaderboards),
+			m_user(p_user),
+			m_context(p_context),
+			m_stat_name(p_stat_name),
+			m_query_type(p_query_type),
+			m_next_page(p_next_page) {}
+
+	~LeaderboardAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+class LeaderboardQueryAsyncContext final : public LeaderboardAsyncContext {
+	CharString m_stat_name_utf8;
+	XblLeaderboardQuery m_query = {};
+
+public:
+	LeaderboardQueryAsyncContext(
+			GDKLeaderboards *p_leaderboards,
+			const Ref<GDKUser> &p_user,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const String &p_stat_name,
+			const String &p_query_type,
+			const String &p_scid,
+			uint64_t p_xbox_user_id,
+			uint32_t p_max_items,
+			XblSocialGroupType p_social_group,
+			XblLeaderboardQueryType p_native_query_type,
+			bool p_around_user) :
+			LeaderboardAsyncContext(p_leaderboards, p_user, p_runtime, p_pending_signal, p_context, p_stat_name, p_query_type, false),
+			m_stat_name_utf8(p_stat_name.utf8()) {
+		const CharString scid_utf8 = p_scid.utf8();
+		std::snprintf(m_query.scid, sizeof(m_query.scid), "%s", scid_utf8.get_data());
+		m_query.xboxUserId = p_native_query_type == XblLeaderboardQueryType::TitleManagedStatBackedGlobal && !p_around_user ? 0 : p_xbox_user_id;
+		m_query.leaderboardName = nullptr;
+		m_query.statName = m_stat_name_utf8.get_data();
+		m_query.socialGroup = p_social_group;
+		m_query.additionalColumnleaderboardNames = nullptr;
+		m_query.additionalColumnleaderboardNamesCount = 0;
+		m_query.order = XblLeaderboardSortOrder::Descending;
+		m_query.maxItems = p_max_items;
+		m_query.skipToXboxUserId = p_around_user ? p_xbox_user_id : 0;
+		m_query.skipResultToRank = 0;
+		m_query.continuationToken = nullptr;
+		m_query.queryType = p_native_query_type;
+	}
+
+	XblLeaderboardQuery get_query() const {
+		return m_query;
+	}
+};
+
+class LeaderboardNextPageAsyncContext final : public LeaderboardAsyncContext {
+	Ref<GDKLeaderboard> m_previous_leaderboard;
+
+public:
+	LeaderboardNextPageAsyncContext(
+			GDKLeaderboards *p_leaderboards,
+			const Ref<GDKLeaderboard> &p_previous_leaderboard,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context) :
+			LeaderboardAsyncContext(
+					p_leaderboards,
+					p_previous_leaderboard->get_user_internal(),
+					p_runtime,
+					p_pending_signal,
+					p_context,
+					p_previous_leaderboard->get_stat_name(),
+					p_previous_leaderboard->get_query_type(),
+					true),
+			m_previous_leaderboard(p_previous_leaderboard) {}
+
+	XblLeaderboardResult *get_previous_native_result() const {
+		return m_previous_leaderboard->get_native_result_internal();
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKLeaderboardColumn::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_stat_name"), &GDKLeaderboardColumn::get_stat_name);
+	ClassDB::bind_method(D_METHOD("get_stat_type"), &GDKLeaderboardColumn::get_stat_type);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "stat_name"), "", "get_stat_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "stat_type"), "", "get_stat_type");
+}
+
+String GDKLeaderboardColumn::get_stat_name() const {
+	return m_stat_name;
+}
+
+String GDKLeaderboardColumn::get_stat_type() const {
+	return m_stat_type;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKLeaderboardColumn::populate_from_native(const XblLeaderboardColumn &p_column) {
+	m_stat_name = _utf8_or_empty(p_column.statName);
+	m_stat_type = _stat_type_to_string(p_column.statType);
+}
+#else
+void GDKLeaderboardColumn::populate_from_native(const XblLeaderboardColumn &p_column) {
+}
+#endif
+
+void GDKLeaderboardRow::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_gamertag"), &GDKLeaderboardRow::get_gamertag);
+	ClassDB::bind_method(D_METHOD("get_modern_gamertag"), &GDKLeaderboardRow::get_modern_gamertag);
+	ClassDB::bind_method(D_METHOD("get_modern_gamertag_suffix"), &GDKLeaderboardRow::get_modern_gamertag_suffix);
+	ClassDB::bind_method(D_METHOD("get_unique_modern_gamertag"), &GDKLeaderboardRow::get_unique_modern_gamertag);
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKLeaderboardRow::get_xuid);
+	ClassDB::bind_method(D_METHOD("get_percentile"), &GDKLeaderboardRow::get_percentile);
+	ClassDB::bind_method(D_METHOD("get_rank"), &GDKLeaderboardRow::get_rank);
+	ClassDB::bind_method(D_METHOD("get_global_rank"), &GDKLeaderboardRow::get_global_rank);
+	ClassDB::bind_method(D_METHOD("get_column_values"), &GDKLeaderboardRow::get_column_values);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamertag"), "", "get_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "modern_gamertag"), "", "get_modern_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "modern_gamertag_suffix"), "", "get_modern_gamertag_suffix");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "unique_modern_gamertag"), "", "get_unique_modern_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "percentile"), "", "get_percentile");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rank"), "", "get_rank");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "global_rank"), "", "get_global_rank");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "column_values"), "", "get_column_values");
+}
+
+String GDKLeaderboardRow::get_gamertag() const {
+	return m_gamertag;
+}
+
+String GDKLeaderboardRow::get_modern_gamertag() const {
+	return m_modern_gamertag;
+}
+
+String GDKLeaderboardRow::get_modern_gamertag_suffix() const {
+	return m_modern_gamertag_suffix;
+}
+
+String GDKLeaderboardRow::get_unique_modern_gamertag() const {
+	return m_unique_modern_gamertag;
+}
+
+String GDKLeaderboardRow::get_xuid() const {
+	return m_xuid;
+}
+
+double GDKLeaderboardRow::get_percentile() const {
+	return m_percentile;
+}
+
+int64_t GDKLeaderboardRow::get_rank() const {
+	return m_rank;
+}
+
+int64_t GDKLeaderboardRow::get_global_rank() const {
+	return m_global_rank;
+}
+
+PackedStringArray GDKLeaderboardRow::get_column_values() const {
+	return m_column_values;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKLeaderboardRow::populate_from_native(const XblLeaderboardRow &p_row) {
+	m_gamertag = _utf8_or_empty(p_row.gamertag);
+	m_modern_gamertag = _utf8_or_empty(p_row.modernGamertag);
+	m_modern_gamertag_suffix = _utf8_or_empty(p_row.modernGamertagSuffix);
+	m_unique_modern_gamertag = _utf8_or_empty(p_row.uniqueModernGamertag);
+	m_xuid = String::num_uint64(p_row.xboxUserId);
+	m_percentile = p_row.percentile;
+	m_rank = p_row.rank;
+	m_global_rank = p_row.globalRank;
+	m_column_values.clear();
+	if (p_row.columnValues != nullptr) {
+		for (size_t i = 0; i < p_row.columnValuesCount; ++i) {
+			m_column_values.push_back(_utf8_or_empty(p_row.columnValues[i]));
+		}
+	}
+}
+#else
+void GDKLeaderboardRow::populate_from_native(const XblLeaderboardRow &p_row) {
+}
+#endif
+
+void GDKLeaderboard::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_stat_name"), &GDKLeaderboard::get_stat_name);
+	ClassDB::bind_method(D_METHOD("get_query_type"), &GDKLeaderboard::get_query_type);
+	ClassDB::bind_method(D_METHOD("get_total_row_count"), &GDKLeaderboard::get_total_row_count);
+	ClassDB::bind_method(D_METHOD("has_next"), &GDKLeaderboard::has_next);
+	ClassDB::bind_method(D_METHOD("get_columns"), &GDKLeaderboard::get_columns);
+	ClassDB::bind_method(D_METHOD("get_rows"), &GDKLeaderboard::get_rows);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "stat_name"), "", "get_stat_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "query_type"), "", "get_query_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "total_row_count"), "", "get_total_row_count");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_next"), "", "has_next");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "columns"), "", "get_columns");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "rows"), "", "get_rows");
+}
+
+String GDKLeaderboard::get_stat_name() const {
+	return m_stat_name;
+}
+
+String GDKLeaderboard::get_query_type() const {
+	return m_query_type;
+}
+
+int64_t GDKLeaderboard::get_total_row_count() const {
+	return m_total_row_count;
+}
+
+bool GDKLeaderboard::has_next() const {
+	return m_has_next;
+}
+
+Array GDKLeaderboard::get_columns() const {
+	return m_columns;
+}
+
+Array GDKLeaderboard::get_rows() const {
+	return m_rows;
+}
+
+Ref<GDKUser> GDKLeaderboard::get_user_internal() const {
+	return m_user;
+}
+
+XblLeaderboardResult *GDKLeaderboard::get_native_result_internal() const {
+	return m_native_result;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKLeaderboard::populate_from_native(
+		const String &p_stat_name,
+		const String &p_query_type,
+		const Ref<GDKUser> &p_user,
+		std::vector<uint8_t> &&p_buffer,
+		XblLeaderboardResult *p_native_result) {
+	m_stat_name = p_stat_name;
+	m_query_type = p_query_type;
+	m_user = p_user;
+	m_native_result_buffer = std::move(p_buffer);
+	m_native_result = p_native_result;
+
+	m_total_row_count = p_native_result == nullptr ? 0 : p_native_result->totalRowCount;
+	m_has_next = p_native_result != nullptr && p_native_result->hasNext;
+	m_columns.clear();
+	m_rows.clear();
+
+	if (p_native_result == nullptr) {
+		return;
+	}
+
+	if (p_native_result->columns != nullptr) {
+		for (size_t i = 0; i < p_native_result->columnsCount; ++i) {
+			Ref<GDKLeaderboardColumn> column;
+			column.instantiate();
+			column->populate_from_native(p_native_result->columns[i]);
+			m_columns.push_back(column);
+		}
+	}
+
+	if (p_native_result->rows != nullptr) {
+		for (size_t i = 0; i < p_native_result->rowsCount; ++i) {
+			Ref<GDKLeaderboardRow> row;
+			row.instantiate();
+			row->populate_from_native(p_native_result->rows[i]);
+			m_rows.push_back(row);
+		}
+	}
+}
+#else
+void GDKLeaderboard::populate_from_native(
+		const String &p_stat_name,
+		const String &p_query_type,
+		const Ref<GDKUser> &p_user,
+		std::vector<uint8_t> &&p_buffer,
+		XblLeaderboardResult *p_native_result) {
+	m_stat_name = p_stat_name;
+	m_query_type = p_query_type;
+	m_user = p_user;
+	m_native_result_buffer = std::move(p_buffer);
+	m_native_result = p_native_result;
+	m_total_row_count = 0;
+	m_has_next = false;
+	m_columns.clear();
+	m_rows.clear();
+}
+#endif
+
+void GDKLeaderboards::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_leaderboard_async", "user", "stat_name", "max_items"), &GDKLeaderboards::get_leaderboard_async, DEFVAL(25));
+	ClassDB::bind_method(D_METHOD("get_leaderboard_around_user_async", "user", "stat_name", "max_items"), &GDKLeaderboards::get_leaderboard_around_user_async, DEFVAL(25));
+	ClassDB::bind_method(D_METHOD("get_social_leaderboard_async", "user", "stat_name", "max_items"), &GDKLeaderboards::get_social_leaderboard_async, DEFVAL(25));
+	ClassDB::bind_method(D_METHOD("get_next_page_async", "leaderboard"), &GDKLeaderboards::get_next_page_async);
+	ClassDB::bind_method(D_METHOD("get_cached_leaderboard", "stat_name"), &GDKLeaderboards::get_cached_leaderboard);
+
+	ADD_SIGNAL(MethodInfo("leaderboard_updated", PropertyInfo(Variant::STRING, "stat_name"), PropertyInfo(Variant::OBJECT, "leaderboard", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKLeaderboard")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKLeaderboards::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKLeaderboards::_get_runtime() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKLeaderboards::_get_xbox_services() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Signal GDKLeaderboards::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_NULL_V(runtime, Signal());
+	return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKLeaderboards::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+	return GDKResult::ok_result();
+}
+
+GDKLeaderboards::CachedLeaderboard *GDKLeaderboards::_find_cached_leaderboard(const String &p_stat_name) {
+	for (CachedLeaderboard &cached : m_cached_leaderboards) {
+		if (cached.stat_name == p_stat_name) {
+			return &cached;
+		}
+	}
+	return nullptr;
+}
+
+Ref<GDKLeaderboard> GDKLeaderboards::_cache_leaderboard(const Ref<GDKLeaderboard> &p_leaderboard) {
+	if (!p_leaderboard.is_valid() || p_leaderboard->get_stat_name().is_empty()) {
+		return p_leaderboard;
+	}
+
+	CachedLeaderboard *cached = _find_cached_leaderboard(p_leaderboard->get_stat_name());
+	if (cached == nullptr) {
+		CachedLeaderboard new_cached;
+		new_cached.stat_name = p_leaderboard->get_stat_name();
+		new_cached.leaderboard = p_leaderboard;
+		m_cached_leaderboards.push_back(new_cached);
+	} else {
+		cached->leaderboard = p_leaderboard;
+	}
+
+	return p_leaderboard;
+}
+
+Ref<GDKResult> GDKLeaderboards::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKLeaderboards::shutdown() {
+	m_cached_leaderboards.clear();
+	m_runtime_ready = false;
+}
+
+Signal GDKLeaderboards::_start_leaderboard_async(
+		const Ref<GDKUser> &p_user,
+		const String &p_stat_name,
+		int64_t p_max_items,
+		XblSocialGroupType p_social_group,
+		XblLeaderboardQueryType p_native_query_type,
+		bool p_around_user) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	String stat_name;
+	Ref<GDKResult> stat_name_result = _parse_stat_name(p_stat_name, &stat_name);
+	if (!stat_name_result->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(stat_name_result->get_hresult()), stat_name_result->get_code(), stat_name_result->get_message());
+	}
+
+	uint32_t max_items = 0;
+	Ref<GDKResult> max_items_result = _parse_max_items(p_max_items, &max_items);
+	if (!max_items_result->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(max_items_result->get_hresult()), max_items_result->get_code(), max_items_result->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	LeaderboardQueryAsyncContext *async_context = new LeaderboardQueryAsyncContext(
+			this,
+			p_user,
+			runtime,
+			pending_signal,
+			context,
+			stat_name,
+			_query_type_to_string(p_native_query_type, p_around_user),
+			xbox_services->get_scid(),
+			xbox_user_id,
+			max_items,
+			p_social_group,
+			p_native_query_type,
+			p_around_user);
+	async_context->bind_cancel_handler();
+
+	hr = XblLeaderboardGetLeaderboardAsync(
+			async_context->get_context(),
+			async_context->get_query(),
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "leaderboard_query_start_failed", "Failed to start leaderboard query.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKLeaderboards::get_leaderboard_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items) {
+	return _start_leaderboard_async(p_user, p_stat_name, p_max_items, XblSocialGroupType::None, XblLeaderboardQueryType::TitleManagedStatBackedGlobal, false);
+}
+
+Signal GDKLeaderboards::get_leaderboard_around_user_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items) {
+	return _start_leaderboard_async(p_user, p_stat_name, p_max_items, XblSocialGroupType::None, XblLeaderboardQueryType::TitleManagedStatBackedGlobal, true);
+}
+
+Signal GDKLeaderboards::get_social_leaderboard_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items) {
+	return _start_leaderboard_async(p_user, p_stat_name, p_max_items, XblSocialGroupType::People, XblLeaderboardQueryType::TitleManagedStatBackedSocial, false);
+}
+
+Signal GDKLeaderboards::get_next_page_async(const Ref<GDKLeaderboard> &p_leaderboard) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+	if (!m_runtime_ready) {
+		return _make_error_signal(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_leaderboard.is_valid() || p_leaderboard->get_native_result_internal() == nullptr) {
+		return _make_error_signal(E_INVALIDARG, "invalid_leaderboard", "A leaderboard returned by this service is required.");
+	}
+	if (!p_leaderboard->has_next()) {
+		return _make_error_signal(E_INVALIDARG, "no_next_page", "Leaderboard has no next page.");
+	}
+
+	Ref<GDKUser> user = p_leaderboard->get_user_internal();
+	Ref<GDKResult> validation = _ensure_ready_user(user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	LeaderboardNextPageAsyncContext *async_context = new LeaderboardNextPageAsyncContext(this, p_leaderboard, runtime, pending_signal, context);
+	async_context->bind_cancel_handler();
+
+	hr = XblLeaderboardResultGetNextAsync(
+			async_context->get_context(),
+			async_context->get_previous_native_result(),
+			0,
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "leaderboard_next_page_start_failed", "Failed to start leaderboard next-page query.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKLeaderboard> GDKLeaderboards::get_cached_leaderboard(const String &p_stat_name) const {
+	const String stat_name = p_stat_name.strip_edges();
+	if (stat_name.is_empty()) {
+		return Ref<GDKLeaderboard>();
+	}
+
+	for (const CachedLeaderboard &cached : m_cached_leaderboards) {
+		if (cached.stat_name == stat_name) {
+			return cached.leaderboard;
+		}
+	}
+	return Ref<GDKLeaderboard>();
+}
+
+Ref<GDKLeaderboard> GDKLeaderboards::cache_leaderboard_internal(const Ref<GDKLeaderboard> &p_leaderboard) {
+	return _cache_leaderboard(p_leaderboard);
+}
+
+void GDKLeaderboards::on_user_removed(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	const int64_t local_id = p_user->get_local_id();
+	m_cached_leaderboards.erase(
+			std::remove_if(
+					m_cached_leaderboards.begin(),
+					m_cached_leaderboards.end(),
+					[local_id](const CachedLeaderboard &cached) {
+						return cached.leaderboard.is_valid() &&
+								cached.leaderboard->get_user_internal().is_valid() &&
+								cached.leaderboard->get_user_internal()->get_local_id() == local_id;
+					}),
+			m_cached_leaderboards.end());
+}
+
+#else
+void GDKLeaderboards::set_owner(GDK *p_owner) {}
+
+Signal GDKLeaderboards::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKLeaderboards::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKLeaderboard> GDKLeaderboards::_cache_leaderboard(const Ref<GDKLeaderboard> &p_leaderboard) {
+	return Ref<GDKLeaderboard>();
+}
+
+Ref<GDKResult> GDKLeaderboards::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKLeaderboards::shutdown() {}
+
+Signal GDKLeaderboards::_start_leaderboard_async(
+		const Ref<GDKUser> &p_user,
+		const String &p_stat_name,
+		int64_t p_max_items,
+		XblSocialGroupType p_social_group,
+		XblLeaderboardQueryType p_native_query_type,
+		bool p_around_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKLeaderboards::get_leaderboard_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKLeaderboards::get_leaderboard_around_user_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKLeaderboards::get_social_leaderboard_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKLeaderboards::get_next_page_async(const Ref<GDKLeaderboard> &p_leaderboard) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKLeaderboard> GDKLeaderboards::get_cached_leaderboard(const String &p_stat_name) const {
+	return Ref<GDKLeaderboard>();
+}
+
+Ref<GDKLeaderboard> GDKLeaderboards::cache_leaderboard_internal(const Ref<GDKLeaderboard> &p_leaderboard) {
+	return Ref<GDKLeaderboard>();
+}
+
+void GDKLeaderboards::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_leaderboards.h
+++ b/modules/xbox_module/gdk/gdk_leaderboards.h
@@ -1,0 +1,184 @@
+/**************************************************************************/
+/*  gdk_leaderboards.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKLeaderboardColumn : public RefCounted {
+	GDCLASS(GDKLeaderboardColumn, RefCounted);
+
+	String m_stat_name;
+	String m_stat_type;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_stat_name() const;
+	String get_stat_type() const;
+
+	void populate_from_native(const XblLeaderboardColumn &p_column);
+};
+
+class GDKLeaderboardRow : public RefCounted {
+	GDCLASS(GDKLeaderboardRow, RefCounted);
+
+	String m_gamertag;
+	String m_modern_gamertag;
+	String m_modern_gamertag_suffix;
+	String m_unique_modern_gamertag;
+	String m_xuid;
+	double m_percentile = 0.0;
+	int64_t m_rank = 0;
+	int64_t m_global_rank = 0;
+	PackedStringArray m_column_values;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_gamertag() const;
+	String get_modern_gamertag() const;
+	String get_modern_gamertag_suffix() const;
+	String get_unique_modern_gamertag() const;
+	String get_xuid() const;
+	double get_percentile() const;
+	int64_t get_rank() const;
+	int64_t get_global_rank() const;
+	PackedStringArray get_column_values() const;
+
+	void populate_from_native(const XblLeaderboardRow &p_row);
+};
+
+class GDKLeaderboard : public RefCounted {
+	GDCLASS(GDKLeaderboard, RefCounted);
+
+	String m_stat_name;
+	String m_query_type;
+	int64_t m_total_row_count = 0;
+	bool m_has_next = false;
+	Array m_columns;
+	Array m_rows;
+	Ref<GDKUser> m_user;
+	std::vector<uint8_t> m_native_result_buffer;
+	XblLeaderboardResult *m_native_result = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_stat_name() const;
+	String get_query_type() const;
+	int64_t get_total_row_count() const;
+	bool has_next() const;
+	Array get_columns() const;
+	Array get_rows() const;
+
+	Ref<GDKUser> get_user_internal() const;
+	XblLeaderboardResult *get_native_result_internal() const;
+	void populate_from_native(
+			const String &p_stat_name,
+			const String &p_query_type,
+			const Ref<GDKUser> &p_user,
+			std::vector<uint8_t> &&p_buffer,
+			XblLeaderboardResult *p_native_result);
+};
+
+class GDKLeaderboards : public RefCounted {
+	GDCLASS(GDKLeaderboards, RefCounted);
+
+	struct CachedLeaderboard {
+		String stat_name;
+		Ref<GDKLeaderboard> leaderboard;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	std::vector<CachedLeaderboard> m_cached_leaderboards;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+	CachedLeaderboard *_find_cached_leaderboard(const String &p_stat_name);
+	Ref<GDKLeaderboard> _cache_leaderboard(const Ref<GDKLeaderboard> &p_leaderboard);
+	Signal _start_leaderboard_async(
+			const Ref<GDKUser> &p_user,
+			const String &p_stat_name,
+			int64_t p_max_items,
+			XblSocialGroupType p_social_group,
+			XblLeaderboardQueryType p_native_query_type,
+			bool p_around_user);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Signal get_leaderboard_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items = 25);
+	Signal get_leaderboard_around_user_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items = 25);
+	Signal get_social_leaderboard_async(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_max_items = 25);
+	Signal get_next_page_async(const Ref<GDKLeaderboard> &p_leaderboard);
+	Ref<GDKLeaderboard> get_cached_leaderboard(const String &p_stat_name) const;
+
+	Ref<GDKLeaderboard> cache_leaderboard_internal(const Ref<GDKLeaderboard> &p_leaderboard);
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_multiplayer_activity.cpp
+++ b/modules/xbox_module/gdk/gdk_multiplayer_activity.cpp
@@ -1,0 +1,1485 @@
+/**************************************************************************/
+/*  gdk_multiplayer_activity.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_multiplayer_activity.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#include <XGameUI.h>
+#endif
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "gdk.h"
+#include "gdk_activation.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	return p_value != nullptr ? String::utf8(p_value) : String();
+}
+
+Ref<GDKResult> _parse_xuids(
+		const PackedStringArray &p_xuids,
+		std::vector<uint64_t> *r_xuids,
+		std::vector<String> *r_normalized_xuids,
+		size_t p_max_count,
+		const String &p_empty_code,
+		const String &p_invalid_code,
+		const String &p_invalid_message) {
+	ERR_FAIL_COND_V(r_xuids == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing XUID output buffer."));
+
+	if (p_xuids.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, p_empty_code, "At least one XUID is required.");
+	}
+	if (p_max_count > 0 && static_cast<size_t>(p_xuids.size()) > p_max_count) {
+		return GDKResult::error_result(E_INVALIDARG, p_invalid_code, "Too many XUIDs were provided for this request.");
+	}
+
+	r_xuids->clear();
+	r_xuids->reserve(static_cast<size_t>(p_xuids.size()));
+
+	if (r_normalized_xuids != nullptr) {
+		r_normalized_xuids->clear();
+		r_normalized_xuids->reserve(static_cast<size_t>(p_xuids.size()));
+	}
+
+	for (int64_t i = 0; i < p_xuids.size(); ++i) {
+		const String xuid_string = p_xuids[i].strip_edges();
+		uint64_t xuid = 0;
+		if (!GDKMultiplayerActivity::try_parse_xuid_internal(xuid_string, &xuid)) {
+			return GDKResult::error_result(E_INVALIDARG, p_invalid_code, p_invalid_message);
+		}
+
+		r_xuids->push_back(xuid);
+		if (r_normalized_xuids != nullptr) {
+			r_normalized_xuids->push_back(String::num_uint64(xuid));
+		}
+	}
+
+	return GDKResult::ok_result();
+}
+
+class MultiplayerActivityXAsyncContext : public GDKSignalXAsyncContext {
+protected:
+	GDKMultiplayerActivity *m_service = nullptr;
+	XblContextHandle m_context = nullptr;
+
+public:
+	MultiplayerActivityXAsyncContext(
+			GDKMultiplayerActivity *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_service(p_service),
+			m_context(p_context) {}
+
+	~MultiplayerActivityXAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+class SetActivityAsyncContext final : public MultiplayerActivityXAsyncContext {
+	String m_local_xuid;
+	String m_connection_string;
+	String m_join_restriction;
+	int64_t m_max_players = 0;
+	int64_t m_current_players = 0;
+	String m_group_id;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Multiplayer activity update cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Multiplayer activity update cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to set the multiplayer activity.",
+					"multiplayer_activity_set_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Ref<GDKMultiplayerActivityInfo> activity;
+		activity.instantiate();
+		activity->set_values(
+				m_local_xuid,
+				m_connection_string,
+				m_join_restriction,
+				m_max_players,
+				m_current_players,
+				m_group_id,
+				"unknown");
+		m_service->cache_activity_internal(activity);
+		m_service->emit_activities_updated_internal({ m_local_xuid });
+
+		get_pending_signal()->complete(GDKResult::ok_result(activity));
+	}
+
+public:
+	SetActivityAsyncContext(
+			GDKMultiplayerActivity *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const String &p_local_xuid,
+			const String &p_connection_string,
+			const String &p_join_restriction,
+			int64_t p_max_players,
+			int64_t p_current_players,
+			const String &p_group_id) :
+			MultiplayerActivityXAsyncContext(p_service, p_runtime, p_pending_signal, p_context),
+			m_local_xuid(p_local_xuid),
+			m_connection_string(p_connection_string),
+			m_join_restriction(p_join_restriction),
+			m_max_players(p_max_players),
+			m_current_players(p_current_players),
+			m_group_id(p_group_id) {}
+};
+
+class GetActivitiesAsyncContext final : public MultiplayerActivityXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Multiplayer activity query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t buffer_size = 0;
+		HRESULT size_hr = XblMultiplayerActivityGetActivityResultSize(p_async_block, &buffer_size);
+		if (size_hr == E_ABORT) {
+			result = GDKResult::cancelled("Multiplayer activity query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(size_hr)) {
+			result = GDKResult::hresult_error(
+					size_hr,
+					"Failed to get the multiplayer activity result size.",
+					"multiplayer_activity_get_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(buffer_size);
+		XblMultiplayerActivityInfo *activities = nullptr;
+		size_t result_count = 0;
+		HRESULT result_hr = XblMultiplayerActivityGetActivityResult(
+				p_async_block,
+				buffer.size(),
+				buffer.empty() ? nullptr : buffer.data(),
+				&activities,
+				&result_count,
+				nullptr);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Multiplayer activity query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to translate the multiplayer activity result.",
+					"multiplayer_activity_get_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Array godot_activities;
+		std::vector<String> updated_xuids;
+		updated_xuids.reserve(result_count);
+		for (size_t i = 0; i < result_count; ++i) {
+			Ref<GDKMultiplayerActivityInfo> activity;
+			activity.instantiate();
+			activity->populate_from_native(activities[i]);
+			m_service->cache_activity_internal(activity);
+			godot_activities.push_back(activity);
+			updated_xuids.push_back(activity->get_xuid());
+		}
+
+		m_service->emit_activities_updated_internal(updated_xuids);
+		get_pending_signal()->complete(GDKResult::ok_result(godot_activities));
+	}
+
+public:
+	GetActivitiesAsyncContext(
+			GDKMultiplayerActivity *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context) :
+			MultiplayerActivityXAsyncContext(p_service, p_runtime, p_pending_signal, p_context) {}
+};
+
+class DeleteActivityAsyncContext final : public MultiplayerActivityXAsyncContext {
+	String m_local_xuid;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Multiplayer activity delete cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Multiplayer activity delete cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to delete the multiplayer activity.",
+					"multiplayer_activity_delete_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		m_service->remove_cached_activity_internal(m_local_xuid);
+		m_service->emit_activities_updated_internal({ m_local_xuid });
+		get_pending_signal()->complete(GDKResult::ok_result(m_local_xuid));
+	}
+
+public:
+	DeleteActivityAsyncContext(
+			GDKMultiplayerActivity *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const String &p_local_xuid) :
+			MultiplayerActivityXAsyncContext(p_service, p_runtime, p_pending_signal, p_context),
+			m_local_xuid(p_local_xuid) {}
+};
+
+class SendInvitesAsyncContext final : public MultiplayerActivityXAsyncContext {
+	size_t m_recipient_count = 0;
+	bool m_allow_cross_platform_join = false;
+	String m_connection_string;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Multiplayer invite send cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Multiplayer invite send cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to send multiplayer invites.",
+					"multiplayer_activity_send_invites_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary data;
+		data["recipient_count"] = static_cast<int64_t>(m_recipient_count);
+		data["allow_cross_platform_join"] = m_allow_cross_platform_join;
+		data["connection_string"] = m_connection_string;
+
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	SendInvitesAsyncContext(
+			GDKMultiplayerActivity *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			size_t p_recipient_count,
+			bool p_allow_cross_platform_join,
+			const String &p_connection_string) :
+			MultiplayerActivityXAsyncContext(p_service, p_runtime, p_pending_signal, p_context),
+			m_recipient_count(p_recipient_count),
+			m_allow_cross_platform_join(p_allow_cross_platform_join),
+			m_connection_string(p_connection_string) {}
+};
+
+class InviteUiAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Invite UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XGameUiShowMultiplayerActivityGameInviteResult(p_async_block);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Invite UI cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to complete the multiplayer invite UI flow.",
+					"multiplayer_activity_invite_ui_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result());
+	}
+
+public:
+	InviteUiAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+class FlushRecentPlayersAsyncContext final : public MultiplayerActivityXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Recent-player flush cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Recent-player flush cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to flush recent-player updates.",
+					"multiplayer_activity_flush_recent_players_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result());
+	}
+
+public:
+	FlushRecentPlayersAsyncContext(
+			GDKMultiplayerActivity *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context) :
+			MultiplayerActivityXAsyncContext(p_service, p_runtime, p_pending_signal, p_context) {}
+};
+
+} //namespace
+
+#endif
+
+void GDKMultiplayerActivityInfo::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKMultiplayerActivityInfo::get_xuid);
+	ClassDB::bind_method(D_METHOD("get_connection_string"), &GDKMultiplayerActivityInfo::get_connection_string);
+	ClassDB::bind_method(D_METHOD("get_join_restriction"), &GDKMultiplayerActivityInfo::get_join_restriction);
+	ClassDB::bind_method(D_METHOD("get_max_players"), &GDKMultiplayerActivityInfo::get_max_players);
+	ClassDB::bind_method(D_METHOD("get_current_players"), &GDKMultiplayerActivityInfo::get_current_players);
+	ClassDB::bind_method(D_METHOD("get_group_id"), &GDKMultiplayerActivityInfo::get_group_id);
+	ClassDB::bind_method(D_METHOD("get_platform"), &GDKMultiplayerActivityInfo::get_platform);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "connection_string"), "", "get_connection_string");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "join_restriction"), "", "get_join_restriction");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_players"), "", "get_max_players");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_players"), "", "get_current_players");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "group_id"), "", "get_group_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "platform"), "", "get_platform");
+}
+
+String GDKMultiplayerActivityInfo::get_xuid() const {
+	return m_xuid;
+}
+
+String GDKMultiplayerActivityInfo::get_connection_string() const {
+	return m_connection_string;
+}
+
+String GDKMultiplayerActivityInfo::get_join_restriction() const {
+	return m_join_restriction;
+}
+
+int64_t GDKMultiplayerActivityInfo::get_max_players() const {
+	return m_max_players;
+}
+
+int64_t GDKMultiplayerActivityInfo::get_current_players() const {
+	return m_current_players;
+}
+
+String GDKMultiplayerActivityInfo::get_group_id() const {
+	return m_group_id;
+}
+
+String GDKMultiplayerActivityInfo::get_platform() const {
+	return m_platform;
+}
+
+void GDKMultiplayerActivityInfo::set_values(
+		const String &p_xuid,
+		const String &p_connection_string,
+		const String &p_join_restriction,
+		int64_t p_max_players,
+		int64_t p_current_players,
+		const String &p_group_id,
+		const String &p_platform) {
+	m_xuid = p_xuid;
+	m_connection_string = p_connection_string;
+	m_join_restriction = p_join_restriction;
+	m_max_players = p_max_players;
+	m_current_players = p_current_players;
+	m_group_id = p_group_id;
+	m_platform = p_platform;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKMultiplayerActivityInfo::populate_from_native(const XblMultiplayerActivityInfo &p_native_activity) {
+	set_values(
+			String::num_uint64(p_native_activity.xuid),
+			_utf8_or_empty(p_native_activity.connectionString),
+			GDKMultiplayerActivity::join_restriction_to_string_internal(p_native_activity.joinRestriction),
+			static_cast<int64_t>(p_native_activity.maxPlayers),
+			static_cast<int64_t>(p_native_activity.currentPlayers),
+			_utf8_or_empty(p_native_activity.groupId),
+			GDKMultiplayerActivity::platform_to_string_internal(p_native_activity.platform));
+}
+#else
+void GDKMultiplayerActivityInfo::populate_from_native(const XblMultiplayerActivityInfo &p_native_activity) {
+}
+#endif
+
+void GDKMultiplayerActivity::_bind_methods() {
+	ClassDB::bind_method(
+			D_METHOD("set_activity_async", "user", "connection_string", "join_restriction", "max_players", "current_players", "group_id", "allow_cross_platform_join"),
+			&GDKMultiplayerActivity::set_activity_async,
+			DEFVAL(String("followed")),
+			DEFVAL(static_cast<int64_t>(0)),
+			DEFVAL(static_cast<int64_t>(0)),
+			DEFVAL(String()),
+			DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_activities_async", "user", "xuids"), &GDKMultiplayerActivity::get_activities_async);
+	ClassDB::bind_method(D_METHOD("get_cached_activity", "xuid"), &GDKMultiplayerActivity::get_cached_activity);
+	ClassDB::bind_method(D_METHOD("delete_activity_async", "user"), &GDKMultiplayerActivity::delete_activity_async);
+	ClassDB::bind_method(
+			D_METHOD("send_invites_async", "user", "xuids", "allow_cross_platform_join", "connection_string"),
+			&GDKMultiplayerActivity::send_invites_async,
+			DEFVAL(true),
+			DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("show_invite_ui_async", "user"), &GDKMultiplayerActivity::show_invite_ui_async);
+	ClassDB::bind_method(
+			D_METHOD("update_recent_players", "user", "xuids", "encounter_type"),
+			&GDKMultiplayerActivity::update_recent_players,
+			DEFVAL(String("default")));
+	ClassDB::bind_method(D_METHOD("flush_recent_players_async", "user"), &GDKMultiplayerActivity::flush_recent_players_async);
+	ClassDB::bind_method(D_METHOD("accept_pending_invite", "invite_uri"), &GDKMultiplayerActivity::accept_pending_invite);
+
+	ADD_SIGNAL(MethodInfo("activities_updated", PropertyInfo(Variant::PACKED_STRING_ARRAY, "xuids")));
+	ADD_SIGNAL(MethodInfo("pending_invite_received", PropertyInfo(Variant::DICTIONARY, "invite")));
+	ADD_SIGNAL(MethodInfo("invite_accepted", PropertyInfo(Variant::DICTIONARY, "invite")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKMultiplayerActivity::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::on_runtime_initialized() {
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"runtime_not_initialized",
+				"Cannot initialize the multiplayer activity service before the GDK runtime.");
+	}
+
+	if (m_activation_listener_id == 0 && m_owner != nullptr) {
+		Ref<GDKActivation> activation = m_owner->get_activation();
+		if (activation.is_valid()) {
+			m_activation_listener_id = activation->add_activation_listener([this](const Dictionary &p_info) {
+				handle_activation_internal(p_info);
+			});
+		}
+	}
+
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKMultiplayerActivity::shutdown() {
+	m_runtime_ready = false;
+
+	if (m_activation_listener_id != 0 && m_owner != nullptr) {
+		Ref<GDKActivation> activation = m_owner->get_activation();
+		if (activation.is_valid()) {
+			activation->remove_activation_listener(m_activation_listener_id);
+		}
+		m_activation_listener_id = 0;
+	}
+
+	m_cached_activities.clear();
+}
+
+void GDKMultiplayerActivity::on_user_removed(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	remove_cached_activity_internal(p_user->get_xuid());
+}
+
+Signal GDKMultiplayerActivity::set_activity_async(
+		const Ref<GDKUser> &p_user,
+		const String &p_connection_string,
+		const String &p_join_restriction,
+		int64_t p_max_players,
+		int64_t p_current_players,
+		const String &p_group_id,
+		bool p_allow_cross_platform_join) {
+	GDKRuntime *runtime = get_runtime_internal();
+
+	if (p_connection_string.strip_edges().is_empty()) {
+		return make_error_signal_internal(
+				E_INVALIDARG,
+				"invalid_connection_string",
+				"A non-empty connection string is required to set the multiplayer activity.");
+	}
+	if (p_max_players < 0 || p_current_players < 0) {
+		return make_error_signal_internal(
+				E_INVALIDARG,
+				"invalid_player_counts",
+				"Player counts must be zero or greater.");
+	}
+	if (p_max_players > 0 && p_current_players > p_max_players) {
+		return make_error_signal_internal(
+				E_INVALIDARG,
+				"invalid_player_counts",
+				"current_players cannot exceed max_players.");
+	}
+
+	XblMultiplayerActivityJoinRestriction join_restriction = XblMultiplayerActivityJoinRestriction::Followed;
+	if (!try_parse_join_restriction_internal(p_join_restriction, &join_restriction)) {
+		return make_error_signal_internal(
+				E_INVALIDARG,
+				"invalid_join_restriction",
+				"join_restriction must be 'public', 'invite_only', or 'followed'.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	Ref<GDKResult> context_result = duplicate_context_for_user_internal(p_user, &context, &xbox_user_id);
+	if (!context_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(context_result->get_hresult()),
+				context_result->get_code(),
+				context_result->get_message(),
+				context_result->get_data());
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	auto *context_wrapper = new SetActivityAsyncContext(
+			this,
+			runtime,
+			pending_signal,
+			context,
+			String::num_uint64(xbox_user_id),
+			p_connection_string,
+			join_restriction_to_string_internal(join_restriction),
+			p_max_players,
+			p_current_players,
+			p_group_id);
+	context_wrapper->bind_cancel_handler();
+
+	CharString connection_string_utf8 = p_connection_string.utf8();
+	CharString group_id_utf8 = p_group_id.utf8();
+
+	XblMultiplayerActivityInfo activity_info = {};
+	activity_info.connectionString = connection_string_utf8.get_data();
+	activity_info.joinRestriction = join_restriction;
+	activity_info.maxPlayers = static_cast<size_t>(p_max_players);
+	activity_info.currentPlayers = static_cast<size_t>(p_current_players);
+	activity_info.groupId = p_group_id.is_empty() ? nullptr : group_id_utf8.get_data();
+
+	HRESULT hr = XblMultiplayerActivitySetActivityAsync(
+			context_wrapper->get_context(),
+			&activity_info,
+			p_allow_cross_platform_join,
+			context_wrapper->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_wrapper;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the multiplayer activity update.",
+				"multiplayer_activity_set_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::get_activities_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids) {
+	GDKRuntime *runtime = get_runtime_internal();
+
+	std::vector<uint64_t> query_xuids;
+	Ref<GDKResult> parse_result = _parse_xuids(
+			p_xuids,
+			&query_xuids,
+			nullptr,
+			30,
+			"missing_xuids",
+			"invalid_xuids",
+			"Each queried XUID must be a non-empty numeric string.");
+	if (!parse_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(parse_result->get_hresult()),
+				parse_result->get_code(),
+				parse_result->get_message());
+	}
+
+	XblContextHandle context = nullptr;
+	Ref<GDKResult> context_result = duplicate_context_for_user_internal(p_user, &context);
+	if (!context_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(context_result->get_hresult()),
+				context_result->get_code(),
+				context_result->get_message(),
+				context_result->get_data());
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	auto *context_wrapper = new GetActivitiesAsyncContext(this, runtime, pending_signal, context);
+	context_wrapper->bind_cancel_handler();
+
+	HRESULT hr = XblMultiplayerActivityGetActivityAsync(
+			context_wrapper->get_context(),
+			query_xuids.data(),
+			query_xuids.size(),
+			context_wrapper->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_wrapper;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the multiplayer activity query.",
+				"multiplayer_activity_get_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKMultiplayerActivityInfo> GDKMultiplayerActivity::get_cached_activity(const String &p_xuid) const {
+	const String normalized_xuid = p_xuid.strip_edges();
+	for (const CachedActivityState &state : m_cached_activities) {
+		if (state.xuid == normalized_xuid) {
+			return state.info;
+		}
+	}
+
+	return Ref<GDKMultiplayerActivityInfo>();
+}
+
+Signal GDKMultiplayerActivity::delete_activity_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = get_runtime_internal();
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	Ref<GDKResult> context_result = duplicate_context_for_user_internal(p_user, &context, &xbox_user_id);
+	if (!context_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(context_result->get_hresult()),
+				context_result->get_code(),
+				context_result->get_message(),
+				context_result->get_data());
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	auto *context_wrapper = new DeleteActivityAsyncContext(
+			this,
+			runtime,
+			pending_signal,
+			context,
+			String::num_uint64(xbox_user_id));
+	context_wrapper->bind_cancel_handler();
+
+	HRESULT hr = XblMultiplayerActivityDeleteActivityAsync(
+			context_wrapper->get_context(),
+			context_wrapper->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_wrapper;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the multiplayer activity delete.",
+				"multiplayer_activity_delete_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::send_invites_async(
+		const Ref<GDKUser> &p_user,
+		const PackedStringArray &p_xuids,
+		bool p_allow_cross_platform_join,
+		const String &p_connection_string) {
+	GDKRuntime *runtime = get_runtime_internal();
+
+	std::vector<uint64_t> target_xuids;
+	Ref<GDKResult> parse_result = _parse_xuids(
+			p_xuids,
+			&target_xuids,
+			nullptr,
+			0,
+			"missing_xuids",
+			"invalid_xuids",
+			"Each invited XUID must be a non-empty numeric string.");
+	if (!parse_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(parse_result->get_hresult()),
+				parse_result->get_code(),
+				parse_result->get_message());
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	Ref<GDKResult> context_result = duplicate_context_for_user_internal(p_user, &context, &xbox_user_id);
+	if (!context_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(context_result->get_hresult()),
+				context_result->get_code(),
+				context_result->get_message(),
+				context_result->get_data());
+	}
+
+	String resolved_connection_string = p_connection_string;
+	if (resolved_connection_string.is_empty()) {
+		Ref<GDKMultiplayerActivityInfo> cached_activity = get_cached_activity(String::num_uint64(xbox_user_id));
+		if (cached_activity.is_valid()) {
+			resolved_connection_string = cached_activity->get_connection_string();
+		}
+	}
+	if (resolved_connection_string.strip_edges().is_empty()) {
+		XblContextCloseHandle(context);
+		return make_error_signal_internal(
+				E_INVALIDARG,
+				"missing_connection_string",
+				"A connection string is required to send multiplayer invites. Set the local activity first or pass one explicitly.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	auto *context_wrapper = new SendInvitesAsyncContext(
+			this,
+			runtime,
+			pending_signal,
+			context,
+			target_xuids.size(),
+			p_allow_cross_platform_join,
+			resolved_connection_string);
+	context_wrapper->bind_cancel_handler();
+
+	CharString connection_string_utf8 = resolved_connection_string.utf8();
+	HRESULT hr = XblMultiplayerActivitySendInvitesAsync(
+			context_wrapper->get_context(),
+			target_xuids.data(),
+			target_xuids.size(),
+			p_allow_cross_platform_join,
+			connection_string_utf8.get_data(),
+			context_wrapper->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_wrapper;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the multiplayer invite request.",
+				"multiplayer_activity_send_invites_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::show_invite_ui_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return make_error_signal_internal(
+				E_FAIL,
+				"not_initialized",
+				"GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return make_error_signal_internal(
+				E_INVALIDARG,
+				"invalid_user",
+				"A signed-in GDKUser is required to show the invite UI.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new InviteUiAsyncContext(runtime, pending_signal);
+	context->bind_cancel_handler();
+
+	HRESULT hr = XGameUiShowMultiplayerActivityGameInviteAsync(
+			context->get_async_block(),
+			p_user->get_handle());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the multiplayer invite UI flow.",
+				"multiplayer_activity_invite_ui_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::update_recent_players(
+		const Ref<GDKUser> &p_user,
+		const PackedStringArray &p_xuids,
+		const String &p_encounter_type) {
+	XblContextHandle context = nullptr;
+	Ref<GDKResult> context_result = duplicate_context_for_user_internal(p_user, &context);
+	if (!context_result->is_ok()) {
+		return context_result;
+	}
+
+	std::vector<uint64_t> recent_player_xuids;
+	Ref<GDKResult> parse_result = _parse_xuids(
+			p_xuids,
+			&recent_player_xuids,
+			nullptr,
+			0,
+			"missing_xuids",
+			"invalid_xuids",
+			"Each recent-player XUID must be a non-empty numeric string.");
+	if (!parse_result->is_ok()) {
+		XblContextCloseHandle(context);
+		return parse_result;
+	}
+
+	XblMultiplayerActivityEncounterType encounter_type = XblMultiplayerActivityEncounterType::Default;
+	if (!try_parse_encounter_type_internal(p_encounter_type, &encounter_type)) {
+		XblContextCloseHandle(context);
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_encounter_type",
+				"encounter_type must be 'default', 'teammate', or 'opponent'.");
+	}
+
+	std::vector<XblMultiplayerActivityRecentPlayerUpdate> updates;
+	updates.reserve(recent_player_xuids.size());
+	for (uint64_t xuid : recent_player_xuids) {
+		XblMultiplayerActivityRecentPlayerUpdate update = {};
+		update.xuid = xuid;
+		update.encounterType = encounter_type;
+		updates.push_back(update);
+	}
+
+	HRESULT hr = XblMultiplayerActivityUpdateRecentPlayers(
+			context,
+			updates.data(),
+			updates.size());
+	XblContextCloseHandle(context);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Failed to update the recent-player list.",
+				"multiplayer_activity_update_recent_players_failed");
+	}
+
+	Dictionary data;
+	data["player_count"] = static_cast<int64_t>(updates.size());
+	data["encounter_type"] = encounter_type_to_string_internal(encounter_type);
+	return GDKResult::ok_result(data);
+}
+
+Signal GDKMultiplayerActivity::flush_recent_players_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = get_runtime_internal();
+
+	XblContextHandle context = nullptr;
+	Ref<GDKResult> context_result = duplicate_context_for_user_internal(p_user, &context);
+	if (!context_result->is_ok()) {
+		return make_error_signal_internal(
+				static_cast<HRESULT>(context_result->get_hresult()),
+				context_result->get_code(),
+				context_result->get_message(),
+				context_result->get_data());
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	auto *context_wrapper = new FlushRecentPlayersAsyncContext(this, runtime, pending_signal, context);
+	context_wrapper->bind_cancel_handler();
+
+	HRESULT hr = XblMultiplayerActivityFlushRecentPlayersAsync(
+			context_wrapper->get_context(),
+			context_wrapper->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_wrapper;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the recent-player flush.",
+				"multiplayer_activity_flush_recent_players_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::accept_pending_invite(const String &p_invite_uri) {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"not_initialized",
+				"GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	const String invite_uri = p_invite_uri.strip_edges();
+	if (invite_uri.is_empty()) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_invite_uri",
+				"A non-empty invite URI is required.");
+	}
+
+	const CharString invite_uri_utf8 = invite_uri.utf8();
+	HRESULT hr = XGameActivationAcceptPendingInvite(invite_uri_utf8.get_data());
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Failed to accept the pending multiplayer invite.",
+				"multiplayer_activity_accept_pending_invite_failed");
+	}
+
+	return GDKResult::ok_result(parse_invite_uri_internal(invite_uri, "pending_game_invite"));
+}
+
+GDKRuntime *GDKMultiplayerActivity::get_runtime_internal() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+GDKXboxServices *GDKMultiplayerActivity::get_xbox_services_internal() const {
+	return m_owner != nullptr ? m_owner->get_xbox_services() : nullptr;
+}
+
+Signal GDKMultiplayerActivity::make_completed_signal_internal(const Ref<GDKResult> &p_result) const {
+	GDKRuntime *runtime = get_runtime_internal();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	if (pending_signal.is_null()) {
+		pending_signal.instantiate();
+	}
+	pending_signal->complete_deferred(p_result);
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::make_error_signal_internal(
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message,
+		const Variant &p_data) const {
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime != nullptr) {
+		return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+	}
+
+	Ref<GDKPendingSignal> pending_signal;
+	pending_signal.instantiate();
+	pending_signal->complete_deferred(GDKResult::error_result(p_hresult, p_code, p_message, p_data));
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::duplicate_context_for_user_internal(
+		const Ref<GDKUser> &p_user,
+		XblContextHandle *r_context,
+		uint64_t *r_xbox_user_id) const {
+	ERR_FAIL_COND_V(r_context == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing multiplayer activity context output."));
+
+	*r_context = nullptr;
+
+	GDKRuntime *runtime = get_runtime_internal();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_user",
+				"A signed-in GDKUser is required for multiplayer activity.");
+	}
+
+	GDKXboxServices *xbox_services = get_xbox_services_internal();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"xbox_services_not_initialized",
+				"Xbox services are unavailable. Ensure the title has a TitleId before using multiplayer activity.");
+	}
+
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, r_context, r_xbox_user_id);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Failed to resolve the Xbox services context for multiplayer activity.",
+				"multiplayer_activity_context_failed");
+	}
+
+	return GDKResult::ok_result();
+}
+
+Ref<GDKMultiplayerActivityInfo> GDKMultiplayerActivity::cache_activity_internal(const Ref<GDKMultiplayerActivityInfo> &p_info) {
+	if (!p_info.is_valid()) {
+		return Ref<GDKMultiplayerActivityInfo>();
+	}
+
+	const String xuid = p_info->get_xuid();
+	for (CachedActivityState &state : m_cached_activities) {
+		if (state.xuid == xuid) {
+			state.info = p_info;
+			return p_info;
+		}
+	}
+
+	CachedActivityState new_state;
+	new_state.xuid = xuid;
+	new_state.info = p_info;
+	m_cached_activities.push_back(new_state);
+	return p_info;
+}
+
+void GDKMultiplayerActivity::remove_cached_activity_internal(const String &p_xuid) {
+	const String normalized_xuid = p_xuid.strip_edges();
+	m_cached_activities.erase(
+			std::remove_if(
+					m_cached_activities.begin(),
+					m_cached_activities.end(),
+					[&normalized_xuid](const CachedActivityState &state) {
+						return state.xuid == normalized_xuid;
+					}),
+			m_cached_activities.end());
+}
+
+void GDKMultiplayerActivity::emit_activities_updated_internal(const std::vector<String> &p_xuids) {
+	PackedStringArray updated_xuids;
+	for (const String &xuid : p_xuids) {
+		if (xuid.is_empty()) {
+			continue;
+		}
+
+		bool already_present = false;
+		for (int64_t i = 0; i < updated_xuids.size(); ++i) {
+			if (updated_xuids[i] == xuid) {
+				already_present = true;
+				break;
+			}
+		}
+		if (!already_present) {
+			updated_xuids.push_back(xuid);
+		}
+	}
+
+	if (!updated_xuids.is_empty()) {
+		emit_signal("activities_updated", updated_xuids);
+	}
+}
+
+void GDKMultiplayerActivity::handle_activation_internal(const Dictionary &p_activation_info) {
+	if (!m_runtime_ready) {
+		return;
+	}
+
+	const int64_t activation_type = static_cast<int64_t>(p_activation_info.get("type", static_cast<int64_t>(-1)));
+	const String invite_uri = p_activation_info.get("invite_uri", String());
+	Dictionary invite = p_activation_info.get("invite", Dictionary());
+
+	if (invite.is_empty() && !invite_uri.is_empty()) {
+		if (activation_type == static_cast<int64_t>(XGameActivationType::PendingGameInvite)) {
+			invite = parse_invite_uri_internal(invite_uri, "pending_game_invite");
+		} else if (activation_type == static_cast<int64_t>(XGameActivationType::AcceptedGameInvite)) {
+			invite = parse_invite_uri_internal(invite_uri, "accepted_game_invite");
+		}
+	}
+
+	switch (static_cast<XGameActivationType>(activation_type)) {
+		case XGameActivationType::PendingGameInvite:
+			emit_signal("pending_invite_received", invite);
+			break;
+		case XGameActivationType::AcceptedGameInvite:
+			emit_signal("invite_accepted", invite);
+			break;
+		default:
+			break;
+	}
+}
+
+String GDKMultiplayerActivity::join_restriction_to_string_internal(XblMultiplayerActivityJoinRestriction p_join_restriction) {
+	switch (p_join_restriction) {
+		case XblMultiplayerActivityJoinRestriction::Public:
+			return "public";
+		case XblMultiplayerActivityJoinRestriction::InviteOnly:
+			return "invite_only";
+		case XblMultiplayerActivityJoinRestriction::Followed:
+		default:
+			return "followed";
+	}
+}
+
+bool GDKMultiplayerActivity::try_parse_join_restriction_internal(
+		const String &p_join_restriction,
+		XblMultiplayerActivityJoinRestriction *r_join_restriction) {
+	ERR_FAIL_COND_V(r_join_restriction == nullptr, false);
+
+	const String normalized = p_join_restriction.strip_edges().to_lower();
+	if (normalized == "public") {
+		*r_join_restriction = XblMultiplayerActivityJoinRestriction::Public;
+		return true;
+	}
+	if (normalized == "invite_only" || normalized == "invite-only" || normalized == "inviteonly") {
+		*r_join_restriction = XblMultiplayerActivityJoinRestriction::InviteOnly;
+		return true;
+	}
+	if (normalized == "followed") {
+		*r_join_restriction = XblMultiplayerActivityJoinRestriction::Followed;
+		return true;
+	}
+
+	return false;
+}
+
+String GDKMultiplayerActivity::platform_to_string_internal(XblMultiplayerActivityPlatform p_platform) {
+	switch (p_platform) {
+		case XblMultiplayerActivityPlatform::XboxOne:
+			return "xbox_one";
+		case XblMultiplayerActivityPlatform::WindowsOneCore:
+			return "windows_one_core";
+		case XblMultiplayerActivityPlatform::Win32:
+			return "win32";
+		case XblMultiplayerActivityPlatform::Scarlett:
+			return "scarlett";
+		case XblMultiplayerActivityPlatform::iOS:
+			return "ios";
+		case XblMultiplayerActivityPlatform::Android:
+			return "android";
+		case XblMultiplayerActivityPlatform::Nintendo:
+			return "nintendo";
+		case XblMultiplayerActivityPlatform::PlayStation:
+			return "playstation";
+		case XblMultiplayerActivityPlatform::All:
+			return "all";
+		case XblMultiplayerActivityPlatform::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String GDKMultiplayerActivity::encounter_type_to_string_internal(XblMultiplayerActivityEncounterType p_encounter_type) {
+	switch (p_encounter_type) {
+		case XblMultiplayerActivityEncounterType::Teammate:
+			return "teammate";
+		case XblMultiplayerActivityEncounterType::Opponent:
+			return "opponent";
+		case XblMultiplayerActivityEncounterType::Default:
+		default:
+			return "default";
+	}
+}
+
+bool GDKMultiplayerActivity::try_parse_encounter_type_internal(
+		const String &p_encounter_type,
+		XblMultiplayerActivityEncounterType *r_encounter_type) {
+	ERR_FAIL_COND_V(r_encounter_type == nullptr, false);
+
+	const String normalized = p_encounter_type.strip_edges().to_lower();
+	if (normalized == "default") {
+		*r_encounter_type = XblMultiplayerActivityEncounterType::Default;
+		return true;
+	}
+	if (normalized == "teammate") {
+		*r_encounter_type = XblMultiplayerActivityEncounterType::Teammate;
+		return true;
+	}
+	if (normalized == "opponent") {
+		*r_encounter_type = XblMultiplayerActivityEncounterType::Opponent;
+		return true;
+	}
+
+	return false;
+}
+
+Dictionary GDKMultiplayerActivity::parse_invite_uri_internal(const String &p_uri, const String &p_activation_type) {
+	return GDKActivation::make_invite_dictionary_internal(p_uri, p_activation_type);
+}
+
+bool GDKMultiplayerActivity::try_parse_xuid_internal(const String &p_xuid, uint64_t *r_xuid) {
+	ERR_FAIL_COND_V(r_xuid == nullptr, false);
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	const char *value = utf8.get_data();
+	if (value == nullptr || *value == '\0') {
+		return false;
+	}
+
+	char *end = nullptr;
+	unsigned long long parsed = std::strtoull(value, &end, 10);
+	if (end == value || (end != nullptr && *end != '\0')) {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+#else
+void GDKMultiplayerActivity::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKMultiplayerActivity::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKMultiplayerActivity::shutdown() {}
+
+void GDKMultiplayerActivity::on_user_removed(const Ref<GDKUser> &p_user) {}
+
+Signal GDKMultiplayerActivity::set_activity_async(
+		const Ref<GDKUser> &p_user,
+		const String &p_connection_string,
+		const String &p_join_restriction,
+		int64_t p_max_players,
+		int64_t p_current_players,
+		const String &p_group_id,
+		bool p_allow_cross_platform_join) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::get_activities_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKMultiplayerActivityInfo> GDKMultiplayerActivity::get_cached_activity(const String &p_xuid) const {
+	return Ref<GDKMultiplayerActivityInfo>();
+}
+
+Signal GDKMultiplayerActivity::delete_activity_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::send_invites_async(
+		const Ref<GDKUser> &p_user,
+		const PackedStringArray &p_xuids,
+		bool p_allow_cross_platform_join,
+		const String &p_connection_string) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::show_invite_ui_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::update_recent_players(
+		const Ref<GDKUser> &p_user,
+		const PackedStringArray &p_xuids,
+		const String &p_encounter_type) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKMultiplayerActivity::flush_recent_players_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::accept_pending_invite(const String &p_invite_uri) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKMultiplayerActivity::make_completed_signal_internal(const Ref<GDKResult> &p_result) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKMultiplayerActivity::make_error_signal_internal(
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message,
+		const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKMultiplayerActivity::duplicate_context_for_user_internal(
+		const Ref<GDKUser> &p_user,
+		XblContextHandle *r_context,
+		uint64_t *r_xbox_user_id) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKMultiplayerActivityInfo> GDKMultiplayerActivity::cache_activity_internal(const Ref<GDKMultiplayerActivityInfo> &p_info) {
+	return Ref<GDKMultiplayerActivityInfo>();
+}
+
+void GDKMultiplayerActivity::remove_cached_activity_internal(const String &p_xuid) {}
+
+void GDKMultiplayerActivity::emit_activities_updated_internal(const std::vector<String> &p_xuids) {}
+
+void GDKMultiplayerActivity::handle_activation_internal(const Dictionary &p_activation_info) {}
+
+String GDKMultiplayerActivity::join_restriction_to_string_internal(XblMultiplayerActivityJoinRestriction p_join_restriction) {
+	return String();
+}
+
+bool GDKMultiplayerActivity::try_parse_join_restriction_internal(
+		const String &p_join_restriction,
+		XblMultiplayerActivityJoinRestriction *r_join_restriction) {
+	return false;
+}
+
+String GDKMultiplayerActivity::platform_to_string_internal(XblMultiplayerActivityPlatform p_platform) {
+	return String();
+}
+
+String GDKMultiplayerActivity::encounter_type_to_string_internal(XblMultiplayerActivityEncounterType p_encounter_type) {
+	return String();
+}
+
+bool GDKMultiplayerActivity::try_parse_encounter_type_internal(
+		const String &p_encounter_type,
+		XblMultiplayerActivityEncounterType *r_encounter_type) {
+	return false;
+}
+
+Dictionary GDKMultiplayerActivity::parse_invite_uri_internal(const String &p_uri, const String &p_activation_type) {
+	return Dictionary();
+}
+
+bool GDKMultiplayerActivity::try_parse_xuid_internal(const String &p_xuid, uint64_t *r_xuid) {
+	return false;
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_multiplayer_activity.h
+++ b/modules/xbox_module/gdk/gdk_multiplayer_activity.h
@@ -1,0 +1,171 @@
+/**************************************************************************/
+/*  gdk_multiplayer_activity.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKPendingSignal;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKMultiplayerActivityInfo : public RefCounted {
+	GDCLASS(GDKMultiplayerActivityInfo, RefCounted);
+
+	String m_xuid;
+	String m_connection_string;
+	String m_join_restriction;
+	int64_t m_max_players = 0;
+	int64_t m_current_players = 0;
+	String m_group_id;
+	String m_platform;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_xuid() const;
+	String get_connection_string() const;
+	String get_join_restriction() const;
+	int64_t get_max_players() const;
+	int64_t get_current_players() const;
+	String get_group_id() const;
+	String get_platform() const;
+
+	void set_values(
+			const String &p_xuid,
+			const String &p_connection_string,
+			const String &p_join_restriction,
+			int64_t p_max_players,
+			int64_t p_current_players,
+			const String &p_group_id,
+			const String &p_platform);
+	void populate_from_native(const XblMultiplayerActivityInfo &p_native_activity);
+};
+
+class GDKMultiplayerActivity : public RefCounted {
+	GDCLASS(GDKMultiplayerActivity, RefCounted);
+
+	struct CachedActivityState {
+		String xuid;
+		Ref<GDKMultiplayerActivityInfo> info;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	uint64_t m_activation_listener_id = 0;
+	std::vector<CachedActivityState> m_cached_activities;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	void on_user_removed(const Ref<GDKUser> &p_user);
+
+	Signal set_activity_async(
+			const Ref<GDKUser> &p_user,
+			const String &p_connection_string,
+			const String &p_join_restriction = "followed",
+			int64_t p_max_players = 0,
+			int64_t p_current_players = 0,
+			const String &p_group_id = String(),
+			bool p_allow_cross_platform_join = false);
+	Signal get_activities_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids);
+	Ref<GDKMultiplayerActivityInfo> get_cached_activity(const String &p_xuid) const;
+	Signal delete_activity_async(const Ref<GDKUser> &p_user);
+	Signal send_invites_async(
+			const Ref<GDKUser> &p_user,
+			const PackedStringArray &p_xuids,
+			bool p_allow_cross_platform_join = true,
+			const String &p_connection_string = String());
+	Signal show_invite_ui_async(const Ref<GDKUser> &p_user);
+	Ref<GDKResult> update_recent_players(
+			const Ref<GDKUser> &p_user,
+			const PackedStringArray &p_xuids,
+			const String &p_encounter_type = "default");
+	Signal flush_recent_players_async(const Ref<GDKUser> &p_user);
+	Ref<GDKResult> accept_pending_invite(const String &p_invite_uri);
+
+	GDKRuntime *get_runtime_internal() const;
+	GDKXboxServices *get_xbox_services_internal() const;
+	Signal make_completed_signal_internal(const Ref<GDKResult> &p_result) const;
+	Signal make_error_signal_internal(
+			HRESULT p_hresult,
+			const String &p_code,
+			const String &p_message,
+			const Variant &p_data = Variant()) const;
+	Ref<GDKResult> duplicate_context_for_user_internal(
+			const Ref<GDKUser> &p_user,
+			XblContextHandle *r_context,
+			uint64_t *r_xbox_user_id = nullptr) const;
+	Ref<GDKMultiplayerActivityInfo> cache_activity_internal(const Ref<GDKMultiplayerActivityInfo> &p_info);
+	void remove_cached_activity_internal(const String &p_xuid);
+	void emit_activities_updated_internal(const std::vector<String> &p_xuids);
+	void handle_activation_internal(const Dictionary &p_activation_info);
+
+	static String join_restriction_to_string_internal(XblMultiplayerActivityJoinRestriction p_join_restriction);
+	static bool try_parse_join_restriction_internal(
+			const String &p_join_restriction,
+			XblMultiplayerActivityJoinRestriction *r_join_restriction);
+	static String platform_to_string_internal(XblMultiplayerActivityPlatform p_platform);
+	static String encounter_type_to_string_internal(XblMultiplayerActivityEncounterType p_encounter_type);
+	static bool try_parse_encounter_type_internal(
+			const String &p_encounter_type,
+			XblMultiplayerActivityEncounterType *r_encounter_type);
+	static Dictionary parse_invite_uri_internal(const String &p_uri, const String &p_activation_type);
+	static bool try_parse_xuid_internal(const String &p_xuid, uint64_t *r_xuid);
+};

--- a/modules/xbox_module/gdk/gdk_package.cpp
+++ b/modules/xbox_module/gdk/gdk_package.cpp
@@ -1,0 +1,980 @@
+/**************************************************************************/
+/*  gdk_package.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_package.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "core/config/project_settings.h"
+#include "core/io/file_access.h"
+#include "core/io/file_access_pack.h"
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String to_string_or_empty(const char *p_text) {
+	return p_text != nullptr ? String::utf8(p_text) : String();
+}
+
+int64_t to_variant_u64(uint64_t p_value) {
+	if (p_value == UINT64_MAX) {
+		return -1;
+	}
+	if (p_value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+		return std::numeric_limits<int64_t>::max();
+	}
+	return static_cast<int64_t>(p_value);
+}
+
+Dictionary package_details_to_dictionary(const XPackageDetails &p_details) {
+	Dictionary package;
+	package["package_identifier"] = to_string_or_empty(p_details.packageIdentifier);
+	package["store_id"] = to_string_or_empty(p_details.storeId);
+	package["display_name"] = to_string_or_empty(p_details.displayName);
+	package["description"] = to_string_or_empty(p_details.description);
+	package["publisher"] = to_string_or_empty(p_details.publisher);
+	package["title_id"] = to_string_or_empty(p_details.titleId);
+	package["installing"] = p_details.installing;
+	package["age_restricted"] = p_details.ageRestricted;
+	package["kind"] = static_cast<int64_t>(p_details.kind);
+	package["kind_name"] = p_details.kind == XPackageKind::Game ? "game" : "content";
+	package["index"] = static_cast<int64_t>(p_details.index);
+	package["count"] = static_cast<int64_t>(p_details.count);
+	return package;
+}
+
+Ref<GDKResult> parse_package_kind(int64_t p_kind, XPackageKind *r_kind) {
+	ERR_FAIL_COND_V(r_kind == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing package kind output."));
+	if (p_kind != static_cast<int64_t>(GDKPackage::PACKAGE_KIND_GAME) &&
+			p_kind != static_cast<int64_t>(GDKPackage::PACKAGE_KIND_CONTENT)) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_kind", "Package kind must be PACKAGE_KIND_GAME or PACKAGE_KIND_CONTENT.");
+	}
+
+	*r_kind = static_cast<XPackageKind>(p_kind);
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> parse_package_scope(int64_t p_scope, XPackageEnumerationScope *r_scope) {
+	ERR_FAIL_COND_V(r_scope == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing package scope output."));
+	if (p_scope != static_cast<int64_t>(GDKPackage::ENUMERATION_SCOPE_THIS_PUBLISHER) &&
+			p_scope != static_cast<int64_t>(GDKPackage::ENUMERATION_SCOPE_THIS_AND_RELATED)) {
+		return GDKResult::error_result(
+				E_INVALIDARG,
+				"invalid_package_scope",
+				"Enumeration scope must be ENUMERATION_SCOPE_THIS_PUBLISHER or ENUMERATION_SCOPE_THIS_AND_RELATED.");
+	}
+
+	*r_scope = static_cast<XPackageEnumerationScope>(p_scope);
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> validate_package_identifier(const String &p_package_identifier) {
+	String trimmed = p_package_identifier.strip_edges();
+	if (trimmed.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_identifier", "Package identifier cannot be empty.");
+	}
+	if (trimmed.length() >= XPACKAGE_IDENTIFIER_MAX_LENGTH) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_identifier", "Package identifier exceeds the native XPackage identifier length.");
+	}
+	if (trimmed.contains("/") || trimmed.contains("\\")) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_identifier", "Package identifier cannot contain path separators.");
+	}
+	return GDKResult::ok_result(trimmed);
+}
+
+Ref<GDKResult> normalize_package_relative_path(const String &p_relative_path, String *r_normalized) {
+	ERR_FAIL_COND_V(r_normalized == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing relative path output."));
+
+	String trimmed = p_relative_path.strip_edges();
+	if (trimmed.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_path", "Package-relative path cannot be empty.");
+	}
+
+	String candidate = trimmed.replace("\\", "/");
+	if (candidate.begins_with("/") || candidate.contains("://") || candidate.contains(":")) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_path", "Package-relative path must not be absolute.");
+	}
+
+	PackedStringArray segments = candidate.split("/", false);
+	for (int64_t i = 0; i < segments.size(); ++i) {
+		String segment = segments[i];
+		if (segment == "." || segment == "..") {
+			return GDKResult::error_result(E_INVALIDARG, "invalid_package_path", "Package-relative path cannot contain current or parent directory segments.");
+		}
+	}
+
+	String normalized = candidate.simplify_path();
+	if (normalized.is_empty() || normalized == "." || normalized.begins_with("../") || normalized == "..") {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_package_path", "Package-relative path must stay inside the mounted package.");
+	}
+
+	*r_normalized = normalized;
+	return GDKResult::ok_result(normalized);
+}
+
+Ref<GDKResult> resolve_under_mount_path(const String &p_mount_path, const String &p_relative_path) {
+	if (p_mount_path.strip_edges().is_empty()) {
+		return GDKResult::error_result(E_FAIL, "package_mount_invalid", "Package mount path is not available.");
+	}
+
+	String normalized;
+	Ref<GDKResult> path_result = normalize_package_relative_path(p_relative_path, &normalized);
+	if (!path_result->is_ok()) {
+		return path_result;
+	}
+
+	return GDKResult::ok_result(p_mount_path.path_join(normalized));
+}
+
+Ref<GDKResult> read_mount_path(XPackageMountHandle p_mount_handle, String *r_mount_path) {
+	ERR_FAIL_COND_V(r_mount_path == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing mount path output."));
+	if (p_mount_handle == nullptr) {
+		return GDKResult::error_result(E_POINTER, "package_mount_failed", "Package mount handle was null.");
+	}
+
+	size_t mount_path_size = 0;
+	HRESULT hr = XPackageGetMountPathSize(p_mount_handle, &mount_path_size);
+	if (FAILED(hr) || mount_path_size == 0) {
+		return GDKResult::hresult_error(
+				FAILED(hr) ? hr : E_FAIL,
+				"Failed to read the mount-path size for the package.",
+				"package_path_unavailable");
+	}
+
+	std::vector<char> mount_path_buffer(mount_path_size, 0);
+	hr = XPackageGetMountPath(p_mount_handle, mount_path_size, mount_path_buffer.data());
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to read the package mount path.", "package_path_unavailable");
+	}
+
+	String mount_path = String::utf8(mount_path_buffer.data()).strip_edges();
+	if (mount_path.is_empty()) {
+		return GDKResult::error_result(E_FAIL, "package_path_unavailable", "The package mount path was empty.");
+	}
+
+	*r_mount_path = mount_path;
+	return GDKResult::ok_result(mount_path);
+}
+
+struct PackageEnumerationContext {
+	Array *packages = nullptr;
+	String target_identifier;
+	bool find_target = false;
+	bool found_target = false;
+	Dictionary found_package;
+};
+
+class PackageMountAsyncContext : public GDKSignalXAsyncContext {
+	GDKPackage *m_package_service = nullptr;
+	String m_package_identifier;
+	Dictionary m_package_details;
+	bool m_load_resource_pack = false;
+	String m_pack_relative_path;
+	bool m_replace_files = false;
+	int64_t m_offset = 0;
+	std::string m_package_identifier_utf8;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			get_pending_signal()->complete(GDKResult::cancelled("Package mount cancelled."));
+			return;
+		}
+
+		XPackageMountHandle mount_handle = nullptr;
+		HRESULT hr = XPackageMountWithUiResult(p_async_block, &mount_handle);
+		if (FAILED(hr)) {
+			m_pending_signal->complete(GDKResult::hresult_error(hr, "Failed to mount the package.", "package_mount_failed"));
+			return;
+		}
+
+		String mount_path;
+		Ref<GDKResult> mount_path_result = read_mount_path(mount_handle, &mount_path);
+		if (!mount_path_result->is_ok()) {
+			XPackageCloseMountHandle(mount_handle);
+			m_pending_signal->complete(mount_path_result);
+			return;
+		}
+
+		if (m_load_resource_pack) {
+			if (m_package_service == nullptr) {
+				XPackageCloseMountHandle(mount_handle);
+				m_pending_signal->complete(GDKResult::error_result(E_FAIL, "not_initialized", "GDK package service is unavailable."));
+				return;
+			}
+
+			Ref<GDKResult> result = m_package_service->finish_resource_pack_load(
+					m_package_identifier,
+					m_package_details,
+					mount_path,
+					mount_handle,
+					m_pack_relative_path,
+					m_replace_files,
+					m_offset);
+			m_pending_signal->complete(result);
+			return;
+		}
+
+		Ref<GDKPackageMount> mount;
+		mount.instantiate();
+		mount->initialize(m_package_identifier, mount_path, m_package_details, mount_handle);
+		m_pending_signal->complete(GDKResult::ok_result(mount));
+	}
+
+public:
+	PackageMountAsyncContext(
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			GDKPackage *p_package_service,
+			const String &p_package_identifier,
+			const Dictionary &p_package_details,
+			bool p_load_resource_pack,
+			const String &p_pack_relative_path,
+			bool p_replace_files,
+			int64_t p_offset) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_package_service(p_package_service),
+			m_package_identifier(p_package_identifier),
+			m_package_details(p_package_details),
+			m_load_resource_pack(p_load_resource_pack),
+			m_pack_relative_path(p_pack_relative_path),
+			m_replace_files(p_replace_files),
+			m_offset(p_offset),
+			m_package_identifier_utf8(p_package_identifier.utf8().get_data()) {}
+
+	const char *get_package_identifier_data() const {
+		return m_package_identifier_utf8.c_str();
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKPackageMount::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_package_identifier"), &GDKPackageMount::get_package_identifier);
+	ClassDB::bind_method(D_METHOD("get_mount_path"), &GDKPackageMount::get_mount_path);
+	ClassDB::bind_method(D_METHOD("get_package_details"), &GDKPackageMount::get_package_details);
+	ClassDB::bind_method(D_METHOD("is_valid"), &GDKPackageMount::is_valid);
+	ClassDB::bind_method(D_METHOD("resolve_path", "relative_path"), &GDKPackageMount::resolve_path);
+	ClassDB::bind_method(D_METHOD("close"), &GDKPackageMount::close);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "package_identifier"), "", "get_package_identifier");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "mount_path"), "", "get_mount_path");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "package_details"), "", "get_package_details");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "valid"), "", "is_valid");
+}
+
+GDKPackageMount::~GDKPackageMount() {
+	_close_handle();
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKPackageMount::_close_handle() {
+	if (m_mount_handle != nullptr) {
+		XPackageCloseMountHandle(m_mount_handle);
+		m_mount_handle = nullptr;
+	}
+	m_valid = false;
+}
+
+void GDKPackageMount::initialize(const String &p_package_identifier, const String &p_mount_path, const Dictionary &p_package_details, XPackageMountHandle p_mount_handle) {
+	_close_handle();
+	m_package_identifier = p_package_identifier;
+	m_mount_path = p_mount_path;
+	m_package_details = p_package_details.duplicate(true);
+	m_mount_handle = p_mount_handle;
+	m_valid = m_mount_handle != nullptr;
+}
+
+XPackageMountHandle GDKPackageMount::release_handle() {
+	XPackageMountHandle handle = m_mount_handle;
+	m_mount_handle = nullptr;
+	m_valid = false;
+	return handle;
+}
+#else
+void GDKPackageMount::_close_handle() {
+	m_mount_handle = nullptr;
+	m_valid = false;
+}
+
+void GDKPackageMount::initialize(const String &p_package_identifier, const String &p_mount_path, const Dictionary &p_package_details, XPackageMountHandle p_mount_handle) {
+	_close_handle();
+	m_package_identifier = p_package_identifier;
+	m_mount_path = p_mount_path;
+	m_package_details = p_package_details.duplicate(true);
+	m_mount_handle = p_mount_handle;
+	m_valid = m_mount_handle != nullptr;
+}
+
+XPackageMountHandle GDKPackageMount::release_handle() {
+	XPackageMountHandle handle = m_mount_handle;
+	m_mount_handle = nullptr;
+	m_valid = false;
+	return handle;
+}
+#endif
+
+String GDKPackageMount::get_package_identifier() const {
+	return m_package_identifier;
+}
+
+String GDKPackageMount::get_mount_path() const {
+	return m_mount_path;
+}
+
+Dictionary GDKPackageMount::get_package_details() const {
+	return m_package_details.duplicate(true);
+}
+
+bool GDKPackageMount::is_valid() const {
+	return m_valid && m_mount_handle != nullptr;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+Ref<GDKResult> GDKPackageMount::resolve_path(const String &p_relative_path) const {
+	if (!is_valid()) {
+		return GDKResult::error_result(E_FAIL, "package_mount_invalid", "Package mount is no longer valid.");
+	}
+
+	return resolve_under_mount_path(m_mount_path, p_relative_path);
+}
+#else
+Ref<GDKResult> GDKPackageMount::resolve_path(const String &p_relative_path) const {
+	if (!is_valid()) {
+		return GDKResult::error_result(E_FAIL, "package_mount_invalid", "Package mount is no longer valid.");
+	}
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_available", "GDK package services are not available.");
+}
+#endif
+
+Ref<GDKResult> GDKPackageMount::close() {
+	_close_handle();
+	return GDKResult::ok_result();
+}
+
+void GDKPackageResourcePack::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_package_identifier"), &GDKPackageResourcePack::get_package_identifier);
+	ClassDB::bind_method(D_METHOD("get_mount_path"), &GDKPackageResourcePack::get_mount_path);
+	ClassDB::bind_method(D_METHOD("get_pack_relative_path"), &GDKPackageResourcePack::get_pack_relative_path);
+	ClassDB::bind_method(D_METHOD("get_pack_path"), &GDKPackageResourcePack::get_pack_path);
+	ClassDB::bind_method(D_METHOD("get_package_details"), &GDKPackageResourcePack::get_package_details);
+	ClassDB::bind_method(D_METHOD("get_replace_files"), &GDKPackageResourcePack::get_replace_files);
+	ClassDB::bind_method(D_METHOD("get_offset"), &GDKPackageResourcePack::get_offset);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "package_identifier"), "", "get_package_identifier");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "mount_path"), "", "get_mount_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "pack_relative_path"), "", "get_pack_relative_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "pack_path"), "", "get_pack_path");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "package_details"), "", "get_package_details");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "replace_files"), "", "get_replace_files");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "offset"), "", "get_offset");
+}
+
+void GDKPackageResourcePack::initialize(
+		const String &p_package_identifier,
+		const String &p_mount_path,
+		const String &p_pack_relative_path,
+		const String &p_pack_path,
+		const Dictionary &p_package_details,
+		bool p_replace_files,
+		int64_t p_offset) {
+	m_package_identifier = p_package_identifier;
+	m_mount_path = p_mount_path;
+	m_pack_relative_path = p_pack_relative_path;
+	m_pack_path = p_pack_path;
+	m_package_details = p_package_details.duplicate(true);
+	m_replace_files = p_replace_files;
+	m_offset = p_offset;
+}
+
+String GDKPackageResourcePack::get_package_identifier() const {
+	return m_package_identifier;
+}
+
+String GDKPackageResourcePack::get_mount_path() const {
+	return m_mount_path;
+}
+
+String GDKPackageResourcePack::get_pack_relative_path() const {
+	return m_pack_relative_path;
+}
+
+String GDKPackageResourcePack::get_pack_path() const {
+	return m_pack_path;
+}
+
+Dictionary GDKPackageResourcePack::get_package_details() const {
+	return m_package_details.duplicate(true);
+}
+
+bool GDKPackageResourcePack::get_replace_files() const {
+	return m_replace_files;
+}
+
+int64_t GDKPackageResourcePack::get_offset() const {
+	return m_offset;
+}
+
+void GDKPackage::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("enumerate_packages", "package_kind", "scope"), &GDKPackage::enumerate_packages, DEFVAL(static_cast<int64_t>(PACKAGE_KIND_CONTENT)), DEFVAL(static_cast<int64_t>(ENUMERATION_SCOPE_THIS_AND_RELATED)));
+	ClassDB::bind_method(D_METHOD("find_package_by_identifier", "package_identifier", "package_kind", "scope"), &GDKPackage::find_package_by_identifier, DEFVAL(static_cast<int64_t>(PACKAGE_KIND_CONTENT)), DEFVAL(static_cast<int64_t>(ENUMERATION_SCOPE_THIS_AND_RELATED)));
+	ClassDB::bind_method(D_METHOD("get_current_process_package_identifier"), &GDKPackage::get_current_process_package_identifier);
+	ClassDB::bind_method(D_METHOD("mount_package_async", "package_identifier"), &GDKPackage::mount_package_async);
+	ClassDB::bind_method(D_METHOD("load_resource_pack_async", "package_identifier", "pack_relative_path", "replace_files", "offset"), &GDKPackage::load_resource_pack_async, DEFVAL(false), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_loaded_resource_packs"), &GDKPackage::get_loaded_resource_packs);
+	ClassDB::bind_method(D_METHOD("get_install_progress", "package_identifier"), &GDKPackage::get_install_progress);
+
+	BIND_ENUM_CONSTANT(PACKAGE_KIND_GAME);
+	BIND_ENUM_CONSTANT(PACKAGE_KIND_CONTENT);
+	BIND_ENUM_CONSTANT(ENUMERATION_SCOPE_THIS_PUBLISHER);
+	BIND_ENUM_CONSTANT(ENUMERATION_SCOPE_THIS_AND_RELATED);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKPackage::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKPackage::on_runtime_initialized() {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_not_initialized", "Cannot initialize the package service before the GDK runtime.");
+	}
+
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKPackage::shutdown() {
+	m_runtime_ready = false;
+	_clear_loaded_resource_packs();
+}
+
+Ref<GDKResult> GDKPackage::enumerate_packages(int64_t p_package_kind, int64_t p_scope) {
+	Ref<GDKResult> runtime_ready = _ensure_runtime_ready();
+	if (!runtime_ready->is_ok()) {
+		return runtime_ready;
+	}
+
+	XPackageKind kind = XPackageKind::Content;
+	Ref<GDKResult> kind_result = parse_package_kind(p_package_kind, &kind);
+	if (!kind_result->is_ok()) {
+		return kind_result;
+	}
+
+	XPackageEnumerationScope scope = XPackageEnumerationScope::ThisAndRelated;
+	Ref<GDKResult> scope_result = parse_package_scope(p_scope, &scope);
+	if (!scope_result->is_ok()) {
+		return scope_result;
+	}
+
+	Array packages;
+	PackageEnumerationContext context;
+	context.packages = &packages;
+
+	HRESULT hr = XPackageEnumeratePackages(
+			kind,
+			scope,
+			&context,
+			[](void *p_context, const XPackageDetails *p_details) -> bool {
+				if (p_context == nullptr || p_details == nullptr) {
+					return true;
+				}
+
+				auto *context = static_cast<PackageEnumerationContext *>(p_context);
+				Dictionary package = package_details_to_dictionary(*p_details);
+				if (context->packages != nullptr) {
+					context->packages->push_back(package);
+				}
+
+				if (context->find_target) {
+					String identifier = package["package_identifier"];
+					if (identifier == context->target_identifier) {
+						context->found_target = true;
+						context->found_package = package;
+					}
+				}
+
+				return true;
+			});
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to enumerate installed packages.", "package_enumeration_failed");
+	}
+
+	return GDKResult::ok_result(packages);
+}
+
+Ref<GDKResult> GDKPackage::find_package_by_identifier(const String &p_package_identifier, int64_t p_package_kind, int64_t p_scope) {
+	Ref<GDKResult> id_result = validate_package_identifier(p_package_identifier);
+	if (!id_result->is_ok()) {
+		return id_result;
+	}
+	String package_identifier = static_cast<String>(id_result->get_data());
+
+	Ref<GDKResult> runtime_ready = _ensure_runtime_ready();
+	if (!runtime_ready->is_ok()) {
+		return runtime_ready;
+	}
+
+	XPackageKind kind = XPackageKind::Content;
+	Ref<GDKResult> kind_result = parse_package_kind(p_package_kind, &kind);
+	if (!kind_result->is_ok()) {
+		return kind_result;
+	}
+
+	XPackageEnumerationScope scope = XPackageEnumerationScope::ThisAndRelated;
+	Ref<GDKResult> scope_result = parse_package_scope(p_scope, &scope);
+	if (!scope_result->is_ok()) {
+		return scope_result;
+	}
+
+	PackageEnumerationContext context;
+	context.find_target = true;
+	context.target_identifier = package_identifier;
+
+	HRESULT hr = XPackageEnumeratePackages(
+			kind,
+			scope,
+			&context,
+			[](void *p_context, const XPackageDetails *p_details) -> bool {
+				if (p_context == nullptr || p_details == nullptr) {
+					return true;
+				}
+
+				auto *context = static_cast<PackageEnumerationContext *>(p_context);
+				if (!context->find_target || context->found_target) {
+					return true;
+				}
+
+				Dictionary package = package_details_to_dictionary(*p_details);
+				String identifier = package["package_identifier"];
+				if (identifier == context->target_identifier) {
+					context->found_target = true;
+					context->found_package = package;
+				}
+
+				return true;
+			});
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to enumerate installed packages.", "package_enumeration_failed");
+	}
+	if (!context.found_target) {
+		return GDKResult::error_result(E_FAIL, "package_not_found", "No installed content package matched the specified package identifier.");
+	}
+
+	return GDKResult::ok_result(context.found_package);
+}
+
+Ref<GDKResult> GDKPackage::get_current_process_package_identifier() {
+	Ref<GDKResult> runtime_ready = _ensure_runtime_ready();
+	if (!runtime_ready->is_ok()) {
+		return runtime_ready;
+	}
+
+	char package_identifier[XPACKAGE_IDENTIFIER_MAX_LENGTH] = {};
+	HRESULT hr = XPackageGetCurrentProcessPackageIdentifier(ARRAYSIZE(package_identifier), package_identifier);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Failed to resolve the current process package identifier. Ensure the title is running as a registered package or loose layout.",
+				"package_identifier_unavailable");
+	}
+
+	String identifier = String::utf8(package_identifier).strip_edges();
+	if (identifier.is_empty()) {
+		return GDKResult::error_result(E_FAIL, "package_identifier_unavailable", "The current process package identifier was empty.");
+	}
+
+	return GDKResult::ok_result(identifier);
+}
+
+Signal GDKPackage::mount_package_async(const String &p_package_identifier) {
+	Signal signal;
+	Ref<GDKResult> start_result = _start_mount_async(p_package_identifier, false, "", false, 0, &signal);
+	if (!start_result->is_ok()) {
+		return _make_completed_signal(start_result);
+	}
+	return signal;
+}
+
+Signal GDKPackage::load_resource_pack_async(const String &p_package_identifier, const String &p_pack_relative_path, bool p_replace_files, int64_t p_offset) {
+	String normalized_path;
+	Ref<GDKResult> path_result = normalize_package_relative_path(p_pack_relative_path, &normalized_path);
+	if (!path_result->is_ok()) {
+		return _make_completed_signal(path_result);
+	}
+
+	if (p_offset < 0) {
+		return _make_error_signal(E_INVALIDARG, "invalid_package_offset", "Resource pack offset cannot be negative.");
+	}
+
+	String extension = normalized_path.get_extension().to_lower();
+	if (extension != "pck" && extension != "zip") {
+		return _make_error_signal(E_INVALIDARG, "invalid_resource_pack", "Resource pack path must point to a .pck or .zip file.");
+	}
+
+	Ref<GDKResult> id_result = validate_package_identifier(p_package_identifier);
+	if (!id_result->is_ok()) {
+		return _make_completed_signal(id_result);
+	}
+	String package_identifier = static_cast<String>(id_result->get_data());
+
+	LoadedResourcePack *loaded = _find_loaded_resource_pack(package_identifier, normalized_path);
+	if (loaded != nullptr && loaded->resource_pack.is_valid()) {
+		Dictionary data;
+		data["resource_pack"] = loaded->resource_pack;
+		data["already_loaded"] = true;
+		return _make_completed_signal(GDKResult::ok_result(data));
+	}
+
+	Signal signal;
+	Ref<GDKResult> start_result = _start_mount_async(package_identifier, true, normalized_path, p_replace_files, p_offset, &signal);
+	if (!start_result->is_ok()) {
+		return _make_completed_signal(start_result);
+	}
+	return signal;
+}
+
+Array GDKPackage::get_loaded_resource_packs() const {
+	Array packs;
+	for (const LoadedResourcePack &loaded : m_loaded_resource_packs) {
+		if (loaded.resource_pack.is_valid()) {
+			packs.push_back(loaded.resource_pack);
+		}
+	}
+	return packs;
+}
+
+Ref<GDKResult> GDKPackage::get_install_progress(const String &p_package_identifier) {
+	Ref<GDKResult> id_result = validate_package_identifier(p_package_identifier);
+	if (!id_result->is_ok()) {
+		return id_result;
+	}
+	String package_identifier = static_cast<String>(id_result->get_data());
+
+	Ref<GDKResult> package_result = find_package_by_identifier(package_identifier);
+	if (!package_result->is_ok()) {
+		return package_result;
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_COND_V(runtime == nullptr, GDKResult::error_result(E_FAIL, "not_initialized", "GDK runtime is not available."));
+
+	CharString identifier_utf8 = package_identifier.utf8();
+	XPackageInstallationMonitorHandle monitor = nullptr;
+	HRESULT hr = XPackageCreateInstallationMonitor(
+			identifier_utf8.get_data(),
+			0,
+			nullptr,
+			1000,
+			runtime->get_task_queue(),
+			&monitor);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to create a package installation monitor.", "package_install_monitor_create_failed");
+	}
+
+	XPackageInstallationProgress progress = {};
+	XPackageGetInstallationProgress(monitor, &progress);
+	XPackageCloseInstallationMonitorHandle(monitor);
+
+	Dictionary data;
+	data["completed"] = progress.completed;
+	data["installed_bytes"] = to_variant_u64(progress.installedBytes);
+	data["total_bytes"] = to_variant_u64(progress.totalBytes);
+	data["total_bytes_unknown"] = progress.totalBytes == UINT64_MAX;
+
+	double progress_ratio = 0.0;
+	if (progress.totalBytes > 0 && progress.totalBytes != UINT64_MAX) {
+		progress_ratio = static_cast<double>(progress.installedBytes) / static_cast<double>(progress.totalBytes);
+	} else if (progress.completed) {
+		progress_ratio = 1.0;
+	}
+	data["progress_ratio"] = progress_ratio;
+
+	return GDKResult::ok_result(data);
+}
+
+GDKRuntime *GDKPackage::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+Ref<GDKResult> GDKPackage::_ensure_runtime_ready() const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	return GDKResult::ok_result();
+}
+
+Signal GDKPackage::_make_completed_signal(const Ref<GDKResult> &p_result) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr && p_result.is_valid() && !p_result->is_ok()) {
+	}
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	if (pending_signal.is_null()) {
+		pending_signal.instantiate();
+	}
+	pending_signal->complete_deferred(p_result);
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPackage::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKResult> result = GDKResult::error_result(p_hresult, p_code, p_message, p_data);
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+	}
+	return _make_completed_signal(result);
+}
+
+Ref<GDKResult> GDKPackage::_start_mount_async(const String &p_package_identifier, bool p_load_resource_pack, const String &p_pack_relative_path, bool p_replace_files, int64_t p_offset, Signal *r_signal) {
+	ERR_FAIL_COND_V(r_signal == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing mount signal output."));
+
+	Ref<GDKResult> runtime_ready = _ensure_runtime_ready();
+	if (!runtime_ready->is_ok()) {
+		return runtime_ready;
+	}
+
+	Ref<GDKResult> id_result = validate_package_identifier(p_package_identifier);
+	if (!id_result->is_ok()) {
+		return id_result;
+	}
+	String package_identifier = static_cast<String>(id_result->get_data());
+
+	Ref<GDKResult> package_result = find_package_by_identifier(package_identifier);
+	if (!package_result->is_ok()) {
+		return package_result;
+	}
+	Dictionary package_details = static_cast<Dictionary>(package_result->get_data());
+
+	int64_t kind = static_cast<int64_t>(package_details.get("kind", static_cast<int64_t>(PACKAGE_KIND_CONTENT)));
+	if (kind != static_cast<int64_t>(PACKAGE_KIND_CONTENT)) {
+		return GDKResult::error_result(E_ACCESSDENIED, "package_not_content", "Only content packages can be mounted for DLC asset access.");
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	auto *context = new PackageMountAsyncContext(
+			runtime,
+			pending_signal,
+			this,
+			package_identifier,
+			package_details,
+			p_load_resource_pack,
+			p_pack_relative_path,
+			p_replace_files,
+			p_offset);
+
+	HRESULT hr = XPackageMountWithUiAsync(context->get_package_identifier_data(), context->get_async_block());
+	if (FAILED(hr)) {
+		delete context;
+		return GDKResult::hresult_error(hr, "Failed to start package mounting.", "package_mount_start_failed");
+	}
+
+	context->bind_cancel_handler();
+	*r_signal = pending_signal->get_completed_signal();
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKPackage::finish_resource_pack_load(
+		const String &p_package_identifier,
+		const Dictionary &p_package_details,
+		const String &p_mount_path,
+		XPackageMountHandle p_mount_handle,
+		const String &p_pack_relative_path,
+		bool p_replace_files,
+		int64_t p_offset) {
+	String normalized_pack_path;
+	Ref<GDKResult> path_result = normalize_package_relative_path(p_pack_relative_path, &normalized_pack_path);
+	if (!path_result->is_ok()) {
+		XPackageCloseMountHandle(p_mount_handle);
+		return path_result;
+	}
+
+	Ref<GDKResult> absolute_pack_result = resolve_under_mount_path(p_mount_path, normalized_pack_path);
+	if (!absolute_pack_result->is_ok()) {
+		XPackageCloseMountHandle(p_mount_handle);
+		return absolute_pack_result;
+	}
+	String absolute_pack_path = static_cast<String>(absolute_pack_result->get_data());
+
+	if (!FileAccess::exists(absolute_pack_path)) {
+		XPackageCloseMountHandle(p_mount_handle);
+		return GDKResult::error_result(E_FAIL, "resource_pack_not_found", "Resource pack file was not found inside the mounted package.");
+	}
+
+	PackedData *packed_data = PackedData::get_singleton();
+	if (packed_data == nullptr) {
+		XPackageCloseMountHandle(p_mount_handle);
+		return GDKResult::error_result(E_FAIL, "packed_data_unavailable", "PackedData singleton is unavailable.");
+	}
+
+	Error pack_err = packed_data->add_pack(absolute_pack_path, p_replace_files, static_cast<uint64_t>(p_offset));
+	if (pack_err != OK) {
+		XPackageCloseMountHandle(p_mount_handle);
+		return GDKResult::error_result(E_FAIL, "resource_pack_load_failed", "Godot failed to load the package resource pack.");
+	}
+
+	Ref<GDKPackageResourcePack> resource_pack;
+	resource_pack.instantiate();
+	resource_pack->initialize(
+			p_package_identifier,
+			p_mount_path,
+			normalized_pack_path,
+			absolute_pack_path,
+			p_package_details,
+			p_replace_files,
+			p_offset);
+
+	LoadedResourcePack loaded_pack;
+	loaded_pack.package_identifier = p_package_identifier;
+	loaded_pack.pack_relative_path = normalized_pack_path;
+	loaded_pack.mount_handle = p_mount_handle;
+	loaded_pack.resource_pack = resource_pack;
+	m_loaded_resource_packs.push_back(loaded_pack);
+
+	Dictionary data;
+	data["resource_pack"] = resource_pack;
+	data["already_loaded"] = false;
+	return GDKResult::ok_result(data);
+}
+
+GDKPackage::LoadedResourcePack *GDKPackage::_find_loaded_resource_pack(const String &p_package_identifier, const String &p_pack_relative_path) {
+	for (LoadedResourcePack &loaded : m_loaded_resource_packs) {
+		if (loaded.package_identifier == p_package_identifier && loaded.pack_relative_path == p_pack_relative_path) {
+			return &loaded;
+		}
+	}
+	return nullptr;
+}
+
+void GDKPackage::_clear_loaded_resource_packs() {
+	for (LoadedResourcePack &loaded : m_loaded_resource_packs) {
+		if (loaded.mount_handle != nullptr) {
+			XPackageCloseMountHandle(loaded.mount_handle);
+			loaded.mount_handle = nullptr;
+		}
+	}
+	m_loaded_resource_packs.clear();
+}
+
+#else
+void GDKPackage::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKPackage::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKPackage::shutdown() {}
+
+Ref<GDKResult> GDKPackage::enumerate_packages(int64_t p_package_kind, int64_t p_scope) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPackage::find_package_by_identifier(const String &p_package_identifier, int64_t p_package_kind, int64_t p_scope) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPackage::get_current_process_package_identifier() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKPackage::mount_package_async(const String &p_package_identifier) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPackage::load_resource_pack_async(const String &p_package_identifier, const String &p_pack_relative_path, bool p_replace_files, int64_t p_offset) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Array GDKPackage::get_loaded_resource_packs() const {
+	return Array();
+}
+
+Ref<GDKResult> GDKPackage::get_install_progress(const String &p_package_identifier) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPackage::_ensure_runtime_ready() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKPackage::_make_completed_signal(const Ref<GDKResult> &p_result) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPackage::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKPackage::_start_mount_async(const String &p_package_identifier, bool p_load_resource_pack, const String &p_pack_relative_path, bool p_replace_files, int64_t p_offset, Signal *r_signal) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPackage::finish_resource_pack_load(
+		const String &p_package_identifier,
+		const Dictionary &p_package_details,
+		const String &p_mount_path,
+		XPackageMountHandle p_mount_handle,
+		const String &p_pack_relative_path,
+		bool p_replace_files,
+		int64_t p_offset) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKPackage::_clear_loaded_resource_packs() {}
+#endif

--- a/modules/xbox_module/gdk/gdk_package.h
+++ b/modules/xbox_module/gdk/gdk_package.h
@@ -1,0 +1,186 @@
+/**************************************************************************/
+/*  gdk_package.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/variant/callable.h"
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/dictionary.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XPackage.h>
+#endif
+
+class GDK;
+class GDKPendingSignal;
+class GDKResult;
+class GDKRuntime;
+
+class GDKPackageMount : public RefCounted {
+	GDCLASS(GDKPackageMount, RefCounted);
+
+	String m_package_identifier;
+	String m_mount_path;
+	Dictionary m_package_details;
+	XPackageMountHandle m_mount_handle = nullptr;
+	bool m_valid = false;
+
+	void _close_handle();
+
+protected:
+	static void _bind_methods();
+
+public:
+	~GDKPackageMount() override;
+
+	void initialize(const String &p_package_identifier, const String &p_mount_path, const Dictionary &p_package_details, XPackageMountHandle p_mount_handle);
+	XPackageMountHandle release_handle();
+
+	String get_package_identifier() const;
+	String get_mount_path() const;
+	Dictionary get_package_details() const;
+	bool is_valid() const;
+	Ref<GDKResult> resolve_path(const String &p_relative_path) const;
+	Ref<GDKResult> close();
+};
+
+class GDKPackageResourcePack : public RefCounted {
+	GDCLASS(GDKPackageResourcePack, RefCounted);
+
+	String m_package_identifier;
+	String m_mount_path;
+	String m_pack_relative_path;
+	String m_pack_path;
+	Dictionary m_package_details;
+	bool m_replace_files = false;
+	int64_t m_offset = 0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void initialize(
+			const String &p_package_identifier,
+			const String &p_mount_path,
+			const String &p_pack_relative_path,
+			const String &p_pack_path,
+			const Dictionary &p_package_details,
+			bool p_replace_files,
+			int64_t p_offset);
+
+	String get_package_identifier() const;
+	String get_mount_path() const;
+	String get_pack_relative_path() const;
+	String get_pack_path() const;
+	Dictionary get_package_details() const;
+	bool get_replace_files() const;
+	int64_t get_offset() const;
+};
+
+class GDKPackage : public RefCounted {
+	GDCLASS(GDKPackage, RefCounted);
+
+public:
+	enum PackageKind {
+		PACKAGE_KIND_GAME = static_cast<int>(XPackageKind::Game),
+		PACKAGE_KIND_CONTENT = static_cast<int>(XPackageKind::Content),
+	};
+
+	enum EnumerationScope {
+		ENUMERATION_SCOPE_THIS_PUBLISHER = static_cast<int>(XPackageEnumerationScope::ThisPublisher),
+		ENUMERATION_SCOPE_THIS_AND_RELATED = static_cast<int>(XPackageEnumerationScope::ThisAndRelated),
+	};
+
+private:
+	struct LoadedResourcePack {
+		String package_identifier;
+		String pack_relative_path;
+		XPackageMountHandle mount_handle = nullptr;
+		Ref<GDKPackageResourcePack> resource_pack;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	std::vector<LoadedResourcePack> m_loaded_resource_packs;
+
+	GDKRuntime *_get_runtime() const;
+	Ref<GDKResult> _ensure_runtime_ready() const;
+	Signal _make_completed_signal(const Ref<GDKResult> &p_result) const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _start_mount_async(const String &p_package_identifier, bool p_load_resource_pack, const String &p_pack_relative_path, bool p_replace_files, int64_t p_offset, Signal *r_signal);
+	LoadedResourcePack *_find_loaded_resource_pack(const String &p_package_identifier, const String &p_pack_relative_path);
+	void _clear_loaded_resource_packs();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Ref<GDKResult> finish_resource_pack_load(
+			const String &p_package_identifier,
+			const Dictionary &p_package_details,
+			const String &p_mount_path,
+			XPackageMountHandle p_mount_handle,
+			const String &p_pack_relative_path,
+			bool p_replace_files,
+			int64_t p_offset);
+
+	Ref<GDKResult> enumerate_packages(
+			int64_t p_package_kind = static_cast<int64_t>(PACKAGE_KIND_CONTENT),
+			int64_t p_scope = static_cast<int64_t>(ENUMERATION_SCOPE_THIS_AND_RELATED));
+	Ref<GDKResult> find_package_by_identifier(
+			const String &p_package_identifier,
+			int64_t p_package_kind = static_cast<int64_t>(PACKAGE_KIND_CONTENT),
+			int64_t p_scope = static_cast<int64_t>(ENUMERATION_SCOPE_THIS_AND_RELATED));
+	Ref<GDKResult> get_current_process_package_identifier();
+	Signal mount_package_async(const String &p_package_identifier);
+	Signal load_resource_pack_async(const String &p_package_identifier, const String &p_pack_relative_path, bool p_replace_files = false, int64_t p_offset = 0);
+	Array get_loaded_resource_packs() const;
+	Ref<GDKResult> get_install_progress(const String &p_package_identifier);
+};
+
+VARIANT_ENUM_CAST(GDKPackage::PackageKind);
+VARIANT_ENUM_CAST(GDKPackage::EnumerationScope);

--- a/modules/xbox_module/gdk/gdk_pending_signal.cpp
+++ b/modules/xbox_module/gdk/gdk_pending_signal.cpp
@@ -1,0 +1,144 @@
+/**************************************************************************/
+/*  gdk_pending_signal.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_pending_signal.h"
+
+void GDKPendingSignal::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_emit_deferred_completion"), &GDKPendingSignal::_emit_deferred_completion);
+
+	ADD_SIGNAL(MethodInfo("completed", PropertyInfo(Variant::OBJECT, "result")));
+}
+
+bool GDKPendingSignal::is_done() const {
+	return m_done;
+}
+
+bool GDKPendingSignal::request_cancel() {
+	if (m_done || m_cancel_requested) {
+		return false;
+	}
+
+	m_cancel_requested = true;
+	return true;
+}
+
+void GDKPendingSignal::invoke_cancel_handler() {
+	if (m_cancel_handler) {
+		m_cancel_handler();
+	}
+}
+
+bool GDKPendingSignal::was_cancel_requested() const {
+	return m_cancel_requested;
+}
+
+Signal GDKPendingSignal::get_completed_signal() const {
+	return Signal(this, "completed");
+}
+
+void GDKPendingSignal::cancel() {
+	if (!request_cancel()) {
+		return;
+	}
+
+	invoke_cancel_handler();
+}
+
+void GDKPendingSignal::complete(const Ref<GDKResult> &p_result) {
+	if (m_done) {
+		return;
+	}
+
+	Ref<GDKPendingSignal> self_guard(this);
+	Ref<GDKResult> final_result = p_result;
+	if (!final_result.is_valid()) {
+		final_result = GDKResult::error_result(E_FAIL, "internal_error", "Async request completed without a result.");
+	}
+
+	if (m_cancel_requested && final_result->get_hresult() != static_cast<int64_t>(E_ABORT)) {
+		final_result = GDKResult::cancelled();
+	}
+
+	m_result = final_result;
+	m_done = true;
+	m_deferred_completion_queued = false;
+	m_deferred_result.unref();
+	m_cancel_handler = nullptr;
+
+	emit_signal("completed", m_result);
+
+	if (m_release_handler) {
+		auto release_handler = m_release_handler;
+		m_release_handler = nullptr;
+		release_handler(this);
+	}
+
+	m_self_ref.unref();
+}
+
+void GDKPendingSignal::complete_deferred(const Ref<GDKResult> &p_result) {
+	if (m_done || m_deferred_completion_queued) {
+		return;
+	}
+
+	if (m_self_ref.is_null()) {
+		m_self_ref = Ref<GDKPendingSignal>(this);
+	}
+
+	m_deferred_result = p_result;
+	m_deferred_completion_queued = true;
+	call_deferred("_emit_deferred_completion");
+}
+
+void GDKPendingSignal::_emit_deferred_completion() {
+	if (m_done) {
+		return;
+	}
+
+	Ref<GDKResult> result = m_deferred_result;
+	m_deferred_completion_queued = false;
+	m_deferred_result.unref();
+	complete(result);
+}
+
+void GDKPendingSignal::set_cancel_handler(std::function<void()> p_handler) {
+	m_cancel_handler = std::move(p_handler);
+}
+
+void GDKPendingSignal::clear_cancel_handler() {
+	m_cancel_handler = nullptr;
+}
+
+void GDKPendingSignal::set_release_handler(std::function<void(GDKPendingSignal *)> p_handler) {
+	m_release_handler = std::move(p_handler);
+}
+
+void GDKPendingSignal::clear_release_handler() {
+	m_release_handler = nullptr;
+}

--- a/modules/xbox_module/gdk/gdk_pending_signal.h
+++ b/modules/xbox_module/gdk/gdk_pending_signal.h
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*  gdk_pending_signal.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#include <functional>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#include "gdk_result.h"
+
+class GDKPendingSignal : public RefCounted {
+	GDCLASS(GDKPendingSignal, RefCounted);
+
+	bool m_done = false;
+	bool m_cancel_requested = false;
+	bool m_deferred_completion_queued = false;
+	Ref<GDKResult> m_result;
+	Ref<GDKResult> m_deferred_result;
+	Ref<GDKPendingSignal> m_self_ref;
+	std::function<void()> m_cancel_handler;
+	std::function<void(GDKPendingSignal *)> m_release_handler;
+
+	void _emit_deferred_completion();
+
+protected:
+	static void _bind_methods();
+	bool request_cancel();
+	void invoke_cancel_handler();
+
+public:
+	bool is_done() const;
+	bool was_cancel_requested() const;
+	Signal get_completed_signal() const;
+
+	void cancel();
+	void complete(const Ref<GDKResult> &p_result);
+	void complete_deferred(const Ref<GDKResult> &p_result);
+
+	void set_cancel_handler(std::function<void()> p_handler);
+	void clear_cancel_handler();
+	void set_release_handler(std::function<void(GDKPendingSignal *)> p_handler);
+	void clear_release_handler();
+};

--- a/modules/xbox_module/gdk/gdk_presence.cpp
+++ b/modules/xbox_module/gdk/gdk_presence.cpp
@@ -1,0 +1,1416 @@
+/**************************************************************************/
+/*  gdk_presence.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_presence.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+static String _presence_user_state_to_name(GDKPresenceRecord::UserState p_state) {
+	switch (p_state) {
+		case GDKPresenceRecord::USER_STATE_ONLINE:
+			return "online";
+		case GDKPresenceRecord::USER_STATE_AWAY:
+			return "away";
+		case GDKPresenceRecord::USER_STATE_OFFLINE:
+			return "offline";
+		case GDKPresenceRecord::USER_STATE_UNKNOWN:
+		default:
+			return "unknown";
+	}
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	if (p_value == nullptr || p_value[0] == '\0') {
+		return String();
+	}
+
+	return String::utf8(p_value);
+}
+
+GDKPresenceRecord::UserState _presence_user_state_to_enum(XblPresenceUserState p_state) {
+	switch (p_state) {
+		case XblPresenceUserState::Online:
+			return GDKPresenceRecord::USER_STATE_ONLINE;
+		case XblPresenceUserState::Away:
+			return GDKPresenceRecord::USER_STATE_AWAY;
+		case XblPresenceUserState::Offline:
+			return GDKPresenceRecord::USER_STATE_OFFLINE;
+		case XblPresenceUserState::Unknown:
+		default:
+			return GDKPresenceRecord::USER_STATE_UNKNOWN;
+	}
+}
+
+String _presence_view_state_to_name(XblPresenceTitleViewState p_view_state) {
+	switch (p_view_state) {
+		case XblPresenceTitleViewState::FullScreen:
+			return "full_screen";
+		case XblPresenceTitleViewState::Filled:
+			return "filled";
+		case XblPresenceTitleViewState::Snapped:
+			return "snapped";
+		case XblPresenceTitleViewState::Background:
+			return "background";
+		case XblPresenceTitleViewState::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String _presence_device_type_to_name(XblPresenceDeviceType p_device_type) {
+	switch (p_device_type) {
+		case XblPresenceDeviceType::WindowsPhone:
+			return "windows_phone";
+		case XblPresenceDeviceType::WindowsPhone7:
+			return "windows_phone_7";
+		case XblPresenceDeviceType::Web:
+			return "web";
+		case XblPresenceDeviceType::Xbox360:
+			return "xbox_360";
+		case XblPresenceDeviceType::PC:
+			return "pc";
+		case XblPresenceDeviceType::Windows8:
+			return "windows_8";
+		case XblPresenceDeviceType::XboxOne:
+			return "xbox_one";
+		case XblPresenceDeviceType::WindowsOneCore:
+			return "windows_one_core";
+		case XblPresenceDeviceType::WindowsOneCoreMobile:
+			return "windows_one_core_mobile";
+		case XblPresenceDeviceType::iOS:
+			return "ios";
+		case XblPresenceDeviceType::Android:
+			return "android";
+		case XblPresenceDeviceType::AppleTV:
+			return "apple_tv";
+		case XblPresenceDeviceType::Nintendo:
+			return "nintendo";
+		case XblPresenceDeviceType::PlayStation:
+			return "playstation";
+		case XblPresenceDeviceType::Win32:
+			return "win32";
+		case XblPresenceDeviceType::Scarlett:
+			return "scarlett";
+		case XblPresenceDeviceType::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String _presence_broadcast_provider_to_name(XblPresenceBroadcastProvider p_provider) {
+	switch (p_provider) {
+		case XblPresenceBroadcastProvider::Twitch:
+			return "twitch";
+		case XblPresenceBroadcastProvider::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+Dictionary _make_title_record_dictionary(const XblPresenceTitleRecord &p_title_record, XblPresenceDeviceType p_device_type) {
+	Dictionary title_record;
+	title_record["title_id"] = static_cast<int64_t>(p_title_record.titleId);
+	title_record["title_name"] = _utf8_or_empty(p_title_record.titleName);
+	title_record["last_modified"] = static_cast<int64_t>(p_title_record.lastModified);
+	title_record["title_active"] = p_title_record.titleActive;
+	title_record["rich_presence_string"] = _utf8_or_empty(p_title_record.richPresenceString);
+	title_record["view_state"] = static_cast<int64_t>(static_cast<uint32_t>(p_title_record.viewState));
+	title_record["view_state_name"] = _presence_view_state_to_name(p_title_record.viewState);
+	title_record["device_type"] = static_cast<int64_t>(static_cast<uint32_t>(p_device_type));
+	title_record["device_type_name"] = _presence_device_type_to_name(p_device_type);
+
+	bool is_broadcasting = p_title_record.broadcastRecord != nullptr;
+	title_record["is_broadcasting"] = is_broadcasting;
+	if (is_broadcasting) {
+		title_record["broadcast_id"] = _utf8_or_empty(p_title_record.broadcastRecord->broadcastId);
+		title_record["broadcast_session"] = _utf8_or_empty(p_title_record.broadcastRecord->session);
+		title_record["broadcast_provider"] = static_cast<int64_t>(static_cast<uint32_t>(p_title_record.broadcastRecord->provider));
+		title_record["broadcast_provider_name"] = _presence_broadcast_provider_to_name(p_title_record.broadcastRecord->provider);
+		title_record["viewer_count"] = static_cast<int64_t>(p_title_record.broadcastRecord->viewerCount);
+		title_record["broadcast_start_time"] = static_cast<int64_t>(p_title_record.broadcastRecord->startTime);
+	}
+
+	return title_record;
+}
+
+Dictionary _make_social_title_record_dictionary(const XblSocialManagerPresenceTitleRecord &p_title_record) {
+	Dictionary title_record;
+	title_record["title_id"] = static_cast<int64_t>(p_title_record.titleId);
+	title_record["title_name"] = _utf8_or_empty(p_title_record.titleName);
+	title_record["title_active"] = p_title_record.isTitleActive;
+	title_record["rich_presence_string"] = _utf8_or_empty(p_title_record.presenceText);
+	title_record["device_type"] = static_cast<int64_t>(static_cast<uint32_t>(p_title_record.deviceType));
+	title_record["device_type_name"] = _presence_device_type_to_name(p_title_record.deviceType);
+	title_record["is_broadcasting"] = p_title_record.isBroadcasting;
+	title_record["is_primary"] = p_title_record.isPrimary;
+	return title_record;
+}
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	char *end_ptr = nullptr;
+	errno = 0;
+	const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
+	if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+Signal _make_presence_error_signal(
+		GDKRuntime *p_runtime,
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message,
+		const Variant &p_data = Variant()) {
+	ERR_FAIL_NULL_V(p_runtime, Signal());
+	return p_runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+class SetPresenceAsyncContext final : public GDKSignalXAsyncContext {
+	GDKPresence *m_presence = nullptr;
+	Ref<GDKUser> m_user;
+	XblContextHandle m_context = nullptr;
+	bool m_is_active = true;
+	String m_presence_id;
+	CharString m_presence_id_utf8;
+	std::vector<CharString> m_token_values;
+	std::vector<const char *> m_token_ptrs;
+	XblPresenceRichPresenceIds m_rich_presence_ids = {};
+	bool m_has_rich_presence = false;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Presence update cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Presence update cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to update presence.", "presence_update_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Ref<GDKPresenceRecord> record;
+		record.instantiate();
+		record->set_data(
+				m_user.is_valid() ? m_user->get_xuid() : String(),
+				m_is_active ? GDKPresenceRecord::USER_STATE_ONLINE : GDKPresenceRecord::USER_STATE_AWAY,
+				Array());
+		m_presence->cache_presence_record(record, false);
+		m_presence->emit_signal("local_presence_set", m_user);
+		m_presence->emit_signal("presence_changed", record->get_xuid(), record);
+
+		Dictionary data;
+		data["xuid"] = record->get_xuid();
+		data["active"] = m_is_active;
+		if (!m_presence_id.is_empty()) {
+			data["presence_id"] = m_presence_id;
+		}
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	SetPresenceAsyncContext(
+			GDKPresence *p_presence,
+			const Ref<GDKUser> &p_user,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			bool p_is_active,
+			const String &p_scid,
+			const String &p_presence_id,
+			const Array &p_token_ids) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_presence(p_presence),
+			m_user(p_user),
+			m_context(p_context),
+			m_is_active(p_is_active),
+			m_presence_id(p_presence_id) {
+		if (!p_presence_id.is_empty()) {
+			std::memset(&m_rich_presence_ids, 0, sizeof(m_rich_presence_ids));
+			CharString scid_utf8 = p_scid.utf8();
+			std::snprintf(m_rich_presence_ids.scid, sizeof(m_rich_presence_ids.scid), "%s", scid_utf8.get_data());
+			m_presence_id = p_presence_id;
+			m_presence_id_utf8 = m_presence_id.utf8();
+			m_rich_presence_ids.presenceId = m_presence_id_utf8.get_data();
+
+			const int64_t token_count = p_token_ids.size();
+			m_token_values.reserve(static_cast<size_t>(token_count));
+			m_token_ptrs.reserve(static_cast<size_t>(token_count));
+			for (int64_t i = 0; i < token_count; ++i) {
+				m_token_values.push_back(String(p_token_ids[i]).utf8());
+			}
+			for (const CharString &token_value : m_token_values) {
+				m_token_ptrs.push_back(token_value.get_data());
+			}
+
+			m_rich_presence_ids.presenceTokenIds = m_token_ptrs.empty() ? nullptr : m_token_ptrs.data();
+			m_rich_presence_ids.presenceTokenIdsCount = m_token_ptrs.size();
+			m_has_rich_presence = true;
+		}
+	}
+
+	~SetPresenceAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	XblPresenceRichPresenceIds *get_rich_presence_ids() {
+		return m_has_rich_presence ? &m_rich_presence_ids : nullptr;
+	}
+};
+
+class GetPresenceAsyncContext final : public GDKSignalXAsyncContext {
+public:
+	enum QueryMode {
+		MODE_XUIDS,
+		MODE_SOCIAL_GROUP,
+	};
+
+private:
+	GDKPresence *m_presence = nullptr;
+	XblContextHandle m_context = nullptr;
+	std::vector<uint64_t> m_xuids;
+	QueryMode m_mode = MODE_XUIDS;
+	String m_social_group;
+	CharString m_social_group_utf8;
+	XblPresenceQueryFilters m_filters = {};
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Presence query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Array records;
+		if (m_mode == MODE_XUIDS && m_xuids.size() == 1) {
+			XblPresenceRecordHandle record_handle = nullptr;
+			HRESULT result_hr = XblPresenceGetPresenceResult(p_async_block, &record_handle);
+			if (result_hr == E_ABORT) {
+				result = GDKResult::cancelled("Presence query cancelled.");
+				get_pending_signal()->complete(result);
+				return;
+			}
+			if (FAILED(result_hr)) {
+				result = GDKResult::hresult_error(result_hr, "Failed to retrieve the presence query result.", "presence_result_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			Ref<GDKPresenceRecord> record;
+			record.instantiate();
+			result_hr = record->populate_from_presence_record(record_handle);
+			XblPresenceRecordCloseHandle(record_handle);
+			if (FAILED(result_hr)) {
+				result = GDKResult::hresult_error(result_hr, "Failed to translate a presence record.", "presence_record_translate_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			m_presence->cache_presence_record(record, true);
+			records.push_back(record);
+		} else {
+			size_t result_count = 0;
+			HRESULT result_hr = m_mode == MODE_SOCIAL_GROUP ? XblPresenceGetPresenceForSocialGroupResultCount(p_async_block, &result_count) : XblPresenceGetPresenceForMultipleUsersResultCount(p_async_block, &result_count);
+			if (result_hr == E_ABORT) {
+				result = GDKResult::cancelled("Presence query cancelled.");
+				get_pending_signal()->complete(result);
+				return;
+			}
+			if (FAILED(result_hr)) {
+				result = GDKResult::hresult_error(result_hr, "Failed to retrieve the presence query result count.", "presence_result_count_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			std::vector<XblPresenceRecordHandle> handles(result_count, nullptr);
+			if (result_count > 0) {
+				result_hr = m_mode == MODE_SOCIAL_GROUP ? XblPresenceGetPresenceForSocialGroupResult(p_async_block, handles.data(), result_count) : XblPresenceGetPresenceForMultipleUsersResult(p_async_block, handles.data(), result_count);
+				if (result_hr == E_ABORT) {
+					result = GDKResult::cancelled("Presence query cancelled.");
+					get_pending_signal()->complete(result);
+					return;
+				}
+				if (FAILED(result_hr)) {
+					result = GDKResult::hresult_error(result_hr, "Failed to retrieve presence records.", "presence_results_failed");
+					get_pending_signal()->complete(result);
+					return;
+				}
+			}
+
+			for (size_t handle_index = 0; handle_index < handles.size(); ++handle_index) {
+				XblPresenceRecordHandle handle = handles[handle_index];
+				if (handle == nullptr) {
+					continue;
+				}
+
+				Ref<GDKPresenceRecord> record;
+				record.instantiate();
+				result_hr = record->populate_from_presence_record(handle);
+				XblPresenceRecordCloseHandle(handle);
+				handles[handle_index] = nullptr;
+				if (FAILED(result_hr)) {
+					for (size_t remaining_index = handle_index + 1; remaining_index < handles.size(); ++remaining_index) {
+						if (handles[remaining_index] != nullptr) {
+							XblPresenceRecordCloseHandle(handles[remaining_index]);
+							handles[remaining_index] = nullptr;
+						}
+					}
+
+					result = GDKResult::hresult_error(result_hr, "Failed to translate a presence record.", "presence_record_translate_failed");
+					get_pending_signal()->complete(result);
+					return;
+				}
+
+				m_presence->cache_presence_record(record, true);
+				records.push_back(record);
+			}
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(records));
+	}
+
+public:
+	GetPresenceAsyncContext(
+			GDKPresence *p_presence,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			std::vector<uint64_t> p_xuids) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_presence(p_presence),
+			m_context(p_context),
+			m_xuids(std::move(p_xuids)),
+			m_mode(MODE_XUIDS) {}
+
+	GetPresenceAsyncContext(
+			GDKPresence *p_presence,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const String &p_social_group) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_presence(p_presence),
+			m_context(p_context),
+			m_mode(MODE_SOCIAL_GROUP),
+			m_social_group(p_social_group) {
+		m_social_group_utf8 = m_social_group.utf8();
+		m_filters.detailLevel = XblPresenceDetailLevel::All;
+	}
+
+	~GetPresenceAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	const std::vector<uint64_t> &get_xuids() const {
+		return m_xuids;
+	}
+
+	const char *get_social_group_name() const {
+		return m_social_group_utf8.get_data();
+	}
+
+	XblPresenceQueryFilters *get_filters() {
+		return &m_filters;
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKPresenceRecord::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKPresenceRecord::get_xuid);
+	ClassDB::bind_method(D_METHOD("get_user_state"), &GDKPresenceRecord::get_user_state);
+	ClassDB::bind_method(D_METHOD("get_user_state_name"), &GDKPresenceRecord::get_user_state_name);
+	ClassDB::bind_method(D_METHOD("is_online"), &GDKPresenceRecord::is_online);
+	ClassDB::bind_method(D_METHOD("get_title_records"), &GDKPresenceRecord::get_title_records);
+
+	BIND_ENUM_CONSTANT(USER_STATE_UNKNOWN);
+	BIND_ENUM_CONSTANT(USER_STATE_ONLINE);
+	BIND_ENUM_CONSTANT(USER_STATE_AWAY);
+	BIND_ENUM_CONSTANT(USER_STATE_OFFLINE);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "user_state", PROPERTY_HINT_ENUM, "Unknown,Online,Away,Offline"), "", "get_user_state");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "title_records"), "", "get_title_records");
+}
+
+String GDKPresenceRecord::get_xuid() const {
+	return m_xuid;
+}
+
+GDKPresenceRecord::UserState GDKPresenceRecord::get_user_state() const {
+	return m_user_state;
+}
+
+String GDKPresenceRecord::get_user_state_name() const {
+	return _presence_user_state_to_name(m_user_state);
+}
+
+bool GDKPresenceRecord::is_online() const {
+	return m_user_state == USER_STATE_ONLINE;
+}
+
+Array GDKPresenceRecord::get_title_records() const {
+	return m_title_records;
+}
+
+void GDKPresenceRecord::set_data(const String &p_xuid, UserState p_user_state, const Array &p_title_records) {
+	m_xuid = p_xuid;
+	m_user_state = p_user_state;
+	m_title_records = p_title_records;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+HRESULT GDKPresenceRecord::populate_from_presence_record(XblPresenceRecordHandle p_record_handle) {
+	if (p_record_handle == nullptr) {
+		return E_INVALIDARG;
+	}
+
+	uint64_t xuid = 0;
+	HRESULT hr = XblPresenceRecordGetXuid(p_record_handle, &xuid);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	XblPresenceUserState user_state = XblPresenceUserState::Unknown;
+	hr = XblPresenceRecordGetUserState(p_record_handle, &user_state);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	const XblPresenceDeviceRecord *device_records = nullptr;
+	size_t device_record_count = 0;
+	hr = XblPresenceRecordGetDeviceRecords(p_record_handle, &device_records, &device_record_count);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	Array title_records;
+	for (size_t device_index = 0; device_index < device_record_count; ++device_index) {
+		const XblPresenceDeviceRecord &device_record = device_records[device_index];
+		for (size_t title_index = 0; title_index < device_record.titleRecordsCount; ++title_index) {
+			title_records.push_back(_make_title_record_dictionary(device_record.titleRecords[title_index], device_record.deviceType));
+		}
+	}
+
+	set_data(String::num_uint64(xuid), _presence_user_state_to_enum(user_state), title_records);
+	return S_OK;
+}
+
+void GDKPresenceRecord::populate_from_social_manager_record(uint64_t p_xuid, const XblSocialManagerPresenceRecord &p_record) {
+	Array title_records;
+	for (uint32_t i = 0; i < p_record.presenceTitleRecordCount && i < XBL_NUM_PRESENCE_RECORDS; ++i) {
+		title_records.push_back(_make_social_title_record_dictionary(p_record.presenceTitleRecords[i]));
+	}
+
+	set_data(String::num_uint64(p_xuid), _presence_user_state_to_enum(p_record.userState), title_records);
+}
+#else
+HRESULT GDKPresenceRecord::populate_from_presence_record(XblPresenceRecordHandle p_record_handle) {
+	return E_NOTIMPL;
+}
+
+void GDKPresenceRecord::populate_from_social_manager_record(uint64_t p_xuid, const XblSocialManagerPresenceRecord &p_record) {
+}
+#endif
+
+void GDKPresence::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_presence_async", "user", "state", "rich_presence"), &GDKPresence::set_presence_async, DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("clear_presence_async", "user"), &GDKPresence::clear_presence_async);
+	ClassDB::bind_method(D_METHOD("get_presence_async", "xuids"), &GDKPresence::get_presence_async);
+	ClassDB::bind_method(D_METHOD("get_presence_for_social_group_async", "user", "social_group"), &GDKPresence::get_presence_for_social_group_async);
+	ClassDB::bind_method(D_METHOD("track_presence", "user", "xuids", "title_ids"), &GDKPresence::track_presence, DEFVAL(PackedInt64Array()));
+	ClassDB::bind_method(D_METHOD("stop_tracking_presence", "user", "xuids", "title_ids"), &GDKPresence::stop_tracking_presence, DEFVAL(PackedStringArray()), DEFVAL(PackedInt64Array()));
+	ClassDB::bind_method(D_METHOD("get_cached_presence", "xuid"), &GDKPresence::get_cached_presence);
+
+	ADD_SIGNAL(MethodInfo("presence_changed",
+			PropertyInfo(Variant::STRING, "xuid"),
+			PropertyInfo(Variant::OBJECT, "presence", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKPresenceRecord")));
+	ADD_SIGNAL(MethodInfo("local_presence_set", PropertyInfo(Variant::OBJECT, "user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser")));
+	ADD_SIGNAL(MethodInfo("device_presence_changed", PropertyInfo(Variant::STRING, "xuid")));
+	ADD_SIGNAL(MethodInfo("title_presence_changed", PropertyInfo(Variant::STRING, "xuid"), PropertyInfo(Variant::INT, "title_id")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKPresence::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKPresence::on_runtime_initialized() {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_not_initialized", "Cannot initialize the presence service before the GDK runtime.");
+	}
+
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKPresence::shutdown() {
+	m_runtime_ready = false;
+
+	for (HandlerState &state : m_handler_states) {
+		_close_handler_state(state);
+	}
+	m_handler_states.clear();
+	{
+		std::lock_guard<std::mutex> lock(m_pending_presence_events_mutex);
+		m_pending_presence_events.clear();
+	}
+	m_cached_presence.clear();
+
+	m_retired_callback_tokens.clear();
+}
+
+int GDKPresence::dispatch() {
+	if (!m_runtime_ready) {
+		return 0;
+	}
+
+	std::vector<PendingPresenceEvent> events;
+	{
+		std::lock_guard<std::mutex> lock(m_pending_presence_events_mutex);
+		events.swap(m_pending_presence_events);
+	}
+
+	int dispatched = 0;
+	for (const PendingPresenceEvent &event : events) {
+		const String xuid = String::num_uint64(event.xuid);
+		if (event.type == PendingPresenceEvent::EVENT_DEVICE) {
+			emit_signal("device_presence_changed", xuid);
+		} else {
+			emit_signal("title_presence_changed", xuid, static_cast<int64_t>(event.title_id));
+		}
+		++dispatched;
+		if (!m_runtime_ready) {
+			break;
+		}
+	}
+	return dispatched;
+}
+
+Signal GDKPresence::set_presence_async(const Ref<GDKUser> &p_user, const String &p_state, const Dictionary &p_rich_presence) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_error_signal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for presence.");
+	}
+
+	const String presence_id = p_state.strip_edges();
+	if (presence_id.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_presence_state", "Presence updates require a non-empty state string.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using presence.");
+	}
+
+	String scid = xbox_services->get_scid();
+	if (p_rich_presence.has("scid")) {
+		scid = String(p_rich_presence["scid"]).strip_edges();
+	}
+	if (scid.is_empty()) {
+		return _make_error_signal(E_FAIL, "missing_presence_scid", "Presence updates require a non-empty SCID.");
+	}
+
+	Array token_ids;
+	if (p_rich_presence.has("token_ids")) {
+		Variant token_value = p_rich_presence["token_ids"];
+		if (token_value.get_type() == Variant::ARRAY) {
+			token_ids = token_value;
+		} else if (token_value.get_type() == Variant::PACKED_STRING_ARRAY) {
+			PackedStringArray packed_tokens = token_value;
+			for (int64_t i = 0; i < packed_tokens.size(); ++i) {
+				token_ids.push_back(packed_tokens[i]);
+			}
+		} else {
+			return _make_error_signal(E_INVALIDARG, "invalid_presence_token_ids", "rich_presence.token_ids must be an Array or PackedStringArray.");
+		}
+	} else if (p_rich_presence.has("tokens")) {
+		Variant token_value = p_rich_presence["tokens"];
+		if (token_value.get_type() == Variant::ARRAY) {
+			token_ids = token_value;
+		} else if (token_value.get_type() == Variant::PACKED_STRING_ARRAY) {
+			PackedStringArray packed_tokens = token_value;
+			for (int64_t i = 0; i < packed_tokens.size(); ++i) {
+				token_ids.push_back(packed_tokens[i]);
+			}
+		} else {
+			return _make_error_signal(E_INVALIDARG, "invalid_presence_token_ids", "rich_presence.tokens must be an Array or PackedStringArray.");
+		}
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to resolve the Xbox services context for the presence update.", "presence_context_failed");
+		pending_signal->complete_deferred(result);
+		return pending_signal->get_completed_signal();
+	}
+
+	auto *context_state = new SetPresenceAsyncContext(this, p_user, runtime, pending_signal, context, true, scid, presence_id, token_ids);
+	context_state->bind_cancel_handler();
+
+	hr = XblPresenceSetPresenceAsync(
+			context_state->get_context(),
+			true,
+			context_state->get_rich_presence_ids(),
+			context_state->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_state;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to start the presence update request.", "presence_update_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPresence::clear_presence_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_error_signal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for presence.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using presence.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to resolve the Xbox services context for the presence update.", "presence_context_failed");
+		pending_signal->complete_deferred(result);
+		return pending_signal->get_completed_signal();
+	}
+
+	auto *context_state = new SetPresenceAsyncContext(this, p_user, runtime, pending_signal, context, false, String(), String(), Array());
+	context_state->bind_cancel_handler();
+
+	hr = XblPresenceSetPresenceAsync(
+			context_state->get_context(),
+			false,
+			nullptr,
+			context_state->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_state;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to start the presence clear request.", "presence_clear_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPresence::get_presence_async(const PackedStringArray &p_xuids) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	std::vector<uint64_t> xuids;
+	Ref<GDKResult> parse_result = _parse_query_xuids(p_xuids, &xuids);
+	if (!parse_result->is_ok()) {
+		return _make_error_signal(
+				static_cast<HRESULT>(parse_result->get_hresult()),
+				parse_result->get_code(),
+				parse_result->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using presence.");
+	}
+
+	Ref<GDKUser> calling_user = _get_presence_calling_user();
+	if (!calling_user.is_valid() || calling_user->get_handle() == nullptr) {
+		return _make_error_signal(E_FAIL, "presence_requires_primary_user", "Presence queries require a signed-in primary user context.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(calling_user, &context);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to resolve the Xbox services context for the presence query.", "presence_context_failed");
+		pending_signal->complete_deferred(result);
+		return pending_signal->get_completed_signal();
+	}
+
+	auto *context_state = new GetPresenceAsyncContext(this, runtime, pending_signal, context, std::move(xuids));
+	context_state->bind_cancel_handler();
+
+	if (context_state->get_xuids().size() == 1) {
+		hr = XblPresenceGetPresenceAsync(
+				context_state->get_context(),
+				context_state->get_xuids().front(),
+				context_state->get_async_block());
+	} else {
+		XblPresenceQueryFilters filters = {};
+		filters.detailLevel = XblPresenceDetailLevel::All;
+		hr = XblPresenceGetPresenceForMultipleUsersAsync(
+				context_state->get_context(),
+				const_cast<uint64_t *>(context_state->get_xuids().data()),
+				context_state->get_xuids().size(),
+				&filters,
+				context_state->get_async_block());
+	}
+
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context_state;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to start the presence query.", "presence_query_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPresence::get_presence_for_social_group_async(const Ref<GDKUser> &p_user, const String &p_social_group) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	const String social_group = p_social_group.strip_edges();
+	if (social_group.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_social_group", "Presence social-group queries require a non-empty social group name.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using presence.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "presence_context_failed", "Failed to resolve the Xbox services context for the social-group presence query.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	auto *context_state = new GetPresenceAsyncContext(this, runtime, pending_signal, context, social_group);
+	context_state->bind_cancel_handler();
+
+	hr = XblPresenceGetPresenceForSocialGroupAsync(
+			context_state->get_context(),
+			context_state->get_social_group_name(),
+			nullptr,
+			context_state->get_filters(),
+			context_state->get_async_block());
+	if (FAILED(hr)) {
+		context_state->clear_cancel_handler();
+		delete context_state;
+		return _make_error_signal(hr, "presence_social_group_query_start_failed", "Failed to start the social-group presence query.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKPresence::track_presence(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedInt64Array &p_title_ids) {
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return validation;
+	}
+
+	std::vector<uint64_t> xuids;
+	Ref<GDKResult> parse_result = _parse_xuids(p_xuids, false, "missing_presence_xuids", "invalid_presence_xuid", &xuids);
+	if (!parse_result->is_ok()) {
+		return parse_result;
+	}
+
+	std::vector<uint32_t> title_ids;
+	parse_result = _parse_title_ids(p_title_ids, &title_ids);
+	if (!parse_result->is_ok()) {
+		return parse_result;
+	}
+
+	HandlerState *state = nullptr;
+	Ref<GDKResult> handler_result = _ensure_handler_state(p_user, &state);
+	if (!handler_result->is_ok()) {
+		return handler_result;
+	}
+
+	HRESULT hr = XblPresenceTrackUsers(state->context, xuids.data(), xuids.size());
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to track Xbox Services presence users.", "presence_track_users_failed");
+	}
+
+	if (!title_ids.empty()) {
+		hr = XblPresenceTrackAdditionalTitles(state->context, title_ids.data(), title_ids.size());
+		if (FAILED(hr)) {
+			return GDKResult::hresult_error(hr, "Failed to track additional Xbox Services presence titles.", "presence_track_titles_failed");
+		}
+	}
+
+	for (uint64_t xuid : xuids) {
+		if (std::find(state->tracked_xuids.begin(), state->tracked_xuids.end(), xuid) == state->tracked_xuids.end()) {
+			state->tracked_xuids.push_back(xuid);
+		}
+	}
+	for (uint32_t title_id : title_ids) {
+		if (std::find(state->tracked_title_ids.begin(), state->tracked_title_ids.end(), title_id) == state->tracked_title_ids.end()) {
+			state->tracked_title_ids.push_back(title_id);
+		}
+	}
+
+	Dictionary data;
+	data["tracked_users"] = static_cast<int64_t>(state->tracked_xuids.size());
+	data["tracked_titles"] = static_cast<int64_t>(state->tracked_title_ids.size());
+	return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKPresence::stop_tracking_presence(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedInt64Array &p_title_ids) {
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return validation;
+	}
+
+	std::vector<uint64_t> xuids;
+	Ref<GDKResult> parse_result = _parse_xuids(p_xuids, true, "missing_presence_xuids", "invalid_presence_xuid", &xuids);
+	if (!parse_result->is_ok()) {
+		return parse_result;
+	}
+
+	std::vector<uint32_t> title_ids;
+	parse_result = _parse_title_ids(p_title_ids, &title_ids);
+	if (!parse_result->is_ok()) {
+		return parse_result;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	HandlerState *state = _find_handler_state(local_id);
+	if (state == nullptr) {
+		return GDKResult::ok_result();
+	}
+
+	if (xuids.empty()) {
+		xuids = state->tracked_xuids;
+	}
+	if (title_ids.empty()) {
+		title_ids = state->tracked_title_ids;
+	}
+
+	if (!xuids.empty()) {
+		HRESULT hr = XblPresenceStopTrackingUsers(state->context, xuids.data(), xuids.size());
+		if (FAILED(hr)) {
+			return GDKResult::hresult_error(hr, "Failed to stop tracking Xbox Services presence users.", "presence_stop_tracking_users_failed");
+		}
+		state->tracked_xuids.erase(
+				std::remove_if(
+						state->tracked_xuids.begin(),
+						state->tracked_xuids.end(),
+						[&xuids](uint64_t tracked_xuid) {
+							return std::find(xuids.begin(), xuids.end(), tracked_xuid) != xuids.end();
+						}),
+				state->tracked_xuids.end());
+	}
+
+	if (!title_ids.empty()) {
+		HRESULT hr = XblPresenceStopTrackingAdditionalTitles(state->context, title_ids.data(), title_ids.size());
+		if (FAILED(hr)) {
+			return GDKResult::hresult_error(hr, "Failed to stop tracking additional Xbox Services presence titles.", "presence_stop_tracking_titles_failed");
+		}
+		state->tracked_title_ids.erase(
+				std::remove_if(
+						state->tracked_title_ids.begin(),
+						state->tracked_title_ids.end(),
+						[&title_ids](uint32_t tracked_title_id) {
+							return std::find(title_ids.begin(), title_ids.end(), tracked_title_id) != title_ids.end();
+						}),
+				state->tracked_title_ids.end());
+	}
+
+	Dictionary data;
+	data["tracked_users"] = static_cast<int64_t>(state->tracked_xuids.size());
+	data["tracked_titles"] = static_cast<int64_t>(state->tracked_title_ids.size());
+	return GDKResult::ok_result(data);
+}
+
+Ref<GDKPresenceRecord> GDKPresence::get_cached_presence(const String &p_xuid) const {
+	return _find_cached_presence(p_xuid.strip_edges());
+}
+
+void GDKPresence::cache_presence_record(const Ref<GDKPresenceRecord> &p_record, bool p_emit_signal) {
+	if (!m_runtime_ready || !p_record.is_valid()) {
+		return;
+	}
+
+	const String xuid = p_record->get_xuid();
+	if (xuid.is_empty()) {
+		return;
+	}
+
+	for (Ref<GDKPresenceRecord> &cached_record : m_cached_presence) {
+		if (cached_record.is_valid() && cached_record->get_xuid() == xuid) {
+			cached_record = p_record;
+			if (p_emit_signal) {
+				emit_signal("presence_changed", xuid, p_record);
+			}
+			return;
+		}
+	}
+
+	m_cached_presence.push_back(p_record);
+	if (p_emit_signal) {
+		emit_signal("presence_changed", xuid, p_record);
+	}
+}
+
+void GDKPresence::on_user_removed(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	m_handler_states.erase(
+			std::remove_if(
+					m_handler_states.begin(),
+					m_handler_states.end(),
+					[this, local_id](HandlerState &state) {
+						if (state.local_id.value != local_id.value) {
+							return false;
+						}
+						_close_handler_state(state);
+						return true;
+					}),
+			m_handler_states.end());
+
+	_remove_cached_presence(p_user->get_xuid());
+}
+
+GDKRuntime *GDKPresence::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+GDKXboxServices *GDKPresence::_get_xbox_services() const {
+	return m_owner != nullptr ? m_owner->get_xbox_services() : nullptr;
+}
+
+Signal GDKPresence::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	return _make_presence_error_signal(_get_runtime(), p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKPresence::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for presence.");
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKUser> GDKPresence::_get_presence_calling_user() const {
+	if (m_owner == nullptr) {
+		return Ref<GDKUser>();
+	}
+
+	Ref<GDKUsers> users = m_owner->get_users();
+	if (!users.is_valid()) {
+		return Ref<GDKUser>();
+	}
+
+	return users->get_primary_user();
+}
+
+Ref<GDKResult> GDKPresence::_parse_query_xuids(const PackedStringArray &p_xuids, std::vector<uint64_t> *r_xuids) const {
+	return _parse_xuids(p_xuids, false, "missing_presence_xuids", "invalid_presence_xuid", r_xuids);
+}
+
+Ref<GDKResult> GDKPresence::_parse_xuids(const PackedStringArray &p_xuids, bool p_allow_empty, const String &p_missing_code, const String &p_invalid_code, std::vector<uint64_t> *r_xuids) const {
+	ERR_FAIL_COND_V(r_xuids == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing presence query output vector."));
+
+	r_xuids->clear();
+	if (p_xuids.is_empty()) {
+		return p_allow_empty ? GDKResult::ok_result() : GDKResult::error_result(E_INVALIDARG, p_missing_code, "Presence operations require at least one XUID.");
+	}
+
+	r_xuids->reserve(static_cast<size_t>(p_xuids.size()));
+	for (int64_t i = 0; i < p_xuids.size(); ++i) {
+		uint64_t xuid = 0;
+		if (!_try_parse_xuid(p_xuids[i], &xuid)) {
+			return GDKResult::error_result(E_INVALIDARG, p_invalid_code, "Presence operations require numeric XUID strings.");
+		}
+		r_xuids->push_back(xuid);
+	}
+
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKPresence::_parse_title_ids(const PackedInt64Array &p_title_ids, std::vector<uint32_t> *r_title_ids) const {
+	ERR_FAIL_COND_V(r_title_ids == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing presence title-id output vector."));
+
+	r_title_ids->clear();
+	r_title_ids->reserve(static_cast<size_t>(p_title_ids.size()));
+	for (int64_t i = 0; i < p_title_ids.size(); ++i) {
+		const int64_t title_id = p_title_ids[i];
+		if (title_id < 0 || title_id > UINT32_MAX) {
+			return GDKResult::error_result(E_INVALIDARG, "invalid_title_id", "Presence title IDs must be unsigned 32-bit values.");
+		}
+		r_title_ids->push_back(static_cast<uint32_t>(title_id));
+	}
+
+	return GDKResult::ok_result();
+}
+
+Ref<GDKPresenceRecord> GDKPresence::_find_cached_presence(const String &p_xuid) const {
+	for (const Ref<GDKPresenceRecord> &record : m_cached_presence) {
+		if (record.is_valid() && record->get_xuid() == p_xuid) {
+			return record;
+		}
+	}
+
+	return Ref<GDKPresenceRecord>();
+}
+
+void GDKPresence::_remove_cached_presence(const String &p_xuid) {
+	m_cached_presence.erase(
+			std::remove_if(
+					m_cached_presence.begin(),
+					m_cached_presence.end(),
+					[&p_xuid](const Ref<GDKPresenceRecord> &record) {
+						return record.is_null() || record->get_xuid() == p_xuid;
+					}),
+			m_cached_presence.end());
+}
+
+GDKPresence::HandlerState *GDKPresence::_find_handler_state(XUserLocalId p_local_id) {
+	for (HandlerState &state : m_handler_states) {
+		if (state.local_id.value == p_local_id.value) {
+			return &state;
+		}
+	}
+	return nullptr;
+}
+
+Ref<GDKResult> GDKPresence::_ensure_handler_state(const Ref<GDKUser> &p_user, HandlerState **r_state) {
+	ERR_FAIL_COND_V(r_state == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing presence handler-state output."));
+	*r_state = nullptr;
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	HandlerState *existing_state = _find_handler_state(local_id);
+	if (existing_state != nullptr) {
+		*r_state = existing_state;
+		return GDKResult::ok_result();
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using presence.");
+	}
+
+	HandlerState state;
+	state.user = p_user;
+	state.local_id = local_id;
+
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &state.context);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to resolve the Xbox services context for presence tracking.", "presence_context_failed");
+	}
+
+	state.callback_context = std::make_shared<HandlerState::CallbackContext>();
+	state.callback_context->presence = this;
+	state.callback_context->local_id = local_id;
+	state.callback_token = std::make_shared<HandlerState::CallbackToken>();
+	state.callback_token->context = state.callback_context;
+	state.device_token = XblPresenceAddDevicePresenceChangedHandler(state.context, _device_presence_changed_handler, state.callback_token.get());
+	state.title_token = XblPresenceAddTitlePresenceChangedHandler(state.context, _title_presence_changed_handler, state.callback_token.get());
+	state.device_registered = true;
+	state.title_registered = true;
+
+	m_handler_states.push_back(state);
+	*r_state = &m_handler_states.back();
+	return GDKResult::ok_result();
+}
+
+void GDKPresence::_close_handler_state(HandlerState &p_state) {
+	if (p_state.callback_context) {
+		std::lock_guard<std::mutex> lock(p_state.callback_context->mutex);
+		p_state.callback_context->active.store(false, std::memory_order_release);
+		p_state.callback_context->presence = nullptr;
+	}
+
+	if (p_state.context != nullptr) {
+		if (p_state.device_registered) {
+			XblPresenceRemoveDevicePresenceChangedHandler(p_state.context, p_state.device_token);
+			p_state.device_registered = false;
+		}
+		if (p_state.title_registered) {
+			XblPresenceRemoveTitlePresenceChangedHandler(p_state.context, p_state.title_token);
+			p_state.title_registered = false;
+		}
+		XblContextCloseHandle(p_state.context);
+		p_state.context = nullptr;
+	}
+
+	if (p_state.callback_token) {
+		constexpr size_t MAX_RETIRED_CALLBACK_TOKENS = 16;
+		m_retired_callback_tokens.push_back(p_state.callback_token);
+		if (m_retired_callback_tokens.size() > MAX_RETIRED_CALLBACK_TOKENS) {
+			m_retired_callback_tokens.erase(m_retired_callback_tokens.begin());
+		}
+		p_state.callback_token.reset();
+	}
+	p_state.callback_context.reset();
+}
+
+void CALLBACK GDKPresence::_device_presence_changed_handler(void *p_context, uint64_t p_xuid, XblPresenceDeviceType p_device_type, bool p_is_user_logged_on_device) {
+	HandlerState::CallbackToken *token = static_cast<HandlerState::CallbackToken *>(p_context);
+	std::shared_ptr<HandlerState::CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+	if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
+		return;
+	}
+
+	PendingPresenceEvent event;
+	event.type = PendingPresenceEvent::EVENT_DEVICE;
+	event.local_id = callback_context->local_id;
+	event.xuid = p_xuid;
+	event.device_type = p_device_type;
+	event.device_logged_on = p_is_user_logged_on_device;
+
+	std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+	GDKPresence *presence = callback_context->presence;
+	if (!callback_context->active.load(std::memory_order_acquire) || presence == nullptr) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> queue_lock(presence->m_pending_presence_events_mutex);
+	presence->m_pending_presence_events.push_back(event);
+}
+
+void CALLBACK GDKPresence::_title_presence_changed_handler(void *p_context, uint64_t p_xuid, uint32_t p_title_id, XblPresenceTitleState p_title_state) {
+	HandlerState::CallbackToken *token = static_cast<HandlerState::CallbackToken *>(p_context);
+	std::shared_ptr<HandlerState::CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+	if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
+		return;
+	}
+
+	PendingPresenceEvent event;
+	event.type = PendingPresenceEvent::EVENT_TITLE;
+	event.local_id = callback_context->local_id;
+	event.xuid = p_xuid;
+	event.title_id = p_title_id;
+	event.title_state = p_title_state;
+
+	std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+	GDKPresence *presence = callback_context->presence;
+	if (!callback_context->active.load(std::memory_order_acquire) || presence == nullptr) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> queue_lock(presence->m_pending_presence_events_mutex);
+	presence->m_pending_presence_events.push_back(event);
+}
+
+#else
+void GDKPresence::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKPresence::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKPresence::shutdown() {}
+
+int GDKPresence::dispatch() {
+	return 0;
+}
+
+Signal GDKPresence::set_presence_async(const Ref<GDKUser> &p_user, const String &p_state, const Dictionary &p_rich_presence) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPresence::clear_presence_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPresence::get_presence_async(const PackedStringArray &p_xuids) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPresence::get_presence_for_social_group_async(const Ref<GDKUser> &p_user, const String &p_social_group) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKPresence::track_presence(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedInt64Array &p_title_ids) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPresence::stop_tracking_presence(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedInt64Array &p_title_ids) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKPresenceRecord> GDKPresence::get_cached_presence(const String &p_xuid) const {
+	return Ref<GDKPresenceRecord>();
+}
+
+void GDKPresence::cache_presence_record(const Ref<GDKPresenceRecord> &p_record, bool p_emit_signal) {}
+
+void GDKPresence::on_user_removed(const Ref<GDKUser> &p_user) {}
+
+Signal GDKPresence::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKPresence::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKUser> GDKPresence::_get_presence_calling_user() const {
+	return Ref<GDKUser>();
+}
+
+Ref<GDKResult> GDKPresence::_parse_query_xuids(const PackedStringArray &p_xuids, std::vector<uint64_t> *r_xuids) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPresence::_parse_xuids(const PackedStringArray &p_xuids, bool p_allow_empty, const String &p_missing_code, const String &p_invalid_code, std::vector<uint64_t> *r_xuids) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPresence::_parse_title_ids(const PackedInt64Array &p_title_ids, std::vector<uint32_t> *r_title_ids) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKPresenceRecord> GDKPresence::_find_cached_presence(const String &p_xuid) const {
+	return Ref<GDKPresenceRecord>();
+}
+
+void GDKPresence::_remove_cached_presence(const String &p_xuid) {}
+
+Ref<GDKResult> GDKPresence::_ensure_handler_state(const Ref<GDKUser> &p_user, HandlerState **r_state) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKPresence::_close_handler_state(HandlerState &p_state) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_presence.h
+++ b/modules/xbox_module/gdk/gdk_presence.h
@@ -1,0 +1,186 @@
+/**************************************************************************/
+/*  gdk_presence.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKPresenceRecord : public RefCounted {
+	GDCLASS(GDKPresenceRecord, RefCounted);
+
+public:
+	enum UserState {
+		USER_STATE_UNKNOWN = 0,
+		USER_STATE_ONLINE,
+		USER_STATE_AWAY,
+		USER_STATE_OFFLINE,
+	};
+
+private:
+	String m_xuid;
+	UserState m_user_state = USER_STATE_UNKNOWN;
+	Array m_title_records;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_xuid() const;
+	UserState get_user_state() const;
+	String get_user_state_name() const;
+	bool is_online() const;
+	Array get_title_records() const;
+
+	void set_data(const String &p_xuid, UserState p_user_state, const Array &p_title_records);
+	HRESULT populate_from_presence_record(XblPresenceRecordHandle p_record_handle);
+	void populate_from_social_manager_record(uint64_t p_xuid, const XblSocialManagerPresenceRecord &p_record);
+};
+
+class GDKPresence : public RefCounted {
+	GDCLASS(GDKPresence, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	std::vector<Ref<GDKPresenceRecord>> m_cached_presence;
+
+	struct HandlerState {
+		struct CallbackContext {
+			GDKPresence *presence = nullptr;
+			XUserLocalId local_id = {};
+			std::atomic_bool active = true;
+			std::mutex mutex;
+		};
+
+		struct CallbackToken {
+			std::weak_ptr<CallbackContext> context;
+		};
+
+		Ref<GDKUser> user;
+		XUserLocalId local_id = {};
+		XblContextHandle context = nullptr;
+		XblFunctionContext device_token = {};
+		XblFunctionContext title_token = {};
+		bool device_registered = false;
+		bool title_registered = false;
+		std::shared_ptr<CallbackContext> callback_context;
+		std::shared_ptr<CallbackToken> callback_token;
+		std::vector<uint64_t> tracked_xuids;
+		std::vector<uint32_t> tracked_title_ids;
+	};
+
+	struct PendingPresenceEvent {
+		enum EventType {
+			EVENT_DEVICE,
+			EVENT_TITLE,
+		};
+
+		EventType type = EVENT_DEVICE;
+		XUserLocalId local_id = {};
+		uint64_t xuid = 0;
+		XblPresenceDeviceType device_type = XblPresenceDeviceType::Unknown;
+		bool device_logged_on = false;
+		uint32_t title_id = 0;
+		XblPresenceTitleState title_state = XblPresenceTitleState::Unknown;
+	};
+
+	std::vector<HandlerState> m_handler_states;
+	std::vector<PendingPresenceEvent> m_pending_presence_events;
+	mutable std::mutex m_pending_presence_events_mutex;
+	std::vector<std::shared_ptr<HandlerState::CallbackToken>> m_retired_callback_tokens;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+	Ref<GDKUser> _get_presence_calling_user() const;
+	Ref<GDKResult> _parse_query_xuids(const PackedStringArray &p_xuids, std::vector<uint64_t> *r_xuids) const;
+	Ref<GDKResult> _parse_xuids(const PackedStringArray &p_xuids, bool p_allow_empty, const String &p_missing_code, const String &p_invalid_code, std::vector<uint64_t> *r_xuids) const;
+	Ref<GDKResult> _parse_title_ids(const PackedInt64Array &p_title_ids, std::vector<uint32_t> *r_title_ids) const;
+	Ref<GDKPresenceRecord> _find_cached_presence(const String &p_xuid) const;
+	void _remove_cached_presence(const String &p_xuid);
+	HandlerState *_find_handler_state(XUserLocalId p_local_id);
+	Ref<GDKResult> _ensure_handler_state(const Ref<GDKUser> &p_user, HandlerState **r_state);
+	void _close_handler_state(HandlerState &p_state);
+	static void CALLBACK _device_presence_changed_handler(void *p_context, uint64_t p_xuid, XblPresenceDeviceType p_device_type, bool p_is_user_logged_on_device);
+	static void CALLBACK _title_presence_changed_handler(void *p_context, uint64_t p_xuid, uint32_t p_title_id, XblPresenceTitleState p_title_state);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	int dispatch();
+
+	Signal set_presence_async(const Ref<GDKUser> &p_user, const String &p_state, const Dictionary &p_rich_presence = Dictionary());
+	Signal clear_presence_async(const Ref<GDKUser> &p_user);
+	Signal get_presence_async(const PackedStringArray &p_xuids);
+	Signal get_presence_for_social_group_async(const Ref<GDKUser> &p_user, const String &p_social_group);
+	Ref<GDKResult> track_presence(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedInt64Array &p_title_ids = PackedInt64Array());
+	Ref<GDKResult> stop_tracking_presence(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids = PackedStringArray(), const PackedInt64Array &p_title_ids = PackedInt64Array());
+	Ref<GDKPresenceRecord> get_cached_presence(const String &p_xuid) const;
+
+	void cache_presence_record(const Ref<GDKPresenceRecord> &p_record, bool p_emit_signal = true);
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};
+
+VARIANT_ENUM_CAST(GDKPresenceRecord::UserState);

--- a/modules/xbox_module/gdk/gdk_privacy.cpp
+++ b/modules/xbox_module/gdk/gdk_privacy.cpp
@@ -1,0 +1,773 @@
+/**************************************************************************/
+/*  gdk_privacy.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_privacy.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <vector>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _normalize_token(const String &p_value) {
+	return p_value.strip_edges().to_lower().replace("-", "_").replace(" ", "_");
+}
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	char *end_ptr = nullptr;
+	errno = 0;
+	const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
+	if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+bool _try_parse_permission(const String &p_permission, XblPermission *r_permission) {
+	if (r_permission == nullptr) {
+		return false;
+	}
+
+	const String token = _normalize_token(p_permission);
+	if (token == "communicate_using_text") {
+		*r_permission = XblPermission::CommunicateUsingText;
+	} else if (token == "communicate_using_video") {
+		*r_permission = XblPermission::CommunicateUsingVideo;
+	} else if (token == "communicate_using_voice") {
+		*r_permission = XblPermission::CommunicateUsingVoice;
+	} else if (token == "view_target_profile") {
+		*r_permission = XblPermission::ViewTargetProfile;
+	} else if (token == "view_target_game_history") {
+		*r_permission = XblPermission::ViewTargetGameHistory;
+	} else if (token == "view_target_video_history") {
+		*r_permission = XblPermission::ViewTargetVideoHistory;
+	} else if (token == "view_target_music_history") {
+		*r_permission = XblPermission::ViewTargetMusicHistory;
+	} else if (token == "view_target_exercise_info") {
+		*r_permission = XblPermission::ViewTargetExerciseInfo;
+	} else if (token == "view_target_presence") {
+		*r_permission = XblPermission::ViewTargetPresence;
+	} else if (token == "view_target_video_status") {
+		*r_permission = XblPermission::ViewTargetVideoStatus;
+	} else if (token == "view_target_music_status") {
+		*r_permission = XblPermission::ViewTargetMusicStatus;
+	} else if (token == "play_multiplayer") {
+		*r_permission = XblPermission::PlayMultiplayer;
+	} else if (token == "view_target_user_created_content") {
+		*r_permission = XblPermission::ViewTargetUserCreatedContent;
+	} else if (token == "broadcast_with_twitch") {
+		*r_permission = XblPermission::BroadcastWithTwitch;
+	} else if (token == "write_comment") {
+		*r_permission = XblPermission::WriteComment;
+	} else if (token == "share_item") {
+		*r_permission = XblPermission::ShareItem;
+	} else if (token == "share_target_content_to_external_networks") {
+		*r_permission = XblPermission::ShareTargetContentToExternalNetworks;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+bool _try_parse_anonymous_user_type(const String &p_user_type, XblAnonymousUserType *r_user_type) {
+	if (r_user_type == nullptr) {
+		return false;
+	}
+
+	const String token = _normalize_token(p_user_type);
+	if (token == "cross_network_user") {
+		*r_user_type = XblAnonymousUserType::CrossNetworkUser;
+	} else if (token == "cross_network_friend") {
+		*r_user_type = XblAnonymousUserType::CrossNetworkFriend;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+String _permission_to_string(XblPermission p_permission) {
+	switch (p_permission) {
+		case XblPermission::CommunicateUsingText:
+			return "communicate_using_text";
+		case XblPermission::CommunicateUsingVideo:
+			return "communicate_using_video";
+		case XblPermission::CommunicateUsingVoice:
+			return "communicate_using_voice";
+		case XblPermission::ViewTargetProfile:
+			return "view_target_profile";
+		case XblPermission::ViewTargetGameHistory:
+			return "view_target_game_history";
+		case XblPermission::ViewTargetVideoHistory:
+			return "view_target_video_history";
+		case XblPermission::ViewTargetMusicHistory:
+			return "view_target_music_history";
+		case XblPermission::ViewTargetExerciseInfo:
+			return "view_target_exercise_info";
+		case XblPermission::ViewTargetPresence:
+			return "view_target_presence";
+		case XblPermission::ViewTargetVideoStatus:
+			return "view_target_video_status";
+		case XblPermission::ViewTargetMusicStatus:
+			return "view_target_music_status";
+		case XblPermission::PlayMultiplayer:
+			return "play_multiplayer";
+		case XblPermission::ViewTargetUserCreatedContent:
+			return "view_target_user_created_content";
+		case XblPermission::BroadcastWithTwitch:
+			return "broadcast_with_twitch";
+		case XblPermission::WriteComment:
+			return "write_comment";
+		case XblPermission::ShareItem:
+			return "share_item";
+		case XblPermission::ShareTargetContentToExternalNetworks:
+			return "share_target_content_to_external_networks";
+		case XblPermission::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String _anonymous_user_type_to_string(XblAnonymousUserType p_user_type) {
+	switch (p_user_type) {
+		case XblAnonymousUserType::CrossNetworkUser:
+			return "cross_network_user";
+		case XblAnonymousUserType::CrossNetworkFriend:
+			return "cross_network_friend";
+		case XblAnonymousUserType::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String _deny_reason_to_string(XblPermissionDenyReason p_reason) {
+	switch (p_reason) {
+		case XblPermissionDenyReason::NotAllowed:
+			return "not_allowed";
+		case XblPermissionDenyReason::MissingPrivilege:
+			return "missing_privilege";
+		case XblPermissionDenyReason::PrivilegeRestrictsTarget:
+			return "privilege_restricts_target";
+		case XblPermissionDenyReason::BlockListRestrictsTarget:
+			return "block_list_restricts_target";
+		case XblPermissionDenyReason::MuteListRestrictsTarget:
+			return "mute_list_restricts_target";
+		case XblPermissionDenyReason::PrivacySettingRestrictsTarget:
+			return "privacy_setting_restricts_target";
+		case XblPermissionDenyReason::CrossNetworkUserMustBeFriend:
+			return "cross_network_user_must_be_friend";
+		case XblPermissionDenyReason::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String _privilege_to_string(XblPrivilege p_privilege) {
+	switch (p_privilege) {
+		case XblPrivilege::AllowIngameVoiceCommunications:
+			return "allow_ingame_voice_communications";
+		case XblPrivilege::AllowVideoCommunications:
+			return "allow_video_communications";
+		case XblPrivilege::AllowProfileViewing:
+			return "allow_profile_viewing";
+		case XblPrivilege::AllowCommunications:
+			return "allow_communications";
+		case XblPrivilege::AllowMultiplayer:
+			return "allow_multiplayer";
+		case XblPrivilege::AllowAddFriend:
+			return "allow_add_friend";
+		case XblPrivilege::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+String _privacy_setting_to_string(XblPrivacySetting p_setting) {
+	switch (p_setting) {
+		case XblPrivacySetting::ShareFriendList:
+			return "share_friend_list";
+		case XblPrivacySetting::ShareGameHistory:
+			return "share_game_history";
+		case XblPrivacySetting::CommunicateUsingTextAndVoice:
+			return "communicate_using_text_and_voice";
+		case XblPrivacySetting::SharePresence:
+			return "share_presence";
+		case XblPrivacySetting::ShareProfile:
+			return "share_profile";
+		case XblPrivacySetting::CommunicateDuringCrossNetworkPlay:
+			return "communicate_during_cross_network_play";
+		case XblPrivacySetting::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+Dictionary _make_permission_result_dictionary(const XblPermissionCheckResult &p_result) {
+	Dictionary result;
+	result["allowed"] = p_result.isAllowed;
+	result["target_xuid"] = p_result.targetXuid == 0 ? String() : String::num_uint64(p_result.targetXuid);
+	result["target_user_type"] = _anonymous_user_type_to_string(p_result.targetUserType);
+	result["permission"] = _permission_to_string(p_result.permissionRequested);
+
+	Array reasons;
+	if (p_result.reasons != nullptr) {
+		for (size_t i = 0; i < p_result.reasonsCount; ++i) {
+			const XblPermissionDenyReasonDetails &native_reason = p_result.reasons[i];
+			Dictionary reason;
+			reason["reason"] = _deny_reason_to_string(native_reason.reason);
+			reason["restricted_privilege"] = _privilege_to_string(native_reason.restrictedPrivilege);
+			reason["restricted_privacy_setting"] = _privacy_setting_to_string(native_reason.restrictedPrivacySetting);
+			reasons.push_back(reason);
+		}
+	}
+	result["reasons"] = reasons;
+	return result;
+}
+
+PackedStringArray _make_xuid_array(const std::vector<uint64_t> &p_xuids) {
+	PackedStringArray result;
+	for (uint64_t xuid : p_xuids) {
+		result.push_back(String::num_uint64(xuid));
+	}
+	return result;
+}
+
+class PrivacyPermissionAsyncContext final : public GDKSignalXAsyncContext {
+public:
+	enum Mode {
+		MODE_SINGLE,
+		MODE_ANONYMOUS,
+		MODE_BATCH,
+	};
+
+private:
+	XblContextHandle m_context = nullptr;
+	Mode m_mode = MODE_SINGLE;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Privacy permission check cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t result_size = 0;
+		HRESULT result_hr = m_mode == MODE_BATCH ? XblPrivacyBatchCheckPermissionResultSize(p_async_block, &result_size) : (m_mode == MODE_ANONYMOUS ? XblPrivacyCheckPermissionForAnonymousUserResultSize(p_async_block, &result_size) : XblPrivacyCheckPermissionResultSize(p_async_block, &result_size));
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Privacy permission check cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve privacy permission result size.", "privacy_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(result_size);
+		size_t buffer_used = 0;
+		if (m_mode == MODE_BATCH) {
+			XblPermissionCheckResult *results = nullptr;
+			size_t result_count = 0;
+			result_hr = XblPrivacyBatchCheckPermissionResult(
+					p_async_block,
+					buffer.size(),
+					buffer.empty() ? nullptr : buffer.data(),
+					&results,
+					&result_count,
+					&buffer_used);
+			if (FAILED(result_hr)) {
+				result = result_hr == E_ABORT ? GDKResult::cancelled("Privacy permission check cancelled.") : GDKResult::hresult_error(result_hr, "Failed to retrieve privacy permission results.", "privacy_results_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			Array payload;
+			for (size_t i = 0; i < result_count; ++i) {
+				payload.push_back(_make_permission_result_dictionary(results[i]));
+			}
+			get_pending_signal()->complete(GDKResult::ok_result(payload));
+			return;
+		}
+
+		XblPermissionCheckResult *permission_result = nullptr;
+		result_hr = m_mode == MODE_ANONYMOUS ? XblPrivacyCheckPermissionForAnonymousUserResult(
+													   p_async_block,
+													   buffer.size(),
+													   buffer.empty() ? nullptr : buffer.data(),
+													   &permission_result,
+													   &buffer_used)
+											 : XblPrivacyCheckPermissionResult(
+													   p_async_block,
+													   buffer.size(),
+													   buffer.empty() ? nullptr : buffer.data(),
+													   &permission_result,
+													   &buffer_used);
+		if (FAILED(result_hr)) {
+			result = result_hr == E_ABORT ? GDKResult::cancelled("Privacy permission check cancelled.") : GDKResult::hresult_error(result_hr, "Failed to retrieve privacy permission result.", "privacy_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary payload = permission_result == nullptr ? Dictionary() : _make_permission_result_dictionary(*permission_result);
+		get_pending_signal()->complete(GDKResult::ok_result(payload));
+	}
+
+public:
+	PrivacyPermissionAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, Mode p_mode) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_mode(p_mode) {}
+
+	~PrivacyPermissionAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+class PrivacyListAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	bool m_mute_list = false;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Privacy list query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t xuid_count = 0;
+		HRESULT result_hr = m_mute_list ? XblPrivacyGetMuteListResultCount(p_async_block, &xuid_count) : XblPrivacyGetAvoidListResultCount(p_async_block, &xuid_count);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Privacy list query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve privacy list result count.", "privacy_list_count_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint64_t> xuids(xuid_count);
+		result_hr = m_mute_list ? XblPrivacyGetMuteListResult(p_async_block, xuids.size(), xuids.empty() ? nullptr : xuids.data()) : XblPrivacyGetAvoidListResult(p_async_block, xuids.size(), xuids.empty() ? nullptr : xuids.data());
+		if (FAILED(result_hr)) {
+			result = result_hr == E_ABORT ? GDKResult::cancelled("Privacy list query cancelled.") : GDKResult::hresult_error(result_hr, "Failed to retrieve privacy list results.", "privacy_list_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(_make_xuid_array(xuids)));
+	}
+
+public:
+	PrivacyListAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, bool p_mute_list) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_mute_list(p_mute_list) {}
+
+	~PrivacyListAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKPrivacy::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("check_permission_async", "user", "permission", "target_xuid"), &GDKPrivacy::check_permission_async);
+	ClassDB::bind_method(D_METHOD("check_permission_for_anonymous_user_async", "user", "permission", "anonymous_user_type"), &GDKPrivacy::check_permission_for_anonymous_user_async);
+	ClassDB::bind_method(D_METHOD("batch_check_permission_async", "user", "permission", "target_xuids"), &GDKPrivacy::batch_check_permission_async);
+	ClassDB::bind_method(D_METHOD("get_avoid_list_async", "user"), &GDKPrivacy::get_avoid_list_async);
+	ClassDB::bind_method(D_METHOD("get_mute_list_async", "user"), &GDKPrivacy::get_mute_list_async);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKPrivacy::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKPrivacy::_get_runtime() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKPrivacy::_get_xbox_services() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Signal GDKPrivacy::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_NULL_V(runtime, Signal());
+	return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKPrivacy::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKPrivacy::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKPrivacy::shutdown() {
+	m_runtime_ready = false;
+}
+
+int GDKPrivacy::dispatch() {
+	return 0;
+}
+
+Signal GDKPrivacy::check_permission_async(const Ref<GDKUser> &p_user, const String &p_permission, const String &p_target_xuid) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblPermission permission = XblPermission::Unknown;
+	if (!_try_parse_permission(p_permission, &permission)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_permission", "Unknown privacy permission.");
+	}
+
+	uint64_t target_xuid = 0;
+	if (!_try_parse_xuid(p_target_xuid, &target_xuid)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_xuid", "target_xuid must be a non-empty decimal XUID string.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using privacy.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	PrivacyPermissionAsyncContext *async_context = new PrivacyPermissionAsyncContext(runtime, pending_signal, context, PrivacyPermissionAsyncContext::MODE_SINGLE);
+	async_context->bind_cancel_handler();
+	hr = XblPrivacyCheckPermissionAsync(async_context->get_context(), permission, target_xuid, async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "privacy_check_start_failed", "Failed to start privacy permission check.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPrivacy::check_permission_for_anonymous_user_async(const Ref<GDKUser> &p_user, const String &p_permission, const String &p_anonymous_user_type) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblPermission permission = XblPermission::Unknown;
+	if (!_try_parse_permission(p_permission, &permission)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_permission", "Unknown privacy permission.");
+	}
+
+	XblAnonymousUserType user_type = XblAnonymousUserType::Unknown;
+	if (!_try_parse_anonymous_user_type(p_anonymous_user_type, &user_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_anonymous_user_type", "Unknown anonymous user type.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using privacy.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	PrivacyPermissionAsyncContext *async_context = new PrivacyPermissionAsyncContext(runtime, pending_signal, context, PrivacyPermissionAsyncContext::MODE_ANONYMOUS);
+	async_context->bind_cancel_handler();
+	hr = XblPrivacyCheckPermissionForAnonymousUserAsync(async_context->get_context(), permission, user_type, async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "privacy_check_start_failed", "Failed to start anonymous privacy permission check.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPrivacy::batch_check_permission_async(const Ref<GDKUser> &p_user, const String &p_permission, const PackedStringArray &p_target_xuids) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblPermission permission = XblPermission::Unknown;
+	if (!_try_parse_permission(p_permission, &permission)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_permission", "Unknown privacy permission.");
+	}
+	if (p_target_xuids.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_xuids", "At least one target XUID is required.");
+	}
+
+	std::vector<uint64_t> xuids;
+	xuids.reserve(static_cast<size_t>(p_target_xuids.size()));
+	for (int64_t i = 0; i < p_target_xuids.size(); ++i) {
+		uint64_t xuid = 0;
+		if (!_try_parse_xuid(p_target_xuids[i], &xuid)) {
+			return _make_error_signal(E_INVALIDARG, "invalid_xuid", "target_xuids must contain decimal XUID strings.");
+		}
+		xuids.push_back(xuid);
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using privacy.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	PrivacyPermissionAsyncContext *async_context = new PrivacyPermissionAsyncContext(runtime, pending_signal, context, PrivacyPermissionAsyncContext::MODE_BATCH);
+	async_context->bind_cancel_handler();
+	hr = XblPrivacyBatchCheckPermissionAsync(async_context->get_context(), &permission, 1, xuids.data(), xuids.size(), nullptr, 0, async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "privacy_batch_check_start_failed", "Failed to start batch privacy permission check.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPrivacy::get_avoid_list_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using privacy.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	PrivacyListAsyncContext *async_context = new PrivacyListAsyncContext(runtime, pending_signal, context, false);
+	async_context->bind_cancel_handler();
+	hr = XblPrivacyGetAvoidListAsync(async_context->get_context(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "privacy_avoid_list_start_failed", "Failed to start privacy avoid-list query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKPrivacy::get_mute_list_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using privacy.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	PrivacyListAsyncContext *async_context = new PrivacyListAsyncContext(runtime, pending_signal, context, true);
+	async_context->bind_cancel_handler();
+	hr = XblPrivacyGetMuteListAsync(async_context->get_context(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "privacy_mute_list_start_failed", "Failed to start privacy mute-list query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+void GDKPrivacy::on_user_removed(const Ref<GDKUser> &p_user) {
+	(void)p_user;
+}
+
+#else
+void GDKPrivacy::set_owner(GDK *p_owner) {}
+
+Signal GDKPrivacy::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKPrivacy::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKPrivacy::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKPrivacy::shutdown() {}
+
+int GDKPrivacy::dispatch() {
+	return 0;
+}
+
+Signal GDKPrivacy::check_permission_async(const Ref<GDKUser> &p_user, const String &p_permission, const String &p_target_xuid) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPrivacy::check_permission_for_anonymous_user_async(const Ref<GDKUser> &p_user, const String &p_permission, const String &p_anonymous_user_type) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPrivacy::batch_check_permission_async(const Ref<GDKUser> &p_user, const String &p_permission, const PackedStringArray &p_target_xuids) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPrivacy::get_avoid_list_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKPrivacy::get_mute_list_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKPrivacy::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_privacy.h
+++ b/modules/xbox_module/gdk/gdk_privacy.h
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*  gdk_privacy.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKPrivacy : public RefCounted {
+	GDCLASS(GDKPrivacy, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	int dispatch();
+
+	Signal check_permission_async(const Ref<GDKUser> &p_user, const String &p_permission, const String &p_target_xuid);
+	Signal check_permission_for_anonymous_user_async(const Ref<GDKUser> &p_user, const String &p_permission, const String &p_anonymous_user_type);
+	Signal batch_check_permission_async(const Ref<GDKUser> &p_user, const String &p_permission, const PackedStringArray &p_target_xuids);
+	Signal get_avoid_list_async(const Ref<GDKUser> &p_user);
+	Signal get_mute_list_async(const Ref<GDKUser> &p_user);
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_profile.cpp
+++ b/modules/xbox_module/gdk/gdk_profile.cpp
@@ -1,0 +1,524 @@
+/**************************************************************************/
+/*  gdk_profile.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_profile.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	if (p_value == nullptr || p_value[0] == '\0') {
+		return String();
+	}
+	return String::utf8(p_value);
+}
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	char *end_ptr = nullptr;
+	errno = 0;
+	const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
+	if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+Ref<GDKUserProfile> _make_user_profile(const XblUserProfile &p_profile) {
+	Ref<GDKUserProfile> profile;
+	profile.instantiate();
+	profile->populate_from_native(p_profile);
+	return profile;
+}
+
+Array _make_user_profile_array(const std::vector<XblUserProfile> &p_profiles) {
+	Array result;
+	for (const XblUserProfile &profile : p_profiles) {
+		result.push_back(_make_user_profile(profile));
+	}
+	return result;
+}
+
+class ProfileAsyncContext final : public GDKSignalXAsyncContext {
+public:
+	enum Mode {
+		MODE_SINGLE,
+		MODE_MULTIPLE,
+		MODE_SOCIAL_GROUP,
+	};
+
+private:
+	XblContextHandle m_context = nullptr;
+	Mode m_mode = MODE_SINGLE;
+	uint64_t m_target_xuid = 0;
+	std::vector<uint64_t> m_xuids;
+	String m_social_group;
+	CharString m_social_group_utf8;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Profile query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (m_mode == MODE_SINGLE) {
+			XblUserProfile profile = {};
+			HRESULT result_hr = XblProfileGetUserProfileResult(p_async_block, &profile);
+			if (result_hr == E_ABORT) {
+				result = GDKResult::cancelled("Profile query cancelled.");
+				get_pending_signal()->complete(result);
+				return;
+			}
+			if (FAILED(result_hr)) {
+				result = GDKResult::hresult_error(result_hr, "Failed to retrieve the profile result.", "profile_result_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			get_pending_signal()->complete(GDKResult::ok_result(_make_user_profile(profile)));
+			return;
+		}
+
+		size_t profile_count = 0;
+		HRESULT result_hr = m_mode == MODE_SOCIAL_GROUP ? XblProfileGetUserProfilesForSocialGroupResultCount(p_async_block, &profile_count) : XblProfileGetUserProfilesResultCount(p_async_block, &profile_count);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Profile query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve the profile result count.", "profile_result_count_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<XblUserProfile> profiles(profile_count);
+		if (profile_count > 0) {
+			result_hr = m_mode == MODE_SOCIAL_GROUP ? XblProfileGetUserProfilesForSocialGroupResult(p_async_block, profiles.size(), profiles.data()) : XblProfileGetUserProfilesResult(p_async_block, profiles.size(), profiles.data());
+			if (result_hr == E_ABORT) {
+				result = GDKResult::cancelled("Profile query cancelled.");
+				get_pending_signal()->complete(result);
+				return;
+			}
+			if (FAILED(result_hr)) {
+				result = GDKResult::hresult_error(result_hr, "Failed to retrieve profile results.", "profile_results_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(_make_user_profile_array(profiles)));
+	}
+
+public:
+	ProfileAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, uint64_t p_target_xuid) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_mode(MODE_SINGLE),
+			m_target_xuid(p_target_xuid) {}
+
+	ProfileAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, std::vector<uint64_t> p_xuids) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_mode(MODE_MULTIPLE),
+			m_xuids(std::move(p_xuids)) {}
+
+	ProfileAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const String &p_social_group) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_mode(MODE_SOCIAL_GROUP),
+			m_social_group(p_social_group) {
+		m_social_group_utf8 = m_social_group.utf8();
+	}
+
+	~ProfileAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	uint64_t get_target_xuid() const {
+		return m_target_xuid;
+	}
+
+	uint64_t *get_xuids_data() {
+		return m_xuids.data();
+	}
+
+	size_t get_xuids_count() const {
+		return m_xuids.size();
+	}
+
+	const char *get_social_group() const {
+		return m_social_group_utf8.get_data();
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKUserProfile::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKUserProfile::get_xuid);
+	ClassDB::bind_method(D_METHOD("get_app_display_name"), &GDKUserProfile::get_app_display_name);
+	ClassDB::bind_method(D_METHOD("get_app_display_picture_resize_uri"), &GDKUserProfile::get_app_display_picture_resize_uri);
+	ClassDB::bind_method(D_METHOD("get_game_display_name"), &GDKUserProfile::get_game_display_name);
+	ClassDB::bind_method(D_METHOD("get_game_display_picture_resize_uri"), &GDKUserProfile::get_game_display_picture_resize_uri);
+	ClassDB::bind_method(D_METHOD("get_gamerscore"), &GDKUserProfile::get_gamerscore);
+	ClassDB::bind_method(D_METHOD("get_gamertag"), &GDKUserProfile::get_gamertag);
+	ClassDB::bind_method(D_METHOD("get_modern_gamertag"), &GDKUserProfile::get_modern_gamertag);
+	ClassDB::bind_method(D_METHOD("get_modern_gamertag_suffix"), &GDKUserProfile::get_modern_gamertag_suffix);
+	ClassDB::bind_method(D_METHOD("get_unique_modern_gamertag"), &GDKUserProfile::get_unique_modern_gamertag);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "app_display_name"), "", "get_app_display_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "app_display_picture_resize_uri"), "", "get_app_display_picture_resize_uri");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "game_display_name"), "", "get_game_display_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "game_display_picture_resize_uri"), "", "get_game_display_picture_resize_uri");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamerscore"), "", "get_gamerscore");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamertag"), "", "get_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "modern_gamertag"), "", "get_modern_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "modern_gamertag_suffix"), "", "get_modern_gamertag_suffix");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "unique_modern_gamertag"), "", "get_unique_modern_gamertag");
+}
+
+String GDKUserProfile::get_xuid() const {
+	return m_xuid;
+}
+
+String GDKUserProfile::get_app_display_name() const {
+	return m_app_display_name;
+}
+
+String GDKUserProfile::get_app_display_picture_resize_uri() const {
+	return m_app_display_picture_resize_uri;
+}
+
+String GDKUserProfile::get_game_display_name() const {
+	return m_game_display_name;
+}
+
+String GDKUserProfile::get_game_display_picture_resize_uri() const {
+	return m_game_display_picture_resize_uri;
+}
+
+String GDKUserProfile::get_gamerscore() const {
+	return m_gamerscore;
+}
+
+String GDKUserProfile::get_gamertag() const {
+	return m_gamertag;
+}
+
+String GDKUserProfile::get_modern_gamertag() const {
+	return m_modern_gamertag;
+}
+
+String GDKUserProfile::get_modern_gamertag_suffix() const {
+	return m_modern_gamertag_suffix;
+}
+
+String GDKUserProfile::get_unique_modern_gamertag() const {
+	return m_unique_modern_gamertag;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKUserProfile::populate_from_native(const XblUserProfile &p_profile) {
+	m_xuid = String::num_uint64(p_profile.xboxUserId);
+	m_app_display_name = _utf8_or_empty(p_profile.appDisplayName);
+	m_app_display_picture_resize_uri = _utf8_or_empty(p_profile.appDisplayPictureResizeUri);
+	m_game_display_name = _utf8_or_empty(p_profile.gameDisplayName);
+	m_game_display_picture_resize_uri = _utf8_or_empty(p_profile.gameDisplayPictureResizeUri);
+	m_gamerscore = _utf8_or_empty(p_profile.gamerscore);
+	m_gamertag = _utf8_or_empty(p_profile.gamertag);
+	m_modern_gamertag = _utf8_or_empty(p_profile.modernGamertag);
+	m_modern_gamertag_suffix = _utf8_or_empty(p_profile.modernGamertagSuffix);
+	m_unique_modern_gamertag = _utf8_or_empty(p_profile.uniqueModernGamertag);
+}
+#else
+void GDKUserProfile::populate_from_native(const XblUserProfile &p_profile) {
+}
+#endif
+
+void GDKProfile::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_profile_async", "user", "xuid"), &GDKProfile::get_profile_async);
+	ClassDB::bind_method(D_METHOD("get_profiles_async", "user", "xuids"), &GDKProfile::get_profiles_async);
+	ClassDB::bind_method(D_METHOD("get_profiles_for_social_group_async", "user", "social_group"), &GDKProfile::get_profiles_for_social_group_async);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKProfile::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKProfile::_get_runtime() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKProfile::_get_xbox_services() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Signal GDKProfile::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_NULL_V(runtime, Signal());
+	return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKProfile::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKProfile::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKProfile::shutdown() {
+	m_runtime_ready = false;
+}
+
+Signal GDKProfile::get_profile_async(const Ref<GDKUser> &p_user, const String &p_xuid) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	uint64_t target_xuid = 0;
+	if (!_try_parse_xuid(p_xuid, &target_xuid)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_xuid", "xuid must be a non-empty decimal XUID string.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using profile.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	ProfileAsyncContext *async_context = new ProfileAsyncContext(runtime, pending_signal, context, target_xuid);
+	async_context->bind_cancel_handler();
+	hr = XblProfileGetUserProfileAsync(async_context->get_context(), async_context->get_target_xuid(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "profile_query_start_failed", "Failed to start the profile query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKProfile::get_profiles_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	if (p_xuids.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_xuids", "At least one XUID is required.");
+	}
+
+	std::vector<uint64_t> xuids;
+	xuids.reserve(static_cast<size_t>(p_xuids.size()));
+	for (int64_t i = 0; i < p_xuids.size(); ++i) {
+		uint64_t xuid = 0;
+		if (!_try_parse_xuid(p_xuids[i], &xuid)) {
+			return _make_error_signal(E_INVALIDARG, "invalid_xuid", "xuids must contain decimal XUID strings.");
+		}
+		xuids.push_back(xuid);
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using profile.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	ProfileAsyncContext *async_context = new ProfileAsyncContext(runtime, pending_signal, context, std::move(xuids));
+	async_context->bind_cancel_handler();
+	hr = XblProfileGetUserProfilesAsync(async_context->get_context(), async_context->get_xuids_data(), async_context->get_xuids_count(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "profile_query_start_failed", "Failed to start the profiles query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKProfile::get_profiles_for_social_group_async(const Ref<GDKUser> &p_user, const String &p_social_group) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	const String social_group = p_social_group.strip_edges();
+	if (social_group.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_social_group", "Profile social-group queries require a non-empty social group name.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using profile.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	ProfileAsyncContext *async_context = new ProfileAsyncContext(runtime, pending_signal, context, social_group);
+	async_context->bind_cancel_handler();
+	hr = XblProfileGetUserProfilesForSocialGroupAsync(async_context->get_context(), async_context->get_social_group(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "profile_social_group_query_start_failed", "Failed to start the social-group profile query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+void GDKProfile::on_user_removed(const Ref<GDKUser> &p_user) {
+	(void)p_user;
+}
+
+#else
+void GDKProfile::set_owner(GDK *p_owner) {}
+
+Signal GDKProfile::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKProfile::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKProfile::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKProfile::shutdown() {}
+
+Signal GDKProfile::get_profile_async(const Ref<GDKUser> &p_user, const String &p_xuid) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKProfile::get_profiles_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKProfile::get_profiles_for_social_group_async(const Ref<GDKUser> &p_user, const String &p_social_group) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKProfile::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_profile.h
+++ b/modules/xbox_module/gdk/gdk_profile.h
@@ -1,0 +1,116 @@
+/**************************************************************************/
+/*  gdk_profile.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKUserProfile : public RefCounted {
+	GDCLASS(GDKUserProfile, RefCounted);
+
+	String m_xuid;
+	String m_app_display_name;
+	String m_app_display_picture_resize_uri;
+	String m_game_display_name;
+	String m_game_display_picture_resize_uri;
+	String m_gamerscore;
+	String m_gamertag;
+	String m_modern_gamertag;
+	String m_modern_gamertag_suffix;
+	String m_unique_modern_gamertag;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_xuid() const;
+	String get_app_display_name() const;
+	String get_app_display_picture_resize_uri() const;
+	String get_game_display_name() const;
+	String get_game_display_picture_resize_uri() const;
+	String get_gamerscore() const;
+	String get_gamertag() const;
+	String get_modern_gamertag() const;
+	String get_modern_gamertag_suffix() const;
+	String get_unique_modern_gamertag() const;
+
+	void populate_from_native(const XblUserProfile &p_profile);
+};
+
+class GDKProfile : public RefCounted {
+	GDCLASS(GDKProfile, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Signal get_profile_async(const Ref<GDKUser> &p_user, const String &p_xuid);
+	Signal get_profiles_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids);
+	Signal get_profiles_for_social_group_async(const Ref<GDKUser> &p_user, const String &p_social_group);
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_result.cpp
+++ b/modules/xbox_module/gdk/gdk_result.cpp
@@ -1,0 +1,109 @@
+/**************************************************************************/
+/*  gdk_result.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_result.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include "gdk_result_codes_internal.h"
+
+void GDKResult::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_ok"), &GDKResult::is_ok);
+	ClassDB::bind_method(D_METHOD("get_hresult"), &GDKResult::get_hresult);
+	ClassDB::bind_method(D_METHOD("get_code"), &GDKResult::get_code);
+	ClassDB::bind_method(D_METHOD("get_message"), &GDKResult::get_message);
+	ClassDB::bind_method(D_METHOD("get_data"), &GDKResult::get_data);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ok"), "", "is_ok");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hresult"), "", "get_hresult");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code"), "", "get_code");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "message"), "", "get_message");
+	ADD_PROPERTY(PropertyInfo(Variant::NIL, "data"), "", "get_data");
+}
+
+bool GDKResult::is_ok() const {
+	return m_ok;
+}
+
+int64_t GDKResult::get_hresult() const {
+	return m_hresult;
+}
+
+String GDKResult::get_code() const {
+	return m_code;
+}
+
+String GDKResult::get_message() const {
+	return m_message;
+}
+
+Variant GDKResult::get_data() const {
+	return m_data;
+}
+
+void GDKResult::set_values(bool p_ok, HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) {
+	m_ok = p_ok;
+	m_hresult = static_cast<int64_t>(p_hresult);
+	m_code = p_code;
+	m_message = p_message;
+	m_data = p_data;
+}
+
+Ref<GDKResult> GDKResult::ok_result(const Variant &p_data) {
+	Ref<GDKResult> result;
+	result.instantiate();
+	result->set_values(true, S_OK, "ok", "", p_data);
+	return result;
+}
+
+Ref<GDKResult> GDKResult::error_result(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) {
+	Ref<GDKResult> result;
+	result.instantiate();
+	result->set_values(false, p_hresult, p_code, p_message, p_data);
+	return result;
+}
+
+Ref<GDKResult> GDKResult::hresult_error(HRESULT p_hresult, const String &p_action, const String &p_code, const Variant &p_data) {
+	return error_result(
+			p_hresult,
+			gdk_internal::code_or_format_hresult(p_code, p_hresult),
+			gdk_internal::format_hresult_message(p_action, p_hresult),
+			p_data);
+}
+
+Ref<GDKResult> GDKResult::cancelled(const String &p_message) {
+	return error_result(E_ABORT, "cancelled", p_message);
+}
+
+String GDKResult::format_hresult(HRESULT p_hresult) {
+	return gdk_internal::format_hresult_string(p_hresult);
+}

--- a/modules/xbox_module/gdk/gdk_result.h
+++ b/modules/xbox_module/gdk/gdk_result.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  gdk_result.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/variant.h"
+
+class GDKResult : public RefCounted {
+	GDCLASS(GDKResult, RefCounted);
+
+	bool m_ok = false;
+	int64_t m_hresult = 0;
+	String m_code;
+	String m_message;
+	Variant m_data;
+
+protected:
+	static void _bind_methods();
+
+public:
+	bool is_ok() const;
+	int64_t get_hresult() const;
+	String get_code() const;
+	String get_message() const;
+	Variant get_data() const;
+
+	void set_values(bool p_ok, HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant());
+
+	static Ref<GDKResult> ok_result(const Variant &p_data = Variant());
+	static Ref<GDKResult> error_result(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant());
+	static Ref<GDKResult> hresult_error(HRESULT p_hresult, const String &p_action, const String &p_code = String(), const Variant &p_data = Variant());
+	static Ref<GDKResult> cancelled(const String &p_message = "Operation cancelled.");
+	static String format_hresult(HRESULT p_hresult);
+};

--- a/modules/xbox_module/gdk/gdk_result_codes_internal.cpp
+++ b/modules/xbox_module/gdk/gdk_result_codes_internal.cpp
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  gdk_result_codes_internal.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_result_codes_internal.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cstdio>
+
+namespace gdk_internal {
+
+char *format_hresult_hex(HRESULT p_hresult, char *out_buffer, std::size_t buffer_size) noexcept {
+	if (out_buffer == nullptr || buffer_size == 0) {
+		return out_buffer;
+	}
+	if (buffer_size < HRESULT_HEX_BUFFER_SIZE) {
+		out_buffer[0] = '\0';
+		return out_buffer;
+	}
+	std::snprintf(out_buffer, buffer_size, "0x%08X", static_cast<unsigned int>(p_hresult));
+	return out_buffer;
+}
+
+String format_hresult_string(HRESULT p_hresult) {
+	char buffer[16];
+	format_hresult_hex(p_hresult, buffer, sizeof(buffer));
+	return String(buffer);
+}
+
+String format_hresult_message(const String &p_action, HRESULT p_hresult) {
+	String message = p_action;
+	if (!message.is_empty()) {
+		message += " ";
+	}
+	message += "(HRESULT " + format_hresult_string(p_hresult) + ")";
+	return message;
+}
+
+String code_or_format_hresult(const String &p_provided, HRESULT p_hresult) {
+	return p_provided.is_empty() ? format_hresult_string(p_hresult) : p_provided;
+}
+
+} //namespace gdk_internal

--- a/modules/xbox_module/gdk/gdk_result_codes_internal.h
+++ b/modules/xbox_module/gdk/gdk_result_codes_internal.h
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  gdk_result_codes_internal.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef GDK_RESULT_CODES_INTERNAL_H
+#define GDK_RESULT_CODES_INTERNAL_H
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <cstddef>
+
+#include "core/string/ustring.h"
+
+namespace gdk_internal {
+
+inline constexpr std::size_t HRESULT_HEX_BUFFER_SIZE = 11;
+
+char *format_hresult_hex(HRESULT p_hresult, char *out_buffer, std::size_t buffer_size) noexcept;
+
+String format_hresult_string(HRESULT p_hresult);
+
+String format_hresult_message(const String &p_action, HRESULT p_hresult);
+
+String code_or_format_hresult(const String &p_provided, HRESULT p_hresult);
+
+} //namespace gdk_internal
+
+#endif

--- a/modules/xbox_module/gdk/gdk_runtime.cpp
+++ b/modules/xbox_module/gdk/gdk_runtime.cpp
@@ -1,0 +1,318 @@
+/**************************************************************************/
+/*  gdk_runtime.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_runtime.h"
+
+#include <algorithm>
+
+#include "core/config/project_settings.h"
+
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+
+namespace {
+
+#if defined(XBOX_MODULE_GDK_ENABLED)
+constexpr bool GDK_PLATFORM_AVAILABLE = true;
+#else
+constexpr bool GDK_PLATFORM_AVAILABLE = false;
+#endif
+
+constexpr const char *GAME_CONFIG_RES_PATH = "res://MicrosoftGame.config";
+
+CharString g_xgame_runtime_config_path;
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+String _resolve_game_config_path() {
+	ProjectSettings *settings = ProjectSettings::get_singleton();
+	if (settings == nullptr) {
+		return String();
+	}
+
+	String resolved = settings->globalize_path(GAME_CONFIG_RES_PATH);
+	if (resolved.is_empty() || resolved.begins_with("res://")) {
+		return String();
+	}
+
+	Char16String wide_path = resolved.utf16();
+	WIN32_FILE_ATTRIBUTE_DATA attrs = {};
+	BOOL ok = GetFileAttributesExW(
+			reinterpret_cast<LPCWSTR>(wide_path.get_data()),
+			GetFileExInfoStandard,
+			&attrs);
+	if (!ok) {
+		return String();
+	}
+	if ((attrs.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+		return String();
+	}
+	return resolved;
+}
+#endif
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+HRESULT _initialize_xgame_runtime(String &r_config_path) {
+	String resolved = _resolve_game_config_path();
+	if (resolved.is_empty()) {
+		r_config_path = String();
+		return XGameRuntimeInitialize();
+	}
+
+	g_xgame_runtime_config_path = resolved.utf8();
+	XGameRuntimeOptions options = {};
+	options.gameConfigSource = XGameRuntimeGameConfigSource::File;
+	options.gameConfig = g_xgame_runtime_config_path.get_data();
+	r_config_path = resolved;
+	return XGameRuntimeInitializeWithOptions(&options);
+}
+#endif
+
+} //namespace
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+GDKRuntime::GDKRuntime() {
+}
+
+GDKRuntime::~GDKRuntime() {
+	shutdown();
+
+	if (m_xgame_runtime_initialized) {
+		XGameRuntimeUninitialize();
+		m_xgame_runtime_initialized = false;
+	}
+}
+
+Ref<GDKResult> GDKRuntime::initialize() {
+	if (m_initialized) {
+		Ref<GDKResult> result = GDKResult::error_result(E_FAIL, "already_initialized", "GDK runtime is already initialized.");
+		return result;
+	}
+
+	if (!m_xgame_runtime_initialized) {
+		String attempted_config_path;
+		HRESULT hr = _initialize_xgame_runtime(attempted_config_path);
+		if (FAILED(hr)) {
+			String message = "Failed to initialize GDK runtime.";
+			if (!attempted_config_path.is_empty()) {
+				message += " Tried game config at: " + attempted_config_path;
+			}
+			Ref<GDKResult> result = GDKResult::hresult_error(hr, message, "runtime_initialize_failed");
+			return result;
+		}
+		m_xgame_runtime_initialized = true;
+	}
+
+	HRESULT hr = XTaskQueueCreate(
+			XTaskQueueDispatchMode::ThreadPool,
+			XTaskQueueDispatchMode::Manual,
+			&m_task_queue);
+	if (FAILED(hr)) {
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to create the shared XTaskQueue.", "task_queue_create_failed");
+		return result;
+	}
+
+	m_initialized = true;
+	m_shutting_down = false;
+	return GDKResult::ok_result();
+}
+
+void GDKRuntime::shutdown() {
+	if (!m_initialized) {
+		return;
+	}
+
+	m_shutting_down = true;
+
+	std::vector<Ref<GDKPendingSignal>> active_pending_signals = m_active_pending_signals;
+	for (const Ref<GDKPendingSignal> &pending_signal : active_pending_signals) {
+		if (pending_signal.is_valid()) {
+			pending_signal->cancel();
+			if (!pending_signal->is_done()) {
+				pending_signal->complete(GDKResult::cancelled("GDK runtime shutdown cancelled the async request."));
+			}
+		}
+	}
+
+	if (m_task_queue) {
+		bool terminated = false;
+		HRESULT terminate_hr = XTaskQueueTerminate(m_task_queue, false, &terminated, _queue_terminated);
+		if (SUCCEEDED(terminate_hr)) {
+			while (!terminated) {
+				XTaskQueueDispatch(m_task_queue, XTaskQueuePort::Completion, 10);
+			}
+		}
+
+		XTaskQueueCloseHandle(m_task_queue);
+		m_task_queue = nullptr;
+	}
+
+	for (Ref<GDKPendingSignal> &pending_signal : m_active_pending_signals) {
+		if (pending_signal.is_valid()) {
+			pending_signal->clear_cancel_handler();
+			pending_signal->clear_release_handler();
+		}
+	}
+	m_active_pending_signals.clear();
+
+	m_initialized = false;
+	m_shutting_down = false;
+}
+
+int GDKRuntime::dispatch() {
+	if (!m_initialized || !m_task_queue) {
+		return 0;
+	}
+
+	int dispatched = 0;
+	while (XTaskQueueDispatch(m_task_queue, XTaskQueuePort::Completion, 0)) {
+		++dispatched;
+	}
+
+	return dispatched;
+}
+
+bool GDKRuntime::is_initialized() const {
+	return m_initialized;
+}
+
+bool GDKRuntime::is_shutting_down() const {
+	return m_shutting_down;
+}
+
+bool GDKRuntime::is_available() const {
+	return GDK_PLATFORM_AVAILABLE;
+}
+
+XTaskQueueHandle GDKRuntime::get_task_queue() const {
+	return m_task_queue;
+}
+
+void GDKRuntime::retain_pending_signal(const Ref<GDKPendingSignal> &p_pending_signal) {
+	if (!p_pending_signal.is_valid() || p_pending_signal->is_done()) {
+		return;
+	}
+
+	p_pending_signal->set_release_handler([this](GDKPendingSignal *p_completed_signal) {
+		release_pending_signal(p_completed_signal);
+	});
+	m_active_pending_signals.push_back(p_pending_signal);
+}
+
+void GDKRuntime::release_pending_signal(GDKPendingSignal *p_pending_signal) {
+	m_active_pending_signals.erase(
+			std::remove_if(
+					m_active_pending_signals.begin(),
+					m_active_pending_signals.end(),
+					[p_pending_signal](const Ref<GDKPendingSignal> &candidate) {
+						return candidate.is_null() || candidate.operator->() == p_pending_signal;
+					}),
+			m_active_pending_signals.end());
+}
+
+Ref<GDKPendingSignal> GDKRuntime::make_pending_signal() {
+	Ref<GDKPendingSignal> pending_signal;
+	pending_signal.instantiate();
+	retain_pending_signal(pending_signal);
+	return pending_signal;
+}
+
+Signal GDKRuntime::make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) {
+	Ref<GDKPendingSignal> pending_signal = make_pending_signal();
+	Ref<GDKResult> result = GDKResult::error_result(p_hresult, p_code, p_message, p_data);
+	pending_signal->complete_deferred(result);
+	return pending_signal->get_completed_signal();
+}
+
+void CALLBACK GDKRuntime::_queue_terminated(void *p_context) {
+	bool *terminated = static_cast<bool *>(p_context);
+	if (terminated != nullptr) {
+		*terminated = true;
+	}
+}
+
+#else
+
+GDKRuntime::GDKRuntime() {
+}
+
+GDKRuntime::~GDKRuntime() {
+	shutdown();
+}
+
+Ref<GDKResult> GDKRuntime::initialize() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKRuntime::shutdown() {
+	m_initialized = false;
+	m_shutting_down = false;
+	m_active_pending_signals.clear();
+}
+
+int GDKRuntime::dispatch() {
+	return 0;
+}
+
+bool GDKRuntime::is_initialized() const {
+	return false;
+}
+
+bool GDKRuntime::is_shutting_down() const {
+	return false;
+}
+
+bool GDKRuntime::is_available() const {
+	return false;
+}
+
+XTaskQueueHandle GDKRuntime::get_task_queue() const {
+	return nullptr;
+}
+
+void GDKRuntime::retain_pending_signal(const Ref<GDKPendingSignal> &p_pending_signal) {
+}
+
+void GDKRuntime::release_pending_signal(GDKPendingSignal *p_pending_signal) {
+}
+
+Ref<GDKPendingSignal> GDKRuntime::make_pending_signal() {
+	Ref<GDKPendingSignal> pending;
+	pending.instantiate();
+	pending->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return pending;
+}
+
+Signal GDKRuntime::make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) {
+	Ref<GDKPendingSignal> pending = make_pending_signal();
+	Ref<GDKResult> result = GDKResult::error_result(p_hresult, p_code, p_message, p_data);
+	pending->complete_deferred(result);
+	return pending->get_completed_signal();
+}
+
+#endif

--- a/modules/xbox_module/gdk/gdk_runtime.h
+++ b/modules/xbox_module/gdk/gdk_runtime.h
@@ -1,0 +1,81 @@
+/**************************************************************************/
+/*  gdk_runtime.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <vector>
+
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XGameRuntimeInit.h>
+#include <XTaskQueue.h>
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+class GDKPendingSignal;
+class GDKResult;
+
+class GDKRuntime {
+	bool m_initialized = false;
+	bool m_shutting_down = false;
+
+	bool m_xgame_runtime_initialized = false;
+	XTaskQueueHandle m_task_queue = nullptr;
+	std::vector<Ref<GDKPendingSignal>> m_active_pending_signals;
+
+	static void CALLBACK _queue_terminated(void *p_context);
+
+public:
+	GDKRuntime();
+	~GDKRuntime();
+
+	Ref<GDKResult> initialize();
+	void shutdown();
+	int dispatch();
+
+	bool is_initialized() const;
+	bool is_shutting_down() const;
+	bool is_available() const;
+	XTaskQueueHandle get_task_queue() const;
+
+	void retain_pending_signal(const Ref<GDKPendingSignal> &p_pending_signal);
+	void release_pending_signal(GDKPendingSignal *p_pending_signal);
+	Ref<GDKPendingSignal> make_pending_signal();
+	Signal make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant());
+};

--- a/modules/xbox_module/gdk/gdk_signal_xasync_context.cpp
+++ b/modules/xbox_module/gdk/gdk_signal_xasync_context.cpp
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  gdk_signal_xasync_context.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_signal_xasync_context.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+GDKSignalXAsyncContext::GDKSignalXAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+		m_runtime(p_runtime),
+		m_pending_signal(p_pending_signal) {
+	m_async_block.queue = m_runtime != nullptr ? m_runtime->get_task_queue() : nullptr;
+	m_async_block.context = this;
+	m_async_block.callback = _completion_thunk;
+}
+
+XAsyncBlock *GDKSignalXAsyncContext::get_async_block() {
+	return &m_async_block;
+}
+
+GDKRuntime *GDKSignalXAsyncContext::get_runtime() const {
+	return m_runtime;
+}
+
+Ref<GDKPendingSignal> GDKSignalXAsyncContext::get_pending_signal() const {
+	return m_pending_signal;
+}
+
+void GDKSignalXAsyncContext::bind_cancel_handler() {
+	if (m_pending_signal.is_valid()) {
+		m_pending_signal->set_cancel_handler([this]() {
+			XAsyncCancel(&m_async_block);
+		});
+	}
+}
+
+void GDKSignalXAsyncContext::clear_cancel_handler() {
+	if (m_pending_signal.is_valid()) {
+		m_pending_signal->clear_cancel_handler();
+	}
+}
+
+void CALLBACK GDKSignalXAsyncContext::_completion_thunk(XAsyncBlock *p_async_block) {
+	auto *context = static_cast<GDKSignalXAsyncContext *>(p_async_block->context);
+
+	context->clear_cancel_handler();
+	context->finalize(p_async_block);
+	delete context;
+}
+
+#else
+
+GDKSignalXAsyncContext::GDKSignalXAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+		m_runtime(p_runtime),
+		m_pending_signal(p_pending_signal) {
+}
+
+XAsyncBlock *GDKSignalXAsyncContext::get_async_block() {
+	return nullptr;
+}
+
+GDKRuntime *GDKSignalXAsyncContext::get_runtime() const {
+	return m_runtime;
+}
+
+Ref<GDKPendingSignal> GDKSignalXAsyncContext::get_pending_signal() const {
+	return m_pending_signal;
+}
+
+void GDKSignalXAsyncContext::bind_cancel_handler() {
+}
+
+void GDKSignalXAsyncContext::clear_cancel_handler() {
+}
+
+#endif

--- a/modules/xbox_module/gdk/gdk_signal_xasync_context.h
+++ b/modules/xbox_module/gdk/gdk_signal_xasync_context.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  gdk_signal_xasync_context.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XAsync.h>
+#endif
+
+#include "gdk_pending_signal.h"
+#include "gdk_runtime.h"
+
+class GDKSignalXAsyncContext {
+	XAsyncBlock m_async_block = {};
+
+	static void CALLBACK _completion_thunk(XAsyncBlock *p_async_block);
+
+protected:
+	GDKRuntime *m_runtime = nullptr;
+	Ref<GDKPendingSignal> m_pending_signal;
+
+	virtual void finalize(XAsyncBlock *p_async_block) = 0;
+
+public:
+	GDKSignalXAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal);
+	virtual ~GDKSignalXAsyncContext() = default;
+
+	XAsyncBlock *get_async_block();
+	GDKRuntime *get_runtime() const;
+	Ref<GDKPendingSignal> get_pending_signal() const;
+	void bind_cancel_handler();
+	void clear_cancel_handler();
+};

--- a/modules/xbox_module/gdk/gdk_social.cpp
+++ b/modules/xbox_module/gdk/gdk_social.cpp
@@ -1,0 +1,1732 @@
+/**************************************************************************/
+/*  gdk_social.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_social.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	if (p_value == nullptr || p_value[0] == '\0') {
+		return String();
+	}
+
+	return String::utf8(p_value);
+}
+
+String _normalize_token(const String &p_value) {
+	return p_value.strip_edges().to_lower().replace("-", "_").replace(" ", "_");
+}
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	char *end_ptr = nullptr;
+	errno = 0;
+	const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
+	if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+bool _try_parse_reputation_feedback_type(const String &p_feedback_type, XblReputationFeedbackType *r_feedback_type) {
+	if (r_feedback_type == nullptr) {
+		return false;
+	}
+
+	const String token = _normalize_token(p_feedback_type);
+	if (token == "fair_play_kills_teammates") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayKillsTeammates;
+	} else if (token == "fair_play_cheater") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayCheater;
+	} else if (token == "fair_play_tampering") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayTampering;
+	} else if (token == "fair_play_quitter") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayQuitter;
+	} else if (token == "fair_play_kicked") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayKicked;
+	} else if (token == "communications_inappropriate_video") {
+		*r_feedback_type = XblReputationFeedbackType::CommunicationsInappropriateVideo;
+	} else if (token == "communications_abusive_voice") {
+		*r_feedback_type = XblReputationFeedbackType::CommunicationsAbusiveVoice;
+	} else if (token == "inappropriate_user_generated_content") {
+		*r_feedback_type = XblReputationFeedbackType::InappropriateUserGeneratedContent;
+	} else if (token == "positive_skilled_player") {
+		*r_feedback_type = XblReputationFeedbackType::PositiveSkilledPlayer;
+	} else if (token == "positive_helpful_player") {
+		*r_feedback_type = XblReputationFeedbackType::PositiveHelpfulPlayer;
+	} else if (token == "positive_high_quality_user_generated_content") {
+		*r_feedback_type = XblReputationFeedbackType::PositiveHighQualityUserGeneratedContent;
+	} else if (token == "comms_phishing") {
+		*r_feedback_type = XblReputationFeedbackType::CommsPhishing;
+	} else if (token == "comms_picture_message") {
+		*r_feedback_type = XblReputationFeedbackType::CommsPictureMessage;
+	} else if (token == "comms_spam") {
+		*r_feedback_type = XblReputationFeedbackType::CommsSpam;
+	} else if (token == "comms_text_message") {
+		*r_feedback_type = XblReputationFeedbackType::CommsTextMessage;
+	} else if (token == "comms_voice_message") {
+		*r_feedback_type = XblReputationFeedbackType::CommsVoiceMessage;
+	} else if (token == "fair_play_console_ban_request") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayConsoleBanRequest;
+	} else if (token == "fair_play_idler") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayIdler;
+	} else if (token == "fair_play_user_ban_request") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayUserBanRequest;
+	} else if (token == "user_content_gamerpic") {
+		*r_feedback_type = XblReputationFeedbackType::UserContentGamerpic;
+	} else if (token == "user_content_personal_info") {
+		*r_feedback_type = XblReputationFeedbackType::UserContentPersonalInfo;
+	} else if (token == "fair_play_unsporting") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayUnsporting;
+	} else if (token == "fair_play_leaderboard_cheater") {
+		*r_feedback_type = XblReputationFeedbackType::FairPlayLeaderboardCheater;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+XblPresenceFilter _presence_filter_to_native(GDKSocialFilter::PresenceFilter p_filter) {
+	switch (p_filter) {
+		case GDKSocialFilter::PRESENCE_FILTER_TITLE_ONLINE:
+			return XblPresenceFilter::TitleOnline;
+		case GDKSocialFilter::PRESENCE_FILTER_TITLE_OFFLINE:
+			return XblPresenceFilter::TitleOffline;
+		case GDKSocialFilter::PRESENCE_FILTER_TITLE_ONLINE_OUTSIDE_TITLE:
+			return XblPresenceFilter::TitleOnlineOutsideTitle;
+		case GDKSocialFilter::PRESENCE_FILTER_ALL_ONLINE:
+			return XblPresenceFilter::AllOnline;
+		case GDKSocialFilter::PRESENCE_FILTER_ALL_OFFLINE:
+			return XblPresenceFilter::AllOffline;
+		case GDKSocialFilter::PRESENCE_FILTER_ALL_TITLE:
+			return XblPresenceFilter::AllTitle;
+		case GDKSocialFilter::PRESENCE_FILTER_ALL:
+			return XblPresenceFilter::All;
+		case GDKSocialFilter::PRESENCE_FILTER_UNKNOWN:
+		default:
+			return XblPresenceFilter::Unknown;
+	}
+}
+
+GDKSocialFilter::PresenceFilter _presence_filter_from_native(XblPresenceFilter p_filter) {
+	switch (p_filter) {
+		case XblPresenceFilter::TitleOnline:
+			return GDKSocialFilter::PRESENCE_FILTER_TITLE_ONLINE;
+		case XblPresenceFilter::TitleOffline:
+			return GDKSocialFilter::PRESENCE_FILTER_TITLE_OFFLINE;
+		case XblPresenceFilter::TitleOnlineOutsideTitle:
+			return GDKSocialFilter::PRESENCE_FILTER_TITLE_ONLINE_OUTSIDE_TITLE;
+		case XblPresenceFilter::AllOnline:
+			return GDKSocialFilter::PRESENCE_FILTER_ALL_ONLINE;
+		case XblPresenceFilter::AllOffline:
+			return GDKSocialFilter::PRESENCE_FILTER_ALL_OFFLINE;
+		case XblPresenceFilter::AllTitle:
+			return GDKSocialFilter::PRESENCE_FILTER_ALL_TITLE;
+		case XblPresenceFilter::All:
+			return GDKSocialFilter::PRESENCE_FILTER_ALL;
+		case XblPresenceFilter::Unknown:
+		default:
+			return GDKSocialFilter::PRESENCE_FILTER_UNKNOWN;
+	}
+}
+
+XblRelationshipFilter _relationship_filter_to_native(GDKSocialFilter::RelationshipFilter p_filter) {
+	switch (p_filter) {
+		case GDKSocialFilter::RELATIONSHIP_FILTER_FRIENDS:
+			return XblRelationshipFilter::Friends;
+		case GDKSocialFilter::RELATIONSHIP_FILTER_FAVORITE:
+			return XblRelationshipFilter::Favorite;
+		case GDKSocialFilter::RELATIONSHIP_FILTER_UNKNOWN:
+		default:
+			return XblRelationshipFilter::Unknown;
+	}
+}
+
+GDKSocialFilter::RelationshipFilter _relationship_filter_from_native(XblRelationshipFilter p_filter) {
+	switch (p_filter) {
+		case XblRelationshipFilter::Friends:
+			return GDKSocialFilter::RELATIONSHIP_FILTER_FRIENDS;
+		case XblRelationshipFilter::Favorite:
+			return GDKSocialFilter::RELATIONSHIP_FILTER_FAVORITE;
+		case XblRelationshipFilter::Unknown:
+		default:
+			return GDKSocialFilter::RELATIONSHIP_FILTER_UNKNOWN;
+	}
+}
+
+Dictionary _make_title_history_dictionary(const XblTitleHistory &p_title_history) {
+	Dictionary history;
+	history["has_user_played"] = p_title_history.hasUserPlayed;
+	history["last_time_user_played"] = static_cast<int64_t>(p_title_history.lastTimeUserPlayed);
+	history["last_time_user_played_text"] = _utf8_or_empty(p_title_history.lastTimeUserPlayedText);
+	return history;
+}
+
+Dictionary _make_preferred_color_dictionary(const XblPreferredColor &p_preferred_color) {
+	Dictionary preferred_color;
+	preferred_color["primary"] = _utf8_or_empty(p_preferred_color.primaryColor);
+	preferred_color["secondary"] = _utf8_or_empty(p_preferred_color.secondaryColor);
+	preferred_color["tertiary"] = _utf8_or_empty(p_preferred_color.tertiaryColor);
+	return preferred_color;
+}
+
+void _append_unique_local_id(std::vector<uint64_t> *r_values, XUserLocalId p_local_id) {
+	if (r_values == nullptr) {
+		return;
+	}
+
+	if (std::find(r_values->begin(), r_values->end(), p_local_id.value) == r_values->end()) {
+		r_values->push_back(p_local_id.value);
+	}
+}
+
+Ref<GDKResult> _make_social_error_result(HRESULT p_hresult, const String &p_code, const String &p_message) {
+	return GDKResult::error_result(p_hresult, p_code, p_message);
+}
+
+struct ParsedReputationFeedbackItem {
+	uint64_t xuid = 0;
+	XblReputationFeedbackType feedback_type = XblReputationFeedbackType::FairPlayCheater;
+	String reason;
+	String evidence_id;
+};
+
+class ReputationFeedbackAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	std::vector<ParsedReputationFeedbackItem> m_parsed_items;
+	std::vector<CharString> m_reason_values;
+	std::vector<CharString> m_evidence_values;
+	std::vector<XblReputationFeedbackItem> m_items;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Reputation feedback submission cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Reputation feedback submission cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to submit reputation feedback.", "reputation_feedback_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary data;
+		data["submitted_feedback_count"] = static_cast<int64_t>(m_items.size());
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	ReputationFeedbackAsyncContext(
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			std::vector<ParsedReputationFeedbackItem> p_items) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_parsed_items(std::move(p_items)) {
+		m_reason_values.reserve(m_parsed_items.size());
+		m_evidence_values.reserve(m_parsed_items.size());
+		m_items.reserve(m_parsed_items.size());
+
+		for (const ParsedReputationFeedbackItem &parsed_item : m_parsed_items) {
+			m_reason_values.push_back(parsed_item.reason.utf8());
+			m_evidence_values.push_back(parsed_item.evidence_id.utf8());
+		}
+
+		for (size_t i = 0; i < m_parsed_items.size(); ++i) {
+			XblReputationFeedbackItem item = {};
+			item.xboxUserId = m_parsed_items[i].xuid;
+			item.feedbackType = m_parsed_items[i].feedback_type;
+			item.sessionReference = nullptr;
+			item.reasonMessage = m_reason_values[i].get_data();
+			item.evidenceResourceId = m_parsed_items[i].evidence_id.is_empty() ? nullptr : m_evidence_values[i].get_data();
+			m_items.push_back(item);
+		}
+	}
+
+	~ReputationFeedbackAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	const XblReputationFeedbackItem *get_items() const {
+		return m_items.data();
+	}
+
+	size_t get_item_count() const {
+		return m_items.size();
+	}
+};
+
+} //namespace
+
+#endif
+
+static String _group_type_to_name(GDKSocialGroup::GroupType p_group_type) {
+	switch (p_group_type) {
+		case GDKSocialGroup::GROUP_TYPE_USER_LIST:
+			return "user_list";
+		case GDKSocialGroup::GROUP_TYPE_FILTER:
+		default:
+			return "filter";
+	}
+}
+
+void GDKSocialFilter::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_presence_filter"), &GDKSocialFilter::get_presence_filter);
+	ClassDB::bind_method(D_METHOD("set_presence_filter", "presence_filter"), &GDKSocialFilter::set_presence_filter);
+	ClassDB::bind_method(D_METHOD("get_relationship_filter"), &GDKSocialFilter::get_relationship_filter);
+	ClassDB::bind_method(D_METHOD("set_relationship_filter", "relationship_filter"), &GDKSocialFilter::set_relationship_filter);
+
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_UNKNOWN);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_TITLE_ONLINE);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_TITLE_OFFLINE);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_TITLE_ONLINE_OUTSIDE_TITLE);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_ALL_ONLINE);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_ALL_OFFLINE);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_ALL_TITLE);
+	BIND_ENUM_CONSTANT(PRESENCE_FILTER_ALL);
+
+	BIND_ENUM_CONSTANT(RELATIONSHIP_FILTER_UNKNOWN);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_FILTER_FRIENDS);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_FILTER_FAVORITE);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "presence_filter", PROPERTY_HINT_ENUM, "Unknown,Title Online,Title Offline,Title Online Outside Title,All Online,All Offline,All Title,All"), "set_presence_filter", "get_presence_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "relationship_filter", PROPERTY_HINT_ENUM, "Unknown,Friends,Favorite"), "set_relationship_filter", "get_relationship_filter");
+}
+
+GDKSocialFilter::PresenceFilter GDKSocialFilter::get_presence_filter() const {
+	return m_presence_filter;
+}
+
+void GDKSocialFilter::set_presence_filter(PresenceFilter p_presence_filter) {
+	m_presence_filter = p_presence_filter;
+}
+
+GDKSocialFilter::RelationshipFilter GDKSocialFilter::get_relationship_filter() const {
+	return m_relationship_filter;
+}
+
+void GDKSocialFilter::set_relationship_filter(RelationshipFilter p_relationship_filter) {
+	m_relationship_filter = p_relationship_filter;
+}
+
+void GDKSocialGroup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_local_user"), &GDKSocialGroup::get_local_user);
+	ClassDB::bind_method(D_METHOD("is_loaded"), &GDKSocialGroup::is_loaded);
+	ClassDB::bind_method(D_METHOD("get_group_type"), &GDKSocialGroup::get_group_type);
+	ClassDB::bind_method(D_METHOD("get_group_type_name"), &GDKSocialGroup::get_group_type_name);
+	ClassDB::bind_method(D_METHOD("get_presence_filter"), &GDKSocialGroup::get_presence_filter);
+	ClassDB::bind_method(D_METHOD("get_relationship_filter"), &GDKSocialGroup::get_relationship_filter);
+	ClassDB::bind_method(D_METHOD("get_tracked_xuids"), &GDKSocialGroup::get_tracked_xuids);
+
+	BIND_ENUM_CONSTANT(GROUP_TYPE_FILTER);
+	BIND_ENUM_CONSTANT(GROUP_TYPE_USER_LIST);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "local_user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser"), "", "get_local_user");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loaded"), "", "is_loaded");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "group_type", PROPERTY_HINT_ENUM, "Filter,User List"), "", "get_group_type");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "tracked_xuids"), "", "get_tracked_xuids");
+}
+
+Ref<GDKUser> GDKSocialGroup::get_local_user() const {
+	return m_local_user;
+}
+
+bool GDKSocialGroup::is_loaded() const {
+	return m_loaded;
+}
+
+GDKSocialGroup::GroupType GDKSocialGroup::get_group_type() const {
+	return m_group_type;
+}
+
+String GDKSocialGroup::get_group_type_name() const {
+	return _group_type_to_name(m_group_type);
+}
+
+GDKSocialFilter::PresenceFilter GDKSocialGroup::get_presence_filter() const {
+	return m_presence_filter;
+}
+
+GDKSocialFilter::RelationshipFilter GDKSocialGroup::get_relationship_filter() const {
+	return m_relationship_filter;
+}
+
+PackedStringArray GDKSocialGroup::get_tracked_xuids() const {
+	return m_tracked_xuids;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKSocialGroup::attach(const Ref<GDKUser> &p_local_user, XblSocialManagerUserGroupHandle p_group_handle) {
+	m_local_user = p_local_user;
+	m_group_handle = p_group_handle;
+}
+
+void GDKSocialGroup::set_group_type(GroupType p_group_type) {
+	m_group_type = p_group_type;
+}
+
+void GDKSocialGroup::set_filters(GDKSocialFilter::PresenceFilter p_presence_filter, GDKSocialFilter::RelationshipFilter p_relationship_filter) {
+	m_presence_filter = p_presence_filter;
+	m_relationship_filter = p_relationship_filter;
+}
+
+void GDKSocialGroup::set_tracked_xuids(const PackedStringArray &p_tracked_xuids) {
+	m_tracked_xuids = p_tracked_xuids;
+}
+
+void GDKSocialGroup::set_loaded(bool p_loaded) {
+	m_loaded = p_loaded;
+}
+
+bool GDKSocialGroup::matches_handle(XblSocialManagerUserGroupHandle p_group_handle) const {
+	return m_group_handle == p_group_handle;
+}
+
+XblSocialManagerUserGroupHandle GDKSocialGroup::get_handle() const {
+	return m_group_handle;
+}
+
+void GDKSocialGroup::invalidate() {
+	m_group_handle = nullptr;
+	m_loaded = false;
+}
+#else
+void GDKSocialGroup::attach(const Ref<GDKUser> &p_local_user, XblSocialManagerUserGroupHandle p_group_handle) {
+	m_local_user = p_local_user;
+	m_group_handle = p_group_handle;
+}
+
+bool GDKSocialGroup::matches_handle(XblSocialManagerUserGroupHandle p_group_handle) const {
+	return m_group_handle == p_group_handle;
+}
+
+XblSocialManagerUserGroupHandle GDKSocialGroup::get_handle() const {
+	return m_group_handle;
+}
+
+void GDKSocialGroup::invalidate() {
+	m_group_handle = nullptr;
+	m_loaded = false;
+}
+#endif
+
+void GDKSocialUser::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKSocialUser::get_xuid);
+	ClassDB::bind_method(D_METHOD("is_favorite"), &GDKSocialUser::is_favorite);
+	ClassDB::bind_method(D_METHOD("is_friend"), &GDKSocialUser::is_friend);
+	ClassDB::bind_method(D_METHOD("is_following_user"), &GDKSocialUser::is_following_user);
+	ClassDB::bind_method(D_METHOD("is_followed_by_caller"), &GDKSocialUser::is_followed_by_caller);
+	ClassDB::bind_method(D_METHOD("get_display_name"), &GDKSocialUser::get_display_name);
+	ClassDB::bind_method(D_METHOD("get_real_name"), &GDKSocialUser::get_real_name);
+	ClassDB::bind_method(D_METHOD("get_display_picture_url"), &GDKSocialUser::get_display_picture_url);
+	ClassDB::bind_method(D_METHOD("uses_avatar"), &GDKSocialUser::uses_avatar);
+	ClassDB::bind_method(D_METHOD("get_gamerscore"), &GDKSocialUser::get_gamerscore);
+	ClassDB::bind_method(D_METHOD("get_gamertag"), &GDKSocialUser::get_gamertag);
+	ClassDB::bind_method(D_METHOD("get_modern_gamertag"), &GDKSocialUser::get_modern_gamertag);
+	ClassDB::bind_method(D_METHOD("get_modern_gamertag_suffix"), &GDKSocialUser::get_modern_gamertag_suffix);
+	ClassDB::bind_method(D_METHOD("get_unique_modern_gamertag"), &GDKSocialUser::get_unique_modern_gamertag);
+	ClassDB::bind_method(D_METHOD("get_presence"), &GDKSocialUser::get_presence);
+	ClassDB::bind_method(D_METHOD("get_title_history"), &GDKSocialUser::get_title_history);
+	ClassDB::bind_method(D_METHOD("get_preferred_color"), &GDKSocialUser::get_preferred_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "favorite"), "", "is_favorite");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "friend"), "", "is_friend");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "display_name"), "", "get_display_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "real_name"), "", "get_real_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "display_picture_url"), "", "get_display_picture_url");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamerscore"), "", "get_gamerscore");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamertag"), "", "get_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "presence", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKPresenceRecord"), "", "get_presence");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "title_history"), "", "get_title_history");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "preferred_color"), "", "get_preferred_color");
+}
+
+String GDKSocialUser::get_xuid() const {
+	return m_xuid;
+}
+
+bool GDKSocialUser::is_favorite() const {
+	return m_is_favorite;
+}
+
+bool GDKSocialUser::is_friend() const {
+	return m_is_friend;
+}
+
+bool GDKSocialUser::is_following_user() const {
+	return m_is_following_user;
+}
+
+bool GDKSocialUser::is_followed_by_caller() const {
+	return m_is_followed_by_caller;
+}
+
+String GDKSocialUser::get_display_name() const {
+	return m_display_name;
+}
+
+String GDKSocialUser::get_real_name() const {
+	return m_real_name;
+}
+
+String GDKSocialUser::get_display_picture_url() const {
+	return m_display_picture_url;
+}
+
+bool GDKSocialUser::uses_avatar() const {
+	return m_use_avatar;
+}
+
+String GDKSocialUser::get_gamerscore() const {
+	return m_gamerscore;
+}
+
+String GDKSocialUser::get_gamertag() const {
+	return m_gamertag;
+}
+
+String GDKSocialUser::get_modern_gamertag() const {
+	return m_modern_gamertag;
+}
+
+String GDKSocialUser::get_modern_gamertag_suffix() const {
+	return m_modern_gamertag_suffix;
+}
+
+String GDKSocialUser::get_unique_modern_gamertag() const {
+	return m_unique_modern_gamertag;
+}
+
+Ref<GDKPresenceRecord> GDKSocialUser::get_presence() const {
+	return m_presence;
+}
+
+Dictionary GDKSocialUser::get_title_history() const {
+	return m_title_history;
+}
+
+Dictionary GDKSocialUser::get_preferred_color() const {
+	return m_preferred_color;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKSocialUser::populate_from_native(const XblSocialManagerUser &p_social_user) {
+	m_xuid = String::num_uint64(p_social_user.xboxUserId);
+	m_is_favorite = p_social_user.isFavorite;
+	m_is_friend = p_social_user.isFriend;
+	m_is_following_user = p_social_user.isFollowingUser;
+	m_is_followed_by_caller = p_social_user.isFollowedByCaller;
+	m_display_name = _utf8_or_empty(p_social_user.displayName);
+	m_real_name = _utf8_or_empty(p_social_user.realName);
+	m_display_picture_url = _utf8_or_empty(p_social_user.displayPicUrlRaw);
+	m_use_avatar = p_social_user.useAvatar;
+	m_gamerscore = _utf8_or_empty(p_social_user.gamerscore);
+	m_gamertag = _utf8_or_empty(p_social_user.gamertag);
+	m_modern_gamertag = _utf8_or_empty(p_social_user.modernGamertag);
+	m_modern_gamertag_suffix = _utf8_or_empty(p_social_user.modernGamertagSuffix);
+	m_unique_modern_gamertag = _utf8_or_empty(p_social_user.uniqueModernGamertag);
+	m_title_history = _make_title_history_dictionary(p_social_user.titleHistory);
+	m_preferred_color = _make_preferred_color_dictionary(p_social_user.preferredColor);
+
+	if (m_presence.is_null()) {
+		m_presence.instantiate();
+	}
+	m_presence->populate_from_social_manager_record(p_social_user.xboxUserId, p_social_user.presenceRecord);
+}
+#else
+void GDKSocialUser::populate_from_native(const XblSocialManagerUser &p_social_user) {
+}
+#endif
+
+void GDKSocial::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("start_social_graph", "user"), &GDKSocial::start_social_graph);
+	ClassDB::bind_method(D_METHOD("stop_social_graph", "user"), &GDKSocial::stop_social_graph);
+	ClassDB::bind_method(D_METHOD("get_friends_async", "user"), &GDKSocial::get_friends_async);
+	ClassDB::bind_method(D_METHOD("create_social_group", "user", "filter"), &GDKSocial::create_social_group, DEFVAL(Ref<GDKSocialFilter>()));
+	ClassDB::bind_method(D_METHOD("create_social_group_from_xuids", "user", "xuids"), &GDKSocial::create_social_group_from_xuids);
+	ClassDB::bind_method(D_METHOD("destroy_social_group", "group"), &GDKSocial::destroy_social_group);
+	ClassDB::bind_method(D_METHOD("get_group_users", "group"), &GDKSocial::get_group_users);
+	ClassDB::bind_method(D_METHOD("submit_reputation_feedback_async", "user", "target_xuid", "feedback_type", "reason", "evidence_id"), &GDKSocial::submit_reputation_feedback_async, DEFVAL(String()), DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("submit_batch_reputation_feedback_async", "user", "feedback_items"), &GDKSocial::submit_batch_reputation_feedback_async);
+
+	ADD_SIGNAL(MethodInfo("social_graph_changed", PropertyInfo(Variant::OBJECT, "user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser")));
+	ADD_SIGNAL(MethodInfo("social_group_updated", PropertyInfo(Variant::OBJECT, "group", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKSocialGroup")));
+	ADD_SIGNAL(MethodInfo("social_user_changed",
+			PropertyInfo(Variant::STRING, "xuid"),
+			PropertyInfo(Variant::OBJECT, "social_user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKSocialUser")));
+	ADD_SIGNAL(MethodInfo("runtime_error", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKResult")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKSocial::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKSocial::on_runtime_initialized() {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_not_initialized", "Cannot initialize the social service before the GDK runtime.");
+	}
+
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKSocial::shutdown() {
+	m_runtime_ready = false;
+
+	Ref<GDKResult> cancelled = GDKResult::cancelled("Social operation cancelled during shutdown.");
+	for (LocalUserState &state : m_local_user_states) {
+		_fail_pending_friend_ops(state.local_id, cancelled);
+	}
+
+	std::vector<Ref<GDKSocialGroup>> groups = m_groups;
+	for (const Ref<GDKSocialGroup> &group : groups) {
+		_destroy_group_internal(group, false);
+	}
+	m_groups.clear();
+
+	for (LocalUserState &state : m_local_user_states) {
+		if (state.graph_started && state.user.is_valid() && state.user->get_handle() != nullptr) {
+			XblSocialManagerRemoveLocalUser(state.user->get_handle());
+		}
+	}
+
+	m_pending_friend_ops.clear();
+	m_local_user_states.clear();
+	m_cached_users.clear();
+}
+
+int GDKSocial::dispatch() {
+	if (!m_runtime_ready) {
+		return 0;
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return 0;
+	}
+
+	const XblSocialManagerEvent *events = nullptr;
+	size_t event_count = 0;
+	HRESULT hr = XblSocialManagerDoWork(&events, &event_count);
+	if (FAILED(hr)) {
+		emit_signal("runtime_error", GDKResult::hresult_error(hr, "Failed to dispatch Social Manager state.", "social_manager_dispatch_failed"));
+		return 0;
+	}
+
+	int handled_events = 0;
+	std::vector<uint64_t> graph_changed_users;
+	std::vector<uint64_t> filter_group_updates;
+
+	for (size_t i = 0; i < event_count; ++i) {
+		const XblSocialManagerEvent &event = events[i];
+		XUserLocalId local_id = {};
+		if (event.user != nullptr) {
+			XUserGetLocalId(event.user, &local_id);
+		}
+
+		LocalUserState *state = _find_local_user_state(local_id);
+		++handled_events;
+
+		if (FAILED(event.hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(event.hr, "A Social Manager event failed.", "social_event_failed");
+			emit_signal("runtime_error", result);
+			if (!m_runtime_ready) {
+				return handled_events;
+			}
+			if (event.eventType == XblSocialManagerEventType::LocalUserAdded) {
+				_fail_pending_friend_ops(local_id, result);
+			}
+			continue;
+		}
+
+		switch (event.eventType) {
+			case XblSocialManagerEventType::LocalUserAdded: {
+				if (state != nullptr) {
+					state->graph_ready = true;
+					_append_unique_local_id(&graph_changed_users, local_id);
+				}
+			} break;
+			case XblSocialManagerEventType::SocialUserGroupLoaded:
+			case XblSocialManagerEventType::SocialUserGroupUpdated: {
+				Ref<GDKSocialGroup> group = _find_group_by_handle(event.groupAffected);
+				if (!group.is_valid()) {
+					continue;
+				}
+
+				group->set_loaded(true);
+				Ref<GDKResult> refresh_result = _refresh_group_metadata(group);
+				if (!refresh_result->is_ok()) {
+					_fail_pending_friend_ops(local_id, refresh_result);
+					emit_signal("runtime_error", refresh_result);
+					if (!m_runtime_ready) {
+						return handled_events;
+					}
+					continue;
+				}
+
+				_get_group_users_internal(group, false, false);
+				if (!m_runtime_ready) {
+					return handled_events;
+				}
+				emit_signal("social_group_updated", group);
+				if (!m_runtime_ready) {
+					return handled_events;
+				}
+				_complete_pending_friend_ops(group->get_handle());
+			} break;
+			case XblSocialManagerEventType::UsersAddedToSocialGraph:
+			case XblSocialManagerEventType::UsersRemovedFromSocialGraph:
+			case XblSocialManagerEventType::PresenceChanged:
+			case XblSocialManagerEventType::ProfilesChanged:
+			case XblSocialManagerEventType::SocialRelationshipsChanged: {
+				for (uint32_t user_index = 0; user_index < XBL_SOCIAL_MANAGER_MAX_AFFECTED_USERS_PER_EVENT; ++user_index) {
+					XblSocialManagerUser *affected_user = event.usersAffected[user_index];
+					if (affected_user == nullptr) {
+						continue;
+					}
+
+					const bool emit_presence_signal = event.eventType == XblSocialManagerEventType::PresenceChanged;
+					_cache_social_user(*affected_user, true, emit_presence_signal);
+					if (!m_runtime_ready) {
+						return handled_events;
+					}
+				}
+
+				if (event.eventType == XblSocialManagerEventType::UsersAddedToSocialGraph ||
+						event.eventType == XblSocialManagerEventType::UsersRemovedFromSocialGraph ||
+						event.eventType == XblSocialManagerEventType::SocialRelationshipsChanged) {
+					_append_unique_local_id(&graph_changed_users, local_id);
+				}
+				if (event.eventType == XblSocialManagerEventType::UsersAddedToSocialGraph ||
+						event.eventType == XblSocialManagerEventType::UsersRemovedFromSocialGraph ||
+						event.eventType == XblSocialManagerEventType::PresenceChanged ||
+						event.eventType == XblSocialManagerEventType::SocialRelationshipsChanged) {
+					_append_unique_local_id(&filter_group_updates, local_id);
+				}
+			} break;
+			case XblSocialManagerEventType::UnknownEvent:
+			default:
+				break;
+		}
+	}
+
+	for (uint64_t local_id_value : filter_group_updates) {
+		if (!m_runtime_ready) {
+			return handled_events;
+		}
+		XUserLocalId local_id = {};
+		local_id.value = local_id_value;
+		_emit_filter_group_updates(local_id);
+	}
+	for (uint64_t local_id_value : graph_changed_users) {
+		if (!m_runtime_ready) {
+			return handled_events;
+		}
+		XUserLocalId local_id = {};
+		local_id.value = local_id_value;
+		_emit_social_graph_changed(local_id);
+	}
+
+	return handled_events;
+}
+
+Ref<GDKResult> GDKSocial::start_social_graph(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_social_error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_social_error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for social graph operations.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_social_error_result(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using social.");
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	LocalUserState *existing_state = _find_local_user_state(local_id);
+	if (existing_state != nullptr && existing_state->graph_started) {
+		return GDKResult::ok_result();
+	}
+
+	const bool created_state = existing_state == nullptr;
+	if (existing_state == nullptr) {
+		LocalUserState state;
+		state.user = p_user;
+		state.local_id = local_id;
+		m_local_user_states.push_back(state);
+		existing_state = &m_local_user_states.back();
+	}
+
+	HRESULT hr = XblSocialManagerAddLocalUser(
+			p_user->get_handle(),
+			XblSocialManagerExtraDetailLevel::All,
+			runtime->get_task_queue());
+	if (FAILED(hr)) {
+		if (created_state) {
+			_erase_local_user_state(local_id);
+		}
+		return GDKResult::hresult_error(hr, "Failed to start the social graph.", "social_graph_start_failed");
+	}
+
+	existing_state->user = p_user;
+	existing_state->graph_started = true;
+	existing_state->graph_ready = false;
+	return GDKResult::ok_result();
+}
+
+void GDKSocial::stop_social_graph(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	LocalUserState *state = _find_local_user_state(local_id);
+	if (state == nullptr) {
+		return;
+	}
+
+	_fail_pending_friend_ops(local_id, GDKResult::cancelled("Friends query cancelled because the social graph stopped."));
+
+	std::vector<Ref<GDKSocialGroup>> groups = m_groups;
+	for (const Ref<GDKSocialGroup> &group : groups) {
+		if (!group.is_valid()) {
+			continue;
+		}
+
+		Ref<GDKUser> local_user = group->get_local_user();
+		if (local_user.is_valid() && local_user->get_local_id() == p_user->get_local_id()) {
+			_destroy_group_internal(group, true);
+		}
+	}
+
+	if (state->graph_started && p_user->get_handle() != nullptr) {
+		XblSocialManagerRemoveLocalUser(p_user->get_handle());
+	}
+
+	_erase_local_user_state(local_id);
+}
+
+Signal GDKSocial::get_friends_async(const Ref<GDKUser> &p_user) {
+	LocalUserState *state = nullptr;
+	Ref<GDKResult> ensure_result = _ensure_local_user_state(p_user, &state, true);
+	if (!ensure_result->is_ok()) {
+		return _make_error_signal(
+				static_cast<HRESULT>(ensure_result->get_hresult()),
+				ensure_result->get_code(),
+				ensure_result->get_message());
+	}
+
+	if (!state->friends_group.is_valid()) {
+		Ref<GDKSocialFilter> filter;
+		filter.instantiate();
+		filter->set_presence_filter(GDKSocialFilter::PRESENCE_FILTER_ALL);
+		filter->set_relationship_filter(GDKSocialFilter::RELATIONSHIP_FILTER_FRIENDS);
+		Ref<GDKResult> create_error;
+		state->friends_group = _create_social_group_internal(state->user, filter, &create_error);
+		if (!state->friends_group.is_valid()) {
+			if (create_error.is_valid() && !create_error->is_ok()) {
+				emit_signal("runtime_error", create_error);
+				return _make_error_signal(
+						static_cast<HRESULT>(create_error->get_hresult()),
+						create_error->get_code(),
+						create_error->get_message());
+			}
+			return _make_error_signal(E_FAIL, "friends_group_create_failed", "Failed to create the default friends social group.");
+		}
+	}
+
+	if (state->friends_group->is_loaded()) {
+		return _make_completed_signal(GDKResult::ok_result(state->friends_group));
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	ERR_FAIL_COND_V(pending_signal.is_null(), Signal());
+
+	PendingFriendsOp pending_op;
+	pending_op.local_id = state->local_id;
+	pending_op.group_handle = state->friends_group->get_handle();
+	pending_op.request = pending_signal;
+	m_pending_friend_ops.push_back(pending_op);
+
+	GDKPendingSignal *pending_signal_ptr = pending_signal.ptr();
+	pending_signal->set_cancel_handler([this, pending_signal_ptr]() {
+		_cancel_pending_friend_signal(pending_signal_ptr);
+	});
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKSocialGroup> GDKSocial::_create_social_group_internal(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter, Ref<GDKResult> *r_error) {
+	LocalUserState *state = nullptr;
+	Ref<GDKResult> ensure_result = _ensure_local_user_state(p_user, &state, true);
+	if (!ensure_result->is_ok()) {
+		if (r_error != nullptr) {
+			*r_error = ensure_result;
+		}
+		return Ref<GDKSocialGroup>();
+	}
+
+	const GDKSocialFilter::PresenceFilter presence_filter = p_filter.is_valid() ? p_filter->get_presence_filter() : GDKSocialFilter::PRESENCE_FILTER_ALL;
+	const GDKSocialFilter::RelationshipFilter relationship_filter = p_filter.is_valid() ? p_filter->get_relationship_filter() : GDKSocialFilter::RELATIONSHIP_FILTER_FRIENDS;
+
+	XblSocialManagerUserGroupHandle group_handle = nullptr;
+	HRESULT hr = XblSocialManagerCreateSocialUserGroupFromFilters(
+			p_user->get_handle(),
+			_presence_filter_to_native(presence_filter),
+			_relationship_filter_to_native(relationship_filter),
+			&group_handle);
+	if (FAILED(hr)) {
+		if (r_error != nullptr) {
+			*r_error = GDKResult::hresult_error(
+					hr,
+					"Failed to create a filter-based social group.",
+					"social_group_create_failed");
+		}
+		return Ref<GDKSocialGroup>();
+	}
+
+	Ref<GDKSocialGroup> group;
+	group.instantiate();
+	group->attach(p_user, group_handle);
+	group->set_group_type(GDKSocialGroup::GROUP_TYPE_FILTER);
+	group->set_filters(presence_filter, relationship_filter);
+	m_groups.push_back(group);
+	if (r_error != nullptr) {
+		*r_error = GDKResult::ok_result();
+	}
+	return group;
+}
+
+Ref<GDKResult> GDKSocial::create_social_group(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter) {
+	Ref<GDKResult> error_result;
+	Ref<GDKSocialGroup> group = _create_social_group_internal(p_user, p_filter, &error_result);
+	if (!group.is_valid()) {
+		if (!error_result.is_valid() || error_result->is_ok()) {
+			error_result = GDKResult::error_result(E_FAIL, "social_group_create_failed", "Failed to create the social group.");
+		}
+		emit_signal("runtime_error", error_result);
+		return error_result;
+	}
+	return GDKResult::ok_result(group);
+}
+
+Ref<GDKSocialGroup> GDKSocial::_create_social_group_from_xuids_internal(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, Ref<GDKResult> *r_error) {
+	LocalUserState *state = nullptr;
+	Ref<GDKResult> ensure_result = _ensure_local_user_state(p_user, &state, true);
+	if (!ensure_result->is_ok()) {
+		if (r_error != nullptr) {
+			*r_error = ensure_result;
+		}
+		return Ref<GDKSocialGroup>();
+	}
+
+	if (p_xuids.is_empty()) {
+		if (r_error != nullptr) {
+			*r_error = GDKResult::error_result(E_INVALIDARG, "missing_social_group_xuids", "Social list groups require at least one XUID.");
+		}
+		return Ref<GDKSocialGroup>();
+	}
+	if (p_xuids.size() > XBL_SOCIAL_MANAGER_MAX_USERS_FROM_LIST) {
+		if (r_error != nullptr) {
+			*r_error = GDKResult::error_result(E_INVALIDARG, "too_many_social_group_xuids", "Social list groups cannot exceed the XSAPI maximum tracked user count.");
+		}
+		return Ref<GDKSocialGroup>();
+	}
+
+	std::vector<uint64_t> native_xuids;
+	native_xuids.reserve(static_cast<size_t>(p_xuids.size()));
+	for (int64_t i = 0; i < p_xuids.size(); ++i) {
+		uint64_t xuid = 0;
+		if (!_try_parse_xuid(p_xuids[i], &xuid)) {
+			if (r_error != nullptr) {
+				*r_error = GDKResult::error_result(E_INVALIDARG, "invalid_social_group_xuid", "Social list groups require numeric XUID strings.");
+			}
+			return Ref<GDKSocialGroup>();
+		}
+		native_xuids.push_back(xuid);
+	}
+
+	XblSocialManagerUserGroupHandle group_handle = nullptr;
+	HRESULT hr = XblSocialManagerCreateSocialUserGroupFromList(
+			p_user->get_handle(),
+			native_xuids.data(),
+			native_xuids.size(),
+			&group_handle);
+	if (FAILED(hr)) {
+		if (r_error != nullptr) {
+			*r_error = GDKResult::hresult_error(
+					hr,
+					"Failed to create a list-based social group.",
+					"social_group_list_create_failed");
+		}
+		return Ref<GDKSocialGroup>();
+	}
+
+	Ref<GDKSocialGroup> group;
+	group.instantiate();
+	group->attach(p_user, group_handle);
+	group->set_group_type(GDKSocialGroup::GROUP_TYPE_USER_LIST);
+	group->set_tracked_xuids(p_xuids);
+	m_groups.push_back(group);
+	if (r_error != nullptr) {
+		*r_error = GDKResult::ok_result();
+	}
+	return group;
+}
+
+Ref<GDKResult> GDKSocial::create_social_group_from_xuids(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids) {
+	Ref<GDKResult> error_result;
+	Ref<GDKSocialGroup> group = _create_social_group_from_xuids_internal(p_user, p_xuids, &error_result);
+	if (!group.is_valid()) {
+		if (!error_result.is_valid() || error_result->is_ok()) {
+			error_result = GDKResult::error_result(E_FAIL, "social_group_list_create_failed", "Failed to create the social group from XUIDs.");
+		}
+		emit_signal("runtime_error", error_result);
+		return error_result;
+	}
+	return GDKResult::ok_result(group);
+}
+
+void GDKSocial::destroy_social_group(const Ref<GDKSocialGroup> &p_group) {
+	_destroy_group_internal(p_group, true);
+}
+
+Ref<GDKResult> GDKSocial::get_group_users(const Ref<GDKSocialGroup> &p_group) {
+	Ref<GDKResult> error_result;
+	Array users = _get_group_users_internal(p_group, false, false, &error_result);
+	if (error_result.is_valid() && !error_result->is_ok()) {
+		emit_signal("runtime_error", error_result);
+		return error_result;
+	}
+	return GDKResult::ok_result(users);
+}
+
+Signal GDKSocial::submit_reputation_feedback_async(const Ref<GDKUser> &p_user, const String &p_target_xuid, const String &p_feedback_type, const String &p_reason, const String &p_evidence_id) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	ParsedReputationFeedbackItem parsed_item;
+	if (!_try_parse_xuid(p_target_xuid, &parsed_item.xuid)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_xuid", "target_xuid must be a non-empty decimal XUID string.");
+	}
+	if (!_try_parse_reputation_feedback_type(p_feedback_type, &parsed_item.feedback_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_feedback_type", "Unknown reputation feedback type.");
+	}
+	parsed_item.reason = p_reason;
+	parsed_item.evidence_id = p_evidence_id;
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using social.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	std::vector<ParsedReputationFeedbackItem> items;
+	items.push_back(parsed_item);
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	auto *async_context = new ReputationFeedbackAsyncContext(runtime, pending_signal, context, std::move(items));
+	async_context->bind_cancel_handler();
+
+	const XblReputationFeedbackItem *native_item = async_context->get_items();
+	hr = XblSocialSubmitReputationFeedbackAsync(
+			async_context->get_context(),
+			native_item[0].xboxUserId,
+			native_item[0].feedbackType,
+			nullptr,
+			native_item[0].reasonMessage,
+			native_item[0].evidenceResourceId,
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "reputation_feedback_start_failed", "Failed to start reputation feedback submission.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKSocial::submit_batch_reputation_feedback_async(const Ref<GDKUser> &p_user, const Array &p_feedback_items) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+	if (p_feedback_items.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_feedback_items", "At least one reputation feedback item is required.");
+	}
+
+	std::vector<ParsedReputationFeedbackItem> items;
+	items.reserve(static_cast<size_t>(p_feedback_items.size()));
+	for (int64_t i = 0; i < p_feedback_items.size(); ++i) {
+		if (p_feedback_items[i].get_type() != Variant::DICTIONARY) {
+			return _make_error_signal(E_INVALIDARG, "invalid_feedback_item", "Reputation feedback items must be dictionaries.");
+		}
+
+		Dictionary item = p_feedback_items[i];
+		if (!item.has("target_xuid") || !item.has("feedback_type")) {
+			return _make_error_signal(E_INVALIDARG, "invalid_feedback_item", "Reputation feedback items require target_xuid and feedback_type.");
+		}
+
+		ParsedReputationFeedbackItem parsed_item;
+		if (!_try_parse_xuid(String(item["target_xuid"]), &parsed_item.xuid)) {
+			return _make_error_signal(E_INVALIDARG, "invalid_xuid", "target_xuid values must be decimal XUID strings.");
+		}
+		if (!_try_parse_reputation_feedback_type(String(item["feedback_type"]), &parsed_item.feedback_type)) {
+			return _make_error_signal(E_INVALIDARG, "invalid_feedback_type", "Unknown reputation feedback type.");
+		}
+		if (item.has("reason")) {
+			parsed_item.reason = String(item["reason"]);
+		}
+		if (item.has("evidence_id")) {
+			parsed_item.evidence_id = String(item["evidence_id"]);
+		}
+		items.push_back(parsed_item);
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using social.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	auto *async_context = new ReputationFeedbackAsyncContext(runtime, pending_signal, context, std::move(items));
+	async_context->bind_cancel_handler();
+
+	hr = XblSocialSubmitBatchReputationFeedbackAsync(
+			async_context->get_context(),
+			async_context->get_items(),
+			async_context->get_item_count(),
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "reputation_feedback_start_failed", "Failed to start batch reputation feedback submission.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+void GDKSocial::on_user_removed(const Ref<GDKUser> &p_user) {
+	stop_social_graph(p_user);
+}
+
+GDKRuntime *GDKSocial::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+GDKXboxServices *GDKSocial::_get_xbox_services() const {
+	return m_owner != nullptr ? m_owner->get_xbox_services() : nullptr;
+}
+
+GDKPresence *GDKSocial::_get_presence_service() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+
+	Ref<GDKPresence> presence = m_owner->get_presence();
+	return presence.ptr();
+}
+
+Signal GDKSocial::_make_completed_signal(const Ref<GDKResult> &p_result) const {
+	GDKRuntime *runtime = _get_runtime();
+	Ref<GDKPendingSignal> pending_signal = runtime != nullptr ? runtime->make_pending_signal() : Ref<GDKPendingSignal>();
+	if (pending_signal.is_null()) {
+		pending_signal.instantiate();
+	}
+	pending_signal->complete_deferred(p_result);
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKSocial::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+		return runtime->make_error_signal(p_hresult, p_code, p_message);
+	}
+
+	Ref<GDKPendingSignal> pending_signal;
+	pending_signal.instantiate();
+	pending_signal->complete_deferred(GDKResult::error_result(p_hresult, p_code, p_message));
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKSocial::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for social operations.");
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKSocial::_ensure_local_user_state(const Ref<GDKUser> &p_user, LocalUserState **r_state, bool p_auto_start) {
+	ERR_FAIL_COND_V(r_state == nullptr, GDKResult::error_result(E_POINTER, "internal_error", "Missing social local-user output."));
+
+	*r_state = nullptr;
+
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required for social graph operations.");
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	LocalUserState *state = _find_local_user_state(local_id);
+	if (state == nullptr || !state->graph_started) {
+		if (!p_auto_start) {
+			return GDKResult::error_result(E_FAIL, "social_graph_not_started", "Start the social graph before using social groups.");
+		}
+
+		Ref<GDKResult> start_result = start_social_graph(p_user);
+		if (!start_result->is_ok()) {
+			return start_result;
+		}
+		state = _find_local_user_state(local_id);
+	}
+
+	if (state == nullptr) {
+		return GDKResult::error_result(E_FAIL, "social_graph_state_missing", "The social graph state could not be created.");
+	}
+
+	*r_state = state;
+	return GDKResult::ok_result();
+}
+
+GDKSocial::LocalUserState *GDKSocial::_find_local_user_state(XUserLocalId p_local_id) {
+	for (LocalUserState &state : m_local_user_states) {
+		if (state.local_id.value == p_local_id.value) {
+			return &state;
+		}
+	}
+
+	return nullptr;
+}
+
+Ref<GDKSocialGroup> GDKSocial::_find_group_by_handle(XblSocialManagerUserGroupHandle p_group_handle) const {
+	for (const Ref<GDKSocialGroup> &group : m_groups) {
+		if (group.is_valid() && group->matches_handle(p_group_handle)) {
+			return group;
+		}
+	}
+
+	return Ref<GDKSocialGroup>();
+}
+
+Ref<GDKSocialUser> GDKSocial::_find_cached_user(const String &p_xuid) const {
+	for (const Ref<GDKSocialUser> &user : m_cached_users) {
+		if (user.is_valid() && user->get_xuid() == p_xuid) {
+			return user;
+		}
+	}
+
+	return Ref<GDKSocialUser>();
+}
+
+Ref<GDKSocialUser> GDKSocial::_cache_social_user(const XblSocialManagerUser &p_social_user, bool p_emit_social_signal, bool p_emit_presence_signal) {
+	if (!m_runtime_ready) {
+		return Ref<GDKSocialUser>();
+	}
+
+	const String xuid = String::num_uint64(p_social_user.xboxUserId);
+	Ref<GDKSocialUser> social_user = _find_cached_user(xuid);
+	if (social_user.is_null()) {
+		social_user.instantiate();
+		m_cached_users.push_back(social_user);
+	}
+
+	social_user->populate_from_native(p_social_user);
+
+	GDKPresence *presence = _get_presence_service();
+	if (presence != nullptr && social_user->get_presence().is_valid()) {
+		presence->cache_presence_record(social_user->get_presence(), p_emit_presence_signal);
+		if (!m_runtime_ready) {
+			return social_user;
+		}
+	}
+
+	if (p_emit_social_signal) {
+		emit_signal("social_user_changed", xuid, social_user);
+	}
+
+	return social_user;
+}
+
+Array GDKSocial::_get_group_users_internal(const Ref<GDKSocialGroup> &p_group, bool p_emit_social_signal, bool p_emit_presence_signal, Ref<GDKResult> *r_error) {
+	Array users;
+	if (r_error != nullptr) {
+		*r_error = GDKResult::ok_result();
+	}
+	if (!p_group.is_valid() || p_group->get_handle() == nullptr || !p_group->is_loaded()) {
+		return users;
+	}
+
+	XblSocialManagerUserPtrArray native_users = nullptr;
+	size_t native_user_count = 0;
+	HRESULT hr = XblSocialManagerUserGroupGetUsers(p_group->get_handle(), &native_users, &native_user_count);
+	if (FAILED(hr)) {
+		Ref<GDKResult> error = GDKResult::hresult_error(
+				hr,
+				"Failed to read the users for a social group.",
+				"social_group_users_failed");
+		if (r_error != nullptr) {
+			*r_error = error;
+		} else {
+			emit_signal("runtime_error", error);
+		}
+		return users;
+	}
+
+	for (size_t i = 0; i < native_user_count; ++i) {
+		if (!m_runtime_ready) {
+			break;
+		}
+		if (native_users[i] == nullptr) {
+			continue;
+		}
+		Ref<GDKSocialUser> user = _cache_social_user(*native_users[i], p_emit_social_signal, p_emit_presence_signal);
+		if (user.is_valid()) {
+			users.push_back(user);
+		}
+	}
+
+	return users;
+}
+
+Ref<GDKResult> GDKSocial::_refresh_group_metadata(const Ref<GDKSocialGroup> &p_group) {
+	ERR_FAIL_COND_V(!p_group.is_valid(), GDKResult::error_result(E_INVALIDARG, "invalid_social_group", "A valid GDKSocialGroup is required."));
+	if (p_group->get_handle() == nullptr) {
+		return GDKResult::error_result(E_FAIL, "social_group_invalidated", "The social group is no longer valid.");
+	}
+
+	XblSocialUserGroupType native_group_type = XblSocialUserGroupType::FilterType;
+	HRESULT hr = XblSocialManagerUserGroupGetType(p_group->get_handle(), &native_group_type);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to read the social group type.", "social_group_type_failed");
+	}
+
+	p_group->set_group_type(native_group_type == XblSocialUserGroupType::UserListType ? GDKSocialGroup::GROUP_TYPE_USER_LIST : GDKSocialGroup::GROUP_TYPE_FILTER);
+
+	if (native_group_type == XblSocialUserGroupType::FilterType) {
+		XblPresenceFilter native_presence_filter = XblPresenceFilter::Unknown;
+		XblRelationshipFilter native_relationship_filter = XblRelationshipFilter::Unknown;
+		hr = XblSocialManagerUserGroupGetFilters(p_group->get_handle(), &native_presence_filter, &native_relationship_filter);
+		if (FAILED(hr)) {
+			return GDKResult::hresult_error(hr, "Failed to read the social group filters.", "social_group_filters_failed");
+		}
+
+		p_group->set_filters(_presence_filter_from_native(native_presence_filter), _relationship_filter_from_native(native_relationship_filter));
+	}
+
+	const uint64_t *tracked_users = nullptr;
+	size_t tracked_user_count = 0;
+	hr = XblSocialManagerUserGroupGetUsersTrackedByGroup(p_group->get_handle(), &tracked_users, &tracked_user_count);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to read the tracked social group users.", "social_group_tracked_users_failed");
+	}
+
+	PackedStringArray tracked_xuids;
+	for (size_t i = 0; i < tracked_user_count; ++i) {
+		tracked_xuids.push_back(String::num_uint64(tracked_users[i]));
+	}
+	p_group->set_tracked_xuids(tracked_xuids);
+	p_group->set_loaded(true);
+	return GDKResult::ok_result();
+}
+
+void GDKSocial::_complete_pending_friend_ops(XblSocialManagerUserGroupHandle p_group_handle) {
+	for (auto it = m_pending_friend_ops.begin(); it != m_pending_friend_ops.end();) {
+		if (!it->request.is_valid()) {
+			it = m_pending_friend_ops.erase(it);
+			continue;
+		}
+		if (it->group_handle != p_group_handle) {
+			++it;
+			continue;
+		}
+
+		Ref<GDKSocialGroup> group = _find_group_by_handle(p_group_handle);
+		it->request->complete(GDKResult::ok_result(group));
+		it = m_pending_friend_ops.erase(it);
+	}
+}
+
+void GDKSocial::_fail_pending_friend_ops(XUserLocalId p_local_id, const Ref<GDKResult> &p_result) {
+	for (auto it = m_pending_friend_ops.begin(); it != m_pending_friend_ops.end();) {
+		if (!it->request.is_valid()) {
+			it = m_pending_friend_ops.erase(it);
+			continue;
+		}
+		if (p_local_id.value != 0 && it->local_id.value != p_local_id.value) {
+			++it;
+			continue;
+		}
+
+		it->request->complete(p_result);
+		it = m_pending_friend_ops.erase(it);
+	}
+}
+
+void GDKSocial::_fail_pending_friend_ops_for_group(XblSocialManagerUserGroupHandle p_group_handle, const Ref<GDKResult> &p_result) {
+	if (p_group_handle == nullptr) {
+		return;
+	}
+
+	for (auto it = m_pending_friend_ops.begin(); it != m_pending_friend_ops.end();) {
+		if (!it->request.is_valid()) {
+			it = m_pending_friend_ops.erase(it);
+			continue;
+		}
+		if (it->group_handle != p_group_handle) {
+			++it;
+			continue;
+		}
+
+		it->request->complete(p_result);
+		it = m_pending_friend_ops.erase(it);
+	}
+}
+
+void GDKSocial::_cancel_pending_friend_signal(GDKPendingSignal *p_request) {
+	if (p_request == nullptr) {
+		return;
+	}
+
+	for (auto it = m_pending_friend_ops.begin(); it != m_pending_friend_ops.end(); ++it) {
+		if (it->request.is_null() || it->request.ptr() != p_request) {
+			continue;
+		}
+
+		Ref<GDKPendingSignal> pending_signal = it->request;
+		m_pending_friend_ops.erase(it);
+		if (pending_signal.is_valid()) {
+			pending_signal->clear_cancel_handler();
+			pending_signal->complete(GDKResult::cancelled("Friends query cancelled."));
+		}
+		return;
+	}
+}
+
+void GDKSocial::_destroy_group_internal(const Ref<GDKSocialGroup> &p_group, bool p_remove_from_collection) {
+	if (!p_group.is_valid()) {
+		return;
+	}
+
+	XblSocialManagerUserGroupHandle group_handle = p_group->get_handle();
+	if (group_handle != nullptr) {
+		_fail_pending_friend_ops_for_group(group_handle, GDKResult::cancelled("Friends query cancelled because the social group was destroyed."));
+		XblSocialManagerDestroySocialUserGroup(group_handle);
+	}
+	p_group->invalidate();
+
+	if (p_remove_from_collection) {
+		m_groups.erase(
+				std::remove_if(
+						m_groups.begin(),
+						m_groups.end(),
+						[&p_group](const Ref<GDKSocialGroup> &group) {
+							return group.is_null() || group == p_group;
+						}),
+				m_groups.end());
+	}
+
+	for (LocalUserState &state : m_local_user_states) {
+		if (state.friends_group == p_group) {
+			state.friends_group.unref();
+		}
+	}
+}
+
+void GDKSocial::_erase_local_user_state(XUserLocalId p_local_id) {
+	m_local_user_states.erase(
+			std::remove_if(
+					m_local_user_states.begin(),
+					m_local_user_states.end(),
+					[p_local_id](const LocalUserState &state) {
+						return state.local_id.value == p_local_id.value;
+					}),
+			m_local_user_states.end());
+}
+
+void GDKSocial::_emit_filter_group_updates(XUserLocalId p_local_id) {
+	if (!m_runtime_ready) {
+		return;
+	}
+
+	std::vector<Ref<GDKSocialGroup>> groups = m_groups;
+	for (const Ref<GDKSocialGroup> &group : groups) {
+		if (!m_runtime_ready) {
+			return;
+		}
+		if (!group.is_valid() || !group->is_loaded() || group->get_handle() == nullptr) {
+			continue;
+		}
+
+		Ref<GDKUser> local_user = group->get_local_user();
+		if (!local_user.is_valid() || local_user->get_local_id() != static_cast<int64_t>(p_local_id.value)) {
+			continue;
+		}
+		if (group->get_group_type() != GDKSocialGroup::GROUP_TYPE_FILTER) {
+			continue;
+		}
+
+		Ref<GDKResult> refresh_result = _refresh_group_metadata(group);
+		if (!refresh_result->is_ok()) {
+			emit_signal("runtime_error", refresh_result);
+			if (!m_runtime_ready) {
+				return;
+			}
+			continue;
+		}
+
+		emit_signal("social_group_updated", group);
+		if (!m_runtime_ready) {
+			return;
+		}
+	}
+}
+
+void GDKSocial::_emit_social_graph_changed(XUserLocalId p_local_id) {
+	if (!m_runtime_ready) {
+		return;
+	}
+
+	LocalUserState *state = _find_local_user_state(p_local_id);
+	if (state != nullptr && state->user.is_valid()) {
+		emit_signal("social_graph_changed", state->user);
+	}
+}
+
+#else
+void GDKSocial::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKSocial::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKSocial::shutdown() {}
+
+int GDKSocial::dispatch() {
+	return 0;
+}
+
+Ref<GDKResult> GDKSocial::start_social_graph(const Ref<GDKUser> &p_user) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKSocial::stop_social_graph(const Ref<GDKUser> &p_user) {}
+
+Signal GDKSocial::get_friends_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKSocialGroup> GDKSocial::_create_social_group_internal(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter, Ref<GDKResult> *r_error) {
+	return Ref<GDKSocialGroup>();
+}
+
+Ref<GDKResult> GDKSocial::create_social_group(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKSocialGroup> GDKSocial::_create_social_group_from_xuids_internal(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, Ref<GDKResult> *r_error) {
+	return Ref<GDKSocialGroup>();
+}
+
+Ref<GDKResult> GDKSocial::create_social_group_from_xuids(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKSocial::destroy_social_group(const Ref<GDKSocialGroup> &p_group) {}
+
+Ref<GDKResult> GDKSocial::get_group_users(const Ref<GDKSocialGroup> &p_group) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKSocial::submit_reputation_feedback_async(const Ref<GDKUser> &p_user, const String &p_target_xuid, const String &p_feedback_type, const String &p_reason, const String &p_evidence_id) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKSocial::submit_batch_reputation_feedback_async(const Ref<GDKUser> &p_user, const Array &p_feedback_items) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKSocial::on_user_removed(const Ref<GDKUser> &p_user) {}
+
+Signal GDKSocial::_make_completed_signal(const Ref<GDKResult> &p_result) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKSocial::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKSocial::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKSocial::_ensure_local_user_state(const Ref<GDKUser> &p_user, LocalUserState **r_state, bool p_auto_start) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKSocialGroup> GDKSocial::_find_group_by_handle(XblSocialManagerUserGroupHandle p_group_handle) const {
+	return Ref<GDKSocialGroup>();
+}
+
+Ref<GDKSocialUser> GDKSocial::_find_cached_user(const String &p_xuid) const {
+	return Ref<GDKSocialUser>();
+}
+
+Ref<GDKSocialUser> GDKSocial::_cache_social_user(const XblSocialManagerUser &p_social_user, bool p_emit_social_signal, bool p_emit_presence_signal) {
+	return Ref<GDKSocialUser>();
+}
+
+Array GDKSocial::_get_group_users_internal(const Ref<GDKSocialGroup> &p_group, bool p_emit_social_signal, bool p_emit_presence_signal, Ref<GDKResult> *r_error) {
+	return Array();
+}
+
+Ref<GDKResult> GDKSocial::_refresh_group_metadata(const Ref<GDKSocialGroup> &p_group) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKSocial::_complete_pending_friend_ops(XblSocialManagerUserGroupHandle p_group_handle) {}
+
+void GDKSocial::_fail_pending_friend_ops(XUserLocalId p_local_id, const Ref<GDKResult> &p_result) {}
+
+void GDKSocial::_fail_pending_friend_ops_for_group(XblSocialManagerUserGroupHandle p_group_handle, const Ref<GDKResult> &p_result) {}
+
+void GDKSocial::_cancel_pending_friend_signal(GDKPendingSignal *p_request) {}
+
+void GDKSocial::_destroy_group_internal(const Ref<GDKSocialGroup> &p_group, bool p_remove_from_collection) {}
+
+void GDKSocial::_erase_local_user_state(XUserLocalId p_local_id) {}
+
+void GDKSocial::_emit_filter_group_updates(XUserLocalId p_local_id) {}
+
+void GDKSocial::_emit_social_graph_changed(XUserLocalId p_local_id) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_social.h
+++ b/modules/xbox_module/gdk/gdk_social.h
@@ -1,0 +1,258 @@
+/**************************************************************************/
+/*  gdk_social.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/variant/callable.h"
+#include "gdk_gdk_stubs.h"
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/dictionary.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+#include "gdk_pending_signal.h"
+#include "gdk_presence.h"
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKSocialFilter : public RefCounted {
+	GDCLASS(GDKSocialFilter, RefCounted);
+
+public:
+	enum PresenceFilter {
+		PRESENCE_FILTER_UNKNOWN = 0,
+		PRESENCE_FILTER_TITLE_ONLINE,
+		PRESENCE_FILTER_TITLE_OFFLINE,
+		PRESENCE_FILTER_TITLE_ONLINE_OUTSIDE_TITLE,
+		PRESENCE_FILTER_ALL_ONLINE,
+		PRESENCE_FILTER_ALL_OFFLINE,
+		PRESENCE_FILTER_ALL_TITLE,
+		PRESENCE_FILTER_ALL,
+	};
+
+	enum RelationshipFilter {
+		RELATIONSHIP_FILTER_UNKNOWN = 0,
+		RELATIONSHIP_FILTER_FRIENDS,
+		RELATIONSHIP_FILTER_FAVORITE,
+	};
+
+private:
+	PresenceFilter m_presence_filter = PRESENCE_FILTER_ALL;
+	RelationshipFilter m_relationship_filter = RELATIONSHIP_FILTER_FRIENDS;
+
+protected:
+	static void _bind_methods();
+
+public:
+	PresenceFilter get_presence_filter() const;
+	void set_presence_filter(PresenceFilter p_presence_filter);
+	RelationshipFilter get_relationship_filter() const;
+	void set_relationship_filter(RelationshipFilter p_relationship_filter);
+};
+
+class GDKSocialGroup : public RefCounted {
+	GDCLASS(GDKSocialGroup, RefCounted);
+
+public:
+	enum GroupType {
+		GROUP_TYPE_FILTER = 0,
+		GROUP_TYPE_USER_LIST,
+	};
+
+private:
+	Ref<GDKUser> m_local_user;
+	XblSocialManagerUserGroupHandle m_group_handle = nullptr;
+	bool m_loaded = false;
+	GroupType m_group_type = GROUP_TYPE_FILTER;
+	GDKSocialFilter::PresenceFilter m_presence_filter = GDKSocialFilter::PRESENCE_FILTER_ALL;
+	GDKSocialFilter::RelationshipFilter m_relationship_filter = GDKSocialFilter::RELATIONSHIP_FILTER_FRIENDS;
+	PackedStringArray m_tracked_xuids;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Ref<GDKUser> get_local_user() const;
+	bool is_loaded() const;
+	GroupType get_group_type() const;
+	String get_group_type_name() const;
+	GDKSocialFilter::PresenceFilter get_presence_filter() const;
+	GDKSocialFilter::RelationshipFilter get_relationship_filter() const;
+	PackedStringArray get_tracked_xuids() const;
+
+	void attach(const Ref<GDKUser> &p_local_user, XblSocialManagerUserGroupHandle p_group_handle);
+	void set_group_type(GroupType p_group_type);
+	void set_filters(GDKSocialFilter::PresenceFilter p_presence_filter, GDKSocialFilter::RelationshipFilter p_relationship_filter);
+	void set_tracked_xuids(const PackedStringArray &p_tracked_xuids);
+	void set_loaded(bool p_loaded);
+	bool matches_handle(XblSocialManagerUserGroupHandle p_group_handle) const;
+	XblSocialManagerUserGroupHandle get_handle() const;
+	void invalidate();
+};
+
+class GDKSocialUser : public RefCounted {
+	GDCLASS(GDKSocialUser, RefCounted);
+
+	String m_xuid;
+	bool m_is_favorite = false;
+	bool m_is_friend = false;
+	bool m_is_following_user = false;
+	bool m_is_followed_by_caller = false;
+	String m_display_name;
+	String m_real_name;
+	String m_display_picture_url;
+	bool m_use_avatar = false;
+	String m_gamerscore;
+	String m_gamertag;
+	String m_modern_gamertag;
+	String m_modern_gamertag_suffix;
+	String m_unique_modern_gamertag;
+	Ref<GDKPresenceRecord> m_presence;
+	Dictionary m_title_history;
+	Dictionary m_preferred_color;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_xuid() const;
+	bool is_favorite() const;
+	bool is_friend() const;
+	bool is_following_user() const;
+	bool is_followed_by_caller() const;
+	String get_display_name() const;
+	String get_real_name() const;
+	String get_display_picture_url() const;
+	bool uses_avatar() const;
+	String get_gamerscore() const;
+	String get_gamertag() const;
+	String get_modern_gamertag() const;
+	String get_modern_gamertag_suffix() const;
+	String get_unique_modern_gamertag() const;
+	Ref<GDKPresenceRecord> get_presence() const;
+	Dictionary get_title_history() const;
+	Dictionary get_preferred_color() const;
+
+	void populate_from_native(const XblSocialManagerUser &p_social_user);
+};
+
+class GDKSocial : public RefCounted {
+	GDCLASS(GDKSocial, RefCounted);
+
+	struct LocalUserState {
+		Ref<GDKUser> user;
+		XUserLocalId local_id = {};
+		bool graph_started = false;
+		bool graph_ready = false;
+		Ref<GDKSocialGroup> friends_group;
+	};
+
+	struct PendingFriendsOp {
+		XUserLocalId local_id = {};
+		XblSocialManagerUserGroupHandle group_handle = nullptr;
+		Ref<GDKPendingSignal> request;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	std::vector<LocalUserState> m_local_user_states;
+	std::vector<Ref<GDKSocialGroup>> m_groups;
+	std::vector<PendingFriendsOp> m_pending_friend_ops;
+	std::vector<Ref<GDKSocialUser>> m_cached_users;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	GDKPresence *_get_presence_service() const;
+	Signal _make_completed_signal(const Ref<GDKResult> &p_result) const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+	Ref<GDKResult> _ensure_local_user_state(const Ref<GDKUser> &p_user, LocalUserState **r_state, bool p_auto_start);
+	LocalUserState *_find_local_user_state(XUserLocalId p_local_id);
+	Ref<GDKSocialGroup> _find_group_by_handle(XblSocialManagerUserGroupHandle p_group_handle) const;
+	Ref<GDKSocialUser> _find_cached_user(const String &p_xuid) const;
+	Ref<GDKSocialUser> _cache_social_user(const XblSocialManagerUser &p_social_user, bool p_emit_social_signal, bool p_emit_presence_signal);
+	Ref<GDKSocialGroup> _create_social_group_internal(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter, Ref<GDKResult> *r_error);
+	Ref<GDKSocialGroup> _create_social_group_from_xuids_internal(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, Ref<GDKResult> *r_error);
+	Array _get_group_users_internal(const Ref<GDKSocialGroup> &p_group, bool p_emit_social_signal, bool p_emit_presence_signal, Ref<GDKResult> *r_error = nullptr);
+	Ref<GDKResult> _refresh_group_metadata(const Ref<GDKSocialGroup> &p_group);
+	void _complete_pending_friend_ops(XblSocialManagerUserGroupHandle p_group_handle);
+	void _fail_pending_friend_ops(XUserLocalId p_local_id, const Ref<GDKResult> &p_result);
+	void _fail_pending_friend_ops_for_group(XblSocialManagerUserGroupHandle p_group_handle, const Ref<GDKResult> &p_result);
+	void _cancel_pending_friend_signal(GDKPendingSignal *p_request);
+	void _destroy_group_internal(const Ref<GDKSocialGroup> &p_group, bool p_remove_from_collection);
+	void _erase_local_user_state(XUserLocalId p_local_id);
+	void _emit_filter_group_updates(XUserLocalId p_local_id);
+	void _emit_social_graph_changed(XUserLocalId p_local_id);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	int dispatch();
+
+	Ref<GDKResult> start_social_graph(const Ref<GDKUser> &p_user);
+	void stop_social_graph(const Ref<GDKUser> &p_user);
+	Signal get_friends_async(const Ref<GDKUser> &p_user);
+	Ref<GDKResult> create_social_group(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter = Ref<GDKSocialFilter>());
+	Ref<GDKResult> create_social_group_from_xuids(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids);
+	void destroy_social_group(const Ref<GDKSocialGroup> &p_group);
+	Ref<GDKResult> get_group_users(const Ref<GDKSocialGroup> &p_group);
+	Signal submit_reputation_feedback_async(const Ref<GDKUser> &p_user, const String &p_target_xuid, const String &p_feedback_type, const String &p_reason = String(), const String &p_evidence_id = String());
+	Signal submit_batch_reputation_feedback_async(const Ref<GDKUser> &p_user, const Array &p_feedback_items);
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};
+
+VARIANT_ENUM_CAST(GDKSocialFilter::PresenceFilter);
+VARIANT_ENUM_CAST(GDKSocialFilter::RelationshipFilter);
+VARIANT_ENUM_CAST(GDKSocialGroup::GroupType);

--- a/modules/xbox_module/gdk/gdk_stats.cpp
+++ b/modules/xbox_module/gdk/gdk_stats.cpp
@@ -1,0 +1,1131 @@
+/**************************************************************************/
+/*  gdk_stats.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_stats.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	if (p_value == nullptr || p_value[0] == '\0') {
+		return String();
+	}
+
+	return String::utf8(p_value);
+}
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	char *end_ptr = nullptr;
+	errno = 0;
+	const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
+	if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+Ref<GDKResult> _parse_stat_names(
+		const PackedStringArray &p_stat_names,
+		std::vector<String> *r_stat_names,
+		std::vector<CharString> *r_stat_name_utf8,
+		std::vector<const char *> *r_stat_name_ptrs) {
+	if (r_stat_names == nullptr || r_stat_name_utf8 == nullptr || r_stat_name_ptrs == nullptr) {
+		return GDKResult::error_result(E_POINTER, "invalid_output", "Statistic name output storage is unavailable.");
+	}
+
+	r_stat_names->clear();
+	r_stat_name_utf8->clear();
+	r_stat_name_ptrs->clear();
+
+	for (int64_t i = 0; i < p_stat_names.size(); ++i) {
+		const String stat_name = String(p_stat_names[i]).strip_edges();
+		if (stat_name.is_empty()) {
+			return GDKResult::error_result(E_INVALIDARG, "invalid_stat_name", "Statistic names must be non-empty strings.");
+		}
+		if (std::find(r_stat_names->begin(), r_stat_names->end(), stat_name) == r_stat_names->end()) {
+			r_stat_names->push_back(stat_name);
+		}
+	}
+
+	if (r_stat_names->empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_stat_names", "At least one statistic name is required.");
+	}
+
+	r_stat_name_utf8->reserve(r_stat_names->size());
+	r_stat_name_ptrs->reserve(r_stat_names->size());
+	for (const String &stat_name : *r_stat_names) {
+		r_stat_name_utf8->push_back(stat_name.utf8());
+	}
+	for (const CharString &stat_name_utf8 : *r_stat_name_utf8) {
+		r_stat_name_ptrs->push_back(stat_name_utf8.get_data());
+	}
+
+	return GDKResult::ok_result();
+}
+
+Dictionary _make_stat_dictionary(const XblStatistic &p_statistic, const String &p_scid) {
+	Dictionary stat;
+	stat["name"] = _utf8_or_empty(p_statistic.statisticName);
+	stat["type"] = _utf8_or_empty(p_statistic.statisticType);
+	stat["value"] = _utf8_or_empty(p_statistic.value);
+	stat["service_configuration_id"] = p_scid;
+	return stat;
+}
+
+Dictionary _make_stats_dictionary(const XblUserStatisticsResult &p_result) {
+	Dictionary stats;
+	if (p_result.serviceConfigStatistics == nullptr) {
+		return stats;
+	}
+
+	for (uint32_t scid_index = 0; scid_index < p_result.serviceConfigStatisticsCount; ++scid_index) {
+		const XblServiceConfigurationStatistic &service_config = p_result.serviceConfigStatistics[scid_index];
+		if (service_config.statistics == nullptr) {
+			continue;
+		}
+		const String scid = _utf8_or_empty(service_config.serviceConfigurationId);
+		for (uint32_t stat_index = 0; stat_index < service_config.statisticsCount; ++stat_index) {
+			const XblStatistic &statistic = service_config.statistics[stat_index];
+			const String stat_name = _utf8_or_empty(statistic.statisticName);
+			if (!stat_name.is_empty()) {
+				stats[stat_name] = _make_stat_dictionary(statistic, scid);
+			}
+		}
+	}
+	return stats;
+}
+
+class QueryStatsAsyncContext final : public GDKSignalXAsyncContext {
+	GDKStats *m_stats = nullptr;
+	Ref<GDKUser> m_user;
+	XblContextHandle m_context = nullptr;
+	CharString m_scid_utf8;
+	std::vector<CharString> m_stat_name_utf8;
+	std::vector<const char *> m_stat_name_ptrs;
+	uint64_t m_xbox_user_id = 0;
+	std::vector<uint64_t> m_xuids;
+	bool m_single_user_payload = true;
+	bool m_multiple_user_result = false;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Statistic query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t result_size = 0;
+		HRESULT result_hr = m_multiple_user_result ? XblUserStatisticsGetMultipleUserStatisticsResultSize(p_async_block, &result_size) : XblUserStatisticsGetSingleUserStatisticsResultSize(p_async_block, &result_size);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Statistic query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve statistic query result size.", "stats_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(result_size);
+		XblUserStatisticsResult *results = nullptr;
+		size_t results_count = 0;
+		size_t buffer_used = 0;
+		if (m_multiple_user_result) {
+			result_hr = XblUserStatisticsGetMultipleUserStatisticsResult(
+					p_async_block,
+					buffer.size(),
+					buffer.empty() ? nullptr : buffer.data(),
+					&results,
+					&results_count,
+					&buffer_used);
+		} else {
+			result_hr = XblUserStatisticsGetSingleUserStatisticsResult(
+					p_async_block,
+					buffer.size(),
+					buffer.empty() ? nullptr : buffer.data(),
+					&results,
+					&buffer_used);
+			results_count = results != nullptr ? 1 : 0;
+		}
+
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Statistic query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve statistic query results.", "stats_results_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary payload = m_stats->_make_query_payload(results, results_count, m_single_user_payload);
+		if (m_single_user_payload) {
+			m_stats->emit_signal("stats_updated", m_user, m_stats->get_cached_stats(m_user));
+		}
+		get_pending_signal()->complete(GDKResult::ok_result(payload));
+	}
+
+public:
+	QueryStatsAsyncContext(
+			GDKStats *p_stats,
+			const Ref<GDKUser> &p_user,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const String &p_scid,
+			const std::vector<String> &p_stat_names,
+			uint64_t p_xbox_user_id,
+			const std::vector<uint64_t> &p_xuids,
+			bool p_single_user_payload,
+			bool p_multiple_user_result) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_stats(p_stats),
+			m_user(p_user),
+			m_context(p_context),
+			m_scid_utf8(p_scid.utf8()),
+			m_xbox_user_id(p_xbox_user_id),
+			m_xuids(p_xuids),
+			m_single_user_payload(p_single_user_payload),
+			m_multiple_user_result(p_multiple_user_result) {
+		m_stat_name_utf8.reserve(p_stat_names.size());
+		m_stat_name_ptrs.reserve(p_stat_names.size());
+		for (const String &stat_name : p_stat_names) {
+			m_stat_name_utf8.push_back(stat_name.utf8());
+		}
+		for (const CharString &stat_name_utf8 : m_stat_name_utf8) {
+			m_stat_name_ptrs.push_back(stat_name_utf8.get_data());
+		}
+	}
+
+	~QueryStatsAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	const char *get_scid() const {
+		return m_scid_utf8.get_data();
+	}
+
+	const char **get_stat_name_ptrs() {
+		return m_stat_name_ptrs.empty() ? nullptr : m_stat_name_ptrs.data();
+	}
+
+	size_t get_stat_name_count() const {
+		return m_stat_name_ptrs.size();
+	}
+
+	uint64_t get_xbox_user_id() const {
+		return m_xbox_user_id;
+	}
+
+	uint64_t *get_xuids() {
+		return m_xuids.empty() ? nullptr : m_xuids.data();
+	}
+
+	size_t get_xuid_count() const {
+		return m_xuids.size();
+	}
+};
+
+class FlushStatsAsyncContext final : public GDKSignalXAsyncContext {
+	GDKStats *m_stats = nullptr;
+	Ref<GDKUser> m_user;
+	XblContextHandle m_context = nullptr;
+	std::vector<GDKStats::StagedStat> m_staged_stats;
+	std::vector<CharString> m_stat_name_utf8;
+	std::vector<XblTitleManagedStatistic> m_native_stats;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Statistic flush cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Statistic flush cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to flush title-managed statistics.", "stats_flush_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		const String xuid = m_user.is_valid() ? m_user->get_xuid() : String();
+		m_stats->_apply_staged_stats_to_cache(m_user, m_staged_stats);
+		m_stats->_clear_staged_stats(m_user);
+
+		Dictionary data;
+		data["xuid"] = xuid;
+		data["count"] = static_cast<int64_t>(m_staged_stats.size());
+		result = GDKResult::ok_result(data);
+		m_stats->emit_signal("stats_flushed", m_user, result);
+		get_pending_signal()->complete(result);
+	}
+
+public:
+	FlushStatsAsyncContext(
+			GDKStats *p_stats,
+			const Ref<GDKUser> &p_user,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			XblContextHandle p_context,
+			const std::vector<GDKStats::StagedStat> &p_staged_stats) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_stats(p_stats),
+			m_user(p_user),
+			m_context(p_context),
+			m_staged_stats(p_staged_stats) {
+		m_stat_name_utf8.reserve(m_staged_stats.size());
+		m_native_stats.reserve(m_staged_stats.size());
+
+		for (const GDKStats::StagedStat &staged_stat : m_staged_stats) {
+			m_stat_name_utf8.push_back(staged_stat.name.utf8());
+		}
+		for (size_t i = 0; i < m_staged_stats.size(); ++i) {
+			XblTitleManagedStatistic native_stat = {};
+			native_stat.statisticName = m_stat_name_utf8[i].get_data();
+			native_stat.statisticType = XblTitleManagedStatType::Number;
+			native_stat.numberValue = m_staged_stats[i].value;
+			native_stat.stringValue = nullptr;
+			m_native_stats.push_back(native_stat);
+		}
+	}
+
+	~FlushStatsAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	const XblTitleManagedStatistic *get_native_stats() const {
+		return m_native_stats.empty() ? nullptr : m_native_stats.data();
+	}
+
+	size_t get_native_stats_count() const {
+		return m_native_stats.size();
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKStats::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("query_user_stats_async", "user", "stat_names"), &GDKStats::query_user_stats_async, DEFVAL(PackedStringArray()));
+	ClassDB::bind_method(D_METHOD("query_users_stats_async", "user", "xuids", "stat_names"), &GDKStats::query_users_stats_async, DEFVAL(PackedStringArray()));
+	ClassDB::bind_method(D_METHOD("set_stat_integer", "user", "stat_name", "value"), &GDKStats::set_stat_integer);
+	ClassDB::bind_method(D_METHOD("set_stat_number", "user", "stat_name", "value"), &GDKStats::set_stat_number);
+	ClassDB::bind_method(D_METHOD("flush_stats_async", "user"), &GDKStats::flush_stats_async);
+	ClassDB::bind_method(D_METHOD("track_stats", "user", "stat_names"), &GDKStats::track_stats);
+	ClassDB::bind_method(D_METHOD("stop_tracking_stats", "user", "stat_names"), &GDKStats::stop_tracking_stats, DEFVAL(PackedStringArray()));
+	ClassDB::bind_method(D_METHOD("get_cached_stats", "user"), &GDKStats::get_cached_stats);
+
+	ADD_SIGNAL(MethodInfo("stats_updated", PropertyInfo(Variant::OBJECT, "user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser"), PropertyInfo(Variant::DICTIONARY, "stats")));
+	ADD_SIGNAL(MethodInfo("stat_changed", PropertyInfo(Variant::OBJECT, "user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser"), PropertyInfo(Variant::STRING, "stat_name"), PropertyInfo(Variant::NIL, "value")));
+	ADD_SIGNAL(MethodInfo("stats_flushed", PropertyInfo(Variant::OBJECT, "user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser"), PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKResult")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKStats::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKStats::_get_runtime() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKStats::_get_xbox_services() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Signal GDKStats::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_NULL_V(runtime, Signal());
+	return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKStats::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+	return GDKResult::ok_result();
+}
+
+GDKStats::CachedStats *GDKStats::_find_cached_stats(const String &p_xuid) {
+	for (CachedStats &cached_stats : m_cached_stats) {
+		if (cached_stats.xuid == p_xuid) {
+			return &cached_stats;
+		}
+	}
+	return nullptr;
+}
+
+const GDKStats::CachedStats *GDKStats::_find_cached_stats(const String &p_xuid) const {
+	for (const CachedStats &cached_stats : m_cached_stats) {
+		if (cached_stats.xuid == p_xuid) {
+			return &cached_stats;
+		}
+	}
+	return nullptr;
+}
+
+GDKStats::StagedStats *GDKStats::_find_staged_stats(XUserLocalId p_local_id) {
+	for (StagedStats &staged_stats : m_staged_stats) {
+		if (staged_stats.local_id.value == p_local_id.value) {
+			return &staged_stats;
+		}
+	}
+	return nullptr;
+}
+
+GDKStats::TrackingState *GDKStats::_find_tracking_state(XUserLocalId p_local_id) {
+	for (TrackingState &state : m_tracking_states) {
+		if (state.local_id.value == p_local_id.value) {
+			return &state;
+		}
+	}
+	return nullptr;
+}
+
+void GDKStats::_cache_stat_value(const String &p_xuid, const String &p_stat_name, const String &p_stat_type, const String &p_value, const String &p_scid) {
+	if (p_xuid.is_empty() || p_stat_name.is_empty()) {
+		return;
+	}
+
+	CachedStats *cached_stats = _find_cached_stats(p_xuid);
+	if (cached_stats == nullptr) {
+		CachedStats new_cached_stats;
+		new_cached_stats.xuid = p_xuid;
+		m_cached_stats.push_back(new_cached_stats);
+		cached_stats = &m_cached_stats.back();
+	}
+
+	Dictionary stat;
+	stat["name"] = p_stat_name;
+	stat["type"] = p_stat_type;
+	stat["value"] = p_value;
+	stat["service_configuration_id"] = p_scid;
+	cached_stats->stats[p_stat_name] = stat;
+}
+
+void GDKStats::_cache_results(const XblUserStatisticsResult *p_results, size_t p_result_count) {
+	if (p_results == nullptr) {
+		return;
+	}
+
+	for (size_t result_index = 0; result_index < p_result_count; ++result_index) {
+		const XblUserStatisticsResult &result = p_results[result_index];
+		if (result.serviceConfigStatistics == nullptr) {
+			continue;
+		}
+		const String xuid = String::num_uint64(result.xboxUserId);
+		for (uint32_t scid_index = 0; scid_index < result.serviceConfigStatisticsCount; ++scid_index) {
+			const XblServiceConfigurationStatistic &service_config = result.serviceConfigStatistics[scid_index];
+			if (service_config.statistics == nullptr) {
+				continue;
+			}
+			const String scid = _utf8_or_empty(service_config.serviceConfigurationId);
+			for (uint32_t stat_index = 0; stat_index < service_config.statisticsCount; ++stat_index) {
+				const XblStatistic &statistic = service_config.statistics[stat_index];
+				_cache_stat_value(
+						xuid,
+						_utf8_or_empty(statistic.statisticName),
+						_utf8_or_empty(statistic.statisticType),
+						_utf8_or_empty(statistic.value),
+						scid);
+			}
+		}
+	}
+}
+
+Dictionary GDKStats::_make_query_payload(const XblUserStatisticsResult *p_results, size_t p_result_count, bool p_single_user_payload) {
+	_cache_results(p_results, p_result_count);
+
+	if (p_single_user_payload) {
+		if (p_results == nullptr || p_result_count == 0) {
+			return Dictionary();
+		}
+		return _make_stats_dictionary(p_results[0]);
+	}
+
+	Dictionary payload;
+	if (p_results == nullptr) {
+		return payload;
+	}
+	for (size_t result_index = 0; result_index < p_result_count; ++result_index) {
+		const String xuid = String::num_uint64(p_results[result_index].xboxUserId);
+		payload[xuid] = _make_stats_dictionary(p_results[result_index]);
+	}
+	return payload;
+}
+
+void GDKStats::_clear_staged_stats(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	m_staged_stats.erase(
+			std::remove_if(
+					m_staged_stats.begin(),
+					m_staged_stats.end(),
+					[local_id](const StagedStats &staged_stats) {
+						return staged_stats.local_id.value == local_id.value;
+					}),
+			m_staged_stats.end());
+}
+
+void GDKStats::_apply_staged_stats_to_cache(const Ref<GDKUser> &p_user, const std::vector<StagedStat> &p_stats) {
+	const String xuid = p_user.is_valid() ? p_user->get_xuid() : String();
+	for (const StagedStat &stat : p_stats) {
+		_cache_stat_value(xuid, stat.name, "number", String::num(stat.value), _get_xbox_services() == nullptr ? String() : _get_xbox_services()->get_scid());
+	}
+
+	CachedStats *cached_stats = _find_cached_stats(xuid);
+	emit_signal("stats_updated", p_user, cached_stats == nullptr ? Dictionary() : cached_stats->stats.duplicate(true));
+}
+
+void GDKStats::_close_tracking_state(TrackingState &p_state) {
+	if (p_state.callback_context) {
+		std::lock_guard<std::mutex> lock(p_state.callback_context->mutex);
+		p_state.callback_context->active.store(false, std::memory_order_release);
+		p_state.callback_context->stats = nullptr;
+	}
+
+	if (p_state.handler_registered && p_state.context != nullptr) {
+		XblUserStatisticsRemoveStatisticChangedHandler(p_state.context, p_state.handler_token);
+	}
+	p_state.handler_registered = false;
+	p_state.handler_token = {};
+
+	if (p_state.context != nullptr) {
+		XblContextCloseHandle(p_state.context);
+		p_state.context = nullptr;
+	}
+
+	if (p_state.callback_token) {
+		constexpr size_t MAX_RETIRED_CALLBACK_TOKENS = 16;
+		m_retired_callback_tokens.push_back(p_state.callback_token);
+		if (m_retired_callback_tokens.size() > MAX_RETIRED_CALLBACK_TOKENS) {
+			m_retired_callback_tokens.erase(m_retired_callback_tokens.begin());
+		}
+		p_state.callback_token.reset();
+	}
+	p_state.callback_context.reset();
+}
+
+Ref<GDKResult> GDKStats::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKStats::shutdown() {
+	m_runtime_ready = false;
+
+	for (TrackingState &state : m_tracking_states) {
+		_close_tracking_state(state);
+	}
+	m_tracking_states.clear();
+	m_staged_stats.clear();
+	m_cached_stats.clear();
+
+	{
+		std::lock_guard<std::mutex> lock(m_pending_stat_changes_mutex);
+		m_pending_stat_changes.clear();
+	}
+}
+
+int GDKStats::dispatch() {
+	if (!m_runtime_ready) {
+		return 0;
+	}
+
+	std::vector<PendingStatChange> changes;
+	{
+		std::lock_guard<std::mutex> lock(m_pending_stat_changes_mutex);
+		changes.swap(m_pending_stat_changes);
+	}
+
+	int dispatched = 0;
+	for (const PendingStatChange &change : changes) {
+		const String xuid = String::num_uint64(change.xbox_user_id);
+		const String stat_name = String::utf8(change.statistic_name.c_str());
+		const String stat_type = String::utf8(change.statistic_type.c_str());
+		const String value = String::utf8(change.value.c_str());
+		_cache_stat_value(xuid, stat_name, stat_type, value, _get_xbox_services() == nullptr ? String() : _get_xbox_services()->get_scid());
+
+		Ref<GDKUser> user;
+		for (const TrackingState &state : m_tracking_states) {
+			if (state.xbox_user_id == change.xbox_user_id) {
+				user = state.user;
+				break;
+			}
+		}
+
+		CachedStats *cached_stats = _find_cached_stats(xuid);
+		emit_signal("stat_changed", user, stat_name, value);
+		if (!m_runtime_ready) {
+			break;
+		}
+		emit_signal("stats_updated", user, cached_stats == nullptr ? Dictionary() : cached_stats->stats.duplicate(true));
+		++dispatched;
+		if (!m_runtime_ready) {
+			break;
+		}
+	}
+
+	return dispatched;
+}
+
+Signal GDKStats::query_user_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	std::vector<String> stat_names;
+	std::vector<CharString> stat_name_utf8;
+	std::vector<const char *> stat_name_ptrs;
+	Ref<GDKResult> parse_result = _parse_stat_names(p_stat_names, &stat_names, &stat_name_utf8, &stat_name_ptrs);
+	if (!parse_result->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(parse_result->get_hresult()), parse_result->get_code(), parse_result->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	QueryStatsAsyncContext *async_context = new QueryStatsAsyncContext(this, p_user, runtime, pending_signal, context, xbox_services->get_scid(), stat_names, xbox_user_id, std::vector<uint64_t>(), true, false);
+	async_context->bind_cancel_handler();
+
+	hr = XblUserStatisticsGetSingleUserStatisticsAsync(
+			async_context->get_context(),
+			async_context->get_xbox_user_id(),
+			async_context->get_scid(),
+			async_context->get_stat_name_ptrs(),
+			async_context->get_stat_name_count(),
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "stats_query_failed", "Failed to start statistic query.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKStats::query_users_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedStringArray &p_stat_names) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+	if (p_xuids.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_xuids", "At least one XUID is required.");
+	}
+
+	std::vector<uint64_t> xuids;
+	xuids.reserve(static_cast<size_t>(p_xuids.size()));
+	for (int64_t i = 0; i < p_xuids.size(); ++i) {
+		uint64_t xuid = 0;
+		if (!_try_parse_xuid(String(p_xuids[i]), &xuid)) {
+			return _make_error_signal(E_INVALIDARG, "invalid_xuid", "XUID values must be non-empty decimal strings.");
+		}
+		xuids.push_back(xuid);
+	}
+
+	std::vector<String> stat_names;
+	std::vector<CharString> stat_name_utf8;
+	std::vector<const char *> stat_name_ptrs;
+	Ref<GDKResult> parse_result = _parse_stat_names(p_stat_names, &stat_names, &stat_name_utf8, &stat_name_ptrs);
+	if (!parse_result->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(parse_result->get_hresult()), parse_result->get_code(), parse_result->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	QueryStatsAsyncContext *async_context = new QueryStatsAsyncContext(this, p_user, runtime, pending_signal, context, xbox_services->get_scid(), stat_names, 0, xuids, false, true);
+	async_context->bind_cancel_handler();
+
+	hr = XblUserStatisticsGetMultipleUserStatisticsAsync(
+			async_context->get_context(),
+			async_context->get_xuids(),
+			async_context->get_xuid_count(),
+			async_context->get_scid(),
+			async_context->get_stat_name_ptrs(),
+			async_context->get_stat_name_count(),
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "stats_query_failed", "Failed to start multi-user statistic query.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKStats::set_stat_integer(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_value) {
+	return set_stat_number(p_user, p_stat_name, static_cast<double>(p_value));
+}
+
+Ref<GDKResult> GDKStats::set_stat_number(const Ref<GDKUser> &p_user, const String &p_stat_name, double p_value) {
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return validation;
+	}
+
+	const String stat_name = p_stat_name.strip_edges();
+	if (stat_name.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_stat_name", "Statistic name must be a non-empty string.");
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	StagedStats *staged_stats = _find_staged_stats(local_id);
+	if (staged_stats == nullptr) {
+		StagedStats new_staged_stats;
+		new_staged_stats.user = p_user;
+		new_staged_stats.local_id = local_id;
+		m_staged_stats.push_back(new_staged_stats);
+		staged_stats = &m_staged_stats.back();
+	}
+
+	for (StagedStat &staged_stat : staged_stats->stats) {
+		if (staged_stat.name == stat_name) {
+			staged_stat.value = p_value;
+			Dictionary data;
+			data["name"] = stat_name;
+			data["value"] = p_value;
+			return GDKResult::ok_result(data);
+		}
+	}
+
+	StagedStat staged_stat;
+	staged_stat.name = stat_name;
+	staged_stat.value = p_value;
+	staged_stats->stats.push_back(staged_stat);
+
+	Dictionary data;
+	data["name"] = stat_name;
+	data["value"] = p_value;
+	return GDKResult::ok_result(data);
+}
+
+Signal GDKStats::flush_stats_async(const Ref<GDKUser> &p_user) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	StagedStats *staged_stats = _find_staged_stats(local_id);
+	if (staged_stats == nullptr || staged_stats->stats.empty()) {
+		return _make_error_signal(E_INVALIDARG, "no_staged_stats", "No staged statistics are available to flush.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	FlushStatsAsyncContext *async_context = new FlushStatsAsyncContext(this, p_user, runtime, pending_signal, context, staged_stats->stats);
+	async_context->bind_cancel_handler();
+
+	hr = XblTitleManagedStatsUpdateStatsAsync(
+			async_context->get_context(),
+			async_context->get_native_stats(),
+			async_context->get_native_stats_count(),
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "stats_flush_start_failed", "Failed to start title-managed statistic flush.");
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKStats::track_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return validation;
+	}
+
+	std::vector<String> stat_names;
+	std::vector<CharString> stat_name_utf8;
+	std::vector<const char *> stat_name_ptrs;
+	Ref<GDKResult> parse_result = _parse_stat_names(p_stat_names, &stat_names, &stat_name_utf8, &stat_name_ptrs);
+	if (!parse_result->is_ok()) {
+		return parse_result;
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	TrackingState *state = _find_tracking_state(local_id);
+	if (state == nullptr) {
+		TrackingState new_state;
+		new_state.user = p_user;
+		new_state.local_id = local_id;
+
+		HRESULT context_hr = xbox_services->duplicate_context_for_user(p_user, &new_state.context, &new_state.xbox_user_id);
+		if (FAILED(context_hr)) {
+			return GDKResult::hresult_error(context_hr, "Failed to create an Xbox services context for statistics tracking.", "xbox_context_unavailable");
+		}
+
+		new_state.callback_context = std::make_shared<TrackingState::CallbackContext>();
+		new_state.callback_context->stats = this;
+		new_state.callback_token = std::make_shared<TrackingState::CallbackToken>();
+		new_state.callback_token->context = new_state.callback_context;
+		new_state.handler_token = XblUserStatisticsAddStatisticChangedHandler(new_state.context, _statistic_changed_handler, new_state.callback_token.get());
+		new_state.handler_registered = true;
+		m_tracking_states.push_back(new_state);
+		state = &m_tracking_states.back();
+	}
+
+	const CharString scid_utf8 = xbox_services->get_scid().utf8();
+	const uint64_t xuid = state->xbox_user_id;
+	HRESULT hr = XblUserStatisticsTrackStatistics(
+			state->context,
+			&xuid,
+			1,
+			scid_utf8.get_data(),
+			stat_name_ptrs.data(),
+			stat_name_ptrs.size());
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to track statistic changes.", "stats_track_failed");
+	}
+
+	Dictionary data;
+	data["xuid"] = String::num_uint64(xuid);
+	data["stat_names"] = p_stat_names;
+	return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKStats::stop_tracking_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return validation;
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	TrackingState *state = _find_tracking_state(local_id);
+	if (state == nullptr) {
+		return GDKResult::ok_result();
+	}
+
+	HRESULT hr = S_OK;
+	const uint64_t xuid = state->xbox_user_id;
+	if (p_stat_names.is_empty()) {
+		hr = XblUserStatisticsStopTrackingUsers(state->context, &xuid, 1);
+		_close_tracking_state(*state);
+		m_tracking_states.erase(
+				std::remove_if(
+						m_tracking_states.begin(),
+						m_tracking_states.end(),
+						[local_id](const TrackingState &candidate) {
+							return candidate.local_id.value == local_id.value;
+						}),
+				m_tracking_states.end());
+	} else {
+		std::vector<String> stat_names;
+		std::vector<CharString> stat_name_utf8;
+		std::vector<const char *> stat_name_ptrs;
+		Ref<GDKResult> parse_result = _parse_stat_names(p_stat_names, &stat_names, &stat_name_utf8, &stat_name_ptrs);
+		if (!parse_result->is_ok()) {
+			return parse_result;
+		}
+
+		const CharString scid_utf8 = xbox_services->get_scid().utf8();
+		hr = XblUserStatisticsStopTrackingStatistics(
+				state->context,
+				&xuid,
+				1,
+				scid_utf8.get_data(),
+				stat_name_ptrs.data(),
+				stat_name_ptrs.size());
+	}
+
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to stop tracking statistic changes.", "stats_stop_tracking_failed");
+	}
+
+	return GDKResult::ok_result();
+}
+
+Dictionary GDKStats::get_cached_stats(const Ref<GDKUser> &p_user) const {
+	if (!p_user.is_valid()) {
+		return Dictionary();
+	}
+
+	const CachedStats *cached_stats = _find_cached_stats(p_user->get_xuid());
+	return cached_stats == nullptr ? Dictionary() : cached_stats->stats.duplicate(true);
+}
+
+void GDKStats::on_user_removed(const Ref<GDKUser> &p_user) {
+	if (!p_user.is_valid()) {
+		return;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+	m_staged_stats.erase(
+			std::remove_if(
+					m_staged_stats.begin(),
+					m_staged_stats.end(),
+					[local_id](const StagedStats &staged_stats) {
+						return staged_stats.local_id.value == local_id.value;
+					}),
+			m_staged_stats.end());
+	m_tracking_states.erase(
+			std::remove_if(
+					m_tracking_states.begin(),
+					m_tracking_states.end(),
+					[this, local_id](TrackingState &state) {
+						if (state.local_id.value != local_id.value) {
+							return false;
+						}
+						_close_tracking_state(state);
+						return true;
+					}),
+			m_tracking_states.end());
+}
+
+void CALLBACK GDKStats::_statistic_changed_handler(XblStatisticChangeEventArgs p_args, void *p_context) {
+	TrackingState::CallbackToken *token = static_cast<TrackingState::CallbackToken *>(p_context);
+	std::shared_ptr<TrackingState::CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+	if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+	GDKStats *stats = callback_context->stats;
+	if (!callback_context->active.load(std::memory_order_acquire) || stats == nullptr) {
+		return;
+	}
+
+	PendingStatChange change;
+	change.xbox_user_id = p_args.xboxUserId;
+	change.statistic_name = p_args.latestStatistic.statisticName == nullptr ? std::string() : std::string(p_args.latestStatistic.statisticName);
+	change.statistic_type = p_args.latestStatistic.statisticType == nullptr ? std::string() : std::string(p_args.latestStatistic.statisticType);
+	change.value = p_args.latestStatistic.value == nullptr ? std::string() : std::string(p_args.latestStatistic.value);
+
+	std::lock_guard<std::mutex> lock(stats->m_pending_stat_changes_mutex);
+	stats->m_pending_stat_changes.push_back(change);
+}
+
+#else
+void GDKStats::set_owner(GDK *p_owner) {}
+
+Signal GDKStats::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKStats::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKStats::_cache_stat_value(const String &p_xuid, const String &p_stat_name, const String &p_stat_type, const String &p_value, const String &p_scid) {}
+
+void GDKStats::_cache_results(const XblUserStatisticsResult *p_results, size_t p_result_count) {}
+
+Dictionary GDKStats::_make_query_payload(const XblUserStatisticsResult *p_results, size_t p_result_count, bool p_single_user_payload) {
+	return Dictionary();
+}
+
+void GDKStats::_clear_staged_stats(const Ref<GDKUser> &p_user) {}
+
+void GDKStats::_apply_staged_stats_to_cache(const Ref<GDKUser> &p_user, const std::vector<StagedStat> &p_stats) {}
+
+void GDKStats::_close_tracking_state(TrackingState &p_state) {}
+
+Ref<GDKResult> GDKStats::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKStats::shutdown() {}
+
+int GDKStats::dispatch() {
+	return 0;
+}
+
+Signal GDKStats::query_user_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKStats::query_users_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedStringArray &p_stat_names) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKStats::set_stat_integer(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_value) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKStats::set_stat_number(const Ref<GDKUser> &p_user, const String &p_stat_name, double p_value) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Signal GDKStats::flush_stats_async(const Ref<GDKUser> &p_user) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKStats::track_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKStats::stop_tracking_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Dictionary GDKStats::get_cached_stats(const Ref<GDKUser> &p_user) const {
+	return Dictionary();
+}
+
+void GDKStats::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_stats.h
+++ b/modules/xbox_module/gdk/gdk_stats.h
@@ -1,0 +1,162 @@
+/**************************************************************************/
+/*  gdk_stats.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKStats : public RefCounted {
+	GDCLASS(GDKStats, RefCounted);
+
+public:
+	struct StagedStat {
+		String name;
+		double value = 0.0;
+	};
+
+private:
+	struct StagedStats {
+		Ref<GDKUser> user;
+		XUserLocalId local_id = {};
+		std::vector<StagedStat> stats;
+	};
+
+	struct CachedStats {
+		String xuid;
+		Dictionary stats;
+	};
+
+	struct TrackingState {
+		struct CallbackContext {
+			GDKStats *stats = nullptr;
+			std::atomic_bool active = true;
+			std::mutex mutex;
+		};
+
+		struct CallbackToken {
+			std::weak_ptr<CallbackContext> context;
+		};
+
+		Ref<GDKUser> user;
+		XUserLocalId local_id = {};
+		uint64_t xbox_user_id = 0;
+		XblContextHandle context = nullptr;
+		XblFunctionContext handler_token = {};
+		bool handler_registered = false;
+		std::shared_ptr<CallbackContext> callback_context;
+		std::shared_ptr<CallbackToken> callback_token;
+	};
+
+	struct PendingStatChange {
+		uint64_t xbox_user_id = 0;
+		std::string statistic_name;
+		std::string statistic_type;
+		std::string value;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	std::vector<CachedStats> m_cached_stats;
+	std::vector<StagedStats> m_staged_stats;
+	std::vector<TrackingState> m_tracking_states;
+	std::vector<PendingStatChange> m_pending_stat_changes;
+	mutable std::mutex m_pending_stat_changes_mutex;
+	std::vector<std::shared_ptr<TrackingState::CallbackToken>> m_retired_callback_tokens;
+
+	static void CALLBACK _statistic_changed_handler(XblStatisticChangeEventArgs p_args, void *p_context);
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+	StagedStats *_find_staged_stats(XUserLocalId p_local_id);
+	CachedStats *_find_cached_stats(const String &p_xuid);
+	const CachedStats *_find_cached_stats(const String &p_xuid) const;
+	TrackingState *_find_tracking_state(XUserLocalId p_local_id);
+	void _cache_stat_value(const String &p_xuid, const String &p_stat_name, const String &p_stat_type, const String &p_value, const String &p_scid);
+	void _cache_results(const XblUserStatisticsResult *p_results, size_t p_result_count);
+	void _close_tracking_state(TrackingState &p_state);
+
+public:
+	Dictionary _make_query_payload(const XblUserStatisticsResult *p_results, size_t p_result_count, bool p_single_user_payload);
+	void _clear_staged_stats(const Ref<GDKUser> &p_user);
+	void _apply_staged_stats_to_cache(const Ref<GDKUser> &p_user, const std::vector<StagedStat> &p_stats);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	int dispatch();
+
+	Signal query_user_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names = PackedStringArray());
+	Signal query_users_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedStringArray &p_stat_names = PackedStringArray());
+	Ref<GDKResult> set_stat_integer(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_value);
+	Ref<GDKResult> set_stat_number(const Ref<GDKUser> &p_user, const String &p_stat_name, double p_value);
+	Signal flush_stats_async(const Ref<GDKUser> &p_user);
+	Ref<GDKResult> track_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names);
+	Ref<GDKResult> stop_tracking_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names = PackedStringArray());
+	Dictionary get_cached_stats(const Ref<GDKUser> &p_user) const;
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_store.cpp
+++ b/modules/xbox_module/gdk/gdk_store.cpp
@@ -1,0 +1,494 @@
+/**************************************************************************/
+/*  gdk_store.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_store.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <string>
+
+#include "core/variant/dictionary.h"
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+class StoreXAsyncContext : public GDKSignalXAsyncContext {
+protected:
+	Ref<GDKStore> m_service;
+	String m_store_id;
+	std::string m_store_id_utf8;
+
+public:
+	StoreXAsyncContext(
+			GDKStore *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			const String &p_store_id) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_service(p_service),
+			m_store_id(p_store_id),
+			m_store_id_utf8(p_store_id.utf8().get_data()) {}
+
+	const char *get_store_id_utf8() const {
+		return m_store_id_utf8.c_str();
+	}
+
+	String get_store_id() const {
+		return m_store_id;
+	}
+};
+
+class StoreLicenseStatusAsyncContext final : public StoreXAsyncContext {
+	bool m_is_refresh = false;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Store license status request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XStoreCanAcquireLicenseResult native_result = {};
+		HRESULT result_hr = XStoreCanAcquireLicenseForStoreIdResult(p_async_block, &native_result);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Store license status request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					m_is_refresh ? "Failed to refresh store entitlements." : "Failed to query store license status.",
+					m_is_refresh ? "store_entitlements_refresh_result_failed" : "store_license_status_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (!m_service.is_valid() || !m_service->is_runtime_ready()) {
+			result = GDKResult::cancelled("GDKStore is shutting down.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Ref<GDKStoreLicenseStatus> status;
+		status.instantiate();
+		status->set_values(get_store_id(), String::utf8(native_result.licensableSku), static_cast<int64_t>(native_result.status));
+		Ref<GDKStoreLicenseStatus> cached_status = m_service->_cache_license_status(status);
+		get_pending_signal()->complete(GDKResult::ok_result(cached_status));
+	}
+
+public:
+	StoreLicenseStatusAsyncContext(
+			GDKStore *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			const String &p_store_id,
+			bool p_is_refresh) :
+			StoreXAsyncContext(p_service, p_runtime, p_pending_signal, p_store_id),
+			m_is_refresh(p_is_refresh) {}
+};
+
+class StorePurchaseUiAsyncContext final : public StoreXAsyncContext {
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Store purchase UI request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XStoreShowPurchaseUIResult(p_async_block);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Store purchase UI was dismissed.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to complete the store purchase UI flow.",
+					"store_purchase_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary data;
+		data["store_id"] = get_store_id();
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	StorePurchaseUiAsyncContext(
+			GDKStore *p_service,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			const String &p_store_id) :
+			StoreXAsyncContext(p_service, p_runtime, p_pending_signal, p_store_id) {}
+};
+
+} //namespace
+
+#endif
+
+void GDKStoreLicenseStatus::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_store_id"), &GDKStoreLicenseStatus::get_store_id);
+	ClassDB::bind_method(D_METHOD("get_licensable_sku"), &GDKStoreLicenseStatus::get_licensable_sku);
+	ClassDB::bind_method(D_METHOD("get_status"), &GDKStoreLicenseStatus::get_status);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "store_id"), "", "get_store_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "licensable_sku"), "", "get_licensable_sku");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "status"), "", "get_status");
+}
+
+String GDKStoreLicenseStatus::get_store_id() const {
+	return m_store_id;
+}
+
+String GDKStoreLicenseStatus::get_licensable_sku() const {
+	return m_licensable_sku;
+}
+
+int64_t GDKStoreLicenseStatus::get_status() const {
+	return m_status;
+}
+
+void GDKStoreLicenseStatus::set_values(const String &p_store_id, const String &p_licensable_sku, int64_t p_status) {
+	m_store_id = p_store_id;
+	m_licensable_sku = p_licensable_sku;
+	m_status = p_status;
+}
+
+void GDKStore::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("query_license_status_async", "user", "store_id"), &GDKStore::query_license_status_async);
+	ClassDB::bind_method(D_METHOD("refresh_entitlements_async", "user", "store_id"), &GDKStore::refresh_entitlements_async);
+	ClassDB::bind_method(D_METHOD("show_purchase_ui_async", "user", "store_id"), &GDKStore::show_purchase_ui_async);
+	ClassDB::bind_method(D_METHOD("get_cached_license_status", "store_id"), &GDKStore::get_cached_license_status);
+	ClassDB::bind_method(D_METHOD("check_cached_license_status", "store_id"), &GDKStore::check_cached_license_status);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+GDKStore::~GDKStore() {
+	shutdown();
+}
+
+void GDKStore::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKStore::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKStore::shutdown() {
+	m_runtime_ready = false;
+	_close_store_context();
+	m_cached_license_status.clear();
+}
+
+bool GDKStore::is_runtime_ready() const {
+	return m_runtime_ready;
+}
+
+void GDKStore::on_user_removed(const Ref<GDKUser> &p_user) {
+	(void)p_user;
+	m_cached_license_status.clear();
+}
+
+Signal GDKStore::query_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+	return _start_license_status_async(p_user, p_store_id, false);
+}
+
+Signal GDKStore::refresh_entitlements_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+	return _start_license_status_async(p_user, p_store_id, true);
+}
+
+Signal GDKStore::show_purchase_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+	const String store_id = _normalize_store_id(p_store_id);
+	if (store_id.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_product_id", "A non-empty Store product ID is required.");
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_available()) {
+		return _make_error_signal(E_FAIL, "runtime_unavailable", "GDK runtime is unavailable in the current process.");
+	}
+	if (!m_runtime_ready || !runtime->is_initialized()) {
+		return _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_error_signal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	HRESULT context_hr = S_OK;
+	XStoreContextHandle store_context = _get_or_create_store_context(context_hr);
+	if (FAILED(context_hr) || store_context == nullptr) {
+		return _make_error_signal(context_hr, "store_context_create_failed", "Failed to create an XStore context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	auto *context = new StorePurchaseUiAsyncContext(this, runtime, pending_signal, store_id);
+	context->bind_cancel_handler();
+
+	HRESULT start_hr = XStoreShowPurchaseUIAsync(store_context, context->get_store_id_utf8(), nullptr, nullptr, context->get_async_block());
+	if (FAILED(start_hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				start_hr,
+				"Failed to start the store purchase UI flow.",
+				"store_purchase_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKStoreLicenseStatus> GDKStore::get_cached_license_status(const String &p_store_id) const {
+	return _find_cached_license_status(_normalize_store_id(p_store_id));
+}
+
+Ref<GDKResult> GDKStore::check_cached_license_status(const String &p_store_id) const {
+	const String store_id = _normalize_store_id(p_store_id);
+	if (store_id.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_product_id", "A non-empty Store product ID is required.");
+	}
+
+	Ref<GDKStoreLicenseStatus> status = _find_cached_license_status(store_id);
+	if (!status.is_valid()) {
+		return GDKResult::error_result(E_FAIL, "license_status_not_cached", "No cached license status is available for the requested Store product ID.");
+	}
+
+	return GDKResult::ok_result(status);
+}
+
+GDKRuntime *GDKStore::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+void GDKStore::_close_store_context() {
+	if (m_store_context != nullptr) {
+		XStoreCloseContextHandle(m_store_context);
+		m_store_context = nullptr;
+	}
+}
+
+XStoreContextHandle GDKStore::_get_or_create_store_context(HRESULT &r_hresult) {
+	if (m_store_context != nullptr) {
+		r_hresult = S_OK;
+		return m_store_context;
+	}
+
+	XStoreContextHandle store_context = nullptr;
+	r_hresult = XStoreCreateContext(nullptr, &store_context);
+	if (FAILED(r_hresult) || store_context == nullptr) {
+		if (SUCCEEDED(r_hresult)) {
+			r_hresult = E_UNEXPECTED;
+		}
+		return nullptr;
+	}
+
+	m_store_context = store_context;
+	return m_store_context;
+}
+
+Signal GDKStore::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime != nullptr) {
+		return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+	}
+
+	Ref<GDKPendingSignal> pending_signal;
+	pending_signal.instantiate();
+	pending_signal->complete_deferred(GDKResult::error_result(p_hresult, p_code, p_message, p_data));
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKStore::_start_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id, bool p_is_refresh) {
+	const String store_id = _normalize_store_id(p_store_id);
+	if (store_id.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_product_id", "A non-empty Store product ID is required.");
+	}
+
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_available()) {
+		return _make_error_signal(E_FAIL, "runtime_unavailable", "GDK runtime is unavailable in the current process.");
+	}
+	if (!m_runtime_ready || !runtime->is_initialized()) {
+		return _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_error_signal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	HRESULT context_hr = S_OK;
+	XStoreContextHandle store_context = _get_or_create_store_context(context_hr);
+	if (FAILED(context_hr) || store_context == nullptr) {
+		return _make_error_signal(context_hr, "store_context_create_failed", "Failed to create an XStore context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	auto *context = new StoreLicenseStatusAsyncContext(this, runtime, pending_signal, store_id, p_is_refresh);
+	context->bind_cancel_handler();
+
+	HRESULT start_hr = XStoreCanAcquireLicenseForStoreIdAsync(store_context, context->get_store_id_utf8(), context->get_async_block());
+	if (FAILED(start_hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				start_hr,
+				p_is_refresh ? "Failed to start entitlements refresh." : "Failed to start store license status query.",
+				p_is_refresh ? "store_entitlements_refresh_start_failed" : "store_license_status_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Ref<GDKStoreLicenseStatus> GDKStore::_find_cached_license_status(const String &p_store_id) const {
+	for (const CachedLicenseStatus &entry : m_cached_license_status) {
+		if (entry.store_id == p_store_id) {
+			return entry.status;
+		}
+	}
+	return Ref<GDKStoreLicenseStatus>();
+}
+
+Ref<GDKStoreLicenseStatus> GDKStore::_cache_license_status(const Ref<GDKStoreLicenseStatus> &p_status) {
+	if (!p_status.is_valid()) {
+		return Ref<GDKStoreLicenseStatus>();
+	}
+
+	const String store_id = p_status->get_store_id();
+	for (CachedLicenseStatus &entry : m_cached_license_status) {
+		if (entry.store_id == store_id) {
+			entry.status = p_status;
+			return p_status;
+		}
+	}
+
+	m_cached_license_status.push_back({ store_id, p_status });
+	return p_status;
+}
+
+String GDKStore::_normalize_store_id(const String &p_store_id) {
+	return p_store_id.strip_edges();
+}
+
+#else
+GDKStore::~GDKStore() {
+}
+
+void GDKStore::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKStore::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKStore::shutdown() {}
+
+bool GDKStore::is_runtime_ready() const {
+	return false;
+}
+
+void GDKStore::on_user_removed(const Ref<GDKUser> &p_user) {}
+
+Signal GDKStore::query_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKStore::refresh_entitlements_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKStore::show_purchase_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKStoreLicenseStatus> GDKStore::get_cached_license_status(const String &p_store_id) const {
+	return Ref<GDKStoreLicenseStatus>();
+}
+
+Ref<GDKResult> GDKStore::check_cached_license_status(const String &p_store_id) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKStore::_close_store_context() {}
+
+Signal GDKStore::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKStore::_start_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id, bool p_is_refresh) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKStoreLicenseStatus> GDKStore::_find_cached_license_status(const String &p_store_id) const {
+	return Ref<GDKStoreLicenseStatus>();
+}
+
+Ref<GDKStoreLicenseStatus> GDKStore::_cache_license_status(const Ref<GDKStoreLicenseStatus> &p_status) {
+	return Ref<GDKStoreLicenseStatus>();
+}
+
+String GDKStore::_normalize_store_id(const String &p_store_id) {
+	return String();
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_store.h
+++ b/modules/xbox_module/gdk/gdk_store.h
@@ -1,0 +1,118 @@
+/**************************************************************************/
+/*  gdk_store.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XStore.h>
+#endif
+
+class GDK;
+class GDKPendingSignal;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+
+class GDKStoreLicenseStatus : public RefCounted {
+	GDCLASS(GDKStoreLicenseStatus, RefCounted);
+
+	String m_store_id;
+	String m_licensable_sku;
+	int64_t m_status = 0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_store_id() const;
+	String get_licensable_sku() const;
+	int64_t get_status() const;
+
+	void set_values(const String &p_store_id, const String &p_licensable_sku, int64_t p_status);
+};
+
+class GDKStore : public RefCounted {
+	GDCLASS(GDKStore, RefCounted);
+
+	struct CachedLicenseStatus {
+		String store_id;
+		Ref<GDKStoreLicenseStatus> status;
+	};
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+	XStoreContextHandle m_store_context = nullptr;
+	std::vector<CachedLicenseStatus> m_cached_license_status;
+
+	GDKRuntime *_get_runtime() const;
+	void _close_store_context();
+	XStoreContextHandle _get_or_create_store_context(HRESULT &r_hresult);
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Signal _start_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id, bool p_is_refresh);
+	static String _normalize_store_id(const String &p_store_id);
+
+protected:
+	static void _bind_methods();
+
+public:
+	~GDKStore() override;
+
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+	bool is_runtime_ready() const;
+	void on_user_removed(const Ref<GDKUser> &p_user);
+
+	Signal query_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id);
+	Signal refresh_entitlements_async(const Ref<GDKUser> &p_user, const String &p_store_id);
+	Signal show_purchase_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id);
+
+	Ref<GDKStoreLicenseStatus> get_cached_license_status(const String &p_store_id) const;
+	Ref<GDKResult> check_cached_license_status(const String &p_store_id) const;
+	Ref<GDKStoreLicenseStatus> _find_cached_license_status(const String &p_store_id) const;
+	Ref<GDKStoreLicenseStatus> _cache_license_status(const Ref<GDKStoreLicenseStatus> &p_status);
+};

--- a/modules/xbox_module/gdk/gdk_string_verify.cpp
+++ b/modules/xbox_module/gdk/gdk_string_verify.cpp
@@ -1,0 +1,368 @@
+/**************************************************************************/
+/*  gdk_string_verify.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_string_verify.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <utility>
+#include <vector>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	if (p_value == nullptr || p_value[0] == '\0') {
+		return String();
+	}
+	return String::utf8(p_value);
+}
+
+String _verify_result_code_to_string(XblVerifyStringResultCode p_result_code) {
+	switch (p_result_code) {
+		case XblVerifyStringResultCode::Success:
+			return "success";
+		case XblVerifyStringResultCode::Offensive:
+			return "offensive";
+		case XblVerifyStringResultCode::TooLong:
+			return "too_long";
+		case XblVerifyStringResultCode::UnknownError:
+		default:
+			return "unknown_error";
+	}
+}
+
+Dictionary _make_verify_result_dictionary(const XblVerifyStringResult &p_result) {
+	Dictionary result;
+	result["result_code"] = _verify_result_code_to_string(p_result.resultCode);
+	result["acceptable"] = p_result.resultCode == XblVerifyStringResultCode::Success;
+	result["first_offending_substring"] = _utf8_or_empty(p_result.firstOffendingSubstring);
+	return result;
+}
+
+Array _make_verify_result_array(const XblVerifyStringResult *p_results, size_t p_count) {
+	Array result;
+	if (p_results == nullptr) {
+		return result;
+	}
+	for (size_t i = 0; i < p_count; ++i) {
+		result.push_back(_make_verify_result_dictionary(p_results[i]));
+	}
+	return result;
+}
+
+class StringVerifyAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	bool m_batch = false;
+	String m_text;
+	CharString m_text_utf8;
+	PackedStringArray m_strings;
+	std::vector<CharString> m_string_utf8_values;
+	std::vector<const char *> m_string_ptrs;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("String verification cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t result_size = 0;
+		HRESULT result_hr = m_batch ? XblStringVerifyStringsResultSize(p_async_block, &result_size) : XblStringVerifyStringResultSize(p_async_block, &result_size);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("String verification cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, "Failed to retrieve string verification result size.", "string_verify_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(result_size);
+		size_t buffer_used = 0;
+		if (m_batch) {
+			XblVerifyStringResult *native_results = nullptr;
+			size_t result_count = 0;
+			result_hr = XblStringVerifyStringsResult(
+					p_async_block,
+					buffer.size(),
+					buffer.empty() ? nullptr : buffer.data(),
+					&native_results,
+					&result_count,
+					&buffer_used);
+			if (FAILED(result_hr)) {
+				result = result_hr == E_ABORT ? GDKResult::cancelled("String verification cancelled.") : GDKResult::hresult_error(result_hr, "Failed to retrieve string verification results.", "string_verify_results_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			get_pending_signal()->complete(GDKResult::ok_result(_make_verify_result_array(native_results, result_count)));
+			return;
+		}
+
+		XblVerifyStringResult *native_result = nullptr;
+		result_hr = XblStringVerifyStringResult(
+				p_async_block,
+				buffer.size(),
+				buffer.empty() ? nullptr : buffer.data(),
+				&native_result,
+				&buffer_used);
+		if (FAILED(result_hr)) {
+			result = result_hr == E_ABORT ? GDKResult::cancelled("String verification cancelled.") : GDKResult::hresult_error(result_hr, "Failed to retrieve string verification result.", "string_verify_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary payload = native_result == nullptr ? Dictionary() : _make_verify_result_dictionary(*native_result);
+		get_pending_signal()->complete(GDKResult::ok_result(payload));
+	}
+
+public:
+	StringVerifyAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const String &p_text) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_text(p_text) {
+		m_text_utf8 = m_text.utf8();
+	}
+
+	StringVerifyAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const PackedStringArray &p_strings) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_batch(true),
+			m_strings(p_strings) {
+		m_string_utf8_values.reserve(static_cast<size_t>(m_strings.size()));
+		m_string_ptrs.reserve(static_cast<size_t>(m_strings.size()));
+		for (int64_t i = 0; i < m_strings.size(); ++i) {
+			m_string_utf8_values.push_back(m_strings[i].utf8());
+		}
+		for (const CharString &utf8 : m_string_utf8_values) {
+			m_string_ptrs.push_back(utf8.get_data());
+		}
+	}
+
+	~StringVerifyAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	const char *get_text() const {
+		return m_text_utf8.get_data();
+	}
+
+	const char **get_strings_data() {
+		return m_string_ptrs.data();
+	}
+
+	uint64_t get_strings_count() const {
+		return static_cast<uint64_t>(m_string_ptrs.size());
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKStringVerify::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("verify_string_async", "user", "text"), &GDKStringVerify::verify_string_async);
+	ClassDB::bind_method(D_METHOD("verify_strings_async", "user", "strings"), &GDKStringVerify::verify_strings_async);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKStringVerify::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKStringVerify::_get_runtime() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKStringVerify::_get_xbox_services() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Signal GDKStringVerify::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_NULL_V(runtime, Signal());
+	return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKStringVerify::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKStringVerify::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKStringVerify::shutdown() {
+	m_runtime_ready = false;
+}
+
+Signal GDKStringVerify::verify_string_async(const Ref<GDKUser> &p_user, const String &p_text) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using string verification.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	StringVerifyAsyncContext *async_context = new StringVerifyAsyncContext(runtime, pending_signal, context, p_text);
+	async_context->bind_cancel_handler();
+	hr = XblStringVerifyStringAsync(async_context->get_context(), async_context->get_text(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "string_verify_start_failed", "Failed to start string verification.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKStringVerify::verify_strings_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_strings) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	if (p_strings.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_strings", "At least one string is required.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using string verification.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	StringVerifyAsyncContext *async_context = new StringVerifyAsyncContext(runtime, pending_signal, context, p_strings);
+	async_context->bind_cancel_handler();
+	hr = XblStringVerifyStringsAsync(async_context->get_context(), async_context->get_strings_data(), async_context->get_strings_count(), async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "string_verify_start_failed", "Failed to start batch string verification.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+void GDKStringVerify::on_user_removed(const Ref<GDKUser> &p_user) {
+	(void)p_user;
+}
+
+#else
+void GDKStringVerify::set_owner(GDK *p_owner) {}
+
+Signal GDKStringVerify::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKStringVerify::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKStringVerify::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKStringVerify::shutdown() {}
+
+Signal GDKStringVerify::verify_string_async(const Ref<GDKUser> &p_user, const String &p_text) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKStringVerify::verify_strings_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_strings) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKStringVerify::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_string_verify.h
+++ b/modules/xbox_module/gdk/gdk_string_verify.h
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  gdk_string_verify.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKStringVerify : public RefCounted {
+	GDCLASS(GDKStringVerify, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Signal verify_string_async(const Ref<GDKUser> &p_user, const String &p_text);
+	Signal verify_strings_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_strings);
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_system.cpp
+++ b/modules/xbox_module/gdk/gdk_system.cpp
@@ -1,0 +1,174 @@
+/**************************************************************************/
+/*  gdk_system.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_system.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#include <XGame.h>
+#include <XSystem.h>
+#endif
+
+#include <cstdio>
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_xbox_services.h"
+
+namespace {
+
+String _format_title_id_hex(uint32_t p_title_id) {
+	char buffer[11];
+	std::snprintf(buffer, sizeof(buffer), "0x%08X", p_title_id);
+	return String(buffer);
+}
+
+} //namespace
+
+void GDKSystem::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_title_id"), &GDKSystem::get_title_id);
+	ClassDB::bind_method(D_METHOD("get_title_id_hex"), &GDKSystem::get_title_id_hex);
+	ClassDB::bind_method(D_METHOD("get_sandbox_id"), &GDKSystem::get_sandbox_id);
+	ClassDB::bind_method(D_METHOD("get_service_configuration_id"), &GDKSystem::get_service_configuration_id);
+	ClassDB::bind_method(D_METHOD("is_xbox_services_initialized"), &GDKSystem::is_xbox_services_initialized);
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKSystem::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKXboxServices *GDKSystem::_get_xbox_services() const {
+	if (m_owner == nullptr) {
+		return nullptr;
+	}
+
+	return m_owner->get_xbox_services();
+}
+
+Ref<GDKResult> GDKSystem::get_title_id() const {
+	uint32_t title_id = 0;
+	HRESULT hr = XGameGetXboxTitleId(&title_id);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Xbox title ID is unavailable.",
+				"xbox_title_id_unavailable");
+	}
+
+	return GDKResult::ok_result(static_cast<int64_t>(title_id));
+}
+
+Ref<GDKResult> GDKSystem::get_title_id_hex() const {
+	Ref<GDKResult> title_id_result = get_title_id();
+	if (title_id_result.is_null() || !title_id_result->is_ok()) {
+		return title_id_result;
+	}
+
+	const uint32_t title_id = static_cast<uint32_t>(int64_t(title_id_result->get_data()));
+	return GDKResult::ok_result(_format_title_id_hex(title_id));
+}
+
+Ref<GDKResult> GDKSystem::get_sandbox_id() const {
+	char sandbox_id[XSystemXboxLiveSandboxIdMaxBytes] = {};
+	size_t sandbox_id_used = 0;
+	const HRESULT hr = XSystemGetXboxLiveSandboxId(sizeof(sandbox_id), sandbox_id, &sandbox_id_used);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(
+				hr,
+				"Xbox Live sandbox ID is unavailable.",
+				"sandbox_id_unavailable");
+	}
+
+	sandbox_id[sizeof(sandbox_id) - 1] = '\0';
+	if (sandbox_id_used == 0 || sandbox_id[0] == '\0') {
+		return GDKResult::error_result(
+				E_FAIL,
+				"sandbox_id_unavailable",
+				"Sandbox ID is unavailable.");
+	}
+
+	return GDKResult::ok_result(String::utf8(sandbox_id));
+}
+
+Ref<GDKResult> GDKSystem::get_service_configuration_id() const {
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"xbox_services_uninitialized",
+				"Xbox services are not initialized.");
+	}
+
+	const String scid = xbox_services->get_scid();
+	if (scid.is_empty()) {
+		return GDKResult::error_result(
+				E_FAIL,
+				"service_configuration_id_unavailable",
+				"Service configuration ID is unavailable.");
+	}
+
+	return GDKResult::ok_result(scid);
+}
+
+bool GDKSystem::is_xbox_services_initialized() const {
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr) {
+		return false;
+	}
+
+	return xbox_services->is_initialized();
+}
+
+#else
+void GDKSystem::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKSystem::get_title_id() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKSystem::get_title_id_hex() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKSystem::get_sandbox_id() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKSystem::get_service_configuration_id() const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+bool GDKSystem::is_xbox_services_initialized() const {
+	return false;
+}
+#endif

--- a/modules/xbox_module/gdk/gdk_system.h
+++ b/modules/xbox_module/gdk/gdk_system.h
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  gdk_system.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+
+class GDK;
+class GDKResult;
+class GDKXboxServices;
+
+class GDKSystem : public RefCounted {
+	GDCLASS(GDKSystem, RefCounted);
+
+	GDK *m_owner = nullptr;
+
+	GDKXboxServices *_get_xbox_services() const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> get_title_id() const;
+	Ref<GDKResult> get_title_id_hex() const;
+	Ref<GDKResult> get_sandbox_id() const;
+	Ref<GDKResult> get_service_configuration_id() const;
+	bool is_xbox_services_initialized() const;
+};

--- a/modules/xbox_module/gdk/gdk_title_storage.cpp
+++ b/modules/xbox_module/gdk/gdk_title_storage.cpp
@@ -1,0 +1,1316 @@
+/**************************************************************************/
+/*  gdk_title_storage.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_title_storage.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+String _utf8_or_empty(const char *p_value) {
+	return p_value != nullptr && p_value[0] != '\0' ? String::utf8(p_value) : String();
+}
+
+String _normalize_token(const String &p_value) {
+	return p_value.strip_edges().to_lower().replace("-", "_").replace(" ", "_");
+}
+
+bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
+	if (r_xuid == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_xuid.strip_edges();
+	if (normalized.is_empty()) {
+		return false;
+	}
+
+	const CharString utf8 = normalized.utf8();
+	char *end_ptr = nullptr;
+	errno = 0;
+	const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
+	if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
+		return false;
+	}
+
+	*r_xuid = static_cast<uint64_t>(parsed);
+	return true;
+}
+
+bool _try_parse_storage_type(const String &p_storage_type, XblTitleStorageType *r_storage_type) {
+	if (r_storage_type == nullptr) {
+		return false;
+	}
+
+	const String token = _normalize_token(p_storage_type);
+	if (token == "trusted_platform" || token == "trusted_platform_storage" || token == "trustedplatform") {
+		*r_storage_type = XblTitleStorageType::TrustedPlatformStorage;
+	} else if (token == "global" || token == "global_storage") {
+		*r_storage_type = XblTitleStorageType::GlobalStorage;
+	} else if (token == "universal") {
+		*r_storage_type = XblTitleStorageType::Universal;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+String _storage_type_to_string(XblTitleStorageType p_storage_type) {
+	switch (p_storage_type) {
+		case XblTitleStorageType::TrustedPlatformStorage:
+			return "trusted_platform";
+		case XblTitleStorageType::GlobalStorage:
+			return "global";
+		case XblTitleStorageType::Universal:
+			return "universal";
+		default:
+			return "unknown";
+	}
+}
+
+String _blob_type_to_string(XblTitleStorageBlobType p_blob_type) {
+	switch (p_blob_type) {
+		case XblTitleStorageBlobType::Binary:
+			return "binary";
+		case XblTitleStorageBlobType::Json:
+			return "json";
+		case XblTitleStorageBlobType::Config:
+			return "config";
+		case XblTitleStorageBlobType::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+bool _try_parse_match_condition(const String &p_match_condition, XblTitleStorageETagMatchCondition *r_match_condition) {
+	if (r_match_condition == nullptr) {
+		return false;
+	}
+
+	const String token = _normalize_token(p_match_condition);
+	if (token == "not_used" || token == "none") {
+		*r_match_condition = XblTitleStorageETagMatchCondition::NotUsed;
+	} else if (token == "if_match") {
+		*r_match_condition = XblTitleStorageETagMatchCondition::IfMatch;
+	} else if (token == "if_not_match") {
+		*r_match_condition = XblTitleStorageETagMatchCondition::IfNotMatch;
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+Ref<GDKResult> _parse_uint32(const String &p_name, int64_t p_value, uint32_t *r_value) {
+	if (r_value == nullptr) {
+		return GDKResult::error_result(E_POINTER, "invalid_output", "Output storage is unavailable.");
+	}
+	if (p_value < 0 || p_value > static_cast<int64_t>(UINT32_MAX)) {
+		return GDKResult::error_result(E_INVALIDARG, String("invalid_") + p_name, p_name + String(" must fit in a non-negative 32-bit unsigned integer."));
+	}
+
+	*r_value = static_cast<uint32_t>(p_value);
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> _copy_utf8_to_buffer(const String &p_value, char *p_buffer, size_t p_buffer_size, const String &p_field_name) {
+	if (p_buffer == nullptr || p_buffer_size == 0) {
+		return GDKResult::error_result(E_POINTER, "invalid_output", "String output storage is unavailable.");
+	}
+
+	const CharString utf8 = p_value.utf8();
+	const size_t length = std::strlen(utf8.get_data());
+	if (length >= p_buffer_size) {
+		return GDKResult::error_result(E_INVALIDARG, String("invalid_") + p_field_name, p_field_name + String(" is too long."));
+	}
+
+	std::memset(p_buffer, 0, p_buffer_size);
+	std::memcpy(p_buffer, utf8.get_data(), length);
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> _make_blob_metadata(
+		const String &p_scid,
+		XblTitleStorageType p_storage_type,
+		uint64_t p_xbox_user_id,
+		const String &p_blob_path,
+		const String &p_display_name,
+		const String &p_e_tag,
+		size_t p_length,
+		XblTitleStorageBlobType p_blob_type,
+		XblTitleStorageBlobMetadata *r_metadata) {
+	if (r_metadata == nullptr) {
+		return GDKResult::error_result(E_POINTER, "invalid_output", "Blob metadata output storage is unavailable.");
+	}
+
+	const String blob_path = p_blob_path.strip_edges();
+	if (blob_path.is_empty()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_blob_path", "blob_path must be a non-empty string.");
+	}
+
+	XblTitleStorageBlobMetadata metadata = {};
+	metadata.storageType = p_storage_type;
+	metadata.blobType = p_blob_type;
+	metadata.length = p_length;
+	metadata.xboxUserId = p_storage_type == XblTitleStorageType::GlobalStorage ? 0 : p_xbox_user_id;
+
+	Ref<GDKResult> copy_result = _copy_utf8_to_buffer(p_scid, metadata.serviceConfigurationId, sizeof(metadata.serviceConfigurationId), "service_configuration_id");
+	if (!copy_result->is_ok()) {
+		return copy_result;
+	}
+	copy_result = _copy_utf8_to_buffer(blob_path, metadata.blobPath, sizeof(metadata.blobPath), "blob_path");
+	if (!copy_result->is_ok()) {
+		return copy_result;
+	}
+	copy_result = _copy_utf8_to_buffer(p_display_name, metadata.displayName, sizeof(metadata.displayName), "display_name");
+	if (!copy_result->is_ok()) {
+		return copy_result;
+	}
+	copy_result = _copy_utf8_to_buffer(p_e_tag, metadata.eTag, sizeof(metadata.eTag), "e_tag");
+	if (!copy_result->is_ok()) {
+		return copy_result;
+	}
+
+	*r_metadata = metadata;
+	return GDKResult::ok_result();
+}
+
+Ref<GDKTitleStorageBlobMetadata> _make_metadata_ref(const XblTitleStorageBlobMetadata &p_metadata) {
+	Ref<GDKTitleStorageBlobMetadata> metadata_ref;
+	metadata_ref.instantiate();
+	metadata_ref->populate_from_native(p_metadata);
+	return metadata_ref;
+}
+
+PackedByteArray _make_packed_byte_array(const std::vector<uint8_t> &p_data) {
+	PackedByteArray result;
+	result.resize(static_cast<int64_t>(p_data.size()));
+	for (int64_t i = 0; i < result.size(); ++i) {
+		result.set(i, p_data[static_cast<size_t>(i)]);
+	}
+	return result;
+}
+
+std::vector<uint8_t> _make_byte_vector(const PackedByteArray &p_data) {
+	std::vector<uint8_t> result;
+	result.reserve(static_cast<size_t>(p_data.size()));
+	for (int64_t i = 0; i < p_data.size(); ++i) {
+		result.push_back(static_cast<uint8_t>(p_data[i]));
+	}
+	return result;
+}
+
+const XblTitleStorageBlobMetadata *_find_exact_metadata(const XblTitleStorageBlobMetadata *p_items, size_t p_count, const String &p_blob_path) {
+	if (p_items == nullptr) {
+		return nullptr;
+	}
+
+	const String blob_path = p_blob_path.strip_edges();
+	for (size_t i = 0; i < p_count; ++i) {
+		if (_utf8_or_empty(p_items[i].blobPath) == blob_path) {
+			return &p_items[i];
+		}
+	}
+	return nullptr;
+}
+
+class QuotaAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	String m_storage_type;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage quota query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t used_bytes = 0;
+		size_t quota_bytes = 0;
+		HRESULT result_hr = XblTitleStorageGetQuotaResult(p_async_block, &used_bytes, &quota_bytes);
+		if (result_hr == E_ABORT) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage quota query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to retrieve Title Storage quota.", "title_storage_quota_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary payload;
+		payload["storage_type"] = m_storage_type;
+		payload["used_bytes"] = static_cast<int64_t>(used_bytes);
+		payload["quota_bytes"] = static_cast<int64_t>(quota_bytes);
+		get_pending_signal()->complete(GDKResult::ok_result(payload));
+	}
+
+public:
+	QuotaAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const String &p_storage_type) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_storage_type(p_storage_type) {}
+
+	~QuotaAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+class BlobMetadataAsyncContext final : public GDKSignalXAsyncContext {
+	Ref<GDKUser> m_user;
+	XblContextHandle m_context = nullptr;
+	String m_storage_type;
+	String m_blob_path;
+	uint32_t m_max_items = 0;
+	bool m_next_page = false;
+	XblTitleStorageBlobMetadataResultHandle m_previous_handle = nullptr;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage metadata query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XblTitleStorageBlobMetadataResultHandle handle = nullptr;
+		HRESULT result_hr = m_next_page ? XblTitleStorageBlobMetadataResultGetNextResult(p_async_block, &handle) : XblTitleStorageGetBlobMetadataResult(p_async_block, &handle);
+		if (result_hr == E_ABORT) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage metadata query cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to retrieve Title Storage metadata.", "title_storage_metadata_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Ref<GDKTitleStorageBlobMetadataResult> metadata_result;
+		metadata_result.instantiate();
+		result_hr = metadata_result->populate_from_handle(m_user, m_storage_type, m_blob_path, m_max_items, handle);
+		if (FAILED(result_hr)) {
+			if (handle != nullptr) {
+				XblTitleStorageBlobMetadataResultCloseHandle(handle);
+			}
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to translate Title Storage metadata.", "title_storage_metadata_translate_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(metadata_result));
+	}
+
+public:
+	BlobMetadataAsyncContext(
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			const Ref<GDKUser> &p_user,
+			XblContextHandle p_context,
+			const String &p_storage_type,
+			const String &p_blob_path,
+			uint32_t p_max_items,
+			bool p_next_page,
+			XblTitleStorageBlobMetadataResultHandle p_previous_handle = nullptr) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_user(p_user),
+			m_context(p_context),
+			m_storage_type(p_storage_type),
+			m_blob_path(p_blob_path),
+			m_max_items(p_max_items),
+			m_next_page(p_next_page),
+			m_previous_handle(p_previous_handle) {}
+
+	~BlobMetadataAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+		if (m_previous_handle != nullptr) {
+			XblTitleStorageBlobMetadataResultCloseHandle(m_previous_handle);
+			m_previous_handle = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	XblTitleStorageBlobMetadataResultHandle get_previous_handle() const {
+		return m_previous_handle;
+	}
+};
+
+class UploadBlobAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	XblTitleStorageBlobMetadata m_metadata = {};
+	std::vector<uint8_t> m_data;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage upload cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XblTitleStorageBlobMetadata native_metadata = {};
+		HRESULT result_hr = XblTitleStorageUploadBlobResult(p_async_block, &native_metadata);
+		if (result_hr == E_ABORT) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage upload cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to upload Title Storage blob.", "title_storage_upload_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(_make_metadata_ref(native_metadata)));
+	}
+
+public:
+	UploadBlobAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const XblTitleStorageBlobMetadata &p_metadata, std::vector<uint8_t> p_data) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_metadata(p_metadata),
+			m_data(std::move(p_data)) {}
+
+	~UploadBlobAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	XblTitleStorageBlobMetadata get_metadata() const {
+		return m_metadata;
+	}
+
+	const uint8_t *get_data() const {
+		return m_data.empty() ? nullptr : m_data.data();
+	}
+
+	size_t get_data_size() const {
+		return m_data.size();
+	}
+};
+
+class DeleteBlobAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage delete cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+		if (result_hr == E_ABORT) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage delete cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to delete Title Storage blob.", "title_storage_delete_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result());
+	}
+
+public:
+	DeleteBlobAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context) {}
+
+	~DeleteBlobAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+class DownloadBlobAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	XblTitleStorageBlobMetadata m_metadata = {};
+	std::vector<uint8_t> m_buffer;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage download cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XblTitleStorageBlobMetadata native_metadata = {};
+		HRESULT result_hr = XblTitleStorageDownloadBlobResult(p_async_block, &native_metadata);
+		if (result_hr == E_ABORT) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage download cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to download Title Storage blob.", "title_storage_download_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary payload;
+		payload["metadata"] = _make_metadata_ref(native_metadata);
+		payload["data"] = _make_packed_byte_array(m_buffer);
+		get_pending_signal()->complete(GDKResult::ok_result(payload));
+	}
+
+public:
+	DownloadBlobAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const XblTitleStorageBlobMetadata &p_metadata) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_metadata(p_metadata),
+			m_buffer(p_metadata.length) {}
+
+	~DownloadBlobAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+
+	XblTitleStorageBlobMetadata get_metadata() const {
+		return m_metadata;
+	}
+
+	uint8_t *get_buffer() {
+		return m_buffer.empty() ? nullptr : m_buffer.data();
+	}
+
+	size_t get_buffer_size() const {
+		return m_buffer.size();
+	}
+};
+
+class DownloadMetadataAsyncContext final : public GDKSignalXAsyncContext {
+	XblContextHandle m_context = nullptr;
+	String m_blob_path;
+	XblTitleStorageETagMatchCondition m_match_condition = XblTitleStorageETagMatchCondition::NotUsed;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage download cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XblTitleStorageBlobMetadataResultHandle handle = nullptr;
+		HRESULT result_hr = XblTitleStorageGetBlobMetadataResult(p_async_block, &handle);
+		if (result_hr == E_ABORT) {
+			Ref<GDKResult> result = GDKResult::cancelled("Title Storage download cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (FAILED(result_hr)) {
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to retrieve Title Storage blob metadata for download.", "title_storage_download_metadata_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		const XblTitleStorageBlobMetadata *items = nullptr;
+		size_t item_count = 0;
+		result_hr = XblTitleStorageBlobMetadataResultGetItems(handle, &items, &item_count);
+		if (FAILED(result_hr)) {
+			XblTitleStorageBlobMetadataResultCloseHandle(handle);
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to read Title Storage blob metadata for download.", "title_storage_download_metadata_items_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		const XblTitleStorageBlobMetadata *matched_metadata = _find_exact_metadata(items, item_count, m_blob_path);
+		if (matched_metadata == nullptr) {
+			XblTitleStorageBlobMetadataResultCloseHandle(handle);
+			Ref<GDKResult> result = GDKResult::error_result(E_BOUNDS, "blob_not_found", "No Title Storage blob metadata matched blob_path.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XblTitleStorageBlobMetadata metadata_copy = *matched_metadata;
+		XblTitleStorageBlobMetadataResultCloseHandle(handle);
+
+		XblContextHandle transferred_context = m_context;
+		m_context = nullptr;
+		DownloadBlobAsyncContext *download_context = new DownloadBlobAsyncContext(get_runtime(), get_pending_signal(), transferred_context, metadata_copy);
+		download_context->bind_cancel_handler();
+		result_hr = XblTitleStorageDownloadBlobAsync(
+				download_context->get_context(),
+				download_context->get_metadata(),
+				download_context->get_buffer(),
+				download_context->get_buffer_size(),
+				m_match_condition,
+				nullptr,
+				0,
+				download_context->get_async_block());
+		if (FAILED(result_hr)) {
+			download_context->clear_cancel_handler();
+			delete download_context;
+			Ref<GDKResult> result = GDKResult::hresult_error(result_hr, "Failed to start Title Storage blob download.", "title_storage_download_start_failed");
+			get_pending_signal()->complete(result);
+		}
+	}
+
+public:
+	DownloadMetadataAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, XblContextHandle p_context, const String &p_blob_path, XblTitleStorageETagMatchCondition p_match_condition) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_context(p_context),
+			m_blob_path(p_blob_path),
+			m_match_condition(p_match_condition) {}
+
+	~DownloadMetadataAsyncContext() override {
+		if (m_context != nullptr) {
+			XblContextCloseHandle(m_context);
+			m_context = nullptr;
+		}
+	}
+
+	XblContextHandle get_context() const {
+		return m_context;
+	}
+};
+
+} //namespace
+
+#endif
+
+void GDKTitleStorageBlobMetadata::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_blob_path"), &GDKTitleStorageBlobMetadata::get_blob_path);
+	ClassDB::bind_method(D_METHOD("get_blob_type"), &GDKTitleStorageBlobMetadata::get_blob_type);
+	ClassDB::bind_method(D_METHOD("get_storage_type"), &GDKTitleStorageBlobMetadata::get_storage_type);
+	ClassDB::bind_method(D_METHOD("get_display_name"), &GDKTitleStorageBlobMetadata::get_display_name);
+	ClassDB::bind_method(D_METHOD("get_e_tag"), &GDKTitleStorageBlobMetadata::get_e_tag);
+	ClassDB::bind_method(D_METHOD("get_client_timestamp"), &GDKTitleStorageBlobMetadata::get_client_timestamp);
+	ClassDB::bind_method(D_METHOD("get_length"), &GDKTitleStorageBlobMetadata::get_length);
+	ClassDB::bind_method(D_METHOD("get_service_configuration_id"), &GDKTitleStorageBlobMetadata::get_service_configuration_id);
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKTitleStorageBlobMetadata::get_xuid);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "blob_path"), "", "get_blob_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "blob_type"), "", "get_blob_type");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "storage_type"), "", "get_storage_type");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "display_name"), "", "get_display_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "e_tag"), "", "get_e_tag");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "client_timestamp"), "", "get_client_timestamp");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "length"), "", "get_length");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "service_configuration_id"), "", "get_service_configuration_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+}
+
+String GDKTitleStorageBlobMetadata::get_blob_path() const {
+	return m_blob_path;
+}
+
+String GDKTitleStorageBlobMetadata::get_blob_type() const {
+	return m_blob_type;
+}
+
+String GDKTitleStorageBlobMetadata::get_storage_type() const {
+	return m_storage_type;
+}
+
+String GDKTitleStorageBlobMetadata::get_display_name() const {
+	return m_display_name;
+}
+
+String GDKTitleStorageBlobMetadata::get_e_tag() const {
+	return m_e_tag;
+}
+
+int64_t GDKTitleStorageBlobMetadata::get_client_timestamp() const {
+	return m_client_timestamp;
+}
+
+int64_t GDKTitleStorageBlobMetadata::get_length() const {
+	return m_length;
+}
+
+String GDKTitleStorageBlobMetadata::get_service_configuration_id() const {
+	return m_service_configuration_id;
+}
+
+String GDKTitleStorageBlobMetadata::get_xuid() const {
+	return m_xuid;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKTitleStorageBlobMetadata::populate_from_native(const XblTitleStorageBlobMetadata &p_metadata) {
+	m_blob_path = _utf8_or_empty(p_metadata.blobPath);
+	m_blob_type = _blob_type_to_string(p_metadata.blobType);
+	m_storage_type = _storage_type_to_string(p_metadata.storageType);
+	m_display_name = _utf8_or_empty(p_metadata.displayName);
+	m_e_tag = _utf8_or_empty(p_metadata.eTag);
+	m_client_timestamp = static_cast<int64_t>(p_metadata.clientTimestamp);
+	m_length = static_cast<int64_t>(p_metadata.length);
+	m_service_configuration_id = _utf8_or_empty(p_metadata.serviceConfigurationId);
+	m_xuid = p_metadata.xboxUserId == 0 ? String() : String::num_uint64(p_metadata.xboxUserId);
+}
+#else
+void GDKTitleStorageBlobMetadata::populate_from_native(const XblTitleStorageBlobMetadata &p_metadata) {
+}
+#endif
+
+void GDKTitleStorageBlobMetadataResult::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_items"), &GDKTitleStorageBlobMetadataResult::get_items);
+	ClassDB::bind_method(D_METHOD("has_next"), &GDKTitleStorageBlobMetadataResult::has_next);
+	ClassDB::bind_method(D_METHOD("get_storage_type"), &GDKTitleStorageBlobMetadataResult::get_storage_type);
+	ClassDB::bind_method(D_METHOD("get_blob_path"), &GDKTitleStorageBlobMetadataResult::get_blob_path);
+
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "items"), "", "get_items");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_next"), "", "has_next");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "storage_type"), "", "get_storage_type");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "blob_path"), "", "get_blob_path");
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+GDKTitleStorageBlobMetadataResult::~GDKTitleStorageBlobMetadataResult() {
+	if (m_handle != nullptr) {
+		XblTitleStorageBlobMetadataResultCloseHandle(m_handle);
+		m_handle = nullptr;
+	}
+}
+#else
+GDKTitleStorageBlobMetadataResult::~GDKTitleStorageBlobMetadataResult() {
+	m_handle = nullptr;
+}
+#endif
+
+Array GDKTitleStorageBlobMetadataResult::get_items() const {
+	return m_items;
+}
+
+bool GDKTitleStorageBlobMetadataResult::has_next() const {
+	return m_has_next;
+}
+
+String GDKTitleStorageBlobMetadataResult::get_storage_type() const {
+	return m_storage_type;
+}
+
+String GDKTitleStorageBlobMetadataResult::get_blob_path() const {
+	return m_blob_path;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+HRESULT GDKTitleStorageBlobMetadataResult::populate_from_handle(
+		const Ref<GDKUser> &p_user,
+		const String &p_storage_type,
+		const String &p_blob_path,
+		uint32_t p_max_items,
+		XblTitleStorageBlobMetadataResultHandle p_handle) {
+	if (p_handle == nullptr) {
+		return E_POINTER;
+	}
+
+	const XblTitleStorageBlobMetadata *items = nullptr;
+	size_t item_count = 0;
+	HRESULT hr = XblTitleStorageBlobMetadataResultGetItems(p_handle, &items, &item_count);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	Array translated_items;
+	for (size_t i = 0; i < item_count; ++i) {
+		translated_items.push_back(_make_metadata_ref(items[i]));
+	}
+
+	bool has_next = false;
+	hr = XblTitleStorageBlobMetadataResultHasNext(p_handle, &has_next);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	if (m_handle != nullptr) {
+		XblTitleStorageBlobMetadataResultCloseHandle(m_handle);
+		m_handle = nullptr;
+	}
+
+	m_user = p_user;
+	m_storage_type = p_storage_type;
+	m_blob_path = p_blob_path;
+	m_max_items = p_max_items;
+	m_handle = p_handle;
+	m_items = translated_items;
+	m_has_next = has_next;
+	return S_OK;
+}
+
+XblTitleStorageBlobMetadataResultHandle GDKTitleStorageBlobMetadataResult::get_handle_internal() const {
+	return m_handle;
+}
+
+Ref<GDKUser> GDKTitleStorageBlobMetadataResult::get_user_internal() const {
+	return m_user;
+}
+
+uint32_t GDKTitleStorageBlobMetadataResult::get_max_items_internal() const {
+	return m_max_items;
+}
+#else
+HRESULT GDKTitleStorageBlobMetadataResult::populate_from_handle(
+		const Ref<GDKUser> &p_user,
+		const String &p_storage_type,
+		const String &p_blob_path,
+		uint32_t p_max_items,
+		XblTitleStorageBlobMetadataResultHandle p_handle) {
+	return E_NOTIMPL;
+}
+
+XblTitleStorageBlobMetadataResultHandle GDKTitleStorageBlobMetadataResult::get_handle_internal() const {
+	return m_handle;
+}
+
+Ref<GDKUser> GDKTitleStorageBlobMetadataResult::get_user_internal() const {
+	return m_user;
+}
+
+uint32_t GDKTitleStorageBlobMetadataResult::get_max_items_internal() const {
+	return m_max_items;
+}
+#endif
+
+void GDKTitleStorage::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_quota_async", "user", "storage_type"), &GDKTitleStorage::get_quota_async);
+	ClassDB::bind_method(D_METHOD("list_blob_metadata_async", "user", "storage_type", "blob_path", "skip_items", "max_items"), &GDKTitleStorage::list_blob_metadata_async, DEFVAL(String()), DEFVAL(0), DEFVAL(25));
+	ClassDB::bind_method(D_METHOD("get_next_blob_metadata_async", "result"), &GDKTitleStorage::get_next_blob_metadata_async);
+	ClassDB::bind_method(D_METHOD("download_blob_async", "user", "storage_type", "blob_path"), &GDKTitleStorage::download_blob_async);
+	ClassDB::bind_method(D_METHOD("upload_blob_async", "user", "storage_type", "blob_path", "data", "display_name", "e_tag", "match_condition"), &GDKTitleStorage::upload_blob_async, DEFVAL(String()), DEFVAL(String()), DEFVAL(String("not_used")));
+	ClassDB::bind_method(D_METHOD("delete_blob_async", "user", "storage_type", "blob_path", "e_tag", "match_condition"), &GDKTitleStorage::delete_blob_async, DEFVAL(String()), DEFVAL(String("not_used")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKTitleStorage::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+GDKRuntime *GDKTitleStorage::_get_runtime() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKTitleStorage::_get_xbox_services() const {
+	return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Signal GDKTitleStorage::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	GDKRuntime *runtime = _get_runtime();
+	ERR_FAIL_NULL_V(runtime, Signal());
+	return runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+Ref<GDKResult> GDKTitleStorage::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	if (!m_runtime_ready) {
+		return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+		return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+	return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKTitleStorage::on_runtime_initialized() {
+	m_runtime_ready = true;
+	return GDKResult::ok_result();
+}
+
+void GDKTitleStorage::shutdown() {
+	m_runtime_ready = false;
+}
+
+Signal GDKTitleStorage::get_quota_async(const Ref<GDKUser> &p_user, const String &p_storage_type) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblTitleStorageType storage_type = XblTitleStorageType::Universal;
+	if (!_try_parse_storage_type(p_storage_type, &storage_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_storage_type", "Unknown Title Storage type.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using Title Storage.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	QuotaAsyncContext *async_context = new QuotaAsyncContext(runtime, pending_signal, context, _storage_type_to_string(storage_type));
+	async_context->bind_cancel_handler();
+	const CharString scid_utf8 = xbox_services->get_scid().utf8();
+	hr = XblTitleStorageGetQuotaAsync(async_context->get_context(), scid_utf8.get_data(), storage_type, async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "title_storage_quota_start_failed", "Failed to start Title Storage quota query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKTitleStorage::list_blob_metadata_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, int64_t p_skip_items, int64_t p_max_items) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblTitleStorageType storage_type = XblTitleStorageType::Universal;
+	if (!_try_parse_storage_type(p_storage_type, &storage_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_storage_type", "Unknown Title Storage type.");
+	}
+
+	uint32_t skip_items = 0;
+	Ref<GDKResult> parse_result = _parse_uint32("skip_items", p_skip_items, &skip_items);
+	if (!parse_result->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(parse_result->get_hresult()), parse_result->get_code(), parse_result->get_message());
+	}
+	uint32_t max_items = 0;
+	parse_result = _parse_uint32("max_items", p_max_items, &max_items);
+	if (!parse_result->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(parse_result->get_hresult()), parse_result->get_code(), parse_result->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using Title Storage.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	const String storage_type_name = _storage_type_to_string(storage_type);
+	const String blob_path = p_blob_path.strip_edges();
+	BlobMetadataAsyncContext *async_context = new BlobMetadataAsyncContext(runtime, pending_signal, p_user, context, storage_type_name, blob_path, max_items, false);
+	async_context->bind_cancel_handler();
+	const CharString scid_utf8 = xbox_services->get_scid().utf8();
+	const CharString blob_path_utf8 = blob_path.utf8();
+	hr = XblTitleStorageGetBlobMetadataAsync(
+			async_context->get_context(),
+			scid_utf8.get_data(),
+			storage_type,
+			blob_path_utf8.get_data(),
+			storage_type == XblTitleStorageType::GlobalStorage ? 0 : xbox_user_id,
+			skip_items,
+			max_items,
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "title_storage_metadata_start_failed", "Failed to start Title Storage metadata query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKTitleStorage::get_next_blob_metadata_async(const Ref<GDKTitleStorageBlobMetadataResult> &p_result) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+	if (!m_runtime_ready) {
+		return _make_error_signal(E_FAIL, "runtime_unavailable", "GDK runtime is not initialized.");
+	}
+	if (!p_result.is_valid() || p_result->get_handle_internal() == nullptr) {
+		return _make_error_signal(E_INVALIDARG, "invalid_metadata_result", "A metadata result returned by this service is required.");
+	}
+	if (!p_result->has_next()) {
+		return _make_error_signal(E_INVALIDARG, "no_next_page", "Metadata result has no next page.");
+	}
+
+	Ref<GDKUser> user = p_result->get_user_internal();
+	Ref<GDKResult> validation = _ensure_ready_user(user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using Title Storage.");
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = xbox_services->duplicate_context_for_user(user, &context);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	XblTitleStorageBlobMetadataResultHandle previous_handle = nullptr;
+	hr = XblTitleStorageBlobMetadataResultDuplicateHandle(p_result->get_handle_internal(), &previous_handle);
+	if (FAILED(hr)) {
+		XblContextCloseHandle(context);
+		return _make_error_signal(hr, "title_storage_metadata_duplicate_failed", "Failed to duplicate Title Storage metadata handle.");
+	}
+
+	BlobMetadataAsyncContext *async_context = new BlobMetadataAsyncContext(runtime, pending_signal, user, context, p_result->get_storage_type(), p_result->get_blob_path(), p_result->get_max_items_internal(), true, previous_handle);
+	async_context->bind_cancel_handler();
+	hr = XblTitleStorageBlobMetadataResultGetNextAsync(
+			async_context->get_previous_handle(),
+			p_result->get_max_items_internal(),
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "title_storage_metadata_next_start_failed", "Failed to start Title Storage metadata next-page query.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKTitleStorage::download_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblTitleStorageType storage_type = XblTitleStorageType::Universal;
+	if (!_try_parse_storage_type(p_storage_type, &storage_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_storage_type", "Unknown Title Storage type.");
+	}
+	const String blob_path = p_blob_path.strip_edges();
+	if (blob_path.is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_blob_path", "blob_path must be a non-empty string.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using Title Storage.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	DownloadMetadataAsyncContext *async_context = new DownloadMetadataAsyncContext(runtime, pending_signal, context, blob_path, XblTitleStorageETagMatchCondition::NotUsed);
+	async_context->bind_cancel_handler();
+	const CharString scid_utf8 = xbox_services->get_scid().utf8();
+	const CharString blob_path_utf8 = blob_path.utf8();
+	hr = XblTitleStorageGetBlobMetadataAsync(
+			async_context->get_context(),
+			scid_utf8.get_data(),
+			storage_type,
+			blob_path_utf8.get_data(),
+			storage_type == XblTitleStorageType::GlobalStorage ? 0 : xbox_user_id,
+			0,
+			1,
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "title_storage_download_metadata_start_failed", "Failed to start Title Storage metadata query for download.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKTitleStorage::upload_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, const PackedByteArray &p_data, const String &p_display_name, const String &p_e_tag, const String &p_match_condition) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblTitleStorageType storage_type = XblTitleStorageType::Universal;
+	if (!_try_parse_storage_type(p_storage_type, &storage_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_storage_type", "Unknown Title Storage type.");
+	}
+	XblTitleStorageETagMatchCondition match_condition = XblTitleStorageETagMatchCondition::NotUsed;
+	if (!_try_parse_match_condition(p_match_condition, &match_condition)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_match_condition", "Unknown Title Storage ETag match condition.");
+	}
+	if (match_condition != XblTitleStorageETagMatchCondition::NotUsed && p_e_tag.strip_edges().is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_e_tag", "An e_tag is required when match_condition is not not_used.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using Title Storage.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	std::vector<uint8_t> data = _make_byte_vector(p_data);
+	XblTitleStorageBlobMetadata native_metadata = {};
+	Ref<GDKResult> metadata_result = _make_blob_metadata(
+			xbox_services->get_scid(),
+			storage_type,
+			xbox_user_id,
+			p_blob_path,
+			p_display_name,
+			p_e_tag,
+			data.size(),
+			XblTitleStorageBlobType::Binary,
+			&native_metadata);
+	if (!metadata_result->is_ok()) {
+		XblContextCloseHandle(context);
+		return _make_error_signal(static_cast<HRESULT>(metadata_result->get_hresult()), metadata_result->get_code(), metadata_result->get_message());
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	UploadBlobAsyncContext *async_context = new UploadBlobAsyncContext(runtime, pending_signal, context, native_metadata, std::move(data));
+	async_context->bind_cancel_handler();
+	hr = XblTitleStorageUploadBlobAsync(
+			async_context->get_context(),
+			async_context->get_metadata(),
+			async_context->get_data(),
+			async_context->get_data_size(),
+			match_condition,
+			0,
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "title_storage_upload_start_failed", "Failed to start Title Storage blob upload.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKTitleStorage::delete_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, const String &p_e_tag, const String &p_match_condition) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr) {
+		return Signal();
+	}
+
+	Ref<GDKResult> validation = _ensure_ready_user(p_user);
+	if (!validation->is_ok()) {
+		return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+	}
+
+	XblTitleStorageType storage_type = XblTitleStorageType::Universal;
+	if (!_try_parse_storage_type(p_storage_type, &storage_type)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_storage_type", "Unknown Title Storage type.");
+	}
+	XblTitleStorageETagMatchCondition match_condition = XblTitleStorageETagMatchCondition::NotUsed;
+	if (!_try_parse_match_condition(p_match_condition, &match_condition)) {
+		return _make_error_signal(E_INVALIDARG, "invalid_match_condition", "Unknown Title Storage ETag match condition.");
+	}
+	if (match_condition == XblTitleStorageETagMatchCondition::IfNotMatch) {
+		return _make_error_signal(E_INVALIDARG, "invalid_match_condition", "delete_blob_async() supports only not_used and if_match.");
+	}
+	if (match_condition == XblTitleStorageETagMatchCondition::IfMatch && p_e_tag.strip_edges().is_empty()) {
+		return _make_error_signal(E_INVALIDARG, "invalid_e_tag", "An e_tag is required for if_match deletes.");
+	}
+
+	GDKXboxServices *xbox_services = _get_xbox_services();
+	if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+		return _make_error_signal(E_FAIL, "xbox_services_not_initialized", "Xbox services are unavailable. Ensure the title has a TitleId before using Title Storage.");
+	}
+
+	XblContextHandle context = nullptr;
+	uint64_t xbox_user_id = 0;
+	HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+	if (FAILED(hr)) {
+		return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+	}
+
+	XblTitleStorageBlobMetadata native_metadata = {};
+	Ref<GDKResult> metadata_result = _make_blob_metadata(
+			xbox_services->get_scid(),
+			storage_type,
+			xbox_user_id,
+			p_blob_path,
+			String(),
+			p_e_tag,
+			0,
+			XblTitleStorageBlobType::Binary,
+			&native_metadata);
+	if (!metadata_result->is_ok()) {
+		XblContextCloseHandle(context);
+		return _make_error_signal(static_cast<HRESULT>(metadata_result->get_hresult()), metadata_result->get_code(), metadata_result->get_message());
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	DeleteBlobAsyncContext *async_context = new DeleteBlobAsyncContext(runtime, pending_signal, context);
+	async_context->bind_cancel_handler();
+	hr = XblTitleStorageDeleteBlobAsync(
+			async_context->get_context(),
+			native_metadata,
+			match_condition == XblTitleStorageETagMatchCondition::IfMatch,
+			async_context->get_async_block());
+	if (FAILED(hr)) {
+		async_context->clear_cancel_handler();
+		delete async_context;
+		return _make_error_signal(hr, "title_storage_delete_start_failed", "Failed to start Title Storage blob delete.");
+	}
+	return pending_signal->get_completed_signal();
+}
+
+void GDKTitleStorage::on_user_removed(const Ref<GDKUser> &p_user) {
+	(void)p_user;
+}
+
+#else
+void GDKTitleStorage::set_owner(GDK *p_owner) {}
+
+Signal GDKTitleStorage::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data) const {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKResult> GDKTitleStorage::_ensure_ready_user(const Ref<GDKUser> &p_user) const {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+Ref<GDKResult> GDKTitleStorage::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKTitleStorage::shutdown() {}
+
+Signal GDKTitleStorage::get_quota_async(const Ref<GDKUser> &p_user, const String &p_storage_type) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKTitleStorage::list_blob_metadata_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, int64_t p_skip_items, int64_t p_max_items) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKTitleStorage::get_next_blob_metadata_async(const Ref<GDKTitleStorageBlobMetadataResult> &p_result) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKTitleStorage::download_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKTitleStorage::upload_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, const PackedByteArray &p_data, const String &p_display_name, const String &p_e_tag, const String &p_match_condition) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKTitleStorage::delete_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, const String &p_e_tag, const String &p_match_condition) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKTitleStorage::on_user_removed(const Ref<GDKUser> &p_user) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_title_storage.h
+++ b/modules/xbox_module/gdk/gdk_title_storage.h
@@ -1,0 +1,150 @@
+/**************************************************************************/
+/*  gdk_title_storage.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gdk_gdk_stubs.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKTitleStorageBlobMetadata : public RefCounted {
+	GDCLASS(GDKTitleStorageBlobMetadata, RefCounted);
+
+	String m_blob_path;
+	String m_blob_type;
+	String m_storage_type;
+	String m_display_name;
+	String m_e_tag;
+	int64_t m_client_timestamp = 0;
+	int64_t m_length = 0;
+	String m_service_configuration_id;
+	String m_xuid;
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_blob_path() const;
+	String get_blob_type() const;
+	String get_storage_type() const;
+	String get_display_name() const;
+	String get_e_tag() const;
+	int64_t get_client_timestamp() const;
+	int64_t get_length() const;
+	String get_service_configuration_id() const;
+	String get_xuid() const;
+
+	void populate_from_native(const XblTitleStorageBlobMetadata &p_metadata);
+};
+
+class GDKTitleStorageBlobMetadataResult : public RefCounted {
+	GDCLASS(GDKTitleStorageBlobMetadataResult, RefCounted);
+
+	Array m_items;
+	bool m_has_next = false;
+	String m_storage_type;
+	String m_blob_path;
+	uint32_t m_max_items = 0;
+	Ref<GDKUser> m_user;
+	XblTitleStorageBlobMetadataResultHandle m_handle = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	~GDKTitleStorageBlobMetadataResult() override;
+
+	Array get_items() const;
+	bool has_next() const;
+	String get_storage_type() const;
+	String get_blob_path() const;
+
+	HRESULT populate_from_handle(
+			const Ref<GDKUser> &p_user,
+			const String &p_storage_type,
+			const String &p_blob_path,
+			uint32_t p_max_items,
+			XblTitleStorageBlobMetadataResultHandle p_handle);
+	XblTitleStorageBlobMetadataResultHandle get_handle_internal() const;
+	Ref<GDKUser> get_user_internal() const;
+	uint32_t get_max_items_internal() const;
+};
+
+class GDKTitleStorage : public RefCounted {
+	GDCLASS(GDKTitleStorage, RefCounted);
+
+	GDK *m_owner = nullptr;
+	bool m_runtime_ready = false;
+
+	GDKRuntime *_get_runtime() const;
+	GDKXboxServices *_get_xbox_services() const;
+	Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+	Ref<GDKResult> _ensure_ready_user(const Ref<GDKUser> &p_user) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Signal get_quota_async(const Ref<GDKUser> &p_user, const String &p_storage_type);
+	Signal list_blob_metadata_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path = String(), int64_t p_skip_items = 0, int64_t p_max_items = 25);
+	Signal get_next_blob_metadata_async(const Ref<GDKTitleStorageBlobMetadataResult> &p_result);
+	Signal download_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path);
+	Signal upload_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, const PackedByteArray &p_data, const String &p_display_name = String(), const String &p_e_tag = String(), const String &p_match_condition = "not_used");
+	Signal delete_blob_async(const Ref<GDKUser> &p_user, const String &p_storage_type, const String &p_blob_path, const String &p_e_tag = String(), const String &p_match_condition = "not_used");
+
+	void on_user_removed(const Ref<GDKUser> &p_user);
+};

--- a/modules/xbox_module/gdk/gdk_user.cpp
+++ b/modules/xbox_module/gdk/gdk_user.cpp
@@ -1,0 +1,1328 @@
+/**************************************************************************/
+/*  gdk_user.cpp                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_user.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "core/io/image.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XGameErr.h>
+#endif
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+namespace {
+
+Signal _make_users_error_signal(
+		GDKRuntime *p_runtime,
+		HRESULT p_hresult,
+		const String &p_code,
+		const String &p_message,
+		const Variant &p_data = Variant()) {
+	ERR_FAIL_NULL_V(p_runtime, Signal());
+	return p_runtime->make_error_signal(p_hresult, p_code, p_message, p_data);
+}
+
+GDKUser::SignInState _user_state_to_sign_in_state(XUserState p_user_state) {
+	switch (p_user_state) {
+		case XUserState::SignedIn:
+			return GDKUser::SIGN_IN_STATE_SIGNED_IN;
+		case XUserState::SigningOut:
+			return GDKUser::SIGN_IN_STATE_SIGNING_OUT;
+		case XUserState::SignedOut:
+		default:
+			return GDKUser::SIGN_IN_STATE_SIGNED_OUT;
+	}
+}
+
+String _user_change_event_to_name(XUserChangeEvent p_event) {
+	switch (p_event) {
+		case XUserChangeEvent::SignedInAgain:
+			return "signed_in_again";
+		case XUserChangeEvent::Gamertag:
+			return "gamertag";
+		case XUserChangeEvent::GamerPicture:
+			return "gamer_picture";
+		case XUserChangeEvent::Privileges:
+			return "privileges";
+		default:
+			return "unknown";
+	}
+}
+
+GDKUser::AgeGroup _age_group_to_enum(XUserAgeGroup p_age_group) {
+	switch (p_age_group) {
+		case XUserAgeGroup::Child:
+			return GDKUser::AGE_GROUP_CHILD;
+		case XUserAgeGroup::Teen:
+			return GDKUser::AGE_GROUP_TEEN;
+		case XUserAgeGroup::Adult:
+			return GDKUser::AGE_GROUP_ADULT;
+		case XUserAgeGroup::Unknown:
+		default:
+			return GDKUser::AGE_GROUP_UNKNOWN;
+	}
+}
+
+String _privilege_deny_reason_to_string(XUserPrivilegeDenyReason p_reason) {
+	switch (p_reason) {
+		case XUserPrivilegeDenyReason::None:
+			return "none";
+		case XUserPrivilegeDenyReason::PurchaseRequired:
+			return "purchase_required";
+		case XUserPrivilegeDenyReason::Restricted:
+			return "restricted";
+		case XUserPrivilegeDenyReason::Banned:
+			return "banned";
+		case XUserPrivilegeDenyReason::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+Dictionary _make_privilege_result(int64_t p_privilege, bool p_has_privilege, XUserPrivilegeDenyReason p_reason) {
+	Dictionary data;
+	data["privilege"] = p_privilege;
+	data["has_privilege"] = p_has_privilege;
+	data["deny_reason"] = _privilege_deny_reason_to_string(p_reason);
+	data["deny_reason_value"] = static_cast<int64_t>(static_cast<uint32_t>(p_reason));
+	return data;
+}
+
+Dictionary _make_privilege_resolution_result(int64_t p_privilege) {
+	Dictionary data;
+	data["privilege"] = p_privilege;
+	return data;
+}
+
+Dictionary _make_issue_resolution_result(const String &p_url) {
+	Dictionary data;
+	if (!p_url.is_empty()) {
+		data["url"] = p_url;
+	}
+	return data;
+}
+
+bool _try_parse_gamer_picture_size(const String &p_size, XUserGamerPictureSize *r_size) {
+	if (r_size == nullptr) {
+		return false;
+	}
+
+	const String normalized = p_size.strip_edges().to_lower();
+	if (normalized == "small") {
+		*r_size = XUserGamerPictureSize::Small;
+		return true;
+	}
+	if (normalized == "medium") {
+		*r_size = XUserGamerPictureSize::Medium;
+		return true;
+	}
+	if (normalized == "large") {
+		*r_size = XUserGamerPictureSize::Large;
+		return true;
+	}
+	if (normalized == "extra_large" || normalized == "extra-large" || normalized == "extralarge") {
+		*r_size = XUserGamerPictureSize::ExtraLarge;
+		return true;
+	}
+
+	return false;
+}
+
+class AddUserAsyncContext final : public GDKSignalXAsyncContext {
+	GDKUsers *m_users = nullptr;
+	String m_action;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("User add operation cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		XUserHandle user_handle = nullptr;
+		HRESULT result_hr = XUserAddResult(p_async_block, &user_handle);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("User add operation cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(result_hr, m_action, "user_add_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		m_users->complete_add_user(user_handle, get_pending_signal());
+	}
+
+public:
+	AddUserAsyncContext(GDKUsers *p_users, GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, const String &p_action) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_users(p_users),
+			m_action(p_action) {}
+};
+
+class ResolvePrivilegeAsyncContext final : public GDKSignalXAsyncContext {
+	GDKUsers *m_users = nullptr;
+	Ref<GDKUser> m_user;
+	int64_t m_privilege = 0;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Privilege resolution cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XUserResolvePrivilegeWithUiResult(p_async_block);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Privilege resolution cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to resolve the requested privilege with UI.",
+					"privilege_resolve_result_failed",
+					_make_privilege_resolution_result(m_privilege));
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (m_user.is_valid()) {
+			HRESULT refresh_hr = m_user->refresh();
+			if (FAILED(refresh_hr)) {
+				result = GDKResult::hresult_error(
+						refresh_hr,
+						"Resolved the privilege UI flow but failed to refresh the cached user state.",
+						"user_refresh_after_privilege_resolution_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			if (m_users != nullptr) {
+				m_users->emit_signal("user_changed", m_user, "privileges");
+			}
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(_make_privilege_resolution_result(m_privilege)));
+	}
+
+public:
+	ResolvePrivilegeAsyncContext(GDKUsers *p_users, const Ref<GDKUser> &p_user, GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, int64_t p_privilege) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_users(p_users),
+			m_user(p_user),
+			m_privilege(p_privilege) {}
+};
+
+class ResolveIssueAsyncContext final : public GDKSignalXAsyncContext {
+	GDKUsers *m_users = nullptr;
+	Ref<GDKUser> m_user;
+	String m_url;
+	std::string m_url_utf8;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("User issue resolution cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		HRESULT result_hr = XUserResolveIssueWithUiResult(p_async_block);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("User issue resolution cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to resolve the user issue with system UI.",
+					"user_issue_resolve_result_failed",
+					_make_issue_resolution_result(m_url));
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (m_user.is_valid()) {
+			HRESULT refresh_hr = m_user->refresh();
+			if (FAILED(refresh_hr)) {
+				result = GDKResult::hresult_error(
+						refresh_hr,
+						"Resolved the user issue but failed to refresh the cached user state.",
+						"user_refresh_after_issue_resolution_failed");
+				get_pending_signal()->complete(result);
+				return;
+			}
+
+			if (m_users != nullptr) {
+				m_users->emit_signal("user_changed", m_user, "privileges");
+			}
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(_make_issue_resolution_result(m_url)));
+	}
+
+public:
+	ResolveIssueAsyncContext(GDKUsers *p_users, const Ref<GDKUser> &p_user, GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal, const String &p_url) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_users(p_users),
+			m_user(p_user),
+			m_url(p_url) {
+		const CharString url_utf8 = p_url.utf8();
+		if (url_utf8.get_data() != nullptr) {
+			m_url_utf8 = url_utf8.get_data();
+		}
+	}
+
+	const char *get_url() const {
+		return m_url_utf8.empty() ? nullptr : m_url_utf8.c_str();
+	}
+};
+
+class GamerPictureAsyncContext final : public GDKSignalXAsyncContext {
+	Ref<GDKUser> m_user;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Gamer picture request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t buffer_size = 0;
+		HRESULT size_hr = XUserGetGamerPictureResultSize(p_async_block, &buffer_size);
+		if (size_hr == E_ABORT) {
+			result = GDKResult::cancelled("Gamer picture request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(size_hr)) {
+			result = GDKResult::hresult_error(
+					size_hr,
+					"Failed to get the gamer picture buffer size.",
+					"gamer_picture_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(buffer_size);
+		size_t buffer_used = 0;
+		HRESULT result_hr = XUserGetGamerPictureResult(
+				p_async_block,
+				buffer.size(),
+				buffer.empty() ? nullptr : buffer.data(),
+				&buffer_used);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Gamer picture request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to retrieve the gamer picture bytes.",
+					"gamer_picture_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		PackedByteArray png_bytes;
+		if (png_bytes.resize(static_cast<int64_t>(buffer_used)) != 0) {
+			result = GDKResult::error_result(E_OUTOFMEMORY, "gamer_picture_buffer_alloc_failed", "Failed to allocate a buffer for the gamer picture.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+		if (buffer_used > 0) {
+			std::memcpy(png_bytes.ptrw(), buffer.data(), buffer_used);
+		}
+
+		Ref<Image> image;
+		image.instantiate();
+		if (image->load_png_from_buffer(png_bytes) != 0) {
+			result = GDKResult::error_result(E_FAIL, "gamer_picture_decode_failed", "Failed to decode the gamer picture PNG into a Godot Image.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		get_pending_signal()->complete(GDKResult::ok_result(image));
+	}
+
+public:
+	GamerPictureAsyncContext(const Ref<GDKUser> &p_user, GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_user(p_user) {}
+};
+
+class TokenAndSignatureAsyncContext final : public GDKSignalXAsyncContext {
+	Ref<GDKUser> m_user;
+	PackedByteArray m_body;
+	bool m_force_refresh = false;
+	std::string m_method_utf8;
+	std::string m_url_utf8;
+	std::vector<std::string> m_header_names;
+	std::vector<std::string> m_header_values;
+	std::vector<XUserGetTokenAndSignatureHttpHeader> m_headers;
+
+protected:
+	void finalize(XAsyncBlock *p_async_block) override {
+		Ref<GDKResult> result;
+
+		if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+			result = GDKResult::cancelled("Token and signature request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		size_t buffer_size = 0;
+		HRESULT size_hr = XUserGetTokenAndSignatureResultSize(p_async_block, &buffer_size);
+		if (size_hr == E_ABORT) {
+			result = GDKResult::cancelled("Token and signature request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(size_hr)) {
+			result = GDKResult::hresult_error(
+					size_hr,
+					"Failed to get the token/signature result size.",
+					"token_signature_result_size_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		std::vector<uint8_t> buffer(buffer_size);
+		XUserGetTokenAndSignatureData *token_data = nullptr;
+		HRESULT result_hr = XUserGetTokenAndSignatureResult(
+				p_async_block,
+				buffer.size(),
+				buffer.empty() ? nullptr : buffer.data(),
+				&token_data,
+				nullptr);
+		if (result_hr == E_ABORT) {
+			result = GDKResult::cancelled("Token and signature request cancelled.");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		if (FAILED(result_hr)) {
+			result = GDKResult::hresult_error(
+					result_hr,
+					"Failed to retrieve the token/signature payload.",
+					"token_signature_result_failed");
+			get_pending_signal()->complete(result);
+			return;
+		}
+
+		Dictionary data;
+		data["token"] = token_data != nullptr && token_data->token != nullptr ? String::utf8(token_data->token) : String();
+		data["signature"] = token_data != nullptr && token_data->signature != nullptr ? String::utf8(token_data->signature) : String();
+
+		get_pending_signal()->complete(GDKResult::ok_result(data));
+	}
+
+public:
+	TokenAndSignatureAsyncContext(
+			const Ref<GDKUser> &p_user,
+			GDKRuntime *p_runtime,
+			const Ref<GDKPendingSignal> &p_pending_signal,
+			const String &p_method,
+			const String &p_url,
+			const Dictionary &p_headers,
+			const PackedByteArray &p_body,
+			bool p_force_refresh) :
+			GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+			m_user(p_user),
+			m_body(p_body),
+			m_force_refresh(p_force_refresh) {
+		const CharString method_utf8 = p_method.utf8();
+		if (method_utf8.get_data() != nullptr) {
+			m_method_utf8 = method_utf8.get_data();
+		}
+
+		const CharString url_utf8 = p_url.utf8();
+		if (url_utf8.get_data() != nullptr) {
+			m_url_utf8 = url_utf8.get_data();
+		}
+
+		const Array header_keys = p_headers.keys();
+		m_header_names.reserve(static_cast<size_t>(header_keys.size()));
+		m_header_values.reserve(static_cast<size_t>(header_keys.size()));
+		for (int64_t i = 0; i < header_keys.size(); ++i) {
+			const Variant key = header_keys[i];
+			const String header_name = String(key);
+			const String header_value = String(p_headers[key]);
+
+			const CharString header_name_utf8 = header_name.utf8();
+			const CharString header_value_utf8 = header_value.utf8();
+
+			m_header_names.emplace_back(header_name_utf8.get_data() != nullptr ? header_name_utf8.get_data() : "");
+			m_header_values.emplace_back(header_value_utf8.get_data() != nullptr ? header_value_utf8.get_data() : "");
+		}
+
+		m_headers.reserve(m_header_names.size());
+		for (size_t i = 0; i < m_header_names.size(); ++i) {
+			XUserGetTokenAndSignatureHttpHeader header = {};
+			header.name = m_header_names[i].c_str();
+			header.value = m_header_values[i].c_str();
+			m_headers.push_back(header);
+		}
+	}
+
+	XUserGetTokenAndSignatureOptions get_options() const {
+		return m_force_refresh ? XUserGetTokenAndSignatureOptions::ForceRefresh : XUserGetTokenAndSignatureOptions::None;
+	}
+
+	const char *get_method() const {
+		return m_method_utf8.c_str();
+	}
+
+	const char *get_url() const {
+		return m_url_utf8.c_str();
+	}
+
+	size_t get_header_count() const {
+		return m_headers.size();
+	}
+
+	const XUserGetTokenAndSignatureHttpHeader *get_headers() const {
+		return m_headers.empty() ? nullptr : m_headers.data();
+	}
+
+	size_t get_body_size() const {
+		return static_cast<size_t>(m_body.size());
+	}
+
+	const void *get_body_data() const {
+		return m_body.is_empty() ? nullptr : static_cast<const void *>(m_body.ptr());
+	}
+};
+
+} //namespace
+
+#endif
+
+static String _sign_in_state_to_name(GDKUser::SignInState p_sign_in_state) {
+	switch (p_sign_in_state) {
+		case GDKUser::SIGN_IN_STATE_SIGNED_IN:
+			return "signed_in";
+		case GDKUser::SIGN_IN_STATE_SIGNING_OUT:
+			return "signing_out";
+		case GDKUser::SIGN_IN_STATE_SIGNED_OUT:
+		default:
+			return "signed_out";
+	}
+}
+
+static String _age_group_to_name(GDKUser::AgeGroup p_age_group) {
+	switch (p_age_group) {
+		case GDKUser::AGE_GROUP_CHILD:
+			return "child";
+		case GDKUser::AGE_GROUP_TEEN:
+			return "teen";
+		case GDKUser::AGE_GROUP_ADULT:
+			return "adult";
+		case GDKUser::AGE_GROUP_UNKNOWN:
+		default:
+			return "unknown";
+	}
+}
+
+void GDKUser::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_local_id"), &GDKUser::get_local_id);
+	ClassDB::bind_method(D_METHOD("get_xuid"), &GDKUser::get_xuid);
+	ClassDB::bind_method(D_METHOD("get_gamertag"), &GDKUser::get_gamertag);
+	ClassDB::bind_method(D_METHOD("get_age_group"), &GDKUser::get_age_group);
+	ClassDB::bind_method(D_METHOD("get_age_group_name"), &GDKUser::get_age_group_name);
+	ClassDB::bind_method(D_METHOD("get_sign_in_state"), &GDKUser::get_sign_in_state);
+	ClassDB::bind_method(D_METHOD("get_sign_in_state_name"), &GDKUser::get_sign_in_state_name);
+	ClassDB::bind_method(D_METHOD("is_guest"), &GDKUser::is_guest);
+	ClassDB::bind_method(D_METHOD("is_signed_in"), &GDKUser::is_signed_in);
+	ClassDB::bind_method(D_METHOD("is_store_user"), &GDKUser::is_store_user);
+
+	BIND_ENUM_CONSTANT(AGE_GROUP_UNKNOWN);
+	BIND_ENUM_CONSTANT(AGE_GROUP_CHILD);
+	BIND_ENUM_CONSTANT(AGE_GROUP_TEEN);
+	BIND_ENUM_CONSTANT(AGE_GROUP_ADULT);
+
+	BIND_ENUM_CONSTANT(SIGN_IN_STATE_SIGNED_OUT);
+	BIND_ENUM_CONSTANT(SIGN_IN_STATE_SIGNING_OUT);
+	BIND_ENUM_CONSTANT(SIGN_IN_STATE_SIGNED_IN);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "local_id"), "", "get_local_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "xuid"), "", "get_xuid");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamertag"), "", "get_gamertag");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "age_group", PROPERTY_HINT_ENUM, "Unknown,Child,Teen,Adult"), "", "get_age_group");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sign_in_state", PROPERTY_HINT_ENUM, "Signed Out,Signing Out,Signed In"), "", "get_sign_in_state");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "guest"), "", "is_guest");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "signed_in"), "", "is_signed_in");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "store_user"), "", "is_store_user");
+}
+
+GDKUser::GDKUser() {}
+
+GDKUser::~GDKUser() {
+	clear();
+}
+
+int64_t GDKUser::get_local_id() const {
+	return static_cast<int64_t>(m_local_id.value);
+}
+
+String GDKUser::get_xuid() const {
+	return m_xuid;
+}
+
+String GDKUser::get_gamertag() const {
+	return m_gamertag;
+}
+
+GDKUser::AgeGroup GDKUser::get_age_group() const {
+	return m_age_group;
+}
+
+String GDKUser::get_age_group_name() const {
+	return _age_group_to_name(m_age_group);
+}
+
+GDKUser::SignInState GDKUser::get_sign_in_state() const {
+	return m_sign_in_state;
+}
+
+String GDKUser::get_sign_in_state_name() const {
+	return _sign_in_state_to_name(m_sign_in_state);
+}
+
+bool GDKUser::is_guest() const {
+	return m_is_guest;
+}
+
+bool GDKUser::is_signed_in() const {
+	return m_is_signed_in;
+}
+
+bool GDKUser::is_store_user() const {
+	return m_is_store_user;
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+HRESULT GDKUser::_populate_from_handle(XUserHandle p_user_handle) {
+	XUserLocalId local_id = {};
+	HRESULT hr = XUserGetLocalId(p_user_handle, &local_id);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	uint64_t xuid = 0;
+	hr = XUserGetId(p_user_handle, &xuid);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	char gamertag[XUserGamertagComponentClassicMaxBytes] = {};
+	size_t gamertag_used = 0;
+	hr = XUserGetGamertag(
+			p_user_handle,
+			XUserGamertagComponent::Classic,
+			sizeof(gamertag),
+			gamertag,
+			&gamertag_used);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	bool is_guest = false;
+	hr = XUserGetIsGuest(p_user_handle, &is_guest);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	XUserState user_state = XUserState::SignedOut;
+	hr = XUserGetState(p_user_handle, &user_state);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	XUserAgeGroup age_group = XUserAgeGroup::Unknown;
+	hr = XUserGetAgeGroup(p_user_handle, &age_group);
+	if (FAILED(hr) && hr != E_GAMEUSER_RESOLVE_USER_ISSUE_REQUIRED) {
+		return hr;
+	}
+
+	m_local_id = local_id;
+	m_xuid = String::num_uint64(xuid);
+	m_gamertag = String::utf8(gamertag);
+	m_age_group = hr == E_GAMEUSER_RESOLVE_USER_ISSUE_REQUIRED ? AGE_GROUP_UNKNOWN : _age_group_to_enum(age_group);
+	m_sign_in_state = _user_state_to_sign_in_state(user_state);
+	m_is_guest = is_guest;
+	m_is_signed_in = user_state == XUserState::SignedIn;
+	m_is_store_user = XUserIsStoreUser(p_user_handle);
+
+	return S_OK;
+}
+
+HRESULT GDKUser::adopt_handle(XUserHandle p_user_handle) {
+	clear();
+
+	if (p_user_handle == nullptr) {
+		return E_INVALIDARG;
+	}
+
+	m_user_handle = p_user_handle;
+	HRESULT hr = _populate_from_handle(m_user_handle);
+	if (FAILED(hr)) {
+		clear();
+	}
+
+	return hr;
+}
+
+HRESULT GDKUser::refresh() {
+	if (m_user_handle == nullptr) {
+		return E_FAIL;
+	}
+
+	return _populate_from_handle(m_user_handle);
+}
+
+bool GDKUser::matches_local_id(XUserLocalId p_user_local_id) const {
+	return m_local_id.value == p_user_local_id.value;
+}
+
+XUserHandle GDKUser::get_handle() const {
+	return m_user_handle;
+}
+
+void GDKUser::clear() {
+	if (m_user_handle != nullptr) {
+		XUserCloseHandle(m_user_handle);
+		m_user_handle = nullptr;
+	}
+
+	m_local_id = {};
+	m_xuid = "";
+	m_gamertag = "";
+	m_age_group = AGE_GROUP_UNKNOWN;
+	m_sign_in_state = SIGN_IN_STATE_SIGNED_OUT;
+	m_is_guest = false;
+	m_is_signed_in = false;
+	m_is_store_user = false;
+}
+#else
+HRESULT GDKUser::_populate_from_handle(XUserHandle p_user_handle) {
+	return E_NOTIMPL;
+}
+
+HRESULT GDKUser::adopt_handle(XUserHandle p_user_handle) {
+	return E_NOTIMPL;
+}
+
+HRESULT GDKUser::refresh() {
+	return E_NOTIMPL;
+}
+
+bool GDKUser::matches_local_id(XUserLocalId p_user_local_id) const {
+	return m_local_id.value == p_user_local_id.value;
+}
+
+XUserHandle GDKUser::get_handle() const {
+	return m_user_handle;
+}
+
+void GDKUser::clear() {
+	m_user_handle = nullptr;
+	m_local_id = {};
+	m_xuid = "";
+	m_gamertag = "";
+	m_age_group = AGE_GROUP_UNKNOWN;
+	m_sign_in_state = SIGN_IN_STATE_SIGNED_OUT;
+	m_is_guest = false;
+	m_is_signed_in = false;
+	m_is_store_user = false;
+}
+#endif
+
+void GDKUsers::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_default_user_async"), &GDKUsers::add_default_user_async);
+	ClassDB::bind_method(D_METHOD("add_user_with_ui_async"), &GDKUsers::add_user_with_ui_async);
+	ClassDB::bind_method(D_METHOD("get_primary_user"), &GDKUsers::get_primary_user);
+	ClassDB::bind_method(D_METHOD("get_users"), &GDKUsers::get_users);
+	ClassDB::bind_method(D_METHOD("check_privilege_async", "user", "privilege"), &GDKUsers::check_privilege_async);
+	ClassDB::bind_method(D_METHOD("resolve_privilege_with_ui_async", "user", "privilege"), &GDKUsers::resolve_privilege_with_ui_async);
+	ClassDB::bind_method(D_METHOD("resolve_issue_with_ui_async", "user", "url"), &GDKUsers::resolve_issue_with_ui_async, DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("get_gamer_picture_async", "user", "size"), &GDKUsers::get_gamer_picture_async, DEFVAL(String("medium")));
+	ClassDB::bind_method(
+			D_METHOD("get_token_and_signature_async", "user", "method", "url", "headers", "body", "force_refresh"),
+			&GDKUsers::get_token_and_signature_async,
+			DEFVAL(Dictionary()),
+			DEFVAL(PackedByteArray()),
+			DEFVAL(false));
+
+	ADD_SIGNAL(MethodInfo(
+			"user_changed",
+			PropertyInfo(Variant::OBJECT, "user", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "GDKUser"),
+			PropertyInfo(Variant::STRING, "change_kind")));
+}
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+void GDKUsers::set_owner(GDK *p_owner) {
+	m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKUsers::on_runtime_initialized() {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return GDKResult::error_result(E_FAIL, "runtime_not_initialized", "Cannot initialize the users service before the GDK runtime.");
+	}
+
+	if (m_change_event_registered) {
+		m_runtime_ready = true;
+		return GDKResult::ok_result();
+	}
+
+	HRESULT hr = XUserRegisterForChangeEvent(
+			runtime->get_task_queue(),
+			this,
+			_user_change_callback,
+			&m_change_token);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to register the runtime-wide XUser change callback.", "user_change_event_register_failed");
+	}
+
+	m_runtime_ready = true;
+	m_change_event_registered = true;
+	return GDKResult::ok_result();
+}
+
+void GDKUsers::shutdown() {
+	m_runtime_ready = false;
+
+	if (m_change_event_registered) {
+		XUserUnregisterForChangeEvent(m_change_token, true);
+		m_change_event_registered = false;
+	}
+
+	m_primary_user.unref();
+	m_users.clear();
+}
+
+Signal GDKUsers::add_default_user_async() {
+	return _start_add_user_async(XUserAddOptions::AddDefaultUserSilently, "Failed to add the default user.");
+}
+
+Signal GDKUsers::add_user_with_ui_async() {
+	return _start_add_user_async(
+			XUserAddOptions::AddDefaultUserAllowingUI | XUserAddOptions::AllowGuests,
+			"Failed to add a user with UI.");
+}
+
+Ref<GDKUser> GDKUsers::get_primary_user() const {
+	return m_primary_user;
+}
+
+Array GDKUsers::get_users() const {
+	Array users;
+	for (const Ref<GDKUser> &user : m_users) {
+		users.push_back(user);
+	}
+	return users;
+}
+
+Signal GDKUsers::check_privilege_async(const Ref<GDKUser> &p_user, int64_t p_privilege) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_users_error_signal(runtime, E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	bool has_privilege = false;
+	XUserPrivilegeDenyReason deny_reason = XUserPrivilegeDenyReason::None;
+	HRESULT hr = XUserCheckPrivilege(
+			p_user->get_handle(),
+			XUserPrivilegeOptions::None,
+			static_cast<XUserPrivilege>(static_cast<uint32_t>(p_privilege)),
+			&has_privilege,
+			&deny_reason);
+	if (hr == E_GAMEUSER_RESOLVE_USER_ISSUE_REQUIRED) {
+		Dictionary data = _make_privilege_result(p_privilege, false, deny_reason);
+		data["needs_user_issue_resolution"] = true;
+		return _make_users_error_signal(
+				runtime,
+				hr,
+				"user_issue_resolution_required",
+				"The user must resolve an account issue with system UI before the privilege can be checked.",
+				data);
+	}
+	if (FAILED(hr)) {
+		return _make_users_error_signal(
+				runtime,
+				hr,
+				"privilege_check_failed",
+				"Failed to check the requested user privilege.",
+				_make_privilege_result(p_privilege, false, deny_reason));
+	}
+
+	Dictionary data = _make_privilege_result(p_privilege, has_privilege, deny_reason);
+	data["needs_user_issue_resolution"] = false;
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+	pending_signal->complete_deferred(GDKResult::ok_result(data));
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKUsers::resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_users_error_signal(runtime, E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new ResolvePrivilegeAsyncContext(this, p_user, runtime, pending_signal, p_privilege);
+	context->bind_cancel_handler();
+
+	HRESULT hr = XUserResolvePrivilegeWithUiAsync(
+			p_user->get_handle(),
+			XUserPrivilegeOptions::None,
+			static_cast<XUserPrivilege>(static_cast<uint32_t>(p_privilege)),
+			context->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the privilege resolution UI.",
+				"privilege_resolve_start_failed",
+				_make_privilege_resolution_result(p_privilege));
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKUsers::resolve_issue_with_ui_async(const Ref<GDKUser> &p_user, const String &p_url) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_users_error_signal(runtime, E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new ResolveIssueAsyncContext(this, p_user, runtime, pending_signal, p_url.strip_edges());
+	context->bind_cancel_handler();
+
+	HRESULT hr = XUserResolveIssueWithUiAsync(
+			p_user->get_handle(),
+			context->get_url(),
+			context->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the user issue resolution UI.",
+				"user_issue_resolve_start_failed",
+				_make_issue_resolution_result(p_url.strip_edges()));
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKUsers::get_gamer_picture_async(const Ref<GDKUser> &p_user, const String &p_size) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_users_error_signal(runtime, E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	XUserGamerPictureSize native_size = XUserGamerPictureSize::Medium;
+	if (!_try_parse_gamer_picture_size(p_size, &native_size)) {
+		return _make_users_error_signal(
+				runtime,
+				E_INVALIDARG,
+				"invalid_gamer_picture_size",
+				"Gamer picture size must be one of: small, medium, large, extra_large.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new GamerPictureAsyncContext(p_user, runtime, pending_signal);
+	context->bind_cancel_handler();
+
+	HRESULT hr = XUserGetGamerPictureAsync(
+			p_user->get_handle(),
+			native_size,
+			context->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the gamer picture request.",
+				"gamer_picture_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+Signal GDKUsers::get_token_and_signature_async(
+		const Ref<GDKUser> &p_user,
+		const String &p_method,
+		const String &p_url,
+		const Dictionary &p_headers,
+		const PackedByteArray &p_body,
+		bool p_force_refresh) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_users_error_signal(runtime, E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+	}
+
+	const String method = p_method.strip_edges();
+	const String url = p_url.strip_edges();
+	if (method.is_empty()) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_http_method", "Token/signature requests require a non-empty HTTP method.");
+	}
+	if (url.is_empty()) {
+		return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_request_url", "Token/signature requests require a non-empty URL.");
+	}
+
+	const Array header_keys = p_headers.keys();
+	for (int64_t i = 0; i < header_keys.size(); ++i) {
+		const String header_name = String(header_keys[i]).strip_edges();
+		if (header_name.is_empty()) {
+			return _make_users_error_signal(runtime, E_INVALIDARG, "invalid_request_headers", "Token/signature request headers require non-empty string keys.");
+		}
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new TokenAndSignatureAsyncContext(p_user, runtime, pending_signal, method, url, p_headers, p_body, p_force_refresh);
+	context->bind_cancel_handler();
+
+	HRESULT hr = XUserGetTokenAndSignatureAsync(
+			p_user->get_handle(),
+			context->get_options(),
+			context->get_method(),
+			context->get_url(),
+			context->get_header_count(),
+			context->get_headers(),
+			context->get_body_size(),
+			context->get_body_data(),
+			context->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(
+				hr,
+				"Failed to start the token/signature request.",
+				"token_signature_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+void GDKUsers::on_user_change(XUserLocalId p_user_local_id, XUserChangeEvent p_event) {
+	GDKRuntime *runtime = _get_runtime();
+	if (!m_runtime_ready || runtime == nullptr || runtime->is_shutting_down()) {
+		return;
+	}
+
+	Ref<GDKUser> user = _find_user_by_local_id(p_user_local_id);
+	if (!user.is_valid()) {
+		return;
+	}
+
+	switch (p_event) {
+		case XUserChangeEvent::SignedOut: {
+			const bool was_primary = m_primary_user.is_valid() && m_primary_user->get_local_id() == user->get_local_id();
+
+			if (m_owner != nullptr) {
+				m_owner->notify_user_removed(user);
+			}
+
+			_remove_user_by_local_id(p_user_local_id);
+			if (was_primary) {
+				m_primary_user.unref();
+			}
+
+			emit_signal("user_changed", user, "removed");
+		} break;
+		case XUserChangeEvent::SignedInAgain:
+		case XUserChangeEvent::Gamertag:
+		case XUserChangeEvent::GamerPicture:
+		case XUserChangeEvent::Privileges: {
+			if (SUCCEEDED(user->refresh())) {
+				emit_signal("user_changed", user, _user_change_event_to_name(p_event));
+			}
+		} break;
+		case XUserChangeEvent::SigningOut:
+		default:
+			break;
+	}
+}
+
+void GDKUsers::complete_add_user(XUserHandle p_user_handle, const Ref<GDKPendingSignal> &p_pending_signal) {
+	Ref<GDKUser> user;
+	user.instantiate();
+
+	HRESULT hr = user->adopt_handle(p_user_handle);
+	if (FAILED(hr)) {
+		if (p_user_handle != nullptr) {
+			XUserCloseHandle(p_user_handle);
+		}
+
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to translate the native XUser into a Godot wrapper.", "user_wrapper_create_failed");
+		p_pending_signal->complete(result);
+		return;
+	}
+
+	const bool is_new_user = _add_or_update_user(user);
+	const bool establish_primary_user = !m_primary_user.is_valid();
+	if (establish_primary_user) {
+		m_primary_user = user;
+	}
+
+	emit_signal("user_changed", user, is_new_user ? String("added") : String("signed_in_again"));
+
+	p_pending_signal->complete(GDKResult::ok_result(user));
+}
+
+void CALLBACK GDKUsers::_user_change_callback(void *p_context, XUserLocalId p_user_local_id, XUserChangeEvent p_event) {
+	auto *users = static_cast<GDKUsers *>(p_context);
+	users->on_user_change(p_user_local_id, p_event);
+}
+
+GDKRuntime *GDKUsers::_get_runtime() const {
+	return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+Signal GDKUsers::_start_add_user_async(XUserAddOptions p_options, const String &p_action) {
+	GDKRuntime *runtime = _get_runtime();
+	if (runtime == nullptr || !runtime->is_initialized()) {
+		return _make_users_error_signal(runtime, E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+	}
+
+	Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+
+	auto *context = new AddUserAsyncContext(this, runtime, pending_signal, p_action);
+	context->bind_cancel_handler();
+
+	HRESULT hr = XUserAddAsync(p_options, context->get_async_block());
+	if (FAILED(hr)) {
+		pending_signal->clear_cancel_handler();
+		delete context;
+
+		Ref<GDKResult> result = GDKResult::hresult_error(hr, p_action, "user_add_start_failed");
+		pending_signal->complete_deferred(result);
+	}
+
+	return pending_signal->get_completed_signal();
+}
+
+bool GDKUsers::_add_or_update_user(const Ref<GDKUser> &p_user) {
+	for (Ref<GDKUser> &existing : m_users) {
+		if (existing.is_valid() && existing->get_local_id() == p_user->get_local_id()) {
+			existing = p_user;
+			return false;
+		}
+	}
+
+	m_users.push_back(p_user);
+	return true;
+}
+
+Ref<GDKUser> GDKUsers::_find_user_by_local_id(XUserLocalId p_user_local_id) const {
+	for (const Ref<GDKUser> &user : m_users) {
+		if (user.is_valid() && user->matches_local_id(p_user_local_id)) {
+			return user;
+		}
+	}
+
+	return Ref<GDKUser>();
+}
+
+void GDKUsers::_remove_user_by_local_id(XUserLocalId p_user_local_id) {
+	m_users.erase(
+			std::remove_if(
+					m_users.begin(),
+					m_users.end(),
+					[p_user_local_id](const Ref<GDKUser> &user) {
+						return user.is_null() || user->matches_local_id(p_user_local_id);
+					}),
+			m_users.end());
+}
+
+#else
+void GDKUsers::set_owner(GDK *p_owner) {}
+
+Ref<GDKResult> GDKUsers::on_runtime_initialized() {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKUsers::shutdown() {}
+
+Signal GDKUsers::add_default_user_async() {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKUsers::add_user_with_ui_async() {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Ref<GDKUser> GDKUsers::get_primary_user() const {
+	return Ref<GDKUser>();
+}
+
+Array GDKUsers::get_users() const {
+	return Array();
+}
+
+Signal GDKUsers::check_privilege_async(const Ref<GDKUser> &p_user, int64_t p_privilege) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKUsers::resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKUsers::resolve_issue_with_ui_async(const Ref<GDKUser> &p_user, const String &p_url) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKUsers::get_gamer_picture_async(const Ref<GDKUser> &p_user, const String &p_size) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+Signal GDKUsers::get_token_and_signature_async(
+		const Ref<GDKUser> &p_user,
+		const String &p_method,
+		const String &p_url,
+		const Dictionary &p_headers,
+		const PackedByteArray &p_body,
+		bool p_force_refresh) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+void GDKUsers::on_user_change(XUserLocalId p_user_local_id, XUserChangeEvent p_event) {}
+
+void GDKUsers::complete_add_user(XUserHandle p_user_handle, const Ref<GDKPendingSignal> &p_pending_signal) {}
+
+Signal GDKUsers::_start_add_user_async(XUserAddOptions p_options, const String &p_action) {
+	Ref<GDKPendingSignal> p;
+	p.instantiate();
+	p->complete(GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build."));
+	return p->get_completed_signal();
+}
+
+bool GDKUsers::_add_or_update_user(const Ref<GDKUser> &p_user) {
+	return false;
+}
+
+Ref<GDKUser> GDKUsers::_find_user_by_local_id(XUserLocalId p_user_local_id) const {
+	return Ref<GDKUser>();
+}
+
+void GDKUsers::_remove_user_by_local_id(XUserLocalId p_user_local_id) {}
+#endif

--- a/modules/xbox_module/gdk/gdk_user.h
+++ b/modules/xbox_module/gdk/gdk_user.h
@@ -1,0 +1,163 @@
+/**************************************************************************/
+/*  gdk_user.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+#include <vector>
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XUser.h>
+#endif
+
+class GDK;
+class GDKPendingSignal;
+class GDKResult;
+class GDKRuntime;
+
+class GDKUser : public RefCounted {
+	GDCLASS(GDKUser, RefCounted);
+
+public:
+	enum AgeGroup {
+		AGE_GROUP_UNKNOWN = 0,
+		AGE_GROUP_CHILD,
+		AGE_GROUP_TEEN,
+		AGE_GROUP_ADULT,
+	};
+
+	enum SignInState {
+		SIGN_IN_STATE_SIGNED_OUT = 0,
+		SIGN_IN_STATE_SIGNING_OUT,
+		SIGN_IN_STATE_SIGNED_IN,
+	};
+
+private:
+	XUserHandle m_user_handle = nullptr;
+	XUserLocalId m_local_id = {};
+	String m_xuid;
+	String m_gamertag;
+	AgeGroup m_age_group = AGE_GROUP_UNKNOWN;
+	SignInState m_sign_in_state = SIGN_IN_STATE_SIGNED_OUT;
+	bool m_is_guest = false;
+	bool m_is_signed_in = false;
+	bool m_is_store_user = false;
+
+	HRESULT _populate_from_handle(XUserHandle p_user_handle);
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDKUser();
+	~GDKUser();
+
+	int64_t get_local_id() const;
+	String get_xuid() const;
+	String get_gamertag() const;
+	AgeGroup get_age_group() const;
+	String get_age_group_name() const;
+	SignInState get_sign_in_state() const;
+	String get_sign_in_state_name() const;
+	bool is_guest() const;
+	bool is_signed_in() const;
+	bool is_store_user() const;
+
+	HRESULT adopt_handle(XUserHandle p_user_handle);
+	HRESULT refresh();
+	bool matches_local_id(XUserLocalId p_user_local_id) const;
+	XUserHandle get_handle() const;
+	void clear();
+};
+
+class GDKUsers : public RefCounted {
+	GDCLASS(GDKUsers, RefCounted);
+
+	GDK *m_owner = nullptr;
+	std::vector<Ref<GDKUser>> m_users;
+	Ref<GDKUser> m_primary_user;
+	bool m_runtime_ready = false;
+	bool m_change_event_registered = false;
+	XTaskQueueRegistrationToken m_change_token = {};
+
+	static void CALLBACK _user_change_callback(void *p_context, XUserLocalId p_user_local_id, XUserChangeEvent p_event);
+
+	GDKRuntime *_get_runtime() const;
+	Signal _start_add_user_async(XUserAddOptions p_options, const String &p_action);
+	bool _add_or_update_user(const Ref<GDKUser> &p_user);
+	Ref<GDKUser> _find_user_by_local_id(XUserLocalId p_user_local_id) const;
+	void _remove_user_by_local_id(XUserLocalId p_user_local_id);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_owner(GDK *p_owner);
+
+	Ref<GDKResult> on_runtime_initialized();
+	void shutdown();
+
+	Signal add_default_user_async();
+	Signal add_user_with_ui_async();
+	Ref<GDKUser> get_primary_user() const;
+	Array get_users() const;
+	Signal check_privilege_async(const Ref<GDKUser> &p_user, int64_t p_privilege);
+	Signal resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege);
+	Signal resolve_issue_with_ui_async(const Ref<GDKUser> &p_user, const String &p_url = String());
+	Signal get_gamer_picture_async(const Ref<GDKUser> &p_user, const String &p_size = "medium");
+	Signal get_token_and_signature_async(
+			const Ref<GDKUser> &p_user,
+			const String &p_method,
+			const String &p_url,
+			const Dictionary &p_headers = Dictionary(),
+			const PackedByteArray &p_body = PackedByteArray(),
+			bool p_force_refresh = false);
+
+	void on_user_change(XUserLocalId p_user_local_id, XUserChangeEvent p_event);
+	void complete_add_user(XUserHandle p_user_handle, const Ref<GDKPendingSignal> &p_pending_signal);
+};
+
+VARIANT_ENUM_CAST(GDKUser::AgeGroup);
+VARIANT_ENUM_CAST(GDKUser::SignInState);

--- a/modules/xbox_module/gdk/gdk_windows.h
+++ b/modules/xbox_module/gdk/gdk_windows.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  gdk_windows.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#ifdef _WIN32
+#undef min
+#undef max
+#undef ERROR
+#undef DELETE
+#undef MessageBox
+#undef Error
+#undef OK
+#undef CONNECT_DEFERRED
+#undef MemoryBarrier
+#undef MONO_FONT
+#endif
+
+#endif

--- a/modules/xbox_module/gdk/gdk_xbox_services.cpp
+++ b/modules/xbox_module/gdk/gdk_xbox_services.cpp
@@ -1,0 +1,303 @@
+/**************************************************************************/
+/*  gdk_xbox_services.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdk_xbox_services.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include "gdk_windows.h"
+
+#include <algorithm>
+#include <cstdio>
+
+#include "core/error/error_macros.h"
+#include "core/variant/dictionary.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XAsync.h>
+#endif
+
+#include "gdk_result.h"
+#include "gdk_user.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+
+String GDKXboxServices::_build_default_scid(uint32_t p_title_id) {
+	char buffer[37];
+	std::snprintf(buffer, sizeof(buffer), "00000000-0000-0000-0000-0000%08x", p_title_id);
+	return String(buffer);
+}
+
+String GDKXboxServices::_extract_scid_override(const Variant &p_config) {
+	if (p_config.get_type() != Variant::DICTIONARY) {
+		return String();
+	}
+
+	Dictionary config = p_config;
+	if (config.has("scid")) {
+		return String(config["scid"]);
+	}
+	if (config.has("service_configuration_id")) {
+		return String(config["service_configuration_id"]);
+	}
+	if (config.has("xbox_live/scid")) {
+		return String(config["xbox_live/scid"]);
+	}
+	if (config.has("xbox_live")) {
+		Variant xbox_live_value = config["xbox_live"];
+		if (xbox_live_value.get_type() == Variant::DICTIONARY) {
+			Dictionary xbox_live = xbox_live_value;
+			if (xbox_live.has("scid")) {
+				return String(xbox_live["scid"]);
+			}
+		}
+	}
+
+	return String();
+}
+
+GDKXboxServices::UserContextState *GDKXboxServices::_find_user_context(XUserLocalId p_local_id) {
+	for (UserContextState &state : m_user_contexts) {
+		if (state.local_id.value == p_local_id.value) {
+			return &state;
+		}
+	}
+
+	return nullptr;
+}
+
+HRESULT GDKXboxServices::_ensure_user_context(const Ref<GDKUser> &p_user, UserContextState **r_context_state) {
+	ERR_FAIL_COND_V(r_context_state == nullptr, E_POINTER);
+
+	if (!m_initialized) {
+		return E_FAIL;
+	}
+	if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+		return E_INVALIDARG;
+	}
+
+	XUserLocalId local_id = {};
+	local_id.value = static_cast<uint64_t>(p_user->get_local_id());
+
+	UserContextState *existing_state = _find_user_context(local_id);
+	if (existing_state != nullptr) {
+		*r_context_state = existing_state;
+		return S_OK;
+	}
+
+	XblContextHandle context = nullptr;
+	HRESULT hr = XblContextCreateHandle(p_user->get_handle(), &context);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	uint64_t xbox_user_id = 0;
+	hr = XblContextGetXboxUserId(context, &xbox_user_id);
+	if (FAILED(hr)) {
+		XblContextCloseHandle(context);
+		return hr;
+	}
+
+	UserContextState state;
+	state.local_id = local_id;
+	state.xbox_user_id = xbox_user_id;
+	state.context = context;
+	m_user_contexts.push_back(state);
+
+	*r_context_state = &m_user_contexts.back();
+	return S_OK;
+}
+
+GDKXboxServices::~GDKXboxServices() {
+	shutdown();
+}
+
+Ref<GDKResult> GDKXboxServices::initialize(XTaskQueueHandle p_queue, const Variant &p_config) {
+	shutdown();
+
+	uint32_t title_id = 0;
+	HRESULT title_hr = XGameGetXboxTitleId(&title_id);
+	if (FAILED(title_hr)) {
+		return GDKResult::hresult_error(
+				title_hr,
+				"Xbox title ID is unavailable; Xbox services were not initialized.",
+				"xbox_title_id_unavailable");
+	}
+
+	String scid = _extract_scid_override(p_config);
+	if (scid.is_empty()) {
+		scid = _build_default_scid(title_id);
+	}
+
+	CharString scid_utf8 = scid.utf8();
+	XblInitArgs init_args = {};
+	init_args.queue = p_queue;
+	init_args.scid = scid_utf8.get_data();
+
+	HRESULT hr = XblInitialize(&init_args);
+	if (FAILED(hr)) {
+		return GDKResult::hresult_error(hr, "Failed to initialize Xbox services.", "xbox_services_initialize_failed");
+	}
+
+	m_initialized = true;
+	m_title_id = title_id;
+	m_scid = scid;
+	return GDKResult::ok_result();
+}
+
+void GDKXboxServices::shutdown() {
+	for (UserContextState &state : m_user_contexts) {
+		if (state.context != nullptr) {
+			XblContextCloseHandle(state.context);
+			state.context = nullptr;
+		}
+	}
+	m_user_contexts.clear();
+
+	if (m_initialized) {
+		XAsyncBlock cleanup_async = {};
+
+		HRESULT cleanup_hr = XblCleanupAsync(&cleanup_async);
+		if (SUCCEEDED(cleanup_hr)) {
+			XAsyncGetStatus(&cleanup_async, true);
+		}
+	}
+
+	m_initialized = false;
+	m_title_id = 0;
+	m_scid = "";
+}
+
+bool GDKXboxServices::is_initialized() const {
+	return m_initialized;
+}
+
+uint32_t GDKXboxServices::get_title_id() const {
+	return m_title_id;
+}
+
+String GDKXboxServices::get_scid() const {
+	return m_scid;
+}
+
+HRESULT GDKXboxServices::get_xbox_user_id(const Ref<GDKUser> &p_user, uint64_t *r_xbox_user_id) {
+	ERR_FAIL_COND_V(r_xbox_user_id == nullptr, E_POINTER);
+
+	UserContextState *state = nullptr;
+	HRESULT hr = _ensure_user_context(p_user, &state);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	*r_xbox_user_id = state->xbox_user_id;
+	return S_OK;
+}
+
+HRESULT GDKXboxServices::duplicate_context_for_user(const Ref<GDKUser> &p_user, XblContextHandle *r_context, uint64_t *r_xbox_user_id) {
+	ERR_FAIL_COND_V(r_context == nullptr, E_POINTER);
+
+	UserContextState *state = nullptr;
+	HRESULT hr = _ensure_user_context(p_user, &state);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	hr = XblContextDuplicateHandle(state->context, r_context);
+	if (FAILED(hr)) {
+		return hr;
+	}
+
+	if (r_xbox_user_id != nullptr) {
+		*r_xbox_user_id = state->xbox_user_id;
+	}
+
+	return S_OK;
+}
+
+void GDKXboxServices::forget_user(XUserLocalId p_local_id) {
+	m_user_contexts.erase(
+			std::remove_if(
+					m_user_contexts.begin(),
+					m_user_contexts.end(),
+					[p_local_id](UserContextState &state) {
+						if (state.local_id.value != p_local_id.value) {
+							return false;
+						}
+
+						if (state.context != nullptr) {
+							XblContextCloseHandle(state.context);
+							state.context = nullptr;
+						}
+						return true;
+					}),
+			m_user_contexts.end());
+}
+
+#else
+
+GDKXboxServices::~GDKXboxServices() {
+	shutdown();
+}
+
+Ref<GDKResult> GDKXboxServices::initialize(XTaskQueueHandle p_queue, const Variant &p_config) {
+	return GDKResult::error_result(E_NOTIMPL, "gdk_not_enabled", "Xbox GDK is not enabled in this build.");
+}
+
+void GDKXboxServices::shutdown() {
+	m_user_contexts.clear();
+	m_initialized = false;
+	m_title_id = 0;
+	m_scid = "";
+}
+
+bool GDKXboxServices::is_initialized() const {
+	return false;
+}
+
+uint32_t GDKXboxServices::get_title_id() const {
+	return 0;
+}
+
+String GDKXboxServices::get_scid() const {
+	return String();
+}
+
+HRESULT GDKXboxServices::get_xbox_user_id(const Ref<GDKUser> &p_user, uint64_t *r_xbox_user_id) {
+	return E_NOTIMPL;
+}
+
+HRESULT GDKXboxServices::duplicate_context_for_user(const Ref<GDKUser> &p_user, XblContextHandle *r_context, uint64_t *r_xbox_user_id) {
+	return E_NOTIMPL;
+}
+
+void GDKXboxServices::forget_user(XUserLocalId p_local_id) {
+}
+
+#endif

--- a/modules/xbox_module/gdk/gdk_xbox_services.h
+++ b/modules/xbox_module/gdk/gdk_xbox_services.h
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  gdk_xbox_services.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include "gdk_windows.h"
+#endif
+
+#include "gdk_gdk_stubs.h"
+
+#include <vector>
+
+#include "core/string/ustring.h"
+#include "core/variant/variant.h"
+
+#ifdef XBOX_MODULE_GDK_ENABLED
+#include <XGame.h>
+#include <XUser.h>
+#include <xsapi-c/services_c.h>
+#endif
+
+class GDKResult;
+class GDKUser;
+
+class GDKXboxServices {
+	struct UserContextState {
+		XUserLocalId local_id = {};
+		uint64_t xbox_user_id = 0;
+		XblContextHandle context = nullptr;
+	};
+
+	bool m_initialized = false;
+	uint32_t m_title_id = 0;
+	String m_scid;
+	std::vector<UserContextState> m_user_contexts;
+
+	static String _build_default_scid(uint32_t p_title_id);
+	static String _extract_scid_override(const Variant &p_config);
+	UserContextState *_find_user_context(XUserLocalId p_local_id);
+	HRESULT _ensure_user_context(const Ref<GDKUser> &p_user, UserContextState **r_context_state);
+
+public:
+	GDKXboxServices() = default;
+	~GDKXboxServices();
+
+	Ref<GDKResult> initialize(XTaskQueueHandle p_queue, const Variant &p_config);
+	void shutdown();
+
+	bool is_initialized() const;
+	uint32_t get_title_id() const;
+	String get_scid() const;
+
+	HRESULT get_xbox_user_id(const Ref<GDKUser> &p_user, uint64_t *r_xbox_user_id);
+	HRESULT duplicate_context_for_user(const Ref<GDKUser> &p_user, XblContextHandle *r_context, uint64_t *r_xbox_user_id = nullptr);
+	void forget_user(XUserLocalId p_local_id);
+};

--- a/modules/xbox_module/register_types.cpp
+++ b/modules/xbox_module/register_types.cpp
@@ -1,0 +1,215 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
+
+#include "gdk/gdk.h"
+#include "gdk/gdk_accessibility.h"
+#include "gdk/gdk_achievement.h"
+#include "gdk/gdk_activation.h"
+#include "gdk/gdk_capture.h"
+#include "gdk/gdk_display.h"
+#include "gdk/gdk_error_reporting.h"
+#include "gdk/gdk_game_ui.h"
+#include "gdk/gdk_launcher.h"
+#include "gdk/gdk_leaderboards.h"
+#include "gdk/gdk_multiplayer_activity.h"
+#include "gdk/gdk_package.h"
+#include "gdk/gdk_pending_signal.h"
+#include "gdk/gdk_presence.h"
+#include "gdk/gdk_privacy.h"
+#include "gdk/gdk_profile.h"
+#include "gdk/gdk_result.h"
+#include "gdk/gdk_social.h"
+#include "gdk/gdk_stats.h"
+#include "gdk/gdk_store.h"
+#include "gdk/gdk_string_verify.h"
+#include "gdk/gdk_system.h"
+#include "gdk/gdk_title_storage.h"
+#ifdef TOOLS_ENABLED
+#include "editor/plugins/editor_plugin.h"
+#include "editor/xbox_editor_plugin.h"
+#endif
+
+#include "gdk/gdk_user.h"
+
+static GDK *gdk_singleton = nullptr;
+static bool gdk_frame_hook_connected = false;
+
+namespace {
+
+constexpr const char *GDK_RUNTIME_INITIALIZE_ON_STARTUP_SETTING = "gdk/runtime/initialize_on_startup";
+constexpr bool GDK_RUNTIME_INITIALIZE_ON_STARTUP_DEFAULT = false;
+constexpr const char *GDK_RUNTIME_EMBED_DISPATCH_SETTING = "gdk/runtime/embed_dispatch";
+constexpr bool GDK_RUNTIME_EMBED_DISPATCH_DEFAULT = true;
+constexpr const char *GDK_RUNTIME_AUTO_ADD_PRIMARY_USER_SETTING = "gdk/runtime/auto_add_primary_user";
+constexpr bool GDK_RUNTIME_AUTO_ADD_PRIMARY_USER_DEFAULT = false;
+
+void register_gdk_project_settings() {
+	GLOBAL_DEF_BASIC(GDK_RUNTIME_INITIALIZE_ON_STARTUP_SETTING, GDK_RUNTIME_INITIALIZE_ON_STARTUP_DEFAULT);
+	GLOBAL_DEF_BASIC(GDK_RUNTIME_EMBED_DISPATCH_SETTING, GDK_RUNTIME_EMBED_DISPATCH_DEFAULT);
+	GLOBAL_DEF_BASIC(GDK_RUNTIME_AUTO_ADD_PRIMARY_USER_SETTING, GDK_RUNTIME_AUTO_ADD_PRIMARY_USER_DEFAULT);
+}
+
+bool is_embed_dispatch_enabled() {
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	if (project_settings == nullptr) {
+		return GDK_RUNTIME_EMBED_DISPATCH_DEFAULT;
+	}
+
+	return static_cast<bool>(project_settings->get_setting(
+			GDK_RUNTIME_EMBED_DISPATCH_SETTING,
+			GDK_RUNTIME_EMBED_DISPATCH_DEFAULT));
+}
+
+void gdk_frame_callback() {
+	if (gdk_singleton == nullptr || !gdk_singleton->is_initialized() || !is_embed_dispatch_enabled()) {
+		return;
+	}
+
+	gdk_singleton->dispatch();
+}
+
+void connect_gdk_frame_hook() {
+	if (gdk_frame_hook_connected) {
+		return;
+	}
+
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	if (scene_tree == nullptr) {
+		return;
+	}
+
+	scene_tree->connect("process_frame", callable_mp_static(&gdk_frame_callback));
+	gdk_frame_hook_connected = true;
+}
+
+void disconnect_gdk_frame_hook() {
+	if (!gdk_frame_hook_connected) {
+		return;
+	}
+
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	if (scene_tree != nullptr) {
+		scene_tree->disconnect("process_frame", callable_mp_static(&gdk_frame_callback));
+	}
+
+	gdk_frame_hook_connected = false;
+}
+
+} //namespace
+
+void initialize_xbox_module_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE && p_level != MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		return;
+	}
+
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+#ifdef TOOLS_ENABLED
+		GDREGISTER_CLASS(XboxEditorPlugin);
+		EditorPlugins::add_by_type<XboxEditorPlugin>();
+#endif
+		return;
+	}
+
+	GDREGISTER_CLASS(GDK);
+	GDREGISTER_CLASS(GDKResult);
+	GDREGISTER_INTERNAL_CLASS(GDKPendingSignal);
+	GDREGISTER_CLASS(GDKUser);
+	GDREGISTER_CLASS(GDKUsers);
+	GDREGISTER_CLASS(GDKGameUI);
+	GDREGISTER_CLASS(GDKClosedCaptionProperties);
+	GDREGISTER_CLASS(GDKAccessibility);
+	GDREGISTER_CLASS(GDKAchievement);
+	GDREGISTER_CLASS(GDKAchievements);
+	GDREGISTER_CLASS(GDKPackageMount);
+	GDREGISTER_CLASS(GDKPackageResourcePack);
+	GDREGISTER_CLASS(GDKPackage);
+	GDREGISTER_CLASS(GDKStats);
+	GDREGISTER_CLASS(GDKLeaderboardColumn);
+	GDREGISTER_CLASS(GDKLeaderboardRow);
+	GDREGISTER_CLASS(GDKLeaderboard);
+	GDREGISTER_CLASS(GDKLeaderboards);
+	GDREGISTER_CLASS(GDKPrivacy);
+	GDREGISTER_CLASS(GDKPresenceRecord);
+	GDREGISTER_CLASS(GDKPresence);
+	GDREGISTER_CLASS(GDKSocialFilter);
+	GDREGISTER_CLASS(GDKSocialGroup);
+	GDREGISTER_CLASS(GDKSocialUser);
+	GDREGISTER_CLASS(GDKSocial);
+	GDREGISTER_CLASS(GDKStoreLicenseStatus);
+	GDREGISTER_CLASS(GDKStore);
+	GDREGISTER_CLASS(GDKUserProfile);
+	GDREGISTER_CLASS(GDKProfile);
+	GDREGISTER_CLASS(GDKStringVerify);
+	GDREGISTER_CLASS(GDKTitleStorageBlobMetadata);
+	GDREGISTER_CLASS(GDKTitleStorageBlobMetadataResult);
+	GDREGISTER_CLASS(GDKTitleStorage);
+	GDREGISTER_CLASS(GDKErrorReporting);
+	GDREGISTER_CLASS(GDKLauncher);
+	GDREGISTER_CLASS(GDKMultiplayerActivityInfo);
+	GDREGISTER_CLASS(GDKMultiplayerActivity);
+	GDREGISTER_CLASS(GDKCaptureMetaData);
+	GDREGISTER_CLASS(GDKCapture);
+	GDREGISTER_CLASS(GDKSystem);
+	GDREGISTER_CLASS(GDKDisplayTimeoutDeferral);
+	GDREGISTER_CLASS(GDKDisplay);
+	GDREGISTER_CLASS(GDKActivation);
+
+	gdk_singleton = memnew(GDK);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GDK", GDK::get_singleton()));
+	register_gdk_project_settings();
+	connect_gdk_frame_hook();
+}
+
+void uninitialize_xbox_module_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		return;
+	}
+#endif
+
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	disconnect_gdk_frame_hook();
+
+	Engine::get_singleton()->remove_singleton("GDK");
+
+	if (gdk_singleton) {
+		memdelete(gdk_singleton);
+		gdk_singleton = nullptr;
+	}
+}

--- a/modules/xbox_module/register_types.h
+++ b/modules/xbox_module/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_xbox_module_module(ModuleInitializationLevel p_level);
+void uninitialize_xbox_module_module(ModuleInitializationLevel p_level);

--- a/modules/xbox_module/tests/test_xbox_module.h
+++ b/modules/xbox_module/tests/test_xbox_module.h
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  test_xbox_module.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "tests/test_macros.h"
+
+#include "../editor/gdk_toolchain.h"
+#include "../editor/microsoft_game_config.h"
+#include "../gdk/gdk.h"
+#include "../gdk/gdk_result.h"
+
+namespace TestXboxModule {
+
+TEST_CASE("[XboxModule] MicrosoftGameConfig injects TargetDeviceFamily") {
+	const String input =
+			"<Game><ExecutableList><Executable Name=\"game.exe\" Id=\"Game\" /></ExecutableList></Game>";
+	const String output = MicrosoftGameConfig::inject_target_device_family(input, "PC");
+	CHECK(output.contains("TargetDeviceFamily=\"PC\""));
+}
+
+TEST_CASE("[XboxModule] MicrosoftGameConfig reads executable name") {
+	const String content = "<Executable Name=\"MyGame.exe\" TargetDeviceFamily=\"PC\" />";
+	CHECK(MicrosoftGameConfig::read_executable_name_from_content(content) == "MyGame.exe");
+}
+
+TEST_CASE("[XboxModule] MicrosoftGameConfig template contains executable") {
+	const String xml = MicrosoftGameConfig::get_template_xml("test.exe");
+	CHECK(xml.contains("Name=\"test.exe\""));
+	CHECK(xml.contains("<TitleId>"));
+}
+
+TEST_CASE("[XboxModule] GDKToolchain constructs") {
+	Ref<GDKToolchain> toolchain = GDKToolchain::create();
+	CHECK(toolchain.is_valid());
+}
+
+TEST_CASE("[XboxModule] GDK runtime availability and initialize stub") {
+	GDK *gdk = GDK::get_singleton();
+	CHECK(gdk != nullptr);
+#ifdef XBOX_MODULE_GDK_ENABLED
+	CHECK(gdk->is_available());
+	Ref<GDKResult> init_result = gdk->initialize();
+	CHECK(init_result.is_valid());
+	gdk->shutdown();
+#else
+	CHECK_FALSE(gdk->is_available());
+	Ref<GDKResult> init_result = gdk->initialize();
+	CHECK(init_result.is_valid());
+	CHECK_FALSE(init_result->is_ok());
+#endif
+}
+
+TEST_CASE("[XboxModule] GDK dispatch returns int") {
+	GDK *gdk = GDK::get_singleton();
+	CHECK(gdk != nullptr);
+	CHECK(gdk->dispatch() >= 0);
+}
+
+} //namespace TestXboxModule

--- a/modules/xbox_module/xbox_module_constants.h
+++ b/modules/xbox_module/xbox_module_constants.h
@@ -1,0 +1,36 @@
+/**************************************************************************/
+/*  xbox_module_constants.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+enum XboxExportTarget {
+	XBOX_EXPORT_TARGET_GDK_DESKTOP = 0,
+	XBOX_EXPORT_TARGET_XBOX_ONE = 1,
+	XBOX_EXPORT_TARGET_XBOX_SERIES = 2,
+};


### PR DESCRIPTION
## Summary
- Adds native `xbox_module` for Xbox on PC (GDK runtime, XSAPI services, export platform, editor plugin).
- Links against Microsoft GDK using Thunks.dll per custom-engine PC guidance (auto-discovery from `C:\Program Files (x86)\Microsoft GDK`, runtime DLL staging in `bin/`).
- Includes C++ doctest coverage and CI wiring for `[XboxModule]*` tests.

## Related
- Autowork GDScript test project: https://github.com/blazium-games/xbox_module_tests

## Test plan
- [x] `python -m SCons module_xbox_module_enabled=yes module_autowork_enabled=yes platform=windows target=editor tests=yes windows_subsystem=console -j8`
- [x] `bin\blazium.windows.editor.tests.x86_64.exe --headless --test --test-case=*[XboxModule]*`
- [x] `xbox_module_tests` Autowork suite headless (83 tests, 0 failures)