### PR TITLE
Extend discord_module with Social SDK presence, OAuth, and Rich Presence API

### DIFF
--- a/modules/discord_module/discord.cpp
+++ b/modules/discord_module/discord.cpp
@@ -29,13 +29,10 @@
 
 #include "discord.h"
 
+#include "core/config/project_settings.h"
 #include "core/os/os.h"
-#include "core/os/time.h"
 #include "discord_auth_client.h"
-
-Discord *Discord::singleton = nullptr;
-
-namespace {
+#include "discord_frame_hook.h"
 
 struct DiscordAuthFlow {
 	Discord *owner = nullptr;
@@ -46,33 +43,55 @@ struct DiscordAuthFlow {
 	String redirect_uri;
 	String pending_token;
 	Discord_AuthorizationTokenType pending_token_type = DISCORD_AUTHORIZATION_TOKEN_TYPE_BEARER;
-	bool authorize_done = false;
-	bool authorize_ok = false;
-	bool token_done = false;
-	bool token_ok = false;
-	bool update_token_done = false;
-	bool update_token_ok = false;
+	CharString auth_code_utf8;
+	CharString verifier_utf8;
+	CharString redirect_utf8;
+	CharString token_utf8;
 };
 
-} //namespace
+Discord *Discord::singleton = nullptr;
+
+static const char *kDefaultOAuthRedirectUri = "http://127.0.0.1/callback";
 
 void Discord::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_available"), &Discord::is_available);
 	ClassDB::bind_method(D_METHOD("initialize", "client_id"), &Discord::initialize, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("shutdown"), &Discord::shutdown);
 	ClassDB::bind_method(D_METHOD("is_initialized"), &Discord::is_initialized);
+	ClassDB::bind_method(D_METHOD("is_client_active"), &Discord::is_client_active);
+	ClassDB::bind_method(D_METHOD("is_ready_for_presence"), &Discord::is_ready_for_presence);
+	ClassDB::bind_method(D_METHOD("get_auth_state"), &Discord::get_auth_state);
+	ClassDB::bind_method(D_METHOD("is_authorization_pending"), &Discord::is_authorization_pending);
+	ClassDB::bind_method(D_METHOD("is_authorized"), &Discord::is_authorized);
 	ClassDB::bind_method(D_METHOD("set_debug_logging", "enabled"), &Discord::set_debug_logging);
 	ClassDB::bind_method(D_METHOD("is_debug_logging_enabled"), &Discord::is_debug_logging_enabled);
 	ClassDB::bind_method(D_METHOD("get_debug_log"), &Discord::get_debug_log);
 	ClassDB::bind_method(D_METHOD("clear_debug_log"), &Discord::clear_debug_log);
 	ClassDB::bind_method(D_METHOD("run_callbacks"), &Discord::run_callbacks);
+	ClassDB::bind_method(D_METHOD("is_frame_hook_connected"), &Discord::is_frame_hook_connected);
 	ClassDB::bind_method(D_METHOD("get_connection_state"), &Discord::get_connection_state);
 	ClassDB::bind_method(D_METHOD("get_access_token"), &Discord::get_access_token);
 	ClassDB::bind_method(D_METHOD("get_username"), &Discord::get_username);
 	ClassDB::bind_method(D_METHOD("get_user_id"), &Discord::get_user_id);
+	ClassDB::bind_method(D_METHOD("get_relationships_count"), &Discord::get_relationships_count);
 	ClassDB::bind_method(D_METHOD("get_last_error"), &Discord::get_last_error);
+	ClassDB::bind_method(D_METHOD("get_default_presence_scopes"), &Discord::get_default_presence_scopes);
+	ClassDB::bind_method(D_METHOD("get_default_communication_scopes"), &Discord::get_default_communication_scopes);
+	ClassDB::bind_method(D_METHOD("get_requested_scopes"), &Discord::get_requested_scopes);
+	ClassDB::bind_method(D_METHOD("get_granted_scopes"), &Discord::get_granted_scopes);
+	ClassDB::bind_method(D_METHOD("get_game_activity"), &Discord::get_game_activity);
+	ClassDB::bind_method(D_METHOD("update_rich_presence", "activity"), &Discord::update_rich_presence);
+	ClassDB::bind_method(D_METHOD("clear_rich_presence"), &Discord::clear_rich_presence);
 	ClassDB::bind_method(D_METHOD("authenticate_with_server", "url", "access_token", "client_id"), &Discord::authenticate_with_server);
 	ClassDB::bind_method(D_METHOD("get_version"), &Discord::get_version);
+
+	ADD_SIGNAL(MethodInfo("connection_state_changed", PropertyInfo(Variant::INT, "state"), PropertyInfo(Variant::INT, "error"), PropertyInfo(Variant::INT, "error_detail")));
+	ADD_SIGNAL(MethodInfo("authorization_started"));
+	ADD_SIGNAL(MethodInfo("authorized"));
+	ADD_SIGNAL(MethodInfo("authorization_failed", PropertyInfo(Variant::STRING, "error")));
+	ADD_SIGNAL(MethodInfo("ready"));
+	ADD_SIGNAL(MethodInfo("relationships_updated", PropertyInfo(Variant::INT, "count")));
+	ADD_SIGNAL(MethodInfo("rich_presence_updated", PropertyInfo(Variant::BOOL, "success"), PropertyInfo(Variant::STRING, "error")));
 
 	BIND_ENUM_CONSTANT(STATE_DISCONNECTED);
 	BIND_ENUM_CONSTANT(STATE_CONNECTING);
@@ -81,6 +100,12 @@ void Discord::_bind_methods() {
 	BIND_ENUM_CONSTANT(STATE_RECONNECTING);
 	BIND_ENUM_CONSTANT(STATE_DISCONNECTING);
 	BIND_ENUM_CONSTANT(STATE_HTTP_WAIT);
+
+	BIND_ENUM_CONSTANT(AUTH_NONE);
+	BIND_ENUM_CONSTANT(AUTH_PENDING);
+	BIND_ENUM_CONSTANT(AUTH_AUTHORIZED);
+	BIND_ENUM_CONSTANT(AUTH_READY);
+	BIND_ENUM_CONSTANT(AUTH_FAILED);
 }
 
 Discord *Discord::get_singleton() {
@@ -103,6 +128,14 @@ Discord::~Discord() {
 	}
 }
 
+void Discord::_log_lifecycle(const String &p_message) {
+	print_line(vformat("[Discord] %s", p_message));
+	if (debug_log.size() >= kMaxDebugLogEntries) {
+		debug_log.remove_at(0);
+	}
+	debug_log.push_back(p_message);
+}
+
 void Discord::_log_debug(const String &p_message) {
 	if (!debug_logging) {
 		return;
@@ -114,9 +147,68 @@ void Discord::_log_debug(const String &p_message) {
 	debug_log.push_back(p_message);
 }
 
+void Discord::_set_auth_state(AuthState p_state) {
+	if (auth_state == p_state) {
+		return;
+	}
+	auth_state = p_state;
+	_log_lifecycle(vformat("Auth state -> %d", (int)p_state));
+}
+
+Error Discord::_require_auth_ready(const char *p_operation) {
+	if (ready_for_presence && auth_state == AUTH_READY) {
+		return OK;
+	}
+	last_error = vformat("Discord is not ready for %s (auth_state=%d, connection=%d)", p_operation, (int)auth_state, (int)connection_state);
+	return ERR_UNAUTHORIZED;
+}
+
 void Discord::_set_last_error(const String &p_error) {
 	last_error = p_error;
 	_log_debug(p_error);
+}
+
+void Discord::_report_authorization_failed(const String &p_error) {
+	last_error = p_error;
+	print_line(vformat("[Discord] %s", p_error));
+	if (p_error.contains("redirect_uri")) {
+		_log_lifecycle("OAuth redirect_uri error — verify Developer Portal OAuth2 settings:");
+		_log_lifecycle("  - Redirect URI exactly: http://127.0.0.1/callback");
+		_log_lifecycle("  - Public Client enabled");
+		_log_lifecycle("  - Social SDK / Activities enabled for this application");
+		_log_lifecycle("  - Restart Discord desktop after portal changes");
+		_log_lifecycle(vformat("  - See SDK log: %s/discord.log", OS::get_singleton()->get_user_data_dir()));
+	}
+	if (auth_flow && auth_flow->owner) {
+		auth_flow->owner->_set_auth_state(AUTH_FAILED);
+	} else {
+		_set_auth_state(AUTH_FAILED);
+	}
+	emit_signal(SNAME("authorization_failed"), p_error);
+}
+
+void Discord::_sync_connection_state(Discord_Client_Status p_status, int p_error, int p_error_detail, bool p_emit_signal) {
+	const ConnectionState new_state = _map_client_status(p_status);
+	connection_state = new_state;
+
+	if (p_error != DISCORD_CLIENT_ERROR_NONE) {
+		_set_last_error(vformat("Discord status error=%d detail=%d", p_error, p_error_detail));
+	} else if ((int)p_status != last_polled_status) {
+		last_polled_status = (int)p_status;
+		_log_debug(vformat("Discord status changed to %d", (int)p_status));
+	}
+
+	if (p_emit_signal &&
+			(new_state != last_emitted_state || p_error != last_emitted_error || p_error_detail != last_emitted_error_detail)) {
+		last_emitted_state = new_state;
+		last_emitted_error = p_error;
+		last_emitted_error_detail = p_error_detail;
+		emit_signal(SNAME("connection_state_changed"), new_state, p_error, p_error_detail);
+	}
+
+	if (connection_state == STATE_READY) {
+		_on_client_ready();
+	}
 }
 
 Discord::ConnectionState Discord::_map_client_status(Discord_Client_Status p_status) {
@@ -142,26 +234,50 @@ Discord::ConnectionState Discord::_map_client_status(Discord_Client_Status p_sta
 
 void Discord::_authorize_callback(Discord_ClientResult *result, Discord_String code, Discord_String redirect_uri, void *user_data) {
 	DiscordAuthFlow *flow = (DiscordAuthFlow *)user_data;
-	flow->authorize_done = true;
-	flow->authorize_ok = flow->loader->client_result_successful(result);
-	if (!flow->authorize_ok) {
-		flow->owner->_set_last_error(vformat("Discord authorize failed: %s", flow->loader->client_result_error(result)));
+	if (!flow || !flow->owner || !flow->loader) {
+		return;
+	}
+	if (!flow->loader->client_result_successful(result)) {
+		flow->owner->_report_authorization_failed(vformat("Discord authorize failed: %s", flow->loader->client_result_error(result)));
 		flow->loader->client_result_drop(result);
 		return;
 	}
 
 	flow->redirect_uri = DiscordAPILoader::to_godot_string(redirect_uri);
+	if (flow->redirect_uri.is_empty()) {
+		flow->redirect_uri = kDefaultOAuthRedirectUri;
+		flow->owner->_log_lifecycle(vformat("Using default OAuth redirect_uri: %s", flow->redirect_uri));
+	}
 	const String auth_code = DiscordAPILoader::to_godot_string(code);
 	flow->loader->client_result_drop(result);
+	flow->owner->_log_lifecycle("Authorization successful, exchanging code for token");
+	flow->owner->_start_token_exchange(flow, auth_code);
+}
 
-	flow->loader->client_get_token(
-			flow->client,
-			(uint64_t)flow->client_id,
-			auth_code,
-			flow->code_verifier,
-			flow->redirect_uri,
+void Discord::_start_token_exchange(DiscordAuthFlow *p_flow, const String &p_auth_code) {
+	if (!p_flow || !p_flow->loader || !p_flow->client) {
+		return;
+	}
+	p_flow->auth_code_utf8 = p_auth_code.utf8();
+	p_flow->verifier_utf8 = p_flow->code_verifier.utf8();
+	p_flow->redirect_utf8 = p_flow->redirect_uri.utf8();
+	Discord_String code;
+	code.ptr = (uint8_t *)p_flow->auth_code_utf8.ptr();
+	code.size = p_flow->auth_code_utf8.length();
+	Discord_String verifier;
+	verifier.ptr = (uint8_t *)p_flow->verifier_utf8.ptr();
+	verifier.size = p_flow->verifier_utf8.length();
+	Discord_String redirect_uri;
+	redirect_uri.ptr = (uint8_t *)p_flow->redirect_utf8.ptr();
+	redirect_uri.size = p_flow->redirect_utf8.length();
+	p_flow->loader->client_get_token(
+			p_flow->client,
+			(uint64_t)p_flow->client_id,
+			code,
+			verifier,
+			redirect_uri,
 			Discord::_token_exchange_callback,
-			user_data);
+			p_flow);
 }
 
 void Discord::_token_exchange_callback(Discord_ClientResult *result,
@@ -173,59 +289,216 @@ void Discord::_token_exchange_callback(Discord_ClientResult *result,
 		void *user_data) {
 	(void)refresh_token;
 	(void)expires_in;
-	(void)scopes;
 	DiscordAuthFlow *flow = (DiscordAuthFlow *)user_data;
-	flow->token_done = true;
-	flow->token_ok = flow->loader->client_result_successful(result);
-	if (!flow->token_ok) {
-		flow->owner->_set_last_error(vformat("Discord token exchange failed: %s", flow->loader->client_result_error(result)));
+	if (!flow || !flow->owner || !flow->loader) {
+		return;
+	}
+	if (!flow->loader->client_result_successful(result)) {
+		flow->owner->_report_authorization_failed(vformat("Discord token exchange failed: %s", flow->loader->client_result_error(result)));
 		flow->loader->client_result_drop(result);
 		return;
 	}
 	flow->pending_token = DiscordAPILoader::to_godot_string(access_token);
 	flow->pending_token_type = token_type;
+	flow->token_utf8 = flow->pending_token.utf8();
+	flow->owner->granted_scopes = DiscordAPILoader::to_godot_string(scopes);
 	flow->loader->client_result_drop(result);
+	flow->owner->_log_lifecycle(vformat("Access token received (reported_type=%d, using Bearer for UpdateToken, granted_scopes='%s')",
+			(int)token_type, flow->owner->granted_scopes));
+	flow->owner->_validate_granted_scopes();
 
+	Discord_String token;
+	token.ptr = (uint8_t *)flow->token_utf8.ptr();
+	token.size = flow->token_utf8.length();
 	flow->loader->client_update_token(
 			flow->client,
-			flow->pending_token_type,
-			flow->pending_token,
+			DISCORD_AUTHORIZATION_TOKEN_TYPE_BEARER,
+			token,
 			Discord::_update_token_callback,
 			user_data);
 }
 
 void Discord::_update_token_callback(Discord_ClientResult *result, void *user_data) {
 	DiscordAuthFlow *flow = (DiscordAuthFlow *)user_data;
-	flow->update_token_done = true;
-	flow->update_token_ok = flow->loader->client_result_successful(result);
-	if (!flow->update_token_ok) {
-		flow->owner->_set_last_error(vformat("Discord UpdateToken failed: %s", flow->loader->client_result_error(result)));
+	if (!flow || !flow->owner || !flow->loader) {
+		return;
+	}
+	if (!flow->loader->client_result_successful(result)) {
+		flow->owner->_report_authorization_failed(vformat("Discord UpdateToken failed: %s", flow->loader->client_result_error(result)));
 		flow->loader->client_result_drop(result);
 		return;
 	}
 	flow->loader->client_result_drop(result);
 	flow->owner->access_token = flow->pending_token;
+	flow->owner->_set_auth_state(AUTH_AUTHORIZED);
+	flow->owner->emit_signal(SNAME("authorized"));
+	flow->owner->_log_lifecycle("Token updated, connecting to Discord...");
 	flow->loader->client_connect(flow->client);
 }
 
 void Discord::_status_changed_callback(Discord_Client_Status status, Discord_Client_Error error, int32_t error_detail, void *user_data) {
 	Discord *discord = (Discord *)user_data;
-	discord->connection_state = Discord::_map_client_status(status);
-	if (error != DISCORD_CLIENT_ERROR_NONE) {
-		discord->_set_last_error(vformat("Discord status error=%d detail=%d", (int)error, (int)error_detail));
+	if (!discord) {
+		return;
+	}
+	discord->_sync_connection_state(status, (int)error, (int)error_detail, true);
+}
+
+void Discord::_authorize_device_screen_closed_callback(void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->_report_authorization_failed("Authorization dismissed");
+}
+
+void Discord::_log_callback(Discord_String message, Discord_LoggingSeverity severity, void *user_data) {
+	(void)severity;
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->_log_lifecycle(vformat("[SDK] %s", DiscordAPILoader::to_godot_string(message)));
+}
+
+void Discord::_update_rich_presence_callback(Discord_ClientResult *result, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	const bool success = discord->loader.client_result_successful(result);
+	const String error = success ? String() : discord->loader.client_result_error(result);
+	discord->loader.client_result_drop(result);
+	if (success) {
+		discord->_log_lifecycle("Rich Presence updated successfully");
+		discord->_log_game_activity_readback();
 	} else {
-		discord->_log_debug(vformat("Discord status changed to %d", (int)status));
+		discord->_log_lifecycle(vformat("Rich Presence update failed: %s", error));
+	}
+	discord->emit_signal(SNAME("rich_presence_updated"), success, error);
+}
+
+void Discord::_on_client_ready() {
+	if (ready_for_presence) {
+		return;
+	}
+	ready_for_presence = true;
+	_set_auth_state(AUTH_READY);
+
+	Discord_UserHandle user;
+	if (loader.client_get_current_user_v2(&client, &user)) {
+		user_id = loader.user_handle_id(&user);
+		username = loader.user_handle_display_name(&user);
+		if (username.is_empty()) {
+			username = loader.user_handle_username(&user);
+		}
+		loader.user_handle_drop(&user);
+		_log_lifecycle(vformat("Discord user ready: %s", username));
+	}
+
+	_refresh_relationships();
+
+	if (!ready_signal_emitted) {
+		ready_signal_emitted = true;
+		_log_lifecycle("Client is ready for rich presence");
+		emit_signal(SNAME("ready"));
+	}
+
+	const bool had_pending = has_pending_presence;
+	_apply_pending_presence();
+	if (!had_pending && last_presence_sent.is_empty()) {
+		Dictionary sample;
+		sample["type"] = DISCORD_ACTIVITY_TYPE_PLAYING;
+		sample["details"] = "Rank: Diamond II";
+		sample["state"] = "In Competitive Match";
+		_send_rich_presence(sample);
+	}
+}
+
+void Discord::_apply_pending_presence() {
+	if (!ready_for_presence || !has_pending_presence) {
+		return;
+	}
+	const Dictionary activity = pending_presence;
+	has_pending_presence = false;
+	pending_presence = Dictionary();
+	_send_rich_presence(activity);
+}
+
+void Discord::_refresh_relationships() {
+	if (!client_active || !ready_for_presence) {
+		return;
+	}
+	Discord_RelationshipHandleSpan span;
+	loader.client_get_relationships(&client, &span);
+	relationships_count = (int)span.size;
+	emit_signal(SNAME("relationships_updated"), relationships_count);
+}
+
+void Discord::_register_log_callback() {
+	if (!client_active || log_callback_registered) {
+		return;
+	}
+	loader.client_add_log_callback(&client, Discord::_log_callback, this, DISCORD_LOGGING_SEVERITY_INFO);
+	log_callback_registered = true;
+}
+
+void Discord::_register_platform_hooks() {
+#ifdef WINDOWS_ENABLED
+	loader.client_set_game_window_pid(&client, (int32_t)OS::get_singleton()->get_process_id());
+#endif
+	if (debug_logging) {
+		const String log_dir = OS::get_singleton()->get_user_data_dir();
+		if (loader.client_set_log_dir(&client, log_dir, DISCORD_LOGGING_SEVERITY_INFO)) {
+			_log_lifecycle(vformat("SDK file logging enabled: %s/discord.log", log_dir));
+		}
+	}
+}
+
+void Discord::_register_authorize_dismiss_callback() {
+	if (!client_active || authorize_dismiss_callback_registered) {
+		return;
+	}
+	if (loader.client_set_authorize_device_screen_closed_callback(&client, Discord::_authorize_device_screen_closed_callback, this)) {
+		authorize_dismiss_callback_registered = true;
+	}
+}
+
+void Discord::_clear_auth_flow() {
+	if (auth_flow) {
+		memdelete(auth_flow);
+		auth_flow = nullptr;
 	}
 }
 
 void Discord::_reset_session() {
+	if (client_active && loader.is_loaded()) {
+		loader.client_clear_rich_presence(&client);
+	}
 	_disconnect_client();
+	_clear_auth_flow();
 	access_token = String();
 	username = String();
+	requested_scopes = String();
+	granted_scopes = String();
+	oauth_scope_preset = String();
 	user_id = 0;
+	relationships_count = -1;
 	connection_state = STATE_DISCONNECTED;
 	last_error = String();
 	initialized = false;
+	ready_for_presence = false;
+	ready_signal_emitted = false;
+	log_callback_registered = false;
+	authorize_dismiss_callback_registered = false;
+	has_pending_presence = false;
+	pending_presence = Dictionary();
+	last_presence_sent = Dictionary();
+	last_emitted_state = STATE_DISCONNECTED;
+	last_emitted_error = 0;
+	last_emitted_error_detail = 0;
+	last_polled_status = -1;
+	auth_state = AUTH_NONE;
 	client_id = 0;
 }
 
@@ -251,6 +524,9 @@ Error Discord::_initialize_client(int64_t p_client_id) {
 	client_active = true;
 	loader.client_set_application_id(&client, (uint64_t)p_client_id);
 	loader.client_set_status_changed_callback(&client, Discord::_status_changed_callback, this);
+	_register_log_callback();
+	_register_authorize_dismiss_callback();
+	_register_platform_hooks();
 
 	Discord_AuthorizationCodeVerifier verifier;
 	loader.client_create_authorization_code_verifier(&client, &verifier);
@@ -258,58 +534,34 @@ Error Discord::_initialize_client(int64_t p_client_id) {
 	Discord_AuthorizationCodeChallenge challenge;
 	loader.authorization_code_verifier_challenge(&verifier, &challenge);
 
-	DiscordAuthFlow flow;
-	flow.owner = this;
-	flow.loader = &loader;
-	flow.client = &client;
-	flow.client_id = p_client_id;
-	flow.code_verifier = loader.authorization_code_verifier_verifier(&verifier);
+	_clear_auth_flow();
+	auth_flow = memnew(DiscordAuthFlow);
+	auth_flow->owner = this;
+	auth_flow->loader = &loader;
+	auth_flow->client = &client;
+	auth_flow->client_id = p_client_id;
+	auth_flow->code_verifier = loader.authorization_code_verifier_verifier(&verifier);
 
 	Discord_AuthorizationArgs auth_args;
 	loader.authorization_args_init(&auth_args);
 	loader.authorization_args_set_client_id(&auth_args, (uint64_t)p_client_id);
-	loader.authorization_args_set_scopes(&auth_args, loader.get_default_communication_scopes());
+	oauth_scope_preset = _resolve_oauth_scope_preset();
+	requested_scopes = _resolve_oauth_scopes();
+	loader.authorization_args_set_scopes(&auth_args, requested_scopes);
 	loader.authorization_args_set_code_challenge(&auth_args, &challenge);
+	const String integration_label = _resolve_integration_type_label();
 
 	connection_state = STATE_CONNECTING;
-	loader.client_authorize(&client, &auth_args, Discord::_authorize_callback, &flow);
+	_set_auth_state(AUTH_PENDING);
+	emit_signal(SNAME("authorization_started"));
+	_log_lifecycle(vformat("Starting OAuth authorization (client_id=%s preset=%s scopes='%s' integration=%s redirect=%s)",
+			String::num_int64(p_client_id), oauth_scope_preset, requested_scopes, integration_label, kDefaultOAuthRedirectUri));
+	_apply_integration_type(&auth_args);
+	loader.client_authorize(&client, &auth_args, Discord::_authorize_callback, auth_flow);
 	loader.authorization_args_drop(&auth_args);
 	loader.authorization_code_verifier_drop(&verifier);
 
-	const double start_usec = Time::get_singleton()->get_ticks_usec();
-	const double timeout_sec = 120.0;
-	while (true) {
-		loader.run_callbacks();
-		connection_state = _map_client_status(loader.client_get_status(&client));
-
-		if (flow.authorize_done && !flow.authorize_ok) {
-			return ERR_CANT_CREATE;
-		}
-		if (flow.token_done && !flow.token_ok) {
-			return ERR_CANT_CREATE;
-		}
-		if (flow.update_token_done && !flow.update_token_ok) {
-			return ERR_CANT_CREATE;
-		}
-		if (connection_state == STATE_READY) {
-			Discord_UserHandle user;
-			if (loader.client_get_current_user_v2(&client, &user)) {
-				user_id = loader.user_handle_id(&user);
-				username = loader.user_handle_display_name(&user);
-				if (username.is_empty()) {
-					username = loader.user_handle_username(&user);
-				}
-				loader.user_handle_drop(&user);
-			}
-			return OK;
-		}
-
-		if ((Time::get_singleton()->get_ticks_usec() - start_usec) / 1000000.0 > timeout_sec) {
-			_set_last_error("Timed out waiting for Discord SDK to become ready");
-			return ERR_TIMEOUT;
-		}
-		::OS::get_singleton()->delay_usec(1000);
-	}
+	return OK;
 }
 
 Error Discord::initialize(int64_t p_client_id) {
@@ -325,6 +577,8 @@ Error Discord::initialize(int64_t p_client_id) {
 		return ERR_INVALID_PARAMETER;
 	}
 
+	discord_try_connect_frame_hook();
+
 	client_id = p_client_id;
 	Error err = _initialize_client(p_client_id);
 	if (err != OK) {
@@ -333,7 +587,7 @@ Error Discord::initialize(int64_t p_client_id) {
 	}
 
 	initialized = true;
-	_log_debug(vformat("Discord initialized (client_id=%s)", String::num_int64(p_client_id)));
+	_log_lifecycle(vformat("Discord auth started (client_id=%s)", String::num_int64(p_client_id)));
 	return OK;
 }
 
@@ -351,11 +605,14 @@ void Discord::shutdown() {
 		return;
 	}
 	_reset_session();
-	_log_debug("Discord shutdown");
+	_log_lifecycle("Discord shutdown");
 }
 
 void Discord::set_debug_logging(bool p_enabled) {
 	debug_logging = p_enabled;
+	if (p_enabled && client_active) {
+		_register_platform_hooks();
+	}
 }
 
 Array Discord::get_debug_log() const {
@@ -371,17 +628,28 @@ void Discord::clear_debug_log() {
 }
 
 void Discord::_run_client_callbacks() {
+	discord_try_connect_frame_hook();
 	if (!client_active) {
 		return;
 	}
 	loader.run_callbacks();
-	connection_state = _map_client_status(loader.client_get_status(&client));
+	const Discord_Client_Status status = loader.client_get_status(&client);
+	_sync_connection_state(status, DISCORD_CLIENT_ERROR_NONE, 0, false);
 }
 
 void Discord::run_callbacks() {
-	if (initialized) {
+	discord_try_connect_frame_hook();
+	if (client_active) {
 		_run_client_callbacks();
 	}
+}
+
+bool Discord::is_frame_hook_connected() const {
+	return discord_is_frame_hook_connected();
+}
+
+void Discord::note_frame_hook_connected() {
+	_log_lifecycle("Frame callback hook connected");
 }
 
 String Discord::get_access_token() const {
@@ -389,14 +657,237 @@ String Discord::get_access_token() const {
 }
 
 String Discord::get_username() const {
+	if (auth_state != AUTH_READY) {
+		return String();
+	}
 	return username;
 }
 
 uint64_t Discord::get_user_id() const {
+	if (auth_state != AUTH_READY) {
+		return 0;
+	}
 	return user_id;
 }
 
+int Discord::get_relationships_count() const {
+	if (auth_state != AUTH_READY) {
+		return -1;
+	}
+	return relationships_count;
+}
+
+String Discord::get_default_presence_scopes() const {
+	if (!loader.is_loaded()) {
+		return String();
+	}
+	return loader.get_default_presence_scopes();
+}
+
+String Discord::get_default_communication_scopes() const {
+	if (!loader.is_loaded()) {
+		return String();
+	}
+	return loader.get_default_communication_scopes();
+}
+
+Error Discord::update_rich_presence(const Dictionary &p_activity) {
+	if (_require_auth_ready("update_rich_presence") != OK) {
+		pending_presence = p_activity;
+		has_pending_presence = true;
+		return ERR_UNAUTHORIZED;
+	}
+	return _send_rich_presence(p_activity);
+}
+
+Error Discord::_send_rich_presence(const Dictionary &p_activity) {
+	if (_require_auth_ready("update_rich_presence") != OK) {
+		return ERR_UNAUTHORIZED;
+	}
+
+	last_presence_sent = p_activity;
+	const String details = p_activity.has("details") ? (String)p_activity["details"] : String();
+	const String state = p_activity.has("state") ? (String)p_activity["state"] : String();
+	const String large_image = p_activity.has("large_image") ? (String)p_activity["large_image"] : String();
+	const String small_image = p_activity.has("small_image") ? (String)p_activity["small_image"] : String();
+	_log_lifecycle(vformat("Sending Rich Presence: details='%s' state='%s' large='%s' small='%s'",
+			details, state, large_image, small_image));
+
+	Discord_Activity activity;
+	loader.activity_init(&activity);
+
+	const int activity_type = p_activity.has("type") ? (int)p_activity["type"] : DISCORD_ACTIVITY_TYPE_PLAYING;
+	loader.activity_set_type(&activity, (Discord_ActivityTypes)activity_type);
+
+	if (p_activity.has("details")) {
+		loader.activity_set_details(&activity, (String)p_activity["details"]);
+	}
+	if (p_activity.has("state")) {
+		loader.activity_set_state(&activity, (String)p_activity["state"]);
+	}
+
+	const bool has_assets = p_activity.has("large_image") || p_activity.has("large_text") ||
+			p_activity.has("small_image") || p_activity.has("small_text");
+	if (has_assets) {
+		Discord_ActivityAssets assets;
+		loader.activity_assets_init(&assets);
+		if (p_activity.has("large_image")) {
+			loader.activity_assets_set_large_image(&assets, (String)p_activity["large_image"]);
+		}
+		if (p_activity.has("large_text")) {
+			loader.activity_assets_set_large_text(&assets, (String)p_activity["large_text"]);
+		}
+		if (p_activity.has("small_image")) {
+			loader.activity_assets_set_small_image(&assets, (String)p_activity["small_image"]);
+		}
+		if (p_activity.has("small_text")) {
+			loader.activity_assets_set_small_text(&assets, (String)p_activity["small_text"]);
+		}
+		loader.activity_set_assets(&activity, &assets);
+		loader.activity_assets_drop(&assets);
+	}
+
+	const bool has_timestamps = p_activity.has("start_timestamp") || p_activity.has("end_timestamp");
+	if (has_timestamps) {
+		Discord_ActivityTimestamps timestamps;
+		loader.activity_timestamps_init(&timestamps);
+		if (p_activity.has("start_timestamp")) {
+			loader.activity_timestamps_set_start(&timestamps, (uint64_t)(int64_t)p_activity["start_timestamp"]);
+		}
+		if (p_activity.has("end_timestamp")) {
+			loader.activity_timestamps_set_end(&timestamps, (uint64_t)(int64_t)p_activity["end_timestamp"]);
+		}
+		loader.activity_set_timestamps(&activity, &timestamps);
+		loader.activity_timestamps_drop(&timestamps);
+	}
+
+	loader.client_update_rich_presence(&client, &activity, Discord::_update_rich_presence_callback, this);
+	loader.activity_drop(&activity);
+	return OK;
+}
+
+void Discord::clear_rich_presence() {
+	if (_require_auth_ready("clear_rich_presence") != OK) {
+		return;
+	}
+	loader.client_clear_rich_presence(&client);
+}
+
+String Discord::_resolve_oauth_scope_preset() {
+	if (ProjectSettings::get_singleton()->has_setting("discord/oauth_scope_preset")) {
+		return ProjectSettings::get_singleton()->get_setting("discord/oauth_scope_preset", "presence");
+	}
+	return "presence";
+}
+
+String Discord::_resolve_oauth_scopes() {
+	if (!loader.is_loaded()) {
+		return String();
+	}
+	const String preset = _resolve_oauth_scope_preset();
+	if (preset == "communication") {
+		return loader.get_default_communication_scopes();
+	}
+	if (preset == "custom") {
+		String custom;
+		if (ProjectSettings::get_singleton()->has_setting("discord/oauth_scopes_custom")) {
+			custom = ProjectSettings::get_singleton()->get_setting("discord/oauth_scopes_custom", "");
+		}
+		if (!custom.is_empty()) {
+			return custom;
+		}
+		_log_lifecycle("oauth_scope_preset=custom but oauth_scopes_custom is empty; falling back to presence scopes");
+	}
+	return loader.get_default_presence_scopes();
+}
+
+String Discord::_resolve_integration_type_label() {
+	String integration = "UserInstall";
+	if (ProjectSettings::get_singleton()->has_setting("discord/oauth_integration_type")) {
+		integration = ProjectSettings::get_singleton()->get_setting("discord/oauth_integration_type", "UserInstall");
+	}
+	if (integration == "None" || integration == "none" || integration.is_empty()) {
+		return "None";
+	}
+	return integration;
+}
+
+bool Discord::_apply_integration_type(Discord_AuthorizationArgs *p_auth_args) {
+	if (!p_auth_args || !loader.is_loaded()) {
+		return false;
+	}
+	const String integration = _resolve_integration_type_label();
+	if (integration == "None") {
+		return false;
+	}
+	loader.authorization_args_set_integration_type(p_auth_args, DISCORD_INTEGRATION_TYPE_USER_INSTALL);
+	return true;
+}
+
+void Discord::_validate_granted_scopes() {
+	if (granted_scopes.is_empty()) {
+		return;
+	}
+	const String preset = oauth_scope_preset.is_empty() ? _resolve_oauth_scope_preset() : oauth_scope_preset;
+	if (preset == "presence" && !granted_scopes.contains("sdk.social_layer_presence")) {
+		print_line("[Discord] Warning: granted scopes missing sdk.social_layer_presence — presence may not display; revoke app auth and re-authorize");
+	} else if (preset == "communication" && !granted_scopes.contains("sdk.social_layer")) {
+		print_line("[Discord] Warning: granted scopes missing sdk.social_layer — communication features may be unavailable; revoke app auth and re-authorize");
+	}
+}
+
+Dictionary Discord::_read_game_activity() {
+	Dictionary out;
+	if (!ready_for_presence || !client_active || !loader.is_loaded()) {
+		return out;
+	}
+	Discord_UserHandle user;
+	if (!loader.client_get_current_user_v2(&client, &user)) {
+		return out;
+	}
+	Discord_Activity activity;
+	if (!loader.user_handle_game_activity(&user, &activity)) {
+		loader.user_handle_drop(&user);
+		return out;
+	}
+	out["type"] = (int)loader.activity_get_type(&activity);
+	out["details"] = loader.activity_get_details(&activity);
+	out["state"] = loader.activity_get_state(&activity);
+	loader.activity_drop(&activity);
+	loader.user_handle_drop(&user);
+	return out;
+}
+
+void Discord::_log_game_activity_readback() {
+	const Dictionary activity = _read_game_activity();
+	if (activity.is_empty()) {
+		_log_lifecycle("GameActivity readback: none (activity not set for this game)");
+		return;
+	}
+	_log_lifecycle(vformat("GameActivity readback: type=%s details='%s' state='%s'",
+			activity.get("type", 0), activity.get("details", ""), activity.get("state", "")));
+}
+
+Dictionary Discord::get_game_activity() {
+	return _read_game_activity();
+}
+
 Ref<DiscordAuthResult> Discord::authenticate_with_server(const String &p_url, const String &p_access_token, int64_t p_client_id) {
+	if (_require_auth_ready("authenticate_with_server") != OK) {
+		Ref<DiscordAuthResult> result;
+		result.instantiate();
+		result->set_error_message(last_error);
+		result->set_success(false);
+		return result;
+	}
+	if (access_token.is_empty()) {
+		last_error = "Discord access token is not available";
+		Ref<DiscordAuthResult> result;
+		result.instantiate();
+		result->set_error_message(last_error);
+		result->set_success(false);
+		return result;
+	}
 	const int64_t resolved_client_id = p_client_id > 0 ? p_client_id : client_id;
 	_log_debug(vformat("Authenticating with server: %s", p_url));
 	return auth_client->authenticate_sync(p_url, p_access_token, resolved_client_id, debug_logging);

--- a/modules/discord_module/discord.h
+++ b/modules/discord_module/discord.h
@@ -30,11 +30,14 @@
 #pragma once
 
 #include "core/object/object.h"
+#include "core/variant/dictionary.h"
 #include "discord_api_loader.h"
 #include "discord_auth_result.h"
 #include "discord_types.h"
 
 class DiscordAuthClient;
+
+struct DiscordAuthFlow;
 
 class Discord : public Object {
 	GDCLASS(Discord, Object);
@@ -50,34 +53,80 @@ public:
 		STATE_HTTP_WAIT,
 	};
 
+	enum AuthState {
+		AUTH_NONE,
+		AUTH_PENDING,
+		AUTH_AUTHORIZED,
+		AUTH_READY,
+		AUTH_FAILED,
+	};
+
 private:
 	static Discord *singleton;
 
 	DiscordAPILoader loader;
 	DiscordAuthClient *auth_client = nullptr;
+	DiscordAuthFlow *auth_flow = nullptr;
 
 	bool dll_available = false;
 	bool initialized = false;
+	bool ready_for_presence = false;
+	bool ready_signal_emitted = false;
 	bool debug_logging = false;
 	bool client_active = false;
+	bool log_callback_registered = false;
+	bool authorize_dismiss_callback_registered = false;
+	bool has_pending_presence = false;
 	int64_t client_id = 0;
+	int relationships_count = -1;
+	int last_emitted_error = 0;
+	int last_emitted_error_detail = 0;
+	int last_polled_status = -1;
+	ConnectionState last_emitted_state = STATE_DISCONNECTED;
+	AuthState auth_state = AUTH_NONE;
 	String access_token;
 	String username;
+	String requested_scopes;
+	String granted_scopes;
+	String oauth_scope_preset;
 	uint64_t user_id = 0;
 	ConnectionState connection_state = STATE_DISCONNECTED;
 	String last_error;
+	Dictionary pending_presence;
+	Dictionary last_presence_sent;
 	Discord_Client client;
 
 	Vector<String> debug_log;
 	static const int kMaxDebugLogEntries = 256;
 
+	void _log_lifecycle(const String &p_message);
 	void _log_debug(const String &p_message);
 	void _set_last_error(const String &p_error);
+	void _set_auth_state(AuthState p_state);
+	void _report_authorization_failed(const String &p_error);
+	Error _require_auth_ready(const char *p_operation);
+	void _sync_connection_state(Discord_Client_Status p_status, int p_error, int p_error_detail, bool p_emit_signal);
 	void _reset_session();
+	void _clear_auth_flow();
+	void _on_client_ready();
+	void _apply_pending_presence();
+	Error _send_rich_presence(const Dictionary &p_activity);
+	void _log_game_activity_readback();
+	Dictionary _read_game_activity();
+	String _resolve_oauth_scopes();
+	String _resolve_oauth_scope_preset();
+	void _validate_granted_scopes();
+	String _resolve_integration_type_label();
+	bool _apply_integration_type(Discord_AuthorizationArgs *p_auth_args);
+	void _refresh_relationships();
+	void _register_log_callback();
+	void _register_authorize_dismiss_callback();
+	void _register_platform_hooks();
 	static ConnectionState _map_client_status(Discord_Client_Status p_status);
 	Error _initialize_client(int64_t p_client_id);
 	void _run_client_callbacks();
 	void _disconnect_client();
+	void _start_token_exchange(DiscordAuthFlow *p_flow, const String &p_auth_code);
 
 	static void _authorize_callback(Discord_ClientResult *result, Discord_String code, Discord_String redirect_uri, void *user_data);
 	static void _token_exchange_callback(Discord_ClientResult *result,
@@ -89,6 +138,9 @@ private:
 			void *user_data);
 	static void _update_token_callback(Discord_ClientResult *result, void *user_data);
 	static void _status_changed_callback(Discord_Client_Status status, Discord_Client_Error error, int32_t error_detail, void *user_data);
+	static void _log_callback(Discord_String message, Discord_LoggingSeverity severity, void *user_data);
+	static void _authorize_device_screen_closed_callback(void *user_data);
+	static void _update_rich_presence_callback(Discord_ClientResult *result, void *user_data);
 
 protected:
 	static void _bind_methods();
@@ -100,6 +152,11 @@ public:
 	Error initialize(int64_t p_client_id = 0);
 	void shutdown();
 	bool is_initialized() const { return initialized; }
+	bool is_client_active() const { return client_active; }
+	bool is_ready_for_presence() const { return ready_for_presence; }
+	AuthState get_auth_state() const { return auth_state; }
+	bool is_authorization_pending() const { return auth_state == AUTH_PENDING; }
+	bool is_authorized() const { return auth_state == AUTH_AUTHORIZED || auth_state == AUTH_READY; }
 
 	void set_debug_logging(bool p_enabled);
 	bool is_debug_logging_enabled() const { return debug_logging; }
@@ -107,11 +164,22 @@ public:
 	void clear_debug_log();
 
 	void run_callbacks();
+	bool is_frame_hook_connected() const;
+	void note_frame_hook_connected();
 	ConnectionState get_connection_state() const { return connection_state; }
 	String get_access_token() const;
 	String get_username() const;
 	uint64_t get_user_id() const;
+	int get_relationships_count() const;
 	String get_last_error() const { return last_error; }
+	String get_default_presence_scopes() const;
+	String get_default_communication_scopes() const;
+	String get_requested_scopes() const { return requested_scopes; }
+	String get_granted_scopes() const { return granted_scopes; }
+	Dictionary get_game_activity();
+
+	Error update_rich_presence(const Dictionary &p_activity);
+	void clear_rich_presence();
 
 	Ref<DiscordAuthResult> authenticate_with_server(const String &p_url, const String &p_access_token, int64_t p_client_id);
 	Dictionary get_version() const;
@@ -121,3 +189,4 @@ public:
 };
 
 VARIANT_ENUM_CAST(Discord::ConnectionState);
+VARIANT_ENUM_CAST(Discord::AuthState);

--- a/modules/discord_module/discord_api_loader.cpp
+++ b/modules/discord_module/discord_api_loader.cpp
@@ -152,13 +152,55 @@ bool DiscordAPILoader::try_load() {
 	LOAD_REQUIRED("Discord_UserHandle_Id", fn_user_handle_id);
 	LOAD_REQUIRED("Discord_UserHandle_DisplayName", fn_user_handle_display_name);
 	LOAD_REQUIRED("Discord_UserHandle_Username", fn_user_handle_username);
+	LOAD_REQUIRED("Discord_UserHandle_GameActivity", fn_user_handle_game_activity);
+	LOAD_REQUIRED("Discord_Activity_Type", fn_activity_type);
+	LOAD_REQUIRED("Discord_Activity_Details", fn_activity_details);
+	LOAD_REQUIRED("Discord_Activity_State", fn_activity_state);
 	LOAD_REQUIRED("Discord_Client_GetDefaultCommunicationScopes", fn_client_get_default_communication_scopes);
+	LOAD_REQUIRED("Discord_Client_GetDefaultPresenceScopes", fn_client_get_default_presence_scopes);
+	LOAD_REQUIRED("Discord_Client_AddLogCallback", fn_client_add_log_callback);
+	LOAD_REQUIRED("Discord_Client_GetRelationships", fn_client_get_relationships);
+	LOAD_REQUIRED("Discord_Activity_Init", fn_activity_init);
+	LOAD_REQUIRED("Discord_Activity_Drop", fn_activity_drop);
+	LOAD_REQUIRED("Discord_Activity_SetType", fn_activity_set_type);
+	LOAD_REQUIRED("Discord_Activity_SetDetails", fn_activity_set_details);
+	LOAD_REQUIRED("Discord_Activity_SetState", fn_activity_set_state);
+	LOAD_REQUIRED("Discord_Activity_SetAssets", fn_activity_set_assets);
+	LOAD_REQUIRED("Discord_Activity_SetTimestamps", fn_activity_set_timestamps);
+	LOAD_REQUIRED("Discord_ActivityAssets_Init", fn_activity_assets_init);
+	LOAD_REQUIRED("Discord_ActivityAssets_Drop", fn_activity_assets_drop);
+	LOAD_REQUIRED("Discord_ActivityAssets_SetLargeImage", fn_activity_assets_set_large_image);
+	LOAD_REQUIRED("Discord_ActivityAssets_SetLargeText", fn_activity_assets_set_large_text);
+	LOAD_REQUIRED("Discord_ActivityAssets_SetSmallImage", fn_activity_assets_set_small_image);
+	LOAD_REQUIRED("Discord_ActivityAssets_SetSmallText", fn_activity_assets_set_small_text);
+	LOAD_REQUIRED("Discord_ActivityTimestamps_Init", fn_activity_timestamps_init);
+	LOAD_REQUIRED("Discord_ActivityTimestamps_Drop", fn_activity_timestamps_drop);
+	LOAD_REQUIRED("Discord_ActivityTimestamps_SetStart", fn_activity_timestamps_set_start);
+	LOAD_REQUIRED("Discord_ActivityTimestamps_SetEnd", fn_activity_timestamps_set_end);
+	LOAD_REQUIRED("Discord_Client_UpdateRichPresence", fn_client_update_rich_presence);
+	LOAD_REQUIRED("Discord_Client_ClearRichPresence", fn_client_clear_rich_presence);
 	LOAD_REQUIRED("Discord_Client_GetVersionHash", fn_client_get_version_hash);
 	LOAD_REQUIRED("Discord_Client_GetVersionMajor", fn_client_get_version_major);
 	LOAD_REQUIRED("Discord_Client_GetVersionMinor", fn_client_get_version_minor);
 	LOAD_REQUIRED("Discord_Client_GetVersionPatch", fn_client_get_version_patch);
 
 #undef LOAD_REQUIRED
+
+#define LOAD_OPTIONAL(name, member)            \
+	{                                          \
+		void *symbol = nullptr;                \
+		if (_load_symbol(name, symbol)) {      \
+			member = (decltype(member))symbol; \
+		}                                      \
+	}
+
+	LOAD_OPTIONAL("Discord_AuthorizationArgs_SetIntegrationType", fn_authorization_args_set_integration_type);
+	LOAD_OPTIONAL("Discord_Client_SetAuthorizeDeviceScreenClosedCallback",
+			fn_client_set_authorize_device_screen_closed_callback);
+	LOAD_OPTIONAL("Discord_Client_SetGameWindowPid", fn_client_set_game_window_pid);
+	LOAD_OPTIONAL("Discord_Client_SetLogDir", fn_client_set_log_dir);
+
+#undef LOAD_OPTIONAL
 
 	loaded = true;
 	return true;
@@ -176,12 +218,14 @@ void DiscordAPILoader::unload() {
 	fn_client_drop = nullptr;
 	fn_client_set_application_id = nullptr;
 	fn_client_set_status_changed_callback = nullptr;
+	fn_client_set_authorize_device_screen_closed_callback = nullptr;
 	fn_client_create_authorization_code_verifier = nullptr;
 	fn_authorization_args_init = nullptr;
 	fn_authorization_args_drop = nullptr;
 	fn_authorization_args_set_client_id = nullptr;
 	fn_authorization_args_set_scopes = nullptr;
 	fn_authorization_args_set_code_challenge = nullptr;
+	fn_authorization_args_set_integration_type = nullptr;
 	fn_authorization_code_verifier_drop = nullptr;
 	fn_authorization_code_verifier_challenge = nullptr;
 	fn_authorization_code_verifier_verifier = nullptr;
@@ -198,11 +242,39 @@ void DiscordAPILoader::unload() {
 	fn_user_handle_id = nullptr;
 	fn_user_handle_display_name = nullptr;
 	fn_user_handle_username = nullptr;
+	fn_user_handle_game_activity = nullptr;
+	fn_activity_type = nullptr;
+	fn_activity_details = nullptr;
+	fn_activity_state = nullptr;
 	fn_client_get_default_communication_scopes = nullptr;
+	fn_client_get_default_presence_scopes = nullptr;
+	fn_client_add_log_callback = nullptr;
+	fn_client_get_relationships = nullptr;
+	fn_activity_init = nullptr;
+	fn_activity_drop = nullptr;
+	fn_activity_set_type = nullptr;
+	fn_activity_set_details = nullptr;
+	fn_activity_set_state = nullptr;
+	fn_activity_set_assets = nullptr;
+	fn_activity_set_timestamps = nullptr;
+	fn_activity_assets_init = nullptr;
+	fn_activity_assets_drop = nullptr;
+	fn_activity_assets_set_large_image = nullptr;
+	fn_activity_assets_set_large_text = nullptr;
+	fn_activity_assets_set_small_image = nullptr;
+	fn_activity_assets_set_small_text = nullptr;
+	fn_activity_timestamps_init = nullptr;
+	fn_activity_timestamps_drop = nullptr;
+	fn_activity_timestamps_set_start = nullptr;
+	fn_activity_timestamps_set_end = nullptr;
+	fn_client_update_rich_presence = nullptr;
+	fn_client_clear_rich_presence = nullptr;
 	fn_client_get_version_hash = nullptr;
 	fn_client_get_version_major = nullptr;
 	fn_client_get_version_minor = nullptr;
 	fn_client_get_version_patch = nullptr;
+	fn_client_set_game_window_pid = nullptr;
+	fn_client_set_log_dir = nullptr;
 }
 
 void DiscordAPILoader::run_callbacks() const {
@@ -227,6 +299,16 @@ void DiscordAPILoader::client_set_status_changed_callback(Discord_Client *self,
 		Discord_Client_OnStatusChanged callback,
 		void *user_data) const {
 	fn_client_set_status_changed_callback(self, callback, nullptr, user_data);
+}
+
+bool DiscordAPILoader::client_set_authorize_device_screen_closed_callback(Discord_Client *self,
+		Discord_Client_AuthorizeDeviceScreenClosedCallback callback,
+		void *user_data) const {
+	if (!fn_client_set_authorize_device_screen_closed_callback) {
+		return false;
+	}
+	fn_client_set_authorize_device_screen_closed_callback(self, callback, nullptr, user_data);
+	return true;
 }
 
 void DiscordAPILoader::client_create_authorization_code_verifier(Discord_Client *self,
@@ -257,6 +339,14 @@ void DiscordAPILoader::authorization_args_set_scopes(Discord_AuthorizationArgs *
 void DiscordAPILoader::authorization_args_set_code_challenge(Discord_AuthorizationArgs *self,
 		Discord_AuthorizationCodeChallenge *value) const {
 	fn_authorization_args_set_code_challenge(self, value);
+}
+
+void DiscordAPILoader::authorization_args_set_integration_type(Discord_AuthorizationArgs *self,
+		Discord_IntegrationType value) const {
+	if (!fn_authorization_args_set_integration_type) {
+		return;
+	}
+	fn_authorization_args_set_integration_type(self, &value);
 }
 
 void DiscordAPILoader::authorization_code_verifier_drop(Discord_AuthorizationCodeVerifier *self) const {
@@ -303,6 +393,16 @@ void DiscordAPILoader::client_get_token(Discord_Client *self,
 	fn_client_get_token(self, application_id, code, verifier, redirect_uri, callback, nullptr, user_data);
 }
 
+void DiscordAPILoader::client_get_token(Discord_Client *self,
+		uint64_t application_id,
+		Discord_String code,
+		Discord_String code_verifier,
+		Discord_String redirect_uri,
+		Discord_Client_TokenExchangeCallback callback,
+		void *user_data) const {
+	fn_client_get_token(self, application_id, code, code_verifier, redirect_uri, callback, nullptr, user_data);
+}
+
 void DiscordAPILoader::client_update_token(Discord_Client *self,
 		Discord_AuthorizationTokenType token_type,
 		const String &p_token,
@@ -312,6 +412,14 @@ void DiscordAPILoader::client_update_token(Discord_Client *self,
 	Discord_String token;
 	token.ptr = (uint8_t *)token_utf8.ptr();
 	token.size = token_utf8.length();
+	fn_client_update_token(self, token_type, token, callback, nullptr, user_data);
+}
+
+void DiscordAPILoader::client_update_token(Discord_Client *self,
+		Discord_AuthorizationTokenType token_type,
+		Discord_String token,
+		Discord_Client_UpdateTokenCallback callback,
+		void *user_data) const {
 	fn_client_update_token(self, token_type, token, callback, nullptr, user_data);
 }
 
@@ -361,10 +469,171 @@ String DiscordAPILoader::user_handle_username(Discord_UserHandle *self) const {
 	return to_godot_string(name);
 }
 
+bool DiscordAPILoader::user_handle_game_activity(Discord_UserHandle *self, Discord_Activity *return_value) const {
+	return fn_user_handle_game_activity(self, return_value);
+}
+
+Discord_ActivityTypes DiscordAPILoader::activity_get_type(Discord_Activity *self) const {
+	return fn_activity_type(self);
+}
+
+String DiscordAPILoader::activity_get_details(Discord_Activity *self) const {
+	Discord_String value;
+	if (!fn_activity_details(self, &value)) {
+		return String();
+	}
+	return to_godot_string(value);
+}
+
+String DiscordAPILoader::activity_get_state(Discord_Activity *self) const {
+	Discord_String value;
+	if (!fn_activity_state(self, &value)) {
+		return String();
+	}
+	return to_godot_string(value);
+}
+
 String DiscordAPILoader::get_default_communication_scopes() const {
 	Discord_String scopes;
 	fn_client_get_default_communication_scopes(&scopes);
 	return to_godot_string(scopes);
+}
+
+String DiscordAPILoader::get_default_presence_scopes() const {
+	Discord_String scopes;
+	fn_client_get_default_presence_scopes(&scopes);
+	return to_godot_string(scopes);
+}
+
+void DiscordAPILoader::client_add_log_callback(Discord_Client *self,
+		Discord_Client_LogCallback callback,
+		void *user_data,
+		Discord_LoggingSeverity min_severity) const {
+	fn_client_add_log_callback(self, callback, nullptr, user_data, min_severity);
+}
+
+void DiscordAPILoader::client_get_relationships(Discord_Client *self, Discord_RelationshipHandleSpan *return_value) const {
+	fn_client_get_relationships(self, return_value);
+}
+
+void DiscordAPILoader::activity_init(Discord_Activity *self) const {
+	fn_activity_init(self);
+}
+
+void DiscordAPILoader::activity_drop(Discord_Activity *self) const {
+	fn_activity_drop(self);
+}
+
+void DiscordAPILoader::activity_set_type(Discord_Activity *self, Discord_ActivityTypes value) const {
+	fn_activity_set_type(self, value);
+}
+
+void DiscordAPILoader::activity_set_details(Discord_Activity *self, const String &p_value) const {
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_set_details(self, &str);
+}
+
+void DiscordAPILoader::activity_set_state(Discord_Activity *self, const String &p_value) const {
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_set_state(self, &str);
+}
+
+void DiscordAPILoader::activity_set_assets(Discord_Activity *self, Discord_ActivityAssets *value) const {
+	fn_activity_set_assets(self, value);
+}
+
+void DiscordAPILoader::activity_set_timestamps(Discord_Activity *self, Discord_ActivityTimestamps *value) const {
+	fn_activity_set_timestamps(self, value);
+}
+
+void DiscordAPILoader::activity_assets_init(Discord_ActivityAssets *self) const {
+	fn_activity_assets_init(self);
+}
+
+void DiscordAPILoader::activity_assets_drop(Discord_ActivityAssets *self) const {
+	fn_activity_assets_drop(self);
+}
+
+void DiscordAPILoader::activity_assets_set_large_image(Discord_ActivityAssets *self, const String &p_value) const {
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_assets_set_large_image(self, &str);
+}
+
+void DiscordAPILoader::activity_assets_set_large_text(Discord_ActivityAssets *self, const String &p_value) const {
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_assets_set_large_text(self, &str);
+}
+
+void DiscordAPILoader::activity_assets_set_small_image(Discord_ActivityAssets *self, const String &p_value) const {
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_assets_set_small_image(self, &str);
+}
+
+void DiscordAPILoader::activity_assets_set_small_text(Discord_ActivityAssets *self, const String &p_value) const {
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_assets_set_small_text(self, &str);
+}
+
+void DiscordAPILoader::activity_timestamps_init(Discord_ActivityTimestamps *self) const {
+	fn_activity_timestamps_init(self);
+}
+
+void DiscordAPILoader::activity_timestamps_drop(Discord_ActivityTimestamps *self) const {
+	fn_activity_timestamps_drop(self);
+}
+
+void DiscordAPILoader::activity_timestamps_set_start(Discord_ActivityTimestamps *self, uint64_t value) const {
+	fn_activity_timestamps_set_start(self, value);
+}
+
+void DiscordAPILoader::activity_timestamps_set_end(Discord_ActivityTimestamps *self, uint64_t value) const {
+	fn_activity_timestamps_set_end(self, value);
+}
+
+void DiscordAPILoader::client_update_rich_presence(Discord_Client *self,
+		Discord_Activity *activity,
+		Discord_Client_UpdateRichPresenceCallback callback,
+		void *user_data) const {
+	fn_client_update_rich_presence(self, activity, callback, nullptr, user_data);
+}
+
+void DiscordAPILoader::client_clear_rich_presence(Discord_Client *self) const {
+	fn_client_clear_rich_presence(self);
+}
+
+void DiscordAPILoader::client_set_game_window_pid(Discord_Client *self, int32_t pid) const {
+	if (fn_client_set_game_window_pid) {
+		fn_client_set_game_window_pid(self, pid);
+	}
+}
+
+bool DiscordAPILoader::client_set_log_dir(Discord_Client *self, const String &p_path, Discord_LoggingSeverity min_severity) const {
+	if (!fn_client_set_log_dir) {
+		return false;
+	}
+	CharString path_utf8 = p_path.utf8();
+	Discord_String path;
+	path.ptr = (uint8_t *)path_utf8.ptr();
+	path.size = path_utf8.length();
+	return fn_client_set_log_dir(self, path, min_severity);
 }
 
 void DiscordAPILoader::fill_version_dict(Dictionary &p_version) const {

--- a/modules/discord_module/discord_api_loader.h
+++ b/modules/discord_module/discord_api_loader.h
@@ -50,6 +50,10 @@ private:
 			Discord_Client_OnStatusChanged callback,
 			Discord_FreeFn callback_user_data_free,
 			void *callback_user_data);
+	typedef void (*Discord_Client_SetAuthorizeDeviceScreenClosedCallbackFn)(Discord_Client *self,
+			Discord_Client_AuthorizeDeviceScreenClosedCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
 	typedef void (*Discord_Client_CreateAuthorizationCodeVerifierFn)(Discord_Client *self,
 			Discord_AuthorizationCodeVerifier *return_value);
 	typedef void (*Discord_AuthorizationArgs_InitFn)(Discord_AuthorizationArgs *self);
@@ -58,6 +62,8 @@ private:
 	typedef void (*Discord_AuthorizationArgs_SetScopesFn)(Discord_AuthorizationArgs *self, Discord_String value);
 	typedef void (*Discord_AuthorizationArgs_SetCodeChallengeFn)(Discord_AuthorizationArgs *self,
 			Discord_AuthorizationCodeChallenge *value);
+	typedef void (*Discord_AuthorizationArgs_SetIntegrationTypeFn)(Discord_AuthorizationArgs *self,
+			Discord_IntegrationType *value);
 	typedef void (*Discord_AuthorizationCodeVerifier_DropFn)(Discord_AuthorizationCodeVerifier *self);
 	typedef void (*Discord_AuthorizationCodeVerifier_ChallengeFn)(Discord_AuthorizationCodeVerifier *self,
 			Discord_AuthorizationCodeChallenge *return_value);
@@ -92,23 +98,62 @@ private:
 	typedef uint64_t (*Discord_UserHandle_IdFn)(Discord_UserHandle *self);
 	typedef void (*Discord_UserHandle_DisplayNameFn)(Discord_UserHandle *self, Discord_String *return_value);
 	typedef void (*Discord_UserHandle_UsernameFn)(Discord_UserHandle *self, Discord_String *return_value);
+	typedef bool (*Discord_UserHandle_GameActivityFn)(Discord_UserHandle *self, Discord_Activity *return_value);
+	typedef Discord_ActivityTypes (*Discord_Activity_TypeFn)(Discord_Activity *self);
+	typedef bool (*Discord_Activity_DetailsFn)(Discord_Activity *self, Discord_String *return_value);
+	typedef bool (*Discord_Activity_StateFn)(Discord_Activity *self, Discord_String *return_value);
 	typedef void (*Discord_Client_GetDefaultCommunicationScopesFn)(Discord_String *return_value);
+	typedef void (*Discord_Client_GetDefaultPresenceScopesFn)(Discord_String *return_value);
+	typedef void (*Discord_Client_AddLogCallbackFn)(Discord_Client *self,
+			Discord_Client_LogCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data,
+			Discord_LoggingSeverity min_severity);
+	typedef void (*Discord_Client_GetRelationshipsFn)(Discord_Client *self,
+			Discord_RelationshipHandleSpan *return_value);
+	typedef void (*Discord_Activity_InitFn)(Discord_Activity *self);
+	typedef void (*Discord_Activity_DropFn)(Discord_Activity *self);
+	typedef void (*Discord_Activity_SetTypeFn)(Discord_Activity *self, Discord_ActivityTypes value);
+	typedef void (*Discord_Activity_SetDetailsFn)(Discord_Activity *self, Discord_String *value);
+	typedef void (*Discord_Activity_SetStateFn)(Discord_Activity *self, Discord_String *value);
+	typedef void (*Discord_Activity_SetAssetsFn)(Discord_Activity *self, Discord_ActivityAssets *value);
+	typedef void (*Discord_Activity_SetTimestampsFn)(Discord_Activity *self, Discord_ActivityTimestamps *value);
+	typedef void (*Discord_ActivityAssets_InitFn)(Discord_ActivityAssets *self);
+	typedef void (*Discord_ActivityAssets_DropFn)(Discord_ActivityAssets *self);
+	typedef void (*Discord_ActivityAssets_SetLargeImageFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityAssets_SetLargeTextFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityAssets_SetSmallImageFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityAssets_SetSmallTextFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityTimestamps_InitFn)(Discord_ActivityTimestamps *self);
+	typedef void (*Discord_ActivityTimestamps_DropFn)(Discord_ActivityTimestamps *self);
+	typedef void (*Discord_ActivityTimestamps_SetStartFn)(Discord_ActivityTimestamps *self, uint64_t value);
+	typedef void (*Discord_ActivityTimestamps_SetEndFn)(Discord_ActivityTimestamps *self, uint64_t value);
+	typedef void (*Discord_Client_UpdateRichPresenceFn)(Discord_Client *self,
+			Discord_Activity *activity,
+			Discord_Client_UpdateRichPresenceCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_ClearRichPresenceFn)(Discord_Client *self);
 	typedef void (*Discord_Client_GetVersionHashFn)(Discord_String *return_value);
 	typedef int32_t (*Discord_Client_GetVersionMajorFn)();
 	typedef int32_t (*Discord_Client_GetVersionMinorFn)();
 	typedef int32_t (*Discord_Client_GetVersionPatchFn)();
+	typedef void (*Discord_Client_SetGameWindowPidFn)(Discord_Client *self, int32_t pid);
+	typedef bool (*Discord_Client_SetLogDirFn)(Discord_Client *self, Discord_String path, Discord_LoggingSeverity min_severity);
 
 	Discord_RunCallbacksFn fn_run_callbacks = nullptr;
 	Discord_Client_InitFn fn_client_init = nullptr;
 	Discord_Client_DropFn fn_client_drop = nullptr;
 	Discord_Client_SetApplicationIdFn fn_client_set_application_id = nullptr;
 	Discord_Client_SetStatusChangedCallbackFn fn_client_set_status_changed_callback = nullptr;
+	Discord_Client_SetAuthorizeDeviceScreenClosedCallbackFn fn_client_set_authorize_device_screen_closed_callback = nullptr;
 	Discord_Client_CreateAuthorizationCodeVerifierFn fn_client_create_authorization_code_verifier = nullptr;
 	Discord_AuthorizationArgs_InitFn fn_authorization_args_init = nullptr;
 	Discord_AuthorizationArgs_DropFn fn_authorization_args_drop = nullptr;
 	Discord_AuthorizationArgs_SetClientIdFn fn_authorization_args_set_client_id = nullptr;
 	Discord_AuthorizationArgs_SetScopesFn fn_authorization_args_set_scopes = nullptr;
 	Discord_AuthorizationArgs_SetCodeChallengeFn fn_authorization_args_set_code_challenge = nullptr;
+	Discord_AuthorizationArgs_SetIntegrationTypeFn fn_authorization_args_set_integration_type = nullptr;
 	Discord_AuthorizationCodeVerifier_DropFn fn_authorization_code_verifier_drop = nullptr;
 	Discord_AuthorizationCodeVerifier_ChallengeFn fn_authorization_code_verifier_challenge = nullptr;
 	Discord_AuthorizationCodeVerifier_VerifierFn fn_authorization_code_verifier_verifier = nullptr;
@@ -125,11 +170,39 @@ private:
 	Discord_UserHandle_IdFn fn_user_handle_id = nullptr;
 	Discord_UserHandle_DisplayNameFn fn_user_handle_display_name = nullptr;
 	Discord_UserHandle_UsernameFn fn_user_handle_username = nullptr;
+	Discord_UserHandle_GameActivityFn fn_user_handle_game_activity = nullptr;
+	Discord_Activity_TypeFn fn_activity_type = nullptr;
+	Discord_Activity_DetailsFn fn_activity_details = nullptr;
+	Discord_Activity_StateFn fn_activity_state = nullptr;
 	Discord_Client_GetDefaultCommunicationScopesFn fn_client_get_default_communication_scopes = nullptr;
+	Discord_Client_GetDefaultPresenceScopesFn fn_client_get_default_presence_scopes = nullptr;
+	Discord_Client_AddLogCallbackFn fn_client_add_log_callback = nullptr;
+	Discord_Client_GetRelationshipsFn fn_client_get_relationships = nullptr;
+	Discord_Activity_InitFn fn_activity_init = nullptr;
+	Discord_Activity_DropFn fn_activity_drop = nullptr;
+	Discord_Activity_SetTypeFn fn_activity_set_type = nullptr;
+	Discord_Activity_SetDetailsFn fn_activity_set_details = nullptr;
+	Discord_Activity_SetStateFn fn_activity_set_state = nullptr;
+	Discord_Activity_SetAssetsFn fn_activity_set_assets = nullptr;
+	Discord_Activity_SetTimestampsFn fn_activity_set_timestamps = nullptr;
+	Discord_ActivityAssets_InitFn fn_activity_assets_init = nullptr;
+	Discord_ActivityAssets_DropFn fn_activity_assets_drop = nullptr;
+	Discord_ActivityAssets_SetLargeImageFn fn_activity_assets_set_large_image = nullptr;
+	Discord_ActivityAssets_SetLargeTextFn fn_activity_assets_set_large_text = nullptr;
+	Discord_ActivityAssets_SetSmallImageFn fn_activity_assets_set_small_image = nullptr;
+	Discord_ActivityAssets_SetSmallTextFn fn_activity_assets_set_small_text = nullptr;
+	Discord_ActivityTimestamps_InitFn fn_activity_timestamps_init = nullptr;
+	Discord_ActivityTimestamps_DropFn fn_activity_timestamps_drop = nullptr;
+	Discord_ActivityTimestamps_SetStartFn fn_activity_timestamps_set_start = nullptr;
+	Discord_ActivityTimestamps_SetEndFn fn_activity_timestamps_set_end = nullptr;
+	Discord_Client_UpdateRichPresenceFn fn_client_update_rich_presence = nullptr;
+	Discord_Client_ClearRichPresenceFn fn_client_clear_rich_presence = nullptr;
 	Discord_Client_GetVersionHashFn fn_client_get_version_hash = nullptr;
 	Discord_Client_GetVersionMajorFn fn_client_get_version_major = nullptr;
 	Discord_Client_GetVersionMinorFn fn_client_get_version_minor = nullptr;
 	Discord_Client_GetVersionPatchFn fn_client_get_version_patch = nullptr;
+	Discord_Client_SetGameWindowPidFn fn_client_set_game_window_pid = nullptr;
+	Discord_Client_SetLogDirFn fn_client_set_log_dir = nullptr;
 
 	bool _load_symbol(const char *p_name, void *&r_symbol);
 
@@ -145,6 +218,9 @@ public:
 	void client_set_status_changed_callback(Discord_Client *self,
 			Discord_Client_OnStatusChanged callback,
 			void *user_data) const;
+	bool client_set_authorize_device_screen_closed_callback(Discord_Client *self,
+			Discord_Client_AuthorizeDeviceScreenClosedCallback callback,
+			void *user_data) const;
 	void client_create_authorization_code_verifier(Discord_Client *self,
 			Discord_AuthorizationCodeVerifier *return_value) const;
 	void authorization_args_init(Discord_AuthorizationArgs *self) const;
@@ -153,6 +229,8 @@ public:
 	void authorization_args_set_scopes(Discord_AuthorizationArgs *self, const String &p_scopes) const;
 	void authorization_args_set_code_challenge(Discord_AuthorizationArgs *self,
 			Discord_AuthorizationCodeChallenge *value) const;
+	void authorization_args_set_integration_type(Discord_AuthorizationArgs *self,
+			Discord_IntegrationType value) const;
 	void authorization_code_verifier_drop(Discord_AuthorizationCodeVerifier *self) const;
 	void authorization_code_verifier_challenge(Discord_AuthorizationCodeVerifier *self,
 			Discord_AuthorizationCodeChallenge *return_value) const;
@@ -168,9 +246,21 @@ public:
 			const String &p_redirect_uri,
 			Discord_Client_TokenExchangeCallback callback,
 			void *user_data) const;
+	void client_get_token(Discord_Client *self,
+			uint64_t application_id,
+			Discord_String code,
+			Discord_String code_verifier,
+			Discord_String redirect_uri,
+			Discord_Client_TokenExchangeCallback callback,
+			void *user_data) const;
 	void client_update_token(Discord_Client *self,
 			Discord_AuthorizationTokenType token_type,
 			const String &p_token,
+			Discord_Client_UpdateTokenCallback callback,
+			void *user_data) const;
+	void client_update_token(Discord_Client *self,
+			Discord_AuthorizationTokenType token_type,
+			Discord_String token,
 			Discord_Client_UpdateTokenCallback callback,
 			void *user_data) const;
 	void client_connect(Discord_Client *self) const;
@@ -183,7 +273,41 @@ public:
 	uint64_t user_handle_id(Discord_UserHandle *self) const;
 	String user_handle_display_name(Discord_UserHandle *self) const;
 	String user_handle_username(Discord_UserHandle *self) const;
+	bool user_handle_game_activity(Discord_UserHandle *self, Discord_Activity *return_value) const;
+	Discord_ActivityTypes activity_get_type(Discord_Activity *self) const;
+	String activity_get_details(Discord_Activity *self) const;
+	String activity_get_state(Discord_Activity *self) const;
 	String get_default_communication_scopes() const;
+	String get_default_presence_scopes() const;
+	void client_add_log_callback(Discord_Client *self,
+			Discord_Client_LogCallback callback,
+			void *user_data,
+			Discord_LoggingSeverity min_severity) const;
+	void client_get_relationships(Discord_Client *self, Discord_RelationshipHandleSpan *return_value) const;
+	void activity_init(Discord_Activity *self) const;
+	void activity_drop(Discord_Activity *self) const;
+	void activity_set_type(Discord_Activity *self, Discord_ActivityTypes value) const;
+	void activity_set_details(Discord_Activity *self, const String &p_value) const;
+	void activity_set_state(Discord_Activity *self, const String &p_value) const;
+	void activity_set_assets(Discord_Activity *self, Discord_ActivityAssets *value) const;
+	void activity_set_timestamps(Discord_Activity *self, Discord_ActivityTimestamps *value) const;
+	void activity_assets_init(Discord_ActivityAssets *self) const;
+	void activity_assets_drop(Discord_ActivityAssets *self) const;
+	void activity_assets_set_large_image(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_assets_set_large_text(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_assets_set_small_image(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_assets_set_small_text(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_timestamps_init(Discord_ActivityTimestamps *self) const;
+	void activity_timestamps_drop(Discord_ActivityTimestamps *self) const;
+	void activity_timestamps_set_start(Discord_ActivityTimestamps *self, uint64_t value) const;
+	void activity_timestamps_set_end(Discord_ActivityTimestamps *self, uint64_t value) const;
+	void client_update_rich_presence(Discord_Client *self,
+			Discord_Activity *activity,
+			Discord_Client_UpdateRichPresenceCallback callback,
+			void *user_data) const;
+	void client_clear_rich_presence(Discord_Client *self) const;
+	void client_set_game_window_pid(Discord_Client *self, int32_t pid) const;
+	bool client_set_log_dir(Discord_Client *self, const String &p_path, Discord_LoggingSeverity min_severity) const;
 	void fill_version_dict(Dictionary &p_version) const;
 
 	static Discord_String make_string(const String &p_value);

--- a/modules/discord_module/discord_frame_hook.h
+++ b/modules/discord_module/discord_frame_hook.h
@@ -1,0 +1,33 @@
+/**************************************************************************/
+/*  discord_frame_hook.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+void discord_try_connect_frame_hook();
+bool discord_is_frame_hook_connected();

--- a/modules/discord_module/discord_types.h
+++ b/modules/discord_module/discord_types.h
@@ -58,6 +58,11 @@ typedef enum Discord_AuthorizationTokenType {
 	DISCORD_AUTHORIZATION_TOKEN_TYPE_BEARER = 1,
 } Discord_AuthorizationTokenType;
 
+typedef enum Discord_IntegrationType {
+	DISCORD_INTEGRATION_TYPE_GUILD_INSTALL = 0,
+	DISCORD_INTEGRATION_TYPE_USER_INSTALL = 1,
+} Discord_IntegrationType;
+
 typedef struct Discord_Client {
 	void *opaque;
 } Discord_Client;
@@ -103,3 +108,51 @@ typedef void (*Discord_Client_OnStatusChanged)(Discord_Client_Status status,
 		Discord_Client_Error error,
 		int32_t error_detail,
 		void *user_data);
+
+typedef enum Discord_ActivityTypes {
+	DISCORD_ACTIVITY_TYPE_PLAYING = 0,
+	DISCORD_ACTIVITY_TYPE_STREAMING = 1,
+	DISCORD_ACTIVITY_TYPE_LISTENING = 2,
+	DISCORD_ACTIVITY_TYPE_WATCHING = 3,
+	DISCORD_ACTIVITY_TYPE_CUSTOM_STATUS = 4,
+	DISCORD_ACTIVITY_TYPE_COMPETING = 5,
+	DISCORD_ACTIVITY_TYPE_HANG_STATUS = 6,
+} Discord_ActivityTypes;
+
+typedef enum Discord_LoggingSeverity {
+	DISCORD_LOGGING_SEVERITY_VERBOSE = 1,
+	DISCORD_LOGGING_SEVERITY_INFO = 2,
+	DISCORD_LOGGING_SEVERITY_WARNING = 3,
+	DISCORD_LOGGING_SEVERITY_ERROR = 4,
+	DISCORD_LOGGING_SEVERITY_NONE = 5,
+} Discord_LoggingSeverity;
+
+typedef struct Discord_Activity {
+	void *opaque;
+} Discord_Activity;
+
+typedef struct Discord_ActivityAssets {
+	void *opaque;
+} Discord_ActivityAssets;
+
+typedef struct Discord_ActivityTimestamps {
+	void *opaque;
+} Discord_ActivityTimestamps;
+
+typedef struct Discord_RelationshipHandle {
+	void *opaque;
+} Discord_RelationshipHandle;
+
+typedef struct Discord_RelationshipHandleSpan {
+	Discord_RelationshipHandle *ptr;
+	size_t size;
+} Discord_RelationshipHandleSpan;
+
+typedef void (*Discord_Client_LogCallback)(Discord_String message,
+		Discord_LoggingSeverity severity,
+		void *user_data);
+
+typedef void (*Discord_Client_UpdateRichPresenceCallback)(Discord_ClientResult *result,
+		void *user_data);
+
+typedef void (*Discord_Client_AuthorizeDeviceScreenClosedCallback)(void *user_data);

--- a/modules/discord_module/doc_classes/Discord.xml
+++ b/modules/discord_module/doc_classes/Discord.xml
@@ -16,7 +16,7 @@
 			<param index="1" name="access_token" type="String" />
 			<param index="2" name="client_id" type="int" />
 			<description>
-				POSTs the OAuth access token to the auth server and returns the parsed response.
+				POSTs the OAuth access token to the auth server and returns the parsed response. Requires [constant AUTH_READY] and a non-empty access token.
 			</description>
 		</method>
 		<method name="clear_debug_log">
@@ -25,10 +25,22 @@
 				Clears the in-memory debug log buffer.
 			</description>
 		</method>
+		<method name="clear_rich_presence">
+			<return type="void" />
+			<description>
+				Clears the player's Discord rich presence. Requires [constant AUTH_READY].
+			</description>
+		</method>
 		<method name="get_access_token" qualifiers="const">
 			<return type="String" />
 			<description>
 				Returns the OAuth access token obtained during [method initialize], or an empty string when not connected.
+			</description>
+		</method>
+		<method name="get_auth_state" qualifiers="const">
+			<return type="int" enum="Discord.AuthState" />
+			<description>
+				Returns the current OAuth/auth lifecycle state.
 			</description>
 		</method>
 		<method name="get_connection_state" qualifiers="const">
@@ -40,7 +52,31 @@
 		<method name="get_debug_log" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns recent debug log lines when debug logging is enabled.
+				Returns recent lifecycle and SDK log lines (always populated for auth/connect/presence steps; verbose SDK detail when debug logging is enabled).
+			</description>
+		</method>
+		<method name="get_default_communication_scopes" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the default OAuth scopes for communication features ([code]openid[/code] and [code]sdk.social_layer[/code]).
+			</description>
+		</method>
+		<method name="get_default_presence_scopes" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the default OAuth scopes for rich presence ([code]openid[/code] and [code]sdk.social_layer_presence[/code]).
+			</description>
+		</method>
+		<method name="get_game_activity">
+			<return type="Dictionary" />
+			<description>
+				Returns the current user's game-associated activity from the SDK readback ([code]type[/code], [code]details[/code], [code]state[/code]), or an empty dictionary when unavailable.
+			</description>
+		</method>
+		<method name="get_granted_scopes" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the OAuth scopes granted by Discord after token exchange.
 			</description>
 		</method>
 		<method name="get_last_error" qualifiers="const">
@@ -49,16 +85,28 @@
 				Returns the most recent error message from Discord initialization or auth.
 			</description>
 		</method>
+		<method name="get_relationships_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the cached Discord relationships count after [constant AUTH_READY], or [code]-1[/code] when unavailable.
+			</description>
+		</method>
+		<method name="get_requested_scopes" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the OAuth scopes requested during the current auth flow.
+			</description>
+		</method>
 		<method name="get_user_id" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the connected Discord user snowflake ID, or [code]0[/code] when unavailable.
+				Returns the connected Discord user snowflake ID after [constant AUTH_READY], or [code]0[/code] when unavailable.
 			</description>
 		</method>
 		<method name="get_username" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the connected Discord display or username.
+				Returns the connected Discord display or username after [constant AUTH_READY], or an empty string when unavailable.
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">
@@ -74,10 +122,28 @@
 				Initializes the Discord Social SDK and starts the OAuth authorization flow for the given application client ID.
 			</description>
 		</method>
+		<method name="is_authorization_pending" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] while waiting for the user to complete OAuth ([constant AUTH_PENDING]).
+			</description>
+		</method>
+		<method name="is_authorized" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] after token exchange succeeds ([constant AUTH_AUTHORIZED] or [constant AUTH_READY]).
+			</description>
+		</method>
 		<method name="is_available">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] when the Discord Partner SDK runtime library is present beside the executable.
+			</description>
+		</method>
+		<method name="is_client_active" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] while the SDK client session is active (including during OAuth).
 			</description>
 		</method>
 		<method name="is_debug_logging_enabled" qualifiers="const">
@@ -86,10 +152,21 @@
 				Returns whether debug logging is enabled.
 			</description>
 		</method>
+		<method name="is_frame_hook_connected" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="is_initialized" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] after a successful [method initialize].
+			</description>
+		</method>
+		<method name="is_ready_for_presence" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the client has reached [constant STATE_READY] and rich presence can be updated.
 			</description>
 		</method>
 		<method name="run_callbacks">
@@ -102,7 +179,7 @@
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
-				Enables or disables verbose debug logging to stdout and the in-memory debug log.
+				Enables verbose SDK file logging ([code]discord.log[/code] in user data) in addition to always-on lifecycle logs.
 			</description>
 		</method>
 		<method name="shutdown">
@@ -111,7 +188,58 @@
 				Shuts down the Discord SDK session and releases resources.
 			</description>
 		</method>
+		<method name="update_rich_presence">
+			<return type="int" enum="Error" />
+			<param index="0" name="activity" type="Dictionary" />
+			<description>
+				Updates Discord rich presence. Dictionary keys: [code]type[/code], [code]details[/code], [code]state[/code], [code]large_image[/code], [code]large_text[/code], [code]small_image[/code], [code]small_text[/code], [code]start_timestamp[/code], [code]end_timestamp[/code]. Requires [constant AUTH_READY]; if called earlier, the activity is cached and applied when [signal ready] fires. Returns [constant ERR_UNAUTHORIZED] when not ready.
+			</description>
+		</method>
 	</methods>
+	<signals>
+		<signal name="authorization_failed">
+			<param index="0" name="error" type="String" />
+			<description>
+				Emitted when OAuth authorization fails or the user dismisses the auth UI.
+			</description>
+		</signal>
+		<signal name="authorization_started">
+			<description>
+				Emitted when the OAuth authorization flow begins (auth popup shown).
+			</description>
+		</signal>
+		<signal name="authorized">
+			<description>
+				Emitted after the access token is stored and [method initialize]'s connect step begins.
+			</description>
+		</signal>
+		<signal name="connection_state_changed">
+			<param index="0" name="state" type="int" />
+			<param index="1" name="error" type="int" />
+			<param index="2" name="error_detail" type="int" />
+			<description>
+				Emitted when the SDK connection state changes. [param state] uses [enum ConnectionState].
+			</description>
+		</signal>
+		<signal name="ready">
+			<description>
+				Emitted once when the client reaches [constant STATE_READY] and rich presence can be updated.
+			</description>
+		</signal>
+		<signal name="relationships_updated">
+			<param index="0" name="count" type="int" />
+			<description>
+				Emitted after relationships are fetched on ready.
+			</description>
+		</signal>
+		<signal name="rich_presence_updated">
+			<param index="0" name="success" type="bool" />
+			<param index="1" name="error" type="String" />
+			<description>
+				Emitted when [method update_rich_presence] completes asynchronously.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="STATE_DISCONNECTED" value="0" enum="ConnectionState">
 		</constant>
@@ -126,6 +254,21 @@
 		<constant name="STATE_DISCONNECTING" value="5" enum="ConnectionState">
 		</constant>
 		<constant name="STATE_HTTP_WAIT" value="6" enum="ConnectionState">
+		</constant>
+		<constant name="AUTH_NONE" value="0" enum="AuthState">
+			No auth flow started.
+		</constant>
+		<constant name="AUTH_PENDING" value="1" enum="AuthState">
+			OAuth popup shown; waiting for user authorization.
+		</constant>
+		<constant name="AUTH_AUTHORIZED" value="2" enum="AuthState">
+			Access token stored; connecting to Discord.
+		</constant>
+		<constant name="AUTH_READY" value="3" enum="AuthState">
+			Client ready; social APIs including rich presence are available.
+		</constant>
+		<constant name="AUTH_FAILED" value="4" enum="AuthState">
+			Authorization failed or was dismissed.
 		</constant>
 	</constants>
 </class>

--- a/modules/discord_module/register_types.cpp
+++ b/modules/discord_module/register_types.cpp
@@ -32,6 +32,7 @@
 #include "core/config/engine.h"
 #include "discord.h"
 #include "discord_auth_result.h"
+#include "discord_frame_hook.h"
 #include "scene/main/scene_tree.h"
 
 #ifdef TESTS_ENABLED
@@ -44,13 +45,15 @@ static bool discord_frame_hook_connected = false;
 namespace {
 
 void discord_frame_callback() {
-	if (discord_singleton == nullptr || !discord_singleton->is_initialized()) {
+	if (discord_singleton == nullptr || !discord_singleton->is_client_active()) {
 		return;
 	}
 	discord_singleton->run_callbacks();
 }
 
-void connect_discord_frame_hook() {
+} //namespace
+
+void discord_try_connect_frame_hook() {
 	if (discord_frame_hook_connected) {
 		return;
 	}
@@ -62,7 +65,17 @@ void connect_discord_frame_hook() {
 
 	scene_tree->connect("process_frame", callable_mp_static(&discord_frame_callback));
 	discord_frame_hook_connected = true;
+
+	if (discord_singleton != nullptr) {
+		discord_singleton->note_frame_hook_connected();
+	}
 }
+
+bool discord_is_frame_hook_connected() {
+	return discord_frame_hook_connected;
+}
+
+namespace {
 
 void disconnect_discord_frame_hook() {
 	if (!discord_frame_hook_connected) {
@@ -85,7 +98,7 @@ void initialize_discord_module_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(Discord);
 		discord_singleton = memnew(Discord);
 		Engine::get_singleton()->add_singleton(Engine::Singleton("Discord", Discord::get_singleton()));
-		connect_discord_frame_hook();
+		discord_try_connect_frame_hook();
 	}
 }
 

--- a/modules/discord_module/tests/test_discord_module.h
+++ b/modules/discord_module/tests/test_discord_module.h
@@ -64,7 +64,70 @@ TEST_CASE("[DiscordModule] unavailable without runtime library") {
 	CHECK(discord->initialize(123456789) == ERR_UNAVAILABLE);
 }
 
-TEST_CASE("[DiscordModule] auth client rejects empty url") {
+TEST_CASE("[DiscordModule] auth state starts none") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK(discord->get_auth_state() == Discord::AUTH_NONE);
+	CHECK_FALSE(discord->is_authorization_pending());
+	CHECK_FALSE(discord->is_authorized());
+}
+
+TEST_CASE("[DiscordModule] rich presence requires ready client") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK_FALSE(discord->is_ready_for_presence());
+	CHECK(discord->get_relationships_count() == -1);
+	Dictionary activity;
+	CHECK(discord->update_rich_presence(activity) == ERR_UNAUTHORIZED);
+}
+
+TEST_CASE("[DiscordModule] auth lifecycle signals are registered") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK(discord->has_signal("authorization_started"));
+	CHECK(discord->has_signal("authorized"));
+	CHECK(discord->has_signal("authorization_failed"));
+	CHECK(discord->has_signal("connection_state_changed"));
+	CHECK(discord->has_signal("ready"));
+	CHECK(discord->has_signal("rich_presence_updated"));
+}
+
+TEST_CASE("[DiscordModule] default presence scopes when loaded") {
+	DiscordAPILoader api_loader;
+	if (!api_loader.try_load()) {
+		return;
+	}
+	const String scopes = api_loader.get_default_presence_scopes();
+	CHECK_FALSE(scopes.is_empty());
+}
+
+TEST_CASE("[DiscordModule] default communication scopes when loaded") {
+	DiscordAPILoader api_loader;
+	if (!api_loader.try_load()) {
+		return;
+	}
+	const String scopes = api_loader.get_default_communication_scopes();
+	CHECK_FALSE(scopes.is_empty());
+}
+
+TEST_CASE("[DiscordModule] game activity empty when not ready") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK(discord->get_game_activity().is_empty());
+	CHECK(discord->get_requested_scopes().is_empty());
+	CHECK(discord->get_granted_scopes().is_empty());
+}
+
+TEST_CASE("[DiscordModule] server auth gated when not ready") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	Ref<DiscordAuthResult> result = discord->authenticate_with_server("http://example.com/auth", "token", 1);
+	REQUIRE(result.is_valid());
+	CHECK_FALSE(result->is_success());
+	CHECK_FALSE(result->get_error_message().is_empty());
+}
+
+TEST_CASE("[DiscordModule] auth client rejects empty url when ready would allow") {
 	Discord *discord = Discord::get_singleton();
 	REQUIRE(discord != nullptr);
 	Ref<DiscordAuthResult> result = discord->authenticate_with_server("", "token", 1);


### PR DESCRIPTION
## Summary

Single squashed commit extending `discord_module` for end-to-end Discord Social SDK Rich Presence on Windows (validated with Demon Lord Clicker export build).

- **OAuth / auth flow** — Full presence OAuth per SDK guide: `Authorize` → `GetToken` → `UpdateToken(Bearer)` → `Connect`. Configurable scope presets (`presence` / `communication` / `custom`) via project settings; logs requested vs granted scopes and warns on permission mismatches. Configurable `IntegrationType` (`UserInstall` default, `None` for sample parity).
- **Auth state machine** — `AuthState` enum (`AUTH_NONE` … `AUTH_READY` / `AUTH_FAILED`) with API gating until ready; lifecycle signals (`authorization_started`, `authorized`, `authorization_failed`, `ready`, `connection_state_changed`).
- **Callback pumping** — `RunCallbacks` via deferred `process_frame` hook (`discord_frame_hook.h`) once `SceneTree` exists; safe to call from `initialize` / `run_callbacks`.
- **Rich Presence API** — `update_rich_presence(activity: Dictionary)` / `clear_rich_presence()` mapping Activity type, details, state, assets, timestamps; pending presence cache until `STATE_READY`; `rich_presence_updated` signal.
- **Diagnostics** — Always-on lifecycle logging; optional SDK file log (`discord.log`); `GameActivity` readback after successful updates (`get_game_activity()`); `SetGameWindowPid` on Windows; relationships count on ready.
- **Tests & docs** — Extended `test_discord_module.h`; updated `Discord.xml` for new methods, signals, and auth states.

## Test plan

- [x] SCons `template_release` + `editor` build on Windows
- [x] SCons editor tests (`tests=yes`): 1523 cases passed
- [x] Manual: exported game with `discord_partner_sdk.dll`, Discord desktop running — OAuth popup non-blocking
- [x] Manual: full auth → `STATE_READY` → `UpdateRichPresence` success + `GameActivity` readback
- [x] Manual: Rich Presence visible on Discord profile while game running (text-only debug payload validated)
- [x] Manual: scope preset `presence` grants `sdk.social_layer_presence`; granted scopes logged after token exchange
