### PR TITLE
Pin macOS CI to macos-15 and select Xcode 16.2

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-15
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:
@@ -42,8 +42,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Verify Xcode selection
+        run: |
+          xcode-select -p
+          xcodebuild -version
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore


### PR DESCRIPTION
## Summary
- Pin macOS build jobs from macos-latest to macos-15, where Xcode 16.2 is installed per the GitHub runner-images readme
- Switch xcode-select to /Applications/Xcode_16.2.app/Contents/Developer
- Add a verify step (xcode-select -p and xcodebuild -version) after selection

## Test plan
- [x] macOS CI jobs pass the Select Xcode 16.2 and Verify Xcode selection steps
- [x] Editor and template universal builds complete
- [x] Unit tests pass on macOS artifacts