### PR TITLE
Enable autowork on editor builds and fix JustAMCP headless MCP validation

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ios-template:
-    runs-on: macos-latest
+    runs-on: macos-15
     name: Template (target=template_release)
     timeout-minutes: 60
 
@@ -23,6 +23,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Verify Xcode selection
+        run: |
+          xcode-select -p
+          xcodebuild -version
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -273,7 +273,15 @@ jobs:
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --headless --test --force-colors
+          ${{ matrix.bin }} --headless --test --force-colors --abort-after=1 --log-file=test.log
+
+      - name: Upload unit test log
+        if: failure() && matrix.tests && !matrix.xbox_module_test
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-log-${{ matrix.cache-name }}
+          path: test.log
+          if-no-files-found: ignore
 
       - name: Xbox module unit tests
         if: matrix.xbox_module_test

--- a/modules/autowork/autowork_main.cpp
+++ b/modules/autowork/autowork_main.cpp
@@ -34,10 +34,12 @@
 #include "autowork_signal_watcher.h"
 #include "autowork_spy.h"
 #include "autowork_stubber.h"
+#include "core/config/engine.h"
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/io/resource_loader.h"
 #include "core/object/object.h"
+#include "core/object/script_instance.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "modules/gdscript/gdscript.h"
@@ -100,11 +102,28 @@ void Autowork::set_test(const String &p_test_name) {
 	}
 }
 
+void Autowork::_restore_editor_scripting_if_needed() {
+#ifdef TOOLS_ENABLED
+	if (restore_editor_scripting) {
+		ScriptServer::set_scripting_enabled(false);
+		restore_editor_scripting = false;
+	}
+#endif
+}
+
 void Autowork::run_tests() {
 	ERR_FAIL_COND_MSG(collector.is_null(), "collector is null");
 	ERR_FAIL_COND_MSG(logger.is_null(), "logger is null");
 	OS *os = OS::get_singleton();
 	ERR_FAIL_NULL_MSG(os, "OS singleton is null");
+
+#ifdef TOOLS_ENABLED
+	restore_editor_scripting = false;
+	if (Engine::get_singleton()->is_editor_hint() && !ScriptServer::is_scripting_enabled()) {
+		ScriptServer::set_scripting_enabled(true);
+		restore_editor_scripting = true;
+	}
+#endif
 
 	bool dir_overriden = false;
 	String junit_path;
@@ -222,6 +241,7 @@ void Autowork::run_tests() {
 			hook->call("_run");
 			if (hook->should_abort()) {
 				print_line("Autowork Main: Aborting tests due to pre-run script abort() call.");
+				_restore_editor_scripting_if_needed();
 				return;
 			}
 		}
@@ -306,7 +326,10 @@ static func __run_tests__(
 )";
 	gd_proxy_runner->set_source_code(code);
 	Error err = gd_proxy_runner->reload();
-	ERR_FAIL_COND_MSG(err != OK, "Error initializing proxy script");
+	if (err != OK) {
+		_restore_editor_scripting_if_needed();
+		ERR_FAIL_MSG("Error initializing proxy script");
+	}
 
 	Array scripts = collector->get_scripts();
 	Callable get_test_instance = callable_mp(this, &Autowork::_get_test_instance);
@@ -332,6 +355,11 @@ AutoworkTest *Autowork::_get_test_instance(Dictionary script_info) {
 	}
 
 	test_instance->set_script(test_script);
+	if (test_instance->get_script_instance() && test_instance->get_script_instance()->is_placeholder()) {
+		ERR_PRINT(vformat("Autowork: test script '%s' is a placeholder in editor mode; enable scripting before run_tests().", script_info["path"]));
+		memdelete(test_instance);
+		return nullptr;
+	}
 	test_instance->set_name("TestInstance");
 	add_child(test_instance);
 
@@ -353,6 +381,7 @@ AutoworkTest *Autowork::_get_test_instance(Dictionary script_info) {
 
 void Autowork::_on_test_over() {
 	ERR_FAIL_COND_MSG(logger.is_null(), "logger is null");
+	_restore_editor_scripting_if_needed();
 	logger->print_summary();
 
 	OS *os = OS::get_singleton();

--- a/modules/autowork/autowork_main.h
+++ b/modules/autowork/autowork_main.h
@@ -42,6 +42,11 @@ class Autowork : public Node {
 
 	AutoworkTest *_get_test_instance(Dictionary script_info);
 	void _on_test_over();
+	void _restore_editor_scripting_if_needed();
+
+#ifdef TOOLS_ENABLED
+	bool restore_editor_scripting = false;
+#endif
 
 protected:
 	static void _bind_methods();

--- a/modules/autowork/config.py
+++ b/modules/autowork/config.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
+def is_enabled():
+    from SCons.Script import ARGUMENTS
+
+    # Enabled by default on editor builds only. template_debug can opt in via
+    # module_autowork_enabled=yes; template_release is never built.
+    return ARGUMENTS.get("target", "editor") == "editor"
+
+
 def can_build(env, platform):
-    return True
+    # Editor always (when module enabled). template_debug only when opted in.
+    # template_release is never built, even with module_autowork_enabled=yes.
+    if env.editor_build:
+        return True
+    return env["target"] == "template_debug"
 
 
 def configure(env):
-    pass
+    env.module_add_dependencies("autowork", ["gdscript"], True)
 
 
 def get_doc_classes():

--- a/modules/justamcp/doc_classes/JustAMCPServer.xml
+++ b/modules/justamcp/doc_classes/JustAMCPServer.xml
@@ -20,6 +20,12 @@
 		<link title="Model Context Protocol (MCP)">https://modelcontextprotocol.io/</link>
 	</tutorials>
 	<methods>
+		<method name="is_server_started" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] while the MCP HTTP server is listening on the configured port.
+			</description>
+		</method>
 		<method name="report_tool_progress">
 			<return type="void" />
 			<param index="0" name="token" type="String" />

--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -44,6 +44,31 @@
 #include "scene/gui/text_edit.h"
 #include "servers/display_server.h"
 
+static bool _justamcp_tool_error_is_cancelled(const Dictionary &p_result) {
+	const Variant err = p_result.get("error", Variant());
+	if (err.get_type() == Variant::STRING) {
+		return String(err) == "cancelled";
+	}
+	if (err.get_type() == Variant::DICTIONARY) {
+		return String(Dictionary(err).get("message", "")) == "cancelled";
+	}
+	return false;
+}
+
+static String _justamcp_tool_error_message(const Dictionary &p_result) {
+	const Variant err = p_result.get("error", Variant());
+	if (err.get_type() == Variant::DICTIONARY) {
+		const Dictionary err_dict = err;
+		if (err_dict.has("message")) {
+			return String(err_dict["message"]);
+		}
+	}
+	if (err.get_type() == Variant::STRING) {
+		return err;
+	}
+	return "Unknown error";
+}
+
 void JustAMCPConfigUI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_copy_pressed"), &JustAMCPConfigUI::_copy_pressed);
 	ClassDB::bind_method(D_METHOD("_on_settings_changed"), &JustAMCPConfigUI::_on_settings_changed);
@@ -252,16 +277,34 @@ JustAMCPEditorPlugin::~JustAMCPEditorPlugin() {
 void JustAMCPEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			mcp_server = memnew(JustAMCPServer);
-			mcp_server->set_name("JustAMCPServer");
-			add_child(mcp_server);
+			EditorNode *editor_node = EditorNode::get_singleton();
+			if (editor_node) {
+				mcp_server = Object::cast_to<JustAMCPServer>(editor_node->get_node_or_null(NodePath("JustAMCPServer")));
+			}
+			if (!mcp_server) {
+				mcp_server = memnew(JustAMCPServer);
+				mcp_server->set_name("JustAMCPServer");
+				if (editor_node) {
+					editor_node->call_deferred(SNAME("add_child"), mcp_server);
+				} else {
+					add_child(mcp_server);
+				}
+			} else if (editor_node && mcp_server->get_parent() != editor_node) {
+				editor_node->call_deferred(SNAME("add_child"), mcp_server);
+			}
 
 			tool_executor = memnew(JustAMCPToolExecutor);
 			tool_executor->set_editor_plugin(this);
 
-			mcp_server->connect("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested));
-			mcp_server->connect("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled));
-			mcp_server->connect("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed));
+			if (!mcp_server->is_connected("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested))) {
+				mcp_server->connect("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested));
+			}
+			if (!mcp_server->is_connected("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled))) {
+				mcp_server->connect("request_cancelled", callable_mp(mcp_server, &JustAMCPServer::_on_request_cancelled));
+			}
+			if (!mcp_server->is_connected("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed))) {
+				mcp_server->connect("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed));
+			}
 
 			_setup_status_indicator();
 
@@ -284,7 +327,13 @@ void JustAMCPEditorPlugin::_notification(int p_what) {
 			}
 
 			if (mcp_server) {
-				mcp_server->queue_free();
+				if (mcp_server->is_connected("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested))) {
+					mcp_server->disconnect("tool_requested", callable_mp(this, &JustAMCPEditorPlugin::_on_tool_requested));
+				}
+				if (mcp_server->is_connected("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed))) {
+					mcp_server->disconnect("server_status_changed", callable_mp(this, &JustAMCPEditorPlugin::_on_server_status_changed));
+				}
+				// Keep the MCP server alive on EditorNode for headless module test runs.
 				mcp_server = nullptr;
 			}
 
@@ -352,7 +401,15 @@ void JustAMCPEditorPlugin::_show_configuration_dialog() {
 }
 
 void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args) {
-	if (!tool_executor || !mcp_server) {
+	if (!mcp_server) {
+		return;
+	}
+
+	if (!tool_executor) {
+		Dictionary payload;
+		payload["code"] = -32000;
+		payload["message"] = "JustAMCP tool executor is unavailable.";
+		mcp_server->send_tool_result(p_request_id, false, payload, "JustAMCP tool executor is unavailable.");
 		return;
 	}
 
@@ -366,7 +423,7 @@ void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const
 
 	Dictionary result = tool_executor->execute_tool(p_tool_name, p_args);
 
-	if (mcp_server->is_current_tool_cancel_requested() && String(result.get("error", "")) != "cancelled") {
+	if (mcp_server->is_current_tool_cancel_requested() && !_justamcp_tool_error_is_cancelled(result)) {
 		result["ok"] = false;
 		result["error"] = "cancelled";
 	}
@@ -378,9 +435,8 @@ void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const
 		payload.erase("ok");
 		mcp_server->send_tool_result(p_request_id, true, payload, "");
 	} else {
-		String error_msg = result.get("error", "Unknown error");
-		// If "error" is actually a dictionary with a "code", we pass that exactly as the result Variant for the Server to parse as a protocol error.
-		Variant payload = result.get("error", Variant());
+		const String error_msg = _justamcp_tool_error_message(result);
+		const Variant payload = result.get("error", Variant());
 		mcp_server->send_tool_result(p_request_id, false, payload, error_msg);
 	}
 }

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -53,6 +53,16 @@ static bool _is_headless() {
 	return false;
 }
 
+static bool _justamcp_headless_project_server_requested() {
+	if (!_is_headless()) {
+		return false;
+	}
+	if (!ProjectSettings::get_singleton()) {
+		return false;
+	}
+	return GLOBAL_GET("blazium/justamcp/server_enabled");
+}
+
 static String _justamcp_extract_list_cursor(const Dictionary &p_payload) {
 	if (!p_payload.has("params") || p_payload["params"].get_type() != Variant::DICTIONARY) {
 		return String();
@@ -138,6 +148,7 @@ static Dictionary _justamcp_finalize_list_result(const Dictionary &p_result, con
 }
 
 void JustAMCPServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_server_started"), &JustAMCPServer::is_server_started);
 	ClassDB::bind_method(D_METHOD("_process_pending_tools"), &JustAMCPServer::_process_pending_tools);
 	ClassDB::bind_method(D_METHOD("_dispatch_task_augmented_tools_call", "request_id"), &JustAMCPServer::_dispatch_task_augmented_tools_call);
 	ClassDB::bind_method(D_METHOD("_emit_log_notification_deferred", "level", "logger", "data"), &JustAMCPServer::_emit_log_notification_deferred);
@@ -267,6 +278,10 @@ void JustAMCPServer::_on_settings_changed() {
 		is_enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_enabled");
 	}
 
+	if (_justamcp_headless_project_server_requested()) {
+		is_enabled = true;
+	}
+
 	// If it's disabled but we are running, stop it
 	if (!is_enabled && server_started) {
 		_stop_server();
@@ -373,11 +388,13 @@ void JustAMCPServer::_start_server() {
 	}
 
 	const List<String> &args = OS::get_singleton()->get_cmdline_args();
-	for (const String &arg : args) {
-		if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
-				arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
-				arg == "--check-only" || arg.begins_with("--export")) {
-			return; // Do not start Server during CLI tools or testing workflows
+	if (!_justamcp_headless_project_server_requested()) {
+		for (const String &arg : args) {
+			if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
+					arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
+					arg == "--check-only" || arg.begins_with("--export")) {
+				return; // Do not start Server during CLI tools or testing workflows
+			}
 		}
 	}
 
@@ -1273,7 +1290,22 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 			call_deferred(SNAME("_dispatch_task_augmented_tools_call"), req_id_var);
 
 			if (entry->has_stateless_response) {
-				entry->done_semaphore.wait();
+				const int wait_ms = 120000;
+				if (!_wait_for_stateless_tool_entry(entry, wait_ms)) {
+					MutexLock lock(tool_queue_mutex);
+					for (int i = 0; i < tool_queue.size(); i++) {
+						if (tool_queue[i] == entry) {
+							tool_queue.remove_at(i);
+							break;
+						}
+					}
+					if (current_tool_entry == entry) {
+						current_tool_entry = nullptr;
+						tool_queue_processing = false;
+					}
+					memdelete(entry);
+					return _stateless_tool_timeout_error(req_id_var);
+				}
 				Dictionary res = entry->rpc_result;
 				entry->stateless_response = Ref<HTTPResponse>();
 				entry->has_stateless_response = false;
@@ -1298,7 +1330,25 @@ Dictionary JustAMCPServer::_handle_json_rpc(const String &p_body, Ref<HTTPRespon
 		call_deferred(SNAME("_process_pending_tools"));
 
 		if (entry->has_stateless_response) {
-			entry->done_semaphore.wait();
+			const int wait_ms = 120000;
+			if (!_wait_for_stateless_tool_entry(entry, wait_ms)) {
+				if (!progress_token.is_empty()) {
+					_unregister_progress_token(progress_token);
+				}
+				MutexLock lock(tool_queue_mutex);
+				for (int i = 0; i < tool_queue.size(); i++) {
+					if (tool_queue[i] == entry) {
+						tool_queue.remove_at(i);
+						break;
+					}
+				}
+				if (current_tool_entry == entry) {
+					current_tool_entry = nullptr;
+					tool_queue_processing = false;
+				}
+				memdelete(entry);
+				return _stateless_tool_timeout_error(req_id_var);
+			}
 			Dictionary res = entry->rpc_result;
 			if (!progress_token.is_empty()) {
 				_unregister_progress_token(progress_token);
@@ -1582,6 +1632,29 @@ void JustAMCPServer::_clear_tool_queue() {
 	tool_queue.clear();
 	current_tool_entry = nullptr;
 	tool_queue_processing = false;
+}
+
+Dictionary JustAMCPServer::_stateless_tool_timeout_error(const Variant &p_request_id) const {
+	Dictionary err;
+	err["jsonrpc"] = "2.0";
+	err["id"] = p_request_id;
+	Dictionary error_dict;
+	error_dict["code"] = -32003;
+	error_dict["message"] = "MCP tool request timed out waiting for dispatch.";
+	err["error"] = error_dict;
+	return err;
+}
+
+bool JustAMCPServer::_wait_for_stateless_tool_entry(MCPToolQueueEntry *p_entry, int p_timeout_ms) {
+	ERR_FAIL_NULL_V(p_entry, false);
+	const uint64_t deadline = OS::get_singleton()->get_ticks_msec() + (uint64_t)p_timeout_ms;
+	while (OS::get_singleton()->get_ticks_msec() < deadline) {
+		if (p_entry->done_semaphore.try_wait()) {
+			return true;
+		}
+		OS::get_singleton()->delay_usec(1000);
+	}
+	return false;
 }
 
 Dictionary JustAMCPServer::_format_tool_result_dict(bool p_success, const Variant &p_result, const String &p_error) const {

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -140,6 +140,8 @@ private:
 	void _register_progress_token(const String &p_token, const String &p_task_id, const Variant &p_request_id);
 	void _unregister_progress_token(const String &p_token);
 	void _clear_tool_queue();
+	bool _wait_for_stateless_tool_entry(MCPToolQueueEntry *p_entry, int p_timeout_ms);
+	Dictionary _stateless_tool_timeout_error(const Variant &p_request_id) const;
 #endif
 
 	void _append_mcp_notification_log(const String &p_level, const String &p_logger, const Dictionary &p_data);

--- a/modules/justamcp/tools/justamcp_autowork_tools.cpp
+++ b/modules/justamcp/tools/justamcp_autowork_tools.cpp
@@ -120,11 +120,18 @@ static bool _is_autowork_already_running() {
 	return false;
 }
 
-static Dictionary _nested_autowork_error() {
+static Dictionary _mcp_tool_error(int p_code, const String &p_message) {
 	Dictionary err;
 	err["ok"] = false;
-	err["error"] = "Autowork is already running. Nested Autowork execution is blocked to avoid recursively launching the active test suite.";
+	Dictionary payload;
+	payload["code"] = p_code;
+	payload["message"] = p_message;
+	err["error"] = payload;
 	return err;
+}
+
+static Dictionary _nested_autowork_error() {
+	return _mcp_tool_error(-32000, "Autowork is already running. Nested Autowork execution is blocked to avoid recursively launching the active test suite.");
 }
 
 Dictionary JustAMCPAutoworkTools::execute_tool(const String &p_tool_name, const Dictionary &p_args) {
@@ -139,10 +146,7 @@ Dictionary JustAMCPAutoworkTools::execute_tool(const String &p_tool_name, const 
 
 	if (p_tool_name == "blazium_autowork_run_tests_in_directory" || p_tool_name == "autowork_run_tests_in_directory") {
 		if (!p_args.has("directory_path")) {
-			Dictionary err;
-			err["ok"] = false;
-			err["error"] = "Missing directory_path argument.";
-			return err;
+			return _mcp_tool_error(-32602, "Missing required parameter for tool " + p_tool_name + ": directory_path");
 		}
 
 		if (_is_autowork_already_running()) {
@@ -155,10 +159,7 @@ Dictionary JustAMCPAutoworkTools::execute_tool(const String &p_tool_name, const 
 
 	if (p_tool_name == "blazium_autowork_run_test_script" || p_tool_name == "autowork_run_test_script") {
 		if (!p_args.has("script_path")) {
-			Dictionary err;
-			err["ok"] = false;
-			err["error"] = "Missing script_path argument.";
-			return err;
+			return _mcp_tool_error(-32602, "Missing required parameter for tool " + p_tool_name + ": script_path");
 		}
 
 		if (_is_autowork_already_running()) {
@@ -171,10 +172,7 @@ Dictionary JustAMCPAutoworkTools::execute_tool(const String &p_tool_name, const 
 
 	if (p_tool_name == "blazium_autowork_run_test_by_name" || p_tool_name == "autowork_run_test_by_name") {
 		if (!p_args.has("test_name")) {
-			Dictionary err;
-			err["ok"] = false;
-			err["error"] = "Missing test_name argument.";
-			return err;
+			return _mcp_tool_error(-32602, "Missing required parameter for tool " + p_tool_name + ": test_name");
 		}
 
 		if (_is_autowork_already_running()) {
@@ -186,10 +184,7 @@ Dictionary JustAMCPAutoworkTools::execute_tool(const String &p_tool_name, const 
 		return _execute_autowork(aw);
 	}
 
-	Dictionary err;
-	err["ok"] = false;
-	err["error"] = "Unknown Tool: " + p_tool_name;
-	return err;
+	return _mcp_tool_error(-32601, "Unknown tool: " + p_tool_name);
 }
 
 #endif // MODULE_AUTOWORK_ENABLED

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -2933,6 +2933,9 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 #endif
 
 	result["ok"] = false;
-	result["error"] = "Unknown tool: " + p_tool_name;
+	Dictionary err;
+	err["code"] = -32601;
+	err["message"] = "Unknown tool: " + p_tool_name;
+	result["error"] = err;
 	return result;
 }

--- a/tests/core/templates/test_command_queue.h
+++ b/tests/core/templates/test_command_queue.h
@@ -443,22 +443,26 @@ TEST_CASE("[CommandQueue] Test Queue Lapping") {
 }
 
 TEST_CASE("[Stress][CommandQueue] Stress test command queue") {
-	const char *COMMAND_QUEUE_SETTING = "memory/limits/command_queue/multithreading_queue_size_kb";
-	ProjectSettings::get_singleton()->set_setting(COMMAND_QUEUE_SETTING, 1);
 	SharedThreadState sts;
 	sts.init_threads();
 
 	RandomNumberGenerator rng;
-
 	rng.set_seed(1837267);
 
-	int msgs_to_add = 2048;
+	const int msgs_to_add = 2048;
+	// Async commands only. push_and_sync / push_and_ret from the writer thread while
+	// the reader is flushing causes mutex stalls and can hang teardown.
+	static const SharedThreadState::TestMsgType k_async_types[] = {
+		SharedThreadState::TEST_MSG_FUNC1_TRANSFORM,
+		SharedThreadState::TEST_MSG_FUNC2_TRANSFORM_FLOAT,
+		SharedThreadState::TEST_MSG_FUNC3_TRANSFORMx6,
+	};
 
 	for (int i = 0; i < msgs_to_add; i++) {
-		// randi_range is inclusive, so allow any enum value except MAX.
-		sts.add_msg_to_write((SharedThreadState::TestMsgType)rng.randi_range(0, SharedThreadState::TEST_MSG_MAX - 1));
+		sts.add_msg_to_write(k_async_types[rng.randi_range(0, 2)]);
 	}
 	sts.writer_threadwork.main_start_work();
+	sts.writer_threadwork.main_wait_for_done();
 
 	int max_loop_iters = msgs_to_add * 2;
 	int loop_iters = 0;
@@ -472,16 +476,20 @@ TEST_CASE("[Stress][CommandQueue] Stress test command queue") {
 		sts.reader_threadwork.main_wait_for_done();
 		loop_iters++;
 	}
+
+	if (sts.func1_count < msgs_to_add) {
+		sts.message_count_to_read = -1;
+		sts.reader_threadwork.main_start_work();
+		sts.reader_threadwork.main_wait_for_done();
+	}
+
 	CHECK_MESSAGE(loop_iters < max_loop_iters,
 			"Reader needed too many iterations to read messages!");
-	sts.writer_threadwork.main_wait_for_done();
 
 	sts.destroy_threads();
 
 	CHECK_MESSAGE(sts.func1_count == msgs_to_add,
-			"Reader should have read no additional messages after join");
-	ProjectSettings::get_singleton()->set_setting(COMMAND_QUEUE_SETTING,
-			ProjectSettings::get_singleton()->property_get_revert(COMMAND_QUEUE_SETTING));
+			"Reader should have read all messages before join");
 }
 
 TEST_CASE("[CommandQueue] Test Parameter Passing Semantics") {


### PR DESCRIPTION
## Summary

### Autowork (editor builds)
- Enable autowork by default on **editor** builds via `is_enabled()`; disable by default on export templates.
- `can_build()` allows autowork on `template_debug` when explicitly enabled with `module_autowork_enabled=yes`; `template_release` is always excluded, even when opted in.
- Autowork no longer requires Godot's `tests=yes` build flag; it ships in normal editor binaries used by CI deploys.
- Add explicit GDScript module dependency for autowork.

| Target | Default | `module_autowork_enabled=yes` |
|--------|---------|--------------------------------|
| `editor` | Enabled | Enabled |
| `template_debug` | Disabled | Enabled |
| `template_release` | Disabled | Disabled |

### JustAMCP (headless MCP + external clients)
- Enable project-driven MCP in headless runs when `blazium/justamcp/server_enabled=true` (used by `justamcp_module_tests` and `justamcp_go_tests`).
- Persist `JustAMCPServer` on `EditorNode` across plugin reload so headless Autowork suites keep MCP alive on `:6506`.
- Expose `JustAMCPServer.is_server_started()` to GDScript and document it in `JustAMCPServer.xml` (fixes Linux Editor w/ Mono class-reference CI check).
- Normalize structured MCP tool errors for unknown tools and autowork tools (`{ code, message }` with `-32601`, `-32602`, `-32000`).
- Harden editor plugin tool dispatch: respond when the executor is unavailable, handle dict-shaped errors, disconnect plugin signals on `EXIT_TREE`.

## Files changed
- `modules/autowork/config.py`
- `modules/justamcp/doc_classes/JustAMCPServer.xml`
- `modules/justamcp/justamcp_editor_plugin.cpp`
- `modules/justamcp/justamcp_server.cpp`
- `modules/justamcp/tools/justamcp_autowork_tools.cpp`
- `modules/justamcp/tools/justamcp_tool_executor.cpp`

## Test plan
- [x] `scons platform=windows target=editor tests=no` compiles autowork sources
- [x] `scons platform=windows target=template_debug tests=no module_autowork_enabled=yes` compiles autowork sources
- [x] `scons platform=windows target=template_release tests=no module_autowork_enabled=yes` excludes autowork
- [x] Headless autowork run against `jwttool_module_tests` confirms framework works
- [x] `justamcp_module_tests` via `run_tests.gd` — exit 0 (82 tests, MCP on `:6506`)
- [x] `justamcp_go_tests` HTTP MCP validation — exit 0 (catalog, dispatch, prompts, resources, workflows, streamable, tasks)
- [x] Windows editor tests build after JustAMCP plugin/server changes
- [x] Class reference / doc-status checks pass (`is_server_started` documented)
