### PR TITLE
Use base64url_decode for JWT header and payload parsing

### DIFF
--- a/modules/jwttool/jwt.cpp
+++ b/modules/jwttool/jwt.cpp
@@ -72,40 +72,19 @@ void JWT::_bind_methods() {
 }
 
 Dictionary JWT::get_header(const String &p_jwt) {
-	// split first portion
 	Vector<String> split = p_jwt.split(".");
 	if (split.size() < 2) {
 		return {};
 	}
-	core_bind::Marshalls *singleton = core_bind::Marshalls::get_singleton();
-	if (singleton == nullptr) {
-		ERR_PRINT("Failed to get Marshalls singleton.");
-	}
-	// pad with = if not multiple of 4
-	String padded_string = split[0];
-	while (padded_string.length() % 4 != 0) {
-		padded_string += "=";
-	}
-	String json_utf8 = singleton->base64_to_utf8(padded_string);
+	String json_utf8 = base64url_decode(split[0]);
 	return JSON::parse_string(json_utf8);
 }
 Dictionary JWT::get_payload(const String &p_jwt) {
-	// split first portion
 	Vector<String> split = p_jwt.split(".");
 	if (split.size() < 2) {
 		return {};
 	}
-	core_bind::Marshalls *singleton = core_bind::Marshalls::get_singleton();
-	if (singleton == nullptr) {
-		ERR_PRINT("Failed to get Marshalls singleton.");
-	}
-
-	// pad with = if not multiple of 4
-	String padded_string = split[1];
-	while (padded_string.length() % 4 != 0) {
-		padded_string += "=";
-	}
-	String json_utf8 = singleton->base64_to_utf8(padded_string);
+	String json_utf8 = base64url_decode(split[1]);
 	return JSON::parse_string(json_utf8);
 }
 


### PR DESCRIPTION
## Summary
- Route `JWT.get_header()` and `JWT.get_payload()` through `base64url_decode()` instead of manual standard-base64 padding.
- Aligns parsing with JWT base64url semantics already used by create/validate paths.
- Fix macOS CI: use `macos-15` and default `Xcode.app` path (`Xcode_16.2.app` is missing on current `macos-latest` runners).

Companion test fix: [jwttool_module_tests#1](https://github.com/blazium-games/jwttool_module_tests/pull/1) (`before_all` → `_before_all`).

## Test plan
- [x] Rebuilt editor with `tests=no`
- [x] Ran jwttool_module_tests headless: 19 tests, 104 passing asserts, exit code 0
- [x] macOS workflow updated to unblock CI Xcode selection failure