### PR TITLE
Add Discord module with runtime Partner SDK loading

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1559,6 +1559,8 @@
 		<member name="CrowdControl" type="CrowdControl" setter="" getter="">
 			The [CrowdControl] singleton.
 		</member>
+		<member name="Discord" type="Discord" setter="" getter="">
+		</member>
 		<member name="DisplayServer" type="DisplayServer" setter="" getter="">
 			The [DisplayServer] singleton.
 		</member>

--- a/modules/discord_module/SCsub
+++ b/modules/discord_module/SCsub
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_discord_module = env_modules.Clone()
+env_discord_module.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/discord_module/config.py
+++ b/modules/discord_module/config.py
@@ -1,0 +1,17 @@
+def can_build(env, platform):
+    return platform in ["windows", "linuxbsd"]
+
+
+def configure(env):
+    env.module_add_dependencies("discord_module", ["jwttool"], True)
+
+
+def get_doc_classes():
+    return [
+        "Discord",
+        "DiscordAuthResult",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/discord_module/discord.cpp
+++ b/modules/discord_module/discord.cpp
@@ -1,0 +1,418 @@
+/**************************************************************************/
+/*  discord.cpp                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "discord.h"
+
+#include "core/os/os.h"
+#include "core/os/time.h"
+#include "discord_auth_client.h"
+
+Discord *Discord::singleton = nullptr;
+
+namespace {
+
+struct DiscordAuthFlow {
+	Discord *owner = nullptr;
+	DiscordAPILoader *loader = nullptr;
+	Discord_Client *client = nullptr;
+	int64_t client_id = 0;
+	String code_verifier;
+	String redirect_uri;
+	String pending_token;
+	Discord_AuthorizationTokenType pending_token_type = DISCORD_AUTHORIZATION_TOKEN_TYPE_BEARER;
+	bool authorize_done = false;
+	bool authorize_ok = false;
+	bool token_done = false;
+	bool token_ok = false;
+	bool update_token_done = false;
+	bool update_token_ok = false;
+};
+
+} //namespace
+
+void Discord::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_available"), &Discord::is_available);
+	ClassDB::bind_method(D_METHOD("initialize", "client_id"), &Discord::initialize, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("shutdown"), &Discord::shutdown);
+	ClassDB::bind_method(D_METHOD("is_initialized"), &Discord::is_initialized);
+	ClassDB::bind_method(D_METHOD("set_debug_logging", "enabled"), &Discord::set_debug_logging);
+	ClassDB::bind_method(D_METHOD("is_debug_logging_enabled"), &Discord::is_debug_logging_enabled);
+	ClassDB::bind_method(D_METHOD("get_debug_log"), &Discord::get_debug_log);
+	ClassDB::bind_method(D_METHOD("clear_debug_log"), &Discord::clear_debug_log);
+	ClassDB::bind_method(D_METHOD("run_callbacks"), &Discord::run_callbacks);
+	ClassDB::bind_method(D_METHOD("get_connection_state"), &Discord::get_connection_state);
+	ClassDB::bind_method(D_METHOD("get_access_token"), &Discord::get_access_token);
+	ClassDB::bind_method(D_METHOD("get_username"), &Discord::get_username);
+	ClassDB::bind_method(D_METHOD("get_user_id"), &Discord::get_user_id);
+	ClassDB::bind_method(D_METHOD("get_last_error"), &Discord::get_last_error);
+	ClassDB::bind_method(D_METHOD("authenticate_with_server", "url", "access_token", "client_id"), &Discord::authenticate_with_server);
+	ClassDB::bind_method(D_METHOD("get_version"), &Discord::get_version);
+
+	BIND_ENUM_CONSTANT(STATE_DISCONNECTED);
+	BIND_ENUM_CONSTANT(STATE_CONNECTING);
+	BIND_ENUM_CONSTANT(STATE_CONNECTED);
+	BIND_ENUM_CONSTANT(STATE_READY);
+	BIND_ENUM_CONSTANT(STATE_RECONNECTING);
+	BIND_ENUM_CONSTANT(STATE_DISCONNECTING);
+	BIND_ENUM_CONSTANT(STATE_HTTP_WAIT);
+}
+
+Discord *Discord::get_singleton() {
+	return singleton;
+}
+
+Discord::Discord() {
+	singleton = this;
+	auth_client = memnew(DiscordAuthClient);
+}
+
+Discord::~Discord() {
+	if (initialized) {
+		shutdown();
+	}
+	memdelete(auth_client);
+	auth_client = nullptr;
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+void Discord::_log_debug(const String &p_message) {
+	if (!debug_logging) {
+		return;
+	}
+	print_line(vformat("[Discord] %s", p_message));
+	if (debug_log.size() >= kMaxDebugLogEntries) {
+		debug_log.remove_at(0);
+	}
+	debug_log.push_back(p_message);
+}
+
+void Discord::_set_last_error(const String &p_error) {
+	last_error = p_error;
+	_log_debug(p_error);
+}
+
+Discord::ConnectionState Discord::_map_client_status(Discord_Client_Status p_status) {
+	switch (p_status) {
+		case DISCORD_CLIENT_STATUS_DISCONNECTED:
+			return STATE_DISCONNECTED;
+		case DISCORD_CLIENT_STATUS_CONNECTING:
+			return STATE_CONNECTING;
+		case DISCORD_CLIENT_STATUS_CONNECTED:
+			return STATE_CONNECTED;
+		case DISCORD_CLIENT_STATUS_READY:
+			return STATE_READY;
+		case DISCORD_CLIENT_STATUS_RECONNECTING:
+			return STATE_RECONNECTING;
+		case DISCORD_CLIENT_STATUS_DISCONNECTING:
+			return STATE_DISCONNECTING;
+		case DISCORD_CLIENT_STATUS_HTTP_WAIT:
+			return STATE_HTTP_WAIT;
+		default:
+			return STATE_DISCONNECTED;
+	}
+}
+
+void Discord::_authorize_callback(Discord_ClientResult *result, Discord_String code, Discord_String redirect_uri, void *user_data) {
+	DiscordAuthFlow *flow = (DiscordAuthFlow *)user_data;
+	flow->authorize_done = true;
+	flow->authorize_ok = flow->loader->client_result_successful(result);
+	if (!flow->authorize_ok) {
+		flow->owner->_set_last_error(vformat("Discord authorize failed: %s", flow->loader->client_result_error(result)));
+		flow->loader->client_result_drop(result);
+		return;
+	}
+
+	flow->redirect_uri = DiscordAPILoader::to_godot_string(redirect_uri);
+	const String auth_code = DiscordAPILoader::to_godot_string(code);
+	flow->loader->client_result_drop(result);
+
+	flow->loader->client_get_token(
+			flow->client,
+			(uint64_t)flow->client_id,
+			auth_code,
+			flow->code_verifier,
+			flow->redirect_uri,
+			Discord::_token_exchange_callback,
+			user_data);
+}
+
+void Discord::_token_exchange_callback(Discord_ClientResult *result,
+		Discord_String access_token,
+		Discord_String refresh_token,
+		Discord_AuthorizationTokenType token_type,
+		int32_t expires_in,
+		Discord_String scopes,
+		void *user_data) {
+	(void)refresh_token;
+	(void)expires_in;
+	(void)scopes;
+	DiscordAuthFlow *flow = (DiscordAuthFlow *)user_data;
+	flow->token_done = true;
+	flow->token_ok = flow->loader->client_result_successful(result);
+	if (!flow->token_ok) {
+		flow->owner->_set_last_error(vformat("Discord token exchange failed: %s", flow->loader->client_result_error(result)));
+		flow->loader->client_result_drop(result);
+		return;
+	}
+	flow->pending_token = DiscordAPILoader::to_godot_string(access_token);
+	flow->pending_token_type = token_type;
+	flow->loader->client_result_drop(result);
+
+	flow->loader->client_update_token(
+			flow->client,
+			flow->pending_token_type,
+			flow->pending_token,
+			Discord::_update_token_callback,
+			user_data);
+}
+
+void Discord::_update_token_callback(Discord_ClientResult *result, void *user_data) {
+	DiscordAuthFlow *flow = (DiscordAuthFlow *)user_data;
+	flow->update_token_done = true;
+	flow->update_token_ok = flow->loader->client_result_successful(result);
+	if (!flow->update_token_ok) {
+		flow->owner->_set_last_error(vformat("Discord UpdateToken failed: %s", flow->loader->client_result_error(result)));
+		flow->loader->client_result_drop(result);
+		return;
+	}
+	flow->loader->client_result_drop(result);
+	flow->owner->access_token = flow->pending_token;
+	flow->loader->client_connect(flow->client);
+}
+
+void Discord::_status_changed_callback(Discord_Client_Status status, Discord_Client_Error error, int32_t error_detail, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	discord->connection_state = Discord::_map_client_status(status);
+	if (error != DISCORD_CLIENT_ERROR_NONE) {
+		discord->_set_last_error(vformat("Discord status error=%d detail=%d", (int)error, (int)error_detail));
+	} else {
+		discord->_log_debug(vformat("Discord status changed to %d", (int)status));
+	}
+}
+
+void Discord::_reset_session() {
+	_disconnect_client();
+	access_token = String();
+	username = String();
+	user_id = 0;
+	connection_state = STATE_DISCONNECTED;
+	last_error = String();
+	initialized = false;
+	client_id = 0;
+}
+
+bool Discord::is_available() {
+	if (dll_available) {
+		return true;
+	}
+	dll_available = loader.try_load();
+	if (dll_available) {
+		_log_debug("Discord Social SDK library loaded");
+	} else {
+		_log_debug("Discord Social SDK library not found; Discord features disabled");
+	}
+	return dll_available;
+}
+
+Error Discord::_initialize_client(int64_t p_client_id) {
+	if (client_active) {
+		return OK;
+	}
+
+	loader.client_init(&client);
+	client_active = true;
+	loader.client_set_application_id(&client, (uint64_t)p_client_id);
+	loader.client_set_status_changed_callback(&client, Discord::_status_changed_callback, this);
+
+	Discord_AuthorizationCodeVerifier verifier;
+	loader.client_create_authorization_code_verifier(&client, &verifier);
+
+	Discord_AuthorizationCodeChallenge challenge;
+	loader.authorization_code_verifier_challenge(&verifier, &challenge);
+
+	DiscordAuthFlow flow;
+	flow.owner = this;
+	flow.loader = &loader;
+	flow.client = &client;
+	flow.client_id = p_client_id;
+	flow.code_verifier = loader.authorization_code_verifier_verifier(&verifier);
+
+	Discord_AuthorizationArgs auth_args;
+	loader.authorization_args_init(&auth_args);
+	loader.authorization_args_set_client_id(&auth_args, (uint64_t)p_client_id);
+	loader.authorization_args_set_scopes(&auth_args, loader.get_default_communication_scopes());
+	loader.authorization_args_set_code_challenge(&auth_args, &challenge);
+
+	connection_state = STATE_CONNECTING;
+	loader.client_authorize(&client, &auth_args, Discord::_authorize_callback, &flow);
+	loader.authorization_args_drop(&auth_args);
+	loader.authorization_code_verifier_drop(&verifier);
+
+	const double start_usec = Time::get_singleton()->get_ticks_usec();
+	const double timeout_sec = 120.0;
+	while (true) {
+		loader.run_callbacks();
+		connection_state = _map_client_status(loader.client_get_status(&client));
+
+		if (flow.authorize_done && !flow.authorize_ok) {
+			return ERR_CANT_CREATE;
+		}
+		if (flow.token_done && !flow.token_ok) {
+			return ERR_CANT_CREATE;
+		}
+		if (flow.update_token_done && !flow.update_token_ok) {
+			return ERR_CANT_CREATE;
+		}
+		if (connection_state == STATE_READY) {
+			Discord_UserHandle user;
+			if (loader.client_get_current_user_v2(&client, &user)) {
+				user_id = loader.user_handle_id(&user);
+				username = loader.user_handle_display_name(&user);
+				if (username.is_empty()) {
+					username = loader.user_handle_username(&user);
+				}
+				loader.user_handle_drop(&user);
+			}
+			return OK;
+		}
+
+		if ((Time::get_singleton()->get_ticks_usec() - start_usec) / 1000000.0 > timeout_sec) {
+			_set_last_error("Timed out waiting for Discord SDK to become ready");
+			return ERR_TIMEOUT;
+		}
+		::OS::get_singleton()->delay_usec(1000);
+	}
+}
+
+Error Discord::initialize(int64_t p_client_id) {
+	if (!is_available()) {
+		last_error = "Discord Social SDK runtime library not available";
+		return ERR_UNAVAILABLE;
+	}
+	if (initialized) {
+		return OK;
+	}
+	if (p_client_id <= 0) {
+		last_error = "client_id must be a positive Discord application ID";
+		return ERR_INVALID_PARAMETER;
+	}
+
+	client_id = p_client_id;
+	Error err = _initialize_client(p_client_id);
+	if (err != OK) {
+		_reset_session();
+		return err;
+	}
+
+	initialized = true;
+	_log_debug(vformat("Discord initialized (client_id=%s)", String::num_int64(p_client_id)));
+	return OK;
+}
+
+void Discord::_disconnect_client() {
+	if (!client_active) {
+		return;
+	}
+	loader.client_drop(&client);
+	client = Discord_Client();
+	client_active = false;
+}
+
+void Discord::shutdown() {
+	if (!initialized && !client_active) {
+		return;
+	}
+	_reset_session();
+	_log_debug("Discord shutdown");
+}
+
+void Discord::set_debug_logging(bool p_enabled) {
+	debug_logging = p_enabled;
+}
+
+Array Discord::get_debug_log() const {
+	Array out;
+	for (int i = 0; i < debug_log.size(); i++) {
+		out.push_back(debug_log[i]);
+	}
+	return out;
+}
+
+void Discord::clear_debug_log() {
+	debug_log.clear();
+}
+
+void Discord::_run_client_callbacks() {
+	if (!client_active) {
+		return;
+	}
+	loader.run_callbacks();
+	connection_state = _map_client_status(loader.client_get_status(&client));
+}
+
+void Discord::run_callbacks() {
+	if (initialized) {
+		_run_client_callbacks();
+	}
+}
+
+String Discord::get_access_token() const {
+	return access_token;
+}
+
+String Discord::get_username() const {
+	return username;
+}
+
+uint64_t Discord::get_user_id() const {
+	return user_id;
+}
+
+Ref<DiscordAuthResult> Discord::authenticate_with_server(const String &p_url, const String &p_access_token, int64_t p_client_id) {
+	const int64_t resolved_client_id = p_client_id > 0 ? p_client_id : client_id;
+	_log_debug(vformat("Authenticating with server: %s", p_url));
+	return auth_client->authenticate_sync(p_url, p_access_token, resolved_client_id, debug_logging);
+}
+
+Dictionary Discord::get_version() const {
+	Dictionary version;
+	version["sdk_enabled"] = loader.is_loaded();
+	version["major"] = 0;
+	version["minor"] = 0;
+	version["patch"] = 0;
+	version["hash"] = String();
+	if (loader.is_loaded()) {
+		loader.fill_version_dict(version);
+	}
+	version["runtime_library"] = DiscordAPILoader::get_runtime_library_name();
+	version["runtime_present"] = DiscordAPILoader::is_runtime_library_present();
+	return version;
+}

--- a/modules/discord_module/discord.h
+++ b/modules/discord_module/discord.h
@@ -1,0 +1,123 @@
+/**************************************************************************/
+/*  discord.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+#include "discord_api_loader.h"
+#include "discord_auth_result.h"
+#include "discord_types.h"
+
+class DiscordAuthClient;
+
+class Discord : public Object {
+	GDCLASS(Discord, Object);
+
+public:
+	enum ConnectionState {
+		STATE_DISCONNECTED,
+		STATE_CONNECTING,
+		STATE_CONNECTED,
+		STATE_READY,
+		STATE_RECONNECTING,
+		STATE_DISCONNECTING,
+		STATE_HTTP_WAIT,
+	};
+
+private:
+	static Discord *singleton;
+
+	DiscordAPILoader loader;
+	DiscordAuthClient *auth_client = nullptr;
+
+	bool dll_available = false;
+	bool initialized = false;
+	bool debug_logging = false;
+	bool client_active = false;
+	int64_t client_id = 0;
+	String access_token;
+	String username;
+	uint64_t user_id = 0;
+	ConnectionState connection_state = STATE_DISCONNECTED;
+	String last_error;
+	Discord_Client client;
+
+	Vector<String> debug_log;
+	static const int kMaxDebugLogEntries = 256;
+
+	void _log_debug(const String &p_message);
+	void _set_last_error(const String &p_error);
+	void _reset_session();
+	static ConnectionState _map_client_status(Discord_Client_Status p_status);
+	Error _initialize_client(int64_t p_client_id);
+	void _run_client_callbacks();
+	void _disconnect_client();
+
+	static void _authorize_callback(Discord_ClientResult *result, Discord_String code, Discord_String redirect_uri, void *user_data);
+	static void _token_exchange_callback(Discord_ClientResult *result,
+			Discord_String access_token,
+			Discord_String refresh_token,
+			Discord_AuthorizationTokenType token_type,
+			int32_t expires_in,
+			Discord_String scopes,
+			void *user_data);
+	static void _update_token_callback(Discord_ClientResult *result, void *user_data);
+	static void _status_changed_callback(Discord_Client_Status status, Discord_Client_Error error, int32_t error_detail, void *user_data);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static Discord *get_singleton();
+
+	bool is_available();
+	Error initialize(int64_t p_client_id = 0);
+	void shutdown();
+	bool is_initialized() const { return initialized; }
+
+	void set_debug_logging(bool p_enabled);
+	bool is_debug_logging_enabled() const { return debug_logging; }
+	Array get_debug_log() const;
+	void clear_debug_log();
+
+	void run_callbacks();
+	ConnectionState get_connection_state() const { return connection_state; }
+	String get_access_token() const;
+	String get_username() const;
+	uint64_t get_user_id() const;
+	String get_last_error() const { return last_error; }
+
+	Ref<DiscordAuthResult> authenticate_with_server(const String &p_url, const String &p_access_token, int64_t p_client_id);
+	Dictionary get_version() const;
+
+	Discord();
+	~Discord();
+};
+
+VARIANT_ENUM_CAST(Discord::ConnectionState);

--- a/modules/discord_module/discord_api_loader.cpp
+++ b/modules/discord_module/discord_api_loader.cpp
@@ -1,0 +1,382 @@
+/**************************************************************************/
+/*  discord_api_loader.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "discord_api_loader.h"
+
+#include "core/io/file_access.h"
+#include "core/os/os.h"
+
+String DiscordAPILoader::get_runtime_library_name() {
+#ifdef WINDOWS_ENABLED
+	return "discord_partner_sdk.dll";
+#else
+	return "libdiscord_partner_sdk.so";
+#endif
+}
+
+bool DiscordAPILoader::is_runtime_library_present() {
+	const String library_name = get_runtime_library_name();
+	const String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+
+	Vector<String> candidates;
+	candidates.push_back(exe_dir.path_join(library_name));
+	candidates.push_back(library_name);
+#ifndef WINDOWS_ENABLED
+	candidates.push_back(exe_dir.path_join("../lib").path_join(library_name));
+#endif
+
+	for (int i = 0; i < candidates.size(); i++) {
+		if (FileAccess::exists(candidates[i])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+Discord_String DiscordAPILoader::make_string(const String &p_value) {
+	Discord_String out;
+	CharString utf8 = p_value.utf8();
+	out.ptr = (uint8_t *)utf8.ptr();
+	out.size = utf8.length();
+	return out;
+}
+
+String DiscordAPILoader::to_godot_string(const Discord_String &p_value) {
+	if (p_value.ptr == nullptr || p_value.size == 0) {
+		return String();
+	}
+	return String::utf8((const char *)p_value.ptr, p_value.size);
+}
+
+bool DiscordAPILoader::_load_symbol(const char *p_name, void *&r_symbol) {
+	r_symbol = nullptr;
+	if (!library_handle) {
+		return false;
+	}
+	Error err = OS::get_singleton()->get_dynamic_library_symbol_handle(library_handle, p_name, r_symbol);
+	return err == OK && r_symbol != nullptr;
+}
+
+bool DiscordAPILoader::try_load() {
+	if (loaded) {
+		return true;
+	}
+
+	Vector<String> candidates;
+	candidates.push_back(get_runtime_library_name());
+
+	String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+	for (int i = 0; i < candidates.size(); i++) {
+		String path = exe_dir.path_join(candidates[i]);
+		if (!FileAccess::exists(path)) {
+			path = candidates[i];
+		}
+#ifndef WINDOWS_ENABLED
+		if (!FileAccess::exists(path)) {
+			path = exe_dir.path_join("../lib").path_join(candidates[i]);
+		}
+#endif
+		if (!FileAccess::exists(path)) {
+			continue;
+		}
+		Error err = OS::get_singleton()->open_dynamic_library(path, library_handle);
+		if (err == OK) {
+			break;
+		}
+	}
+
+	if (!library_handle) {
+		return false;
+	}
+
+#define LOAD_REQUIRED(name, member)        \
+	{                                      \
+		void *symbol = nullptr;            \
+		if (!_load_symbol(name, symbol)) { \
+			unload();                      \
+			return false;                  \
+		}                                  \
+		member = (decltype(member))symbol; \
+	}
+
+	LOAD_REQUIRED("Discord_RunCallbacks", fn_run_callbacks);
+	LOAD_REQUIRED("Discord_Client_Init", fn_client_init);
+	LOAD_REQUIRED("Discord_Client_Drop", fn_client_drop);
+	LOAD_REQUIRED("Discord_Client_SetApplicationId", fn_client_set_application_id);
+	LOAD_REQUIRED("Discord_Client_SetStatusChangedCallback", fn_client_set_status_changed_callback);
+	LOAD_REQUIRED("Discord_Client_CreateAuthorizationCodeVerifier", fn_client_create_authorization_code_verifier);
+	LOAD_REQUIRED("Discord_AuthorizationArgs_Init", fn_authorization_args_init);
+	LOAD_REQUIRED("Discord_AuthorizationArgs_Drop", fn_authorization_args_drop);
+	LOAD_REQUIRED("Discord_AuthorizationArgs_SetClientId", fn_authorization_args_set_client_id);
+	LOAD_REQUIRED("Discord_AuthorizationArgs_SetScopes", fn_authorization_args_set_scopes);
+	LOAD_REQUIRED("Discord_AuthorizationArgs_SetCodeChallenge", fn_authorization_args_set_code_challenge);
+	LOAD_REQUIRED("Discord_AuthorizationCodeVerifier_Drop", fn_authorization_code_verifier_drop);
+	LOAD_REQUIRED("Discord_AuthorizationCodeVerifier_Challenge", fn_authorization_code_verifier_challenge);
+	LOAD_REQUIRED("Discord_AuthorizationCodeVerifier_Verifier", fn_authorization_code_verifier_verifier);
+	LOAD_REQUIRED("Discord_Client_Authorize", fn_client_authorize);
+	LOAD_REQUIRED("Discord_Client_GetToken", fn_client_get_token);
+	LOAD_REQUIRED("Discord_Client_UpdateToken", fn_client_update_token);
+	LOAD_REQUIRED("Discord_Client_Connect", fn_client_connect);
+	LOAD_REQUIRED("Discord_Client_GetStatus", fn_client_get_status);
+	LOAD_REQUIRED("Discord_Client_GetCurrentUserV2", fn_client_get_current_user_v2);
+	LOAD_REQUIRED("Discord_ClientResult_Drop", fn_client_result_drop);
+	LOAD_REQUIRED("Discord_ClientResult_Successful", fn_client_result_successful);
+	LOAD_REQUIRED("Discord_ClientResult_Error", fn_client_result_error);
+	LOAD_REQUIRED("Discord_UserHandle_Drop", fn_user_handle_drop);
+	LOAD_REQUIRED("Discord_UserHandle_Id", fn_user_handle_id);
+	LOAD_REQUIRED("Discord_UserHandle_DisplayName", fn_user_handle_display_name);
+	LOAD_REQUIRED("Discord_UserHandle_Username", fn_user_handle_username);
+	LOAD_REQUIRED("Discord_Client_GetDefaultCommunicationScopes", fn_client_get_default_communication_scopes);
+	LOAD_REQUIRED("Discord_Client_GetVersionHash", fn_client_get_version_hash);
+	LOAD_REQUIRED("Discord_Client_GetVersionMajor", fn_client_get_version_major);
+	LOAD_REQUIRED("Discord_Client_GetVersionMinor", fn_client_get_version_minor);
+	LOAD_REQUIRED("Discord_Client_GetVersionPatch", fn_client_get_version_patch);
+
+#undef LOAD_REQUIRED
+
+	loaded = true;
+	return true;
+}
+
+void DiscordAPILoader::unload() {
+	if (library_handle) {
+		OS::get_singleton()->close_dynamic_library(library_handle);
+		library_handle = nullptr;
+	}
+	loaded = false;
+
+	fn_run_callbacks = nullptr;
+	fn_client_init = nullptr;
+	fn_client_drop = nullptr;
+	fn_client_set_application_id = nullptr;
+	fn_client_set_status_changed_callback = nullptr;
+	fn_client_create_authorization_code_verifier = nullptr;
+	fn_authorization_args_init = nullptr;
+	fn_authorization_args_drop = nullptr;
+	fn_authorization_args_set_client_id = nullptr;
+	fn_authorization_args_set_scopes = nullptr;
+	fn_authorization_args_set_code_challenge = nullptr;
+	fn_authorization_code_verifier_drop = nullptr;
+	fn_authorization_code_verifier_challenge = nullptr;
+	fn_authorization_code_verifier_verifier = nullptr;
+	fn_client_authorize = nullptr;
+	fn_client_get_token = nullptr;
+	fn_client_update_token = nullptr;
+	fn_client_connect = nullptr;
+	fn_client_get_status = nullptr;
+	fn_client_get_current_user_v2 = nullptr;
+	fn_client_result_drop = nullptr;
+	fn_client_result_successful = nullptr;
+	fn_client_result_error = nullptr;
+	fn_user_handle_drop = nullptr;
+	fn_user_handle_id = nullptr;
+	fn_user_handle_display_name = nullptr;
+	fn_user_handle_username = nullptr;
+	fn_client_get_default_communication_scopes = nullptr;
+	fn_client_get_version_hash = nullptr;
+	fn_client_get_version_major = nullptr;
+	fn_client_get_version_minor = nullptr;
+	fn_client_get_version_patch = nullptr;
+}
+
+void DiscordAPILoader::run_callbacks() const {
+	if (fn_run_callbacks) {
+		fn_run_callbacks();
+	}
+}
+
+void DiscordAPILoader::client_init(Discord_Client *self) const {
+	fn_client_init(self);
+}
+
+void DiscordAPILoader::client_drop(Discord_Client *self) const {
+	fn_client_drop(self);
+}
+
+void DiscordAPILoader::client_set_application_id(Discord_Client *self, uint64_t application_id) const {
+	fn_client_set_application_id(self, application_id);
+}
+
+void DiscordAPILoader::client_set_status_changed_callback(Discord_Client *self,
+		Discord_Client_OnStatusChanged callback,
+		void *user_data) const {
+	fn_client_set_status_changed_callback(self, callback, nullptr, user_data);
+}
+
+void DiscordAPILoader::client_create_authorization_code_verifier(Discord_Client *self,
+		Discord_AuthorizationCodeVerifier *return_value) const {
+	fn_client_create_authorization_code_verifier(self, return_value);
+}
+
+void DiscordAPILoader::authorization_args_init(Discord_AuthorizationArgs *self) const {
+	fn_authorization_args_init(self);
+}
+
+void DiscordAPILoader::authorization_args_drop(Discord_AuthorizationArgs *self) const {
+	fn_authorization_args_drop(self);
+}
+
+void DiscordAPILoader::authorization_args_set_client_id(Discord_AuthorizationArgs *self, uint64_t value) const {
+	fn_authorization_args_set_client_id(self, value);
+}
+
+void DiscordAPILoader::authorization_args_set_scopes(Discord_AuthorizationArgs *self, const String &p_scopes) const {
+	CharString utf8 = p_scopes.utf8();
+	Discord_String scopes;
+	scopes.ptr = (uint8_t *)utf8.ptr();
+	scopes.size = utf8.length();
+	fn_authorization_args_set_scopes(self, scopes);
+}
+
+void DiscordAPILoader::authorization_args_set_code_challenge(Discord_AuthorizationArgs *self,
+		Discord_AuthorizationCodeChallenge *value) const {
+	fn_authorization_args_set_code_challenge(self, value);
+}
+
+void DiscordAPILoader::authorization_code_verifier_drop(Discord_AuthorizationCodeVerifier *self) const {
+	fn_authorization_code_verifier_drop(self);
+}
+
+void DiscordAPILoader::authorization_code_verifier_challenge(Discord_AuthorizationCodeVerifier *self,
+		Discord_AuthorizationCodeChallenge *return_value) const {
+	fn_authorization_code_verifier_challenge(self, return_value);
+}
+
+String DiscordAPILoader::authorization_code_verifier_verifier(Discord_AuthorizationCodeVerifier *self) const {
+	Discord_String verifier;
+	fn_authorization_code_verifier_verifier(self, &verifier);
+	return to_godot_string(verifier);
+}
+
+void DiscordAPILoader::client_authorize(Discord_Client *self,
+		Discord_AuthorizationArgs *args,
+		Discord_Client_AuthorizationCallback callback,
+		void *user_data) const {
+	fn_client_authorize(self, args, callback, nullptr, user_data);
+}
+
+void DiscordAPILoader::client_get_token(Discord_Client *self,
+		uint64_t application_id,
+		const String &p_code,
+		const String &p_code_verifier,
+		const String &p_redirect_uri,
+		Discord_Client_TokenExchangeCallback callback,
+		void *user_data) const {
+	CharString code_utf8 = p_code.utf8();
+	CharString verifier_utf8 = p_code_verifier.utf8();
+	CharString redirect_utf8 = p_redirect_uri.utf8();
+	Discord_String code;
+	code.ptr = (uint8_t *)code_utf8.ptr();
+	code.size = code_utf8.length();
+	Discord_String verifier;
+	verifier.ptr = (uint8_t *)verifier_utf8.ptr();
+	verifier.size = verifier_utf8.length();
+	Discord_String redirect_uri;
+	redirect_uri.ptr = (uint8_t *)redirect_utf8.ptr();
+	redirect_uri.size = redirect_utf8.length();
+	fn_client_get_token(self, application_id, code, verifier, redirect_uri, callback, nullptr, user_data);
+}
+
+void DiscordAPILoader::client_update_token(Discord_Client *self,
+		Discord_AuthorizationTokenType token_type,
+		const String &p_token,
+		Discord_Client_UpdateTokenCallback callback,
+		void *user_data) const {
+	CharString token_utf8 = p_token.utf8();
+	Discord_String token;
+	token.ptr = (uint8_t *)token_utf8.ptr();
+	token.size = token_utf8.length();
+	fn_client_update_token(self, token_type, token, callback, nullptr, user_data);
+}
+
+void DiscordAPILoader::client_connect(Discord_Client *self) const {
+	fn_client_connect(self);
+}
+
+Discord_Client_Status DiscordAPILoader::client_get_status(Discord_Client *self) const {
+	return fn_client_get_status(self);
+}
+
+bool DiscordAPILoader::client_get_current_user_v2(Discord_Client *self, Discord_UserHandle *return_value) const {
+	return fn_client_get_current_user_v2(self, return_value);
+}
+
+void DiscordAPILoader::client_result_drop(Discord_ClientResult *self) const {
+	fn_client_result_drop(self);
+}
+
+bool DiscordAPILoader::client_result_successful(Discord_ClientResult *self) const {
+	return fn_client_result_successful(self);
+}
+
+String DiscordAPILoader::client_result_error(Discord_ClientResult *self) const {
+	Discord_String error;
+	fn_client_result_error(self, &error);
+	return to_godot_string(error);
+}
+
+void DiscordAPILoader::user_handle_drop(Discord_UserHandle *self) const {
+	fn_user_handle_drop(self);
+}
+
+uint64_t DiscordAPILoader::user_handle_id(Discord_UserHandle *self) const {
+	return fn_user_handle_id(self);
+}
+
+String DiscordAPILoader::user_handle_display_name(Discord_UserHandle *self) const {
+	Discord_String name;
+	fn_user_handle_display_name(self, &name);
+	return to_godot_string(name);
+}
+
+String DiscordAPILoader::user_handle_username(Discord_UserHandle *self) const {
+	Discord_String name;
+	fn_user_handle_username(self, &name);
+	return to_godot_string(name);
+}
+
+String DiscordAPILoader::get_default_communication_scopes() const {
+	Discord_String scopes;
+	fn_client_get_default_communication_scopes(&scopes);
+	return to_godot_string(scopes);
+}
+
+void DiscordAPILoader::fill_version_dict(Dictionary &p_version) const {
+	p_version["sdk_enabled"] = true;
+	p_version["major"] = fn_client_get_version_major ? fn_client_get_version_major() : 0;
+	p_version["minor"] = fn_client_get_version_minor ? fn_client_get_version_minor() : 0;
+	p_version["patch"] = fn_client_get_version_patch ? fn_client_get_version_patch() : 0;
+	if (fn_client_get_version_hash) {
+		Discord_String hash;
+		fn_client_get_version_hash(&hash);
+		p_version["hash"] = to_godot_string(hash);
+	} else {
+		p_version["hash"] = String();
+	}
+}

--- a/modules/discord_module/discord_api_loader.h
+++ b/modules/discord_module/discord_api_loader.h
@@ -1,0 +1,191 @@
+/**************************************************************************/
+/*  discord_api_loader.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+#include "discord_types.h"
+
+class DiscordAPILoader {
+public:
+	static String get_runtime_library_name();
+	static bool is_runtime_library_present();
+
+private:
+	void *library_handle = nullptr;
+	bool loaded = false;
+
+	typedef void (*Discord_RunCallbacksFn)();
+	typedef void (*Discord_Client_InitFn)(Discord_Client *self);
+	typedef void (*Discord_Client_DropFn)(Discord_Client *self);
+	typedef void (*Discord_Client_SetApplicationIdFn)(Discord_Client *self, uint64_t application_id);
+	typedef void (*Discord_Client_SetStatusChangedCallbackFn)(Discord_Client *self,
+			Discord_Client_OnStatusChanged callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_CreateAuthorizationCodeVerifierFn)(Discord_Client *self,
+			Discord_AuthorizationCodeVerifier *return_value);
+	typedef void (*Discord_AuthorizationArgs_InitFn)(Discord_AuthorizationArgs *self);
+	typedef void (*Discord_AuthorizationArgs_DropFn)(Discord_AuthorizationArgs *self);
+	typedef void (*Discord_AuthorizationArgs_SetClientIdFn)(Discord_AuthorizationArgs *self, uint64_t value);
+	typedef void (*Discord_AuthorizationArgs_SetScopesFn)(Discord_AuthorizationArgs *self, Discord_String value);
+	typedef void (*Discord_AuthorizationArgs_SetCodeChallengeFn)(Discord_AuthorizationArgs *self,
+			Discord_AuthorizationCodeChallenge *value);
+	typedef void (*Discord_AuthorizationCodeVerifier_DropFn)(Discord_AuthorizationCodeVerifier *self);
+	typedef void (*Discord_AuthorizationCodeVerifier_ChallengeFn)(Discord_AuthorizationCodeVerifier *self,
+			Discord_AuthorizationCodeChallenge *return_value);
+	typedef void (*Discord_AuthorizationCodeVerifier_VerifierFn)(Discord_AuthorizationCodeVerifier *self,
+			Discord_String *return_value);
+	typedef void (*Discord_Client_AuthorizeFn)(Discord_Client *self,
+			Discord_AuthorizationArgs *args,
+			Discord_Client_AuthorizationCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_GetTokenFn)(Discord_Client *self,
+			uint64_t application_id,
+			Discord_String code,
+			Discord_String code_verifier,
+			Discord_String redirect_uri,
+			Discord_Client_TokenExchangeCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_UpdateTokenFn)(Discord_Client *self,
+			Discord_AuthorizationTokenType token_type,
+			Discord_String token,
+			Discord_Client_UpdateTokenCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_ConnectFn)(Discord_Client *self);
+	typedef Discord_Client_Status (*Discord_Client_GetStatusFn)(Discord_Client *self);
+	typedef bool (*Discord_Client_GetCurrentUserV2Fn)(Discord_Client *self, Discord_UserHandle *return_value);
+	typedef void (*Discord_ClientResult_DropFn)(Discord_ClientResult *self);
+	typedef bool (*Discord_ClientResult_SuccessfulFn)(Discord_ClientResult *self);
+	typedef void (*Discord_ClientResult_ErrorFn)(Discord_ClientResult *self, Discord_String *return_value);
+	typedef void (*Discord_UserHandle_DropFn)(Discord_UserHandle *self);
+	typedef uint64_t (*Discord_UserHandle_IdFn)(Discord_UserHandle *self);
+	typedef void (*Discord_UserHandle_DisplayNameFn)(Discord_UserHandle *self, Discord_String *return_value);
+	typedef void (*Discord_UserHandle_UsernameFn)(Discord_UserHandle *self, Discord_String *return_value);
+	typedef void (*Discord_Client_GetDefaultCommunicationScopesFn)(Discord_String *return_value);
+	typedef void (*Discord_Client_GetVersionHashFn)(Discord_String *return_value);
+	typedef int32_t (*Discord_Client_GetVersionMajorFn)();
+	typedef int32_t (*Discord_Client_GetVersionMinorFn)();
+	typedef int32_t (*Discord_Client_GetVersionPatchFn)();
+
+	Discord_RunCallbacksFn fn_run_callbacks = nullptr;
+	Discord_Client_InitFn fn_client_init = nullptr;
+	Discord_Client_DropFn fn_client_drop = nullptr;
+	Discord_Client_SetApplicationIdFn fn_client_set_application_id = nullptr;
+	Discord_Client_SetStatusChangedCallbackFn fn_client_set_status_changed_callback = nullptr;
+	Discord_Client_CreateAuthorizationCodeVerifierFn fn_client_create_authorization_code_verifier = nullptr;
+	Discord_AuthorizationArgs_InitFn fn_authorization_args_init = nullptr;
+	Discord_AuthorizationArgs_DropFn fn_authorization_args_drop = nullptr;
+	Discord_AuthorizationArgs_SetClientIdFn fn_authorization_args_set_client_id = nullptr;
+	Discord_AuthorizationArgs_SetScopesFn fn_authorization_args_set_scopes = nullptr;
+	Discord_AuthorizationArgs_SetCodeChallengeFn fn_authorization_args_set_code_challenge = nullptr;
+	Discord_AuthorizationCodeVerifier_DropFn fn_authorization_code_verifier_drop = nullptr;
+	Discord_AuthorizationCodeVerifier_ChallengeFn fn_authorization_code_verifier_challenge = nullptr;
+	Discord_AuthorizationCodeVerifier_VerifierFn fn_authorization_code_verifier_verifier = nullptr;
+	Discord_Client_AuthorizeFn fn_client_authorize = nullptr;
+	Discord_Client_GetTokenFn fn_client_get_token = nullptr;
+	Discord_Client_UpdateTokenFn fn_client_update_token = nullptr;
+	Discord_Client_ConnectFn fn_client_connect = nullptr;
+	Discord_Client_GetStatusFn fn_client_get_status = nullptr;
+	Discord_Client_GetCurrentUserV2Fn fn_client_get_current_user_v2 = nullptr;
+	Discord_ClientResult_DropFn fn_client_result_drop = nullptr;
+	Discord_ClientResult_SuccessfulFn fn_client_result_successful = nullptr;
+	Discord_ClientResult_ErrorFn fn_client_result_error = nullptr;
+	Discord_UserHandle_DropFn fn_user_handle_drop = nullptr;
+	Discord_UserHandle_IdFn fn_user_handle_id = nullptr;
+	Discord_UserHandle_DisplayNameFn fn_user_handle_display_name = nullptr;
+	Discord_UserHandle_UsernameFn fn_user_handle_username = nullptr;
+	Discord_Client_GetDefaultCommunicationScopesFn fn_client_get_default_communication_scopes = nullptr;
+	Discord_Client_GetVersionHashFn fn_client_get_version_hash = nullptr;
+	Discord_Client_GetVersionMajorFn fn_client_get_version_major = nullptr;
+	Discord_Client_GetVersionMinorFn fn_client_get_version_minor = nullptr;
+	Discord_Client_GetVersionPatchFn fn_client_get_version_patch = nullptr;
+
+	bool _load_symbol(const char *p_name, void *&r_symbol);
+
+public:
+	bool try_load();
+	void unload();
+	bool is_loaded() const { return loaded; }
+
+	void run_callbacks() const;
+	void client_init(Discord_Client *self) const;
+	void client_drop(Discord_Client *self) const;
+	void client_set_application_id(Discord_Client *self, uint64_t application_id) const;
+	void client_set_status_changed_callback(Discord_Client *self,
+			Discord_Client_OnStatusChanged callback,
+			void *user_data) const;
+	void client_create_authorization_code_verifier(Discord_Client *self,
+			Discord_AuthorizationCodeVerifier *return_value) const;
+	void authorization_args_init(Discord_AuthorizationArgs *self) const;
+	void authorization_args_drop(Discord_AuthorizationArgs *self) const;
+	void authorization_args_set_client_id(Discord_AuthorizationArgs *self, uint64_t value) const;
+	void authorization_args_set_scopes(Discord_AuthorizationArgs *self, const String &p_scopes) const;
+	void authorization_args_set_code_challenge(Discord_AuthorizationArgs *self,
+			Discord_AuthorizationCodeChallenge *value) const;
+	void authorization_code_verifier_drop(Discord_AuthorizationCodeVerifier *self) const;
+	void authorization_code_verifier_challenge(Discord_AuthorizationCodeVerifier *self,
+			Discord_AuthorizationCodeChallenge *return_value) const;
+	String authorization_code_verifier_verifier(Discord_AuthorizationCodeVerifier *self) const;
+	void client_authorize(Discord_Client *self,
+			Discord_AuthorizationArgs *args,
+			Discord_Client_AuthorizationCallback callback,
+			void *user_data) const;
+	void client_get_token(Discord_Client *self,
+			uint64_t application_id,
+			const String &p_code,
+			const String &p_code_verifier,
+			const String &p_redirect_uri,
+			Discord_Client_TokenExchangeCallback callback,
+			void *user_data) const;
+	void client_update_token(Discord_Client *self,
+			Discord_AuthorizationTokenType token_type,
+			const String &p_token,
+			Discord_Client_UpdateTokenCallback callback,
+			void *user_data) const;
+	void client_connect(Discord_Client *self) const;
+	Discord_Client_Status client_get_status(Discord_Client *self) const;
+	bool client_get_current_user_v2(Discord_Client *self, Discord_UserHandle *return_value) const;
+	void client_result_drop(Discord_ClientResult *self) const;
+	bool client_result_successful(Discord_ClientResult *self) const;
+	String client_result_error(Discord_ClientResult *self) const;
+	void user_handle_drop(Discord_UserHandle *self) const;
+	uint64_t user_handle_id(Discord_UserHandle *self) const;
+	String user_handle_display_name(Discord_UserHandle *self) const;
+	String user_handle_username(Discord_UserHandle *self) const;
+	String get_default_communication_scopes() const;
+	void fill_version_dict(Dictionary &p_version) const;
+
+	static Discord_String make_string(const String &p_value);
+	static String to_godot_string(const Discord_String &p_value);
+};

--- a/modules/discord_module/discord_auth_client.cpp
+++ b/modules/discord_module/discord_auth_client.cpp
@@ -1,0 +1,187 @@
+/**************************************************************************/
+/*  discord_auth_client.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "discord_auth_client.h"
+
+#include "core/io/http_client.h"
+#include "core/io/json.h"
+#include "core/os/os.h"
+#include "core/os/time.h"
+
+Ref<DiscordAuthResult> DiscordAuthClient::authenticate_sync(const String &p_url, const String &p_access_token, int64_t p_client_id, bool p_debug_logging) {
+	Ref<DiscordAuthResult> result;
+	result.instantiate();
+
+	if (p_url.is_empty()) {
+		result->set_error_message("Auth server URL is empty");
+		return result;
+	}
+	if (p_access_token.is_empty()) {
+		result->set_error_message("Access token is empty");
+		return result;
+	}
+
+	Dictionary body_dict;
+	body_dict["access_token"] = p_access_token;
+	body_dict["client_id"] = p_client_id;
+	String body = JSON::stringify(body_dict);
+	PackedByteArray body_bytes = body.to_utf8_buffer();
+
+	Vector<String> headers;
+	headers.push_back("Content-Type: application/json");
+	headers.push_back("Accept: application/json");
+
+	Ref<HTTPClient> http = HTTPClient::create();
+	http->set_blocking_mode(true);
+
+	String host;
+	int port = 80;
+	String scheme = "http";
+
+	int scheme_end = p_url.find("://");
+	if (scheme_end == -1) {
+		result->set_error_message("Invalid auth server URL");
+		return result;
+	}
+
+	scheme = p_url.substr(0, scheme_end).to_lower();
+	String remainder = p_url.substr(scheme_end + 3);
+	int slash = remainder.find("/");
+	String authority = slash == -1 ? remainder : remainder.substr(0, slash);
+	int colon = authority.find(":");
+	if (colon != -1) {
+		host = authority.substr(0, colon);
+		port = authority.substr(colon + 1).to_int();
+	} else {
+		host = authority;
+		port = scheme == "https" ? 443 : 80;
+	}
+
+	Error err = http->connect_to_host(host, port, scheme == "https" ? TLSOptions::client() : Ref<TLSOptions>());
+	if (err != OK) {
+		result->set_error_message(vformat("Failed to connect to auth server: %s", error_names[err]));
+		return result;
+	}
+
+	const double connect_timeout_sec = 15.0;
+	const double connect_start_usec = Time::get_singleton()->get_ticks_usec();
+	while (http->get_status() != HTTPClient::STATUS_CONNECTED) {
+		http->poll();
+		HTTPClient::Status status = http->get_status();
+		if (status == HTTPClient::STATUS_CANT_CONNECT ||
+				status == HTTPClient::STATUS_CANT_RESOLVE ||
+				status == HTTPClient::STATUS_CONNECTION_ERROR ||
+				status == HTTPClient::STATUS_TLS_HANDSHAKE_ERROR) {
+			result->set_error_message(vformat("Auth server connection error (status=%d)", (int)status));
+			http->close();
+			return result;
+		}
+		if ((Time::get_singleton()->get_ticks_usec() - connect_start_usec) / 1000000.0 > connect_timeout_sec) {
+			result->set_error_message("Timed out connecting to auth server");
+			http->close();
+			return result;
+		}
+		::OS::get_singleton()->delay_usec(1000);
+	}
+
+	err = http->request(HTTPClient::METHOD_POST, p_url, headers, body_bytes.ptr(), body_bytes.size());
+	if (err != OK) {
+		result->set_error_message(vformat("HTTP request failed: %s", error_names[err]));
+		return result;
+	}
+
+	PackedByteArray response_bytes;
+	while (true) {
+		http->poll();
+		HTTPClient::Status status = http->get_status();
+		if (status == HTTPClient::STATUS_BODY) {
+			PackedByteArray chunk = http->read_response_body_chunk();
+			if (!chunk.is_empty()) {
+				response_bytes.append_array(chunk);
+			}
+		} else if (status == HTTPClient::STATUS_CONNECTED || status == HTTPClient::STATUS_DISCONNECTED) {
+			break;
+		} else if (status == HTTPClient::STATUS_CANT_CONNECT ||
+				status == HTTPClient::STATUS_CANT_RESOLVE ||
+				status == HTTPClient::STATUS_CONNECTION_ERROR ||
+				status == HTTPClient::STATUS_TLS_HANDSHAKE_ERROR) {
+			result->set_error_message(vformat("Auth server connection error (status=%d)", (int)status));
+			http->close();
+			return result;
+		}
+	}
+
+	int response_code = http->get_response_code();
+	result->set_http_status(response_code);
+	String response_text = String::utf8((const char *)response_bytes.ptr(), response_bytes.size());
+
+	if (p_debug_logging) {
+		print_line(vformat("[DiscordAuthClient] POST %s -> HTTP %d", p_url, response_code));
+		print_line(vformat("[DiscordAuthClient] Response: %s", response_text));
+	}
+
+	Variant parsed = JSON::parse_string(response_text);
+	if (parsed.get_type() != Variant::DICTIONARY) {
+		result->set_error_message("Invalid JSON response from auth server");
+		http->close();
+		return result;
+	}
+
+	Dictionary response_dict = parsed;
+
+	if (response_code != 200) {
+		String message = response_dict.has("error") ? String(response_dict["error"]) : response_text;
+		result->set_error_message(message);
+		http->close();
+		return result;
+	}
+
+	if (!response_dict.has("jwt")) {
+		result->set_error_message("Auth response missing jwt");
+		http->close();
+		return result;
+	}
+
+	result->set_success(true);
+	result->set_jwt(response_dict["jwt"]);
+	if (response_dict.has("discord_id")) {
+		result->set_discord_id(String(response_dict["discord_id"]));
+	}
+	if (response_dict.has("username")) {
+		result->set_username(String(response_dict["username"]));
+	}
+	if (response_dict.has("client_id")) {
+		result->set_client_id((int64_t)response_dict["client_id"]);
+	} else {
+		result->set_client_id(p_client_id);
+	}
+
+	http->close();
+	return result;
+}

--- a/modules/discord_module/discord_auth_client.h
+++ b/modules/discord_module/discord_auth_client.h
@@ -1,0 +1,38 @@
+/**************************************************************************/
+/*  discord_auth_client.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "discord_auth_result.h"
+
+class DiscordAuthClient {
+public:
+	Ref<DiscordAuthResult> authenticate_sync(const String &p_url, const String &p_access_token, int64_t p_client_id, bool p_debug_logging);
+};

--- a/modules/discord_module/discord_auth_result.cpp
+++ b/modules/discord_module/discord_auth_result.cpp
@@ -1,0 +1,40 @@
+/**************************************************************************/
+/*  discord_auth_result.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "discord_auth_result.h"
+
+void DiscordAuthResult::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_jwt"), &DiscordAuthResult::get_jwt);
+	ClassDB::bind_method(D_METHOD("get_discord_id"), &DiscordAuthResult::get_discord_id);
+	ClassDB::bind_method(D_METHOD("get_username"), &DiscordAuthResult::get_username);
+	ClassDB::bind_method(D_METHOD("get_client_id"), &DiscordAuthResult::get_client_id);
+	ClassDB::bind_method(D_METHOD("get_http_status"), &DiscordAuthResult::get_http_status);
+	ClassDB::bind_method(D_METHOD("get_error_message"), &DiscordAuthResult::get_error_message);
+	ClassDB::bind_method(D_METHOD("is_success"), &DiscordAuthResult::is_success);
+}

--- a/modules/discord_module/discord_auth_result.h
+++ b/modules/discord_module/discord_auth_result.h
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  discord_auth_result.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+
+class DiscordAuthResult : public RefCounted {
+	GDCLASS(DiscordAuthResult, RefCounted);
+
+	String jwt;
+	String discord_id;
+	String username;
+	int64_t client_id = 0;
+	int http_status = 0;
+	String error_message;
+	bool success = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_jwt(const String &p_jwt) { jwt = p_jwt; }
+	String get_jwt() const { return jwt; }
+
+	void set_discord_id(const String &p_discord_id) { discord_id = p_discord_id; }
+	String get_discord_id() const { return discord_id; }
+
+	void set_username(const String &p_username) { username = p_username; }
+	String get_username() const { return username; }
+
+	void set_client_id(int64_t p_client_id) { client_id = p_client_id; }
+	int64_t get_client_id() const { return client_id; }
+
+	void set_http_status(int p_status) { http_status = p_status; }
+	int get_http_status() const { return http_status; }
+
+	void set_error_message(const String &p_error) { error_message = p_error; }
+	String get_error_message() const { return error_message; }
+
+	void set_success(bool p_success) { success = p_success; }
+	bool is_success() const { return success; }
+};

--- a/modules/discord_module/discord_types.h
+++ b/modules/discord_module/discord_types.h
@@ -1,0 +1,105 @@
+/**************************************************************************/
+/*  discord_types.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/typedefs.h"
+
+typedef struct Discord_String {
+	uint8_t *ptr;
+	size_t size;
+} Discord_String;
+
+typedef enum Discord_Client_Error {
+	DISCORD_CLIENT_ERROR_NONE = 0,
+	DISCORD_CLIENT_ERROR_CONNECTION_FAILED = 1,
+	DISCORD_CLIENT_ERROR_UNEXPECTED_CLOSE = 2,
+	DISCORD_CLIENT_ERROR_CONNECTION_CANCELED = 3,
+} Discord_Client_Error;
+
+typedef enum Discord_Client_Status {
+	DISCORD_CLIENT_STATUS_DISCONNECTED = 0,
+	DISCORD_CLIENT_STATUS_CONNECTING = 1,
+	DISCORD_CLIENT_STATUS_CONNECTED = 2,
+	DISCORD_CLIENT_STATUS_READY = 3,
+	DISCORD_CLIENT_STATUS_RECONNECTING = 4,
+	DISCORD_CLIENT_STATUS_DISCONNECTING = 5,
+	DISCORD_CLIENT_STATUS_HTTP_WAIT = 6,
+} Discord_Client_Status;
+
+typedef enum Discord_AuthorizationTokenType {
+	DISCORD_AUTHORIZATION_TOKEN_TYPE_USER = 0,
+	DISCORD_AUTHORIZATION_TOKEN_TYPE_BEARER = 1,
+} Discord_AuthorizationTokenType;
+
+typedef struct Discord_Client {
+	void *opaque;
+} Discord_Client;
+
+typedef struct Discord_ClientResult {
+	void *opaque;
+} Discord_ClientResult;
+
+typedef struct Discord_AuthorizationCodeChallenge {
+	void *opaque;
+} Discord_AuthorizationCodeChallenge;
+
+typedef struct Discord_AuthorizationCodeVerifier {
+	void *opaque;
+} Discord_AuthorizationCodeVerifier;
+
+typedef struct Discord_AuthorizationArgs {
+	void *opaque;
+} Discord_AuthorizationArgs;
+
+typedef struct Discord_UserHandle {
+	void *opaque;
+} Discord_UserHandle;
+
+typedef void (*Discord_FreeFn)(void *ptr);
+
+typedef void (*Discord_Client_AuthorizationCallback)(Discord_ClientResult *result,
+		Discord_String code,
+		Discord_String redirect_uri,
+		void *user_data);
+
+typedef void (*Discord_Client_TokenExchangeCallback)(Discord_ClientResult *result,
+		Discord_String access_token,
+		Discord_String refresh_token,
+		Discord_AuthorizationTokenType token_type,
+		int32_t expires_in,
+		Discord_String scopes,
+		void *user_data);
+
+typedef void (*Discord_Client_UpdateTokenCallback)(Discord_ClientResult *result, void *user_data);
+
+typedef void (*Discord_Client_OnStatusChanged)(Discord_Client_Status status,
+		Discord_Client_Error error,
+		int32_t error_detail,
+		void *user_data);

--- a/modules/discord_module/doc_classes/Discord.xml
+++ b/modules/discord_module/doc_classes/Discord.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Discord" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Discord Social SDK integration for OAuth authentication and backend JWT exchange.
+	</brief_description>
+	<description>
+		The Discord singleton dynamically loads the Discord Partner SDK library at runtime. If the library is not found beside the executable, all methods fail gracefully without crashing.
+		Call [method initialize] with your Discord application client ID to start the OAuth flow, pump [method run_callbacks] (or rely on the engine frame hook), then use [method get_access_token] and [method authenticate_with_server] to exchange the token for a JWT from your backend.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="authenticate_with_server">
+			<return type="DiscordAuthResult" />
+			<param index="0" name="url" type="String" />
+			<param index="1" name="access_token" type="String" />
+			<param index="2" name="client_id" type="int" />
+			<description>
+				POSTs the OAuth access token to the auth server and returns the parsed response.
+			</description>
+		</method>
+		<method name="clear_debug_log">
+			<return type="void" />
+			<description>
+				Clears the in-memory debug log buffer.
+			</description>
+		</method>
+		<method name="get_access_token" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the OAuth access token obtained during [method initialize], or an empty string when not connected.
+			</description>
+		</method>
+		<method name="get_connection_state" qualifiers="const">
+			<return type="int" enum="Discord.ConnectionState" />
+			<description>
+				Returns the current Discord SDK connection state.
+			</description>
+		</method>
+		<method name="get_debug_log" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns recent debug log lines when debug logging is enabled.
+			</description>
+		</method>
+		<method name="get_last_error" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the most recent error message from Discord initialization or auth.
+			</description>
+		</method>
+		<method name="get_user_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the connected Discord user snowflake ID, or [code]0[/code] when unavailable.
+			</description>
+		</method>
+		<method name="get_username" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the connected Discord display or username.
+			</description>
+		</method>
+		<method name="get_version" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns SDK version metadata and runtime library availability.
+			</description>
+		</method>
+		<method name="initialize">
+			<return type="int" enum="Error" />
+			<param index="0" name="client_id" type="int" default="0" />
+			<description>
+				Initializes the Discord Social SDK and starts the OAuth authorization flow for the given application client ID.
+			</description>
+		</method>
+		<method name="is_available">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the Discord Partner SDK runtime library is present beside the executable.
+			</description>
+		</method>
+		<method name="is_debug_logging_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether debug logging is enabled.
+			</description>
+		</method>
+		<method name="is_initialized" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] after a successful [method initialize].
+			</description>
+		</method>
+		<method name="run_callbacks">
+			<return type="void" />
+			<description>
+				Pumps Discord SDK callbacks. Also invoked automatically each frame when initialized.
+			</description>
+		</method>
+		<method name="set_debug_logging">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Enables or disables verbose debug logging to stdout and the in-memory debug log.
+			</description>
+		</method>
+		<method name="shutdown">
+			<return type="void" />
+			<description>
+				Shuts down the Discord SDK session and releases resources.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="STATE_DISCONNECTED" value="0" enum="ConnectionState">
+		</constant>
+		<constant name="STATE_CONNECTING" value="1" enum="ConnectionState">
+		</constant>
+		<constant name="STATE_CONNECTED" value="2" enum="ConnectionState">
+		</constant>
+		<constant name="STATE_READY" value="3" enum="ConnectionState">
+		</constant>
+		<constant name="STATE_RECONNECTING" value="4" enum="ConnectionState">
+		</constant>
+		<constant name="STATE_DISCONNECTING" value="5" enum="ConnectionState">
+		</constant>
+		<constant name="STATE_HTTP_WAIT" value="6" enum="ConnectionState">
+		</constant>
+	</constants>
+</class>

--- a/modules/discord_module/doc_classes/DiscordAuthResult.xml
+++ b/modules/discord_module/doc_classes/DiscordAuthResult.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DiscordAuthResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Result of [method Discord.authenticate_with_server].
+	</brief_description>
+	<description>
+		Contains the JWT and user metadata returned by the discord-auth-golang backend, or error details on failure.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_client_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Discord application client ID echoed by the auth server.
+			</description>
+		</method>
+		<method name="get_discord_id" qualifiers="const">
+			<return type="String" />
+			<description>
+				Discord user snowflake ID verified by the auth server.
+			</description>
+		</method>
+		<method name="get_error_message" qualifiers="const">
+			<return type="String" />
+			<description>
+				Human-readable error when [method is_success] is [code]false[/code].
+			</description>
+		</method>
+		<method name="get_http_status" qualifiers="const">
+			<return type="int" />
+			<description>
+				HTTP status code from the auth server response.
+			</description>
+		</method>
+		<method name="get_jwt" qualifiers="const">
+			<return type="String" />
+			<description>
+				Signed JWT issued by the auth server on success.
+			</description>
+		</method>
+		<method name="get_username" qualifiers="const">
+			<return type="String" />
+			<description>
+				Discord username verified by the auth server.
+			</description>
+		</method>
+		<method name="is_success" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when authentication succeeded.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/discord_module/register_types.cpp
+++ b/modules/discord_module/register_types.cpp
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "core/config/engine.h"
+#include "discord.h"
+#include "discord_auth_result.h"
+#include "scene/main/scene_tree.h"
+
+#ifdef TESTS_ENABLED
+#include "tests/test_discord_module.h"
+#endif
+
+static Discord *discord_singleton = nullptr;
+static bool discord_frame_hook_connected = false;
+
+namespace {
+
+void discord_frame_callback() {
+	if (discord_singleton == nullptr || !discord_singleton->is_initialized()) {
+		return;
+	}
+	discord_singleton->run_callbacks();
+}
+
+void connect_discord_frame_hook() {
+	if (discord_frame_hook_connected) {
+		return;
+	}
+
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	if (scene_tree == nullptr) {
+		return;
+	}
+
+	scene_tree->connect("process_frame", callable_mp_static(&discord_frame_callback));
+	discord_frame_hook_connected = true;
+}
+
+void disconnect_discord_frame_hook() {
+	if (!discord_frame_hook_connected) {
+		return;
+	}
+
+	SceneTree *scene_tree = SceneTree::get_singleton();
+	if (scene_tree != nullptr) {
+		scene_tree->disconnect("process_frame", callable_mp_static(&discord_frame_callback));
+	}
+
+	discord_frame_hook_connected = false;
+}
+
+} //namespace
+
+void initialize_discord_module_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(DiscordAuthResult);
+		GDREGISTER_CLASS(Discord);
+		discord_singleton = memnew(Discord);
+		Engine::get_singleton()->add_singleton(Engine::Singleton("Discord", Discord::get_singleton()));
+		connect_discord_frame_hook();
+	}
+}
+
+void uninitialize_discord_module_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		disconnect_discord_frame_hook();
+		if (discord_singleton) {
+			Engine::get_singleton()->remove_singleton("Discord");
+			memdelete(discord_singleton);
+			discord_singleton = nullptr;
+		}
+	}
+}

--- a/modules/discord_module/register_types.h
+++ b/modules/discord_module/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_discord_module_module(ModuleInitializationLevel p_level);
+void uninitialize_discord_module_module(ModuleInitializationLevel p_level);

--- a/modules/discord_module/tests/test_discord_module.h
+++ b/modules/discord_module/tests/test_discord_module.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  test_discord_module.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../discord.h"
+#include "../discord_api_loader.h"
+
+#include "tests/test_macros.h"
+
+namespace TestDiscordModule {
+
+TEST_CASE("[DiscordModule] runtime library name") {
+#ifdef WINDOWS_ENABLED
+	CHECK(DiscordAPILoader::get_runtime_library_name() == "discord_partner_sdk.dll");
+#else
+	CHECK(DiscordAPILoader::get_runtime_library_name() == "libdiscord_partner_sdk.so");
+#endif
+}
+
+TEST_CASE("[DiscordModule] singleton registration") {
+	CHECK(Discord::get_singleton() != nullptr);
+}
+
+TEST_CASE("[DiscordModule] loader unavailable without dll") {
+	DiscordAPILoader api_loader;
+	const bool loaded = api_loader.try_load();
+	CHECK(loaded == api_loader.is_loaded());
+}
+
+TEST_CASE("[DiscordModule] unavailable without runtime library") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	if (DiscordAPILoader::is_runtime_library_present()) {
+		return;
+	}
+	CHECK_FALSE(discord->is_available());
+	CHECK(discord->initialize(123456789) == ERR_UNAVAILABLE);
+}
+
+TEST_CASE("[DiscordModule] auth client rejects empty url") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	Ref<DiscordAuthResult> result = discord->authenticate_with_server("", "token", 1);
+	REQUIRE(result.is_valid());
+	CHECK_FALSE(result->is_success());
+	CHECK_FALSE(result->get_error_message().is_empty());
+}
+
+TEST_CASE("[DiscordModule] version dictionary") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	Dictionary version = discord->get_version();
+	CHECK(version.has("runtime_library"));
+	CHECK(version.has("runtime_present"));
+	CHECK(version.has("sdk_enabled"));
+}
+
+} //namespace TestDiscordModule


### PR DESCRIPTION
## Summary

- Adds a new `discord_module` engine module that mirrors the Steam module pattern: the Discord Partner SDK is loaded at runtime from `discord_partner_sdk.dll` / `libdiscord_partner_sdk.so` with no compile-time SDK dependency.
- Exposes `Discord` and `DiscordAuthResult` singletons to GDScript with OAuth initialization, callback pumping, access-token retrieval, and backend JWT authentication via `DiscordAuthClient`.
- Includes module doctest smoke tests and class reference docs for both public types.

## Test plan

- [x] Build editor with `module_discord_module_enabled=yes` on Windows and Linux
- [x] Run engine doctest suite (smoke tests for `discord_module` register and pass)
- [x] Place Discord Partner SDK next to the executable and verify `Discord.is_available()` returns true
- [x] Call `Discord.initialize(client_id)` and confirm OAuth flow reaches ready state with `run_callbacks()` pumped each frame
- [x] Point `authenticate_with_server(url)` at a backend and verify JWT/discord_id/username in `DiscordAuthResult`
- [x] Confirm module is skipped gracefully when SDK DLL/SO is absent (`is_available()` false, no crash)
