### PR TITLE
Add Discord Social SDK RPC presence, invites, and relationships APIs

### DIFF
--- a/modules/discord_module/discord.cpp
+++ b/modules/discord_module/discord.cpp
@@ -31,6 +31,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
+#include "core/variant/array.h"
 #include "discord_auth_client.h"
 #include "discord_frame_hook.h"
 
@@ -54,44 +55,83 @@ Discord *Discord::singleton = nullptr;
 static const char *kDefaultOAuthRedirectUri = "http://127.0.0.1/callback";
 
 void Discord::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("is_available"), &Discord::is_available);
-	ClassDB::bind_method(D_METHOD("initialize", "client_id"), &Discord::initialize, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("shutdown"), &Discord::shutdown);
-	ClassDB::bind_method(D_METHOD("is_initialized"), &Discord::is_initialized);
-	ClassDB::bind_method(D_METHOD("is_client_active"), &Discord::is_client_active);
-	ClassDB::bind_method(D_METHOD("is_ready_for_presence"), &Discord::is_ready_for_presence);
+	ClassDB::bind_method(D_METHOD("accept_activity_invite", "invite"), &Discord::accept_activity_invite);
+	ClassDB::bind_method(D_METHOD("accept_discord_friend_request", "user_id"), &Discord::accept_discord_friend_request);
+	ClassDB::bind_method(D_METHOD("accept_game_friend_request", "user_id"), &Discord::accept_game_friend_request);
+	ClassDB::bind_method(D_METHOD("authenticate_with_server", "url", "access_token", "client_id"), &Discord::authenticate_with_server);
+	ClassDB::bind_method(D_METHOD("block_user", "user_id"), &Discord::block_user);
+	ClassDB::bind_method(D_METHOD("cancel_discord_friend_request", "user_id"), &Discord::cancel_discord_friend_request);
+	ClassDB::bind_method(D_METHOD("cancel_game_friend_request", "user_id"), &Discord::cancel_game_friend_request);
+	ClassDB::bind_method(D_METHOD("clear_debug_log"), &Discord::clear_debug_log);
+	ClassDB::bind_method(D_METHOD("clear_rich_presence"), &Discord::clear_rich_presence);
+	ClassDB::bind_method(D_METHOD("create_or_join_lobby", "secret"), &Discord::create_or_join_lobby);
+	ClassDB::bind_method(D_METHOD("get_access_token"), &Discord::get_access_token);
 	ClassDB::bind_method(D_METHOD("get_auth_state"), &Discord::get_auth_state);
+	ClassDB::bind_method(D_METHOD("get_connection_state"), &Discord::get_connection_state);
+	ClassDB::bind_method(D_METHOD("get_debug_log"), &Discord::get_debug_log);
+	ClassDB::bind_method(D_METHOD("get_default_communication_scopes"), &Discord::get_default_communication_scopes);
+	ClassDB::bind_method(D_METHOD("get_default_presence_scopes"), &Discord::get_default_presence_scopes);
+	ClassDB::bind_method(D_METHOD("get_game_activity"), &Discord::get_game_activity);
+	ClassDB::bind_method(D_METHOD("get_granted_scopes"), &Discord::get_granted_scopes);
+	ClassDB::bind_method(D_METHOD("get_last_error"), &Discord::get_last_error);
+	ClassDB::bind_method(D_METHOD("get_relationship", "user_id"), &Discord::get_relationship);
+	ClassDB::bind_method(D_METHOD("get_relationships"), &Discord::get_relationships);
+	ClassDB::bind_method(D_METHOD("get_relationships_by_group", "group"), &Discord::get_relationships_by_group);
+	ClassDB::bind_method(D_METHOD("get_relationships_count"), &Discord::get_relationships_count);
+	ClassDB::bind_method(D_METHOD("get_requested_scopes"), &Discord::get_requested_scopes);
+	ClassDB::bind_method(D_METHOD("get_user", "user_id"), &Discord::get_user);
+	ClassDB::bind_method(D_METHOD("get_user_id"), &Discord::get_user_id);
+	ClassDB::bind_method(D_METHOD("get_username"), &Discord::get_username);
+	ClassDB::bind_method(D_METHOD("get_version"), &Discord::get_version);
+	ClassDB::bind_method(D_METHOD("initialize", "client_id"), &Discord::initialize, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("initialize_presence_only", "client_id"), &Discord::initialize_presence_only);
 	ClassDB::bind_method(D_METHOD("is_authorization_pending"), &Discord::is_authorization_pending);
 	ClassDB::bind_method(D_METHOD("is_authorized"), &Discord::is_authorized);
-	ClassDB::bind_method(D_METHOD("set_debug_logging", "enabled"), &Discord::set_debug_logging);
+	ClassDB::bind_method(D_METHOD("is_available"), &Discord::is_available);
+	ClassDB::bind_method(D_METHOD("is_client_active"), &Discord::is_client_active);
 	ClassDB::bind_method(D_METHOD("is_debug_logging_enabled"), &Discord::is_debug_logging_enabled);
-	ClassDB::bind_method(D_METHOD("get_debug_log"), &Discord::get_debug_log);
-	ClassDB::bind_method(D_METHOD("clear_debug_log"), &Discord::clear_debug_log);
-	ClassDB::bind_method(D_METHOD("run_callbacks"), &Discord::run_callbacks);
 	ClassDB::bind_method(D_METHOD("is_frame_hook_connected"), &Discord::is_frame_hook_connected);
-	ClassDB::bind_method(D_METHOD("get_connection_state"), &Discord::get_connection_state);
-	ClassDB::bind_method(D_METHOD("get_access_token"), &Discord::get_access_token);
-	ClassDB::bind_method(D_METHOD("get_username"), &Discord::get_username);
-	ClassDB::bind_method(D_METHOD("get_user_id"), &Discord::get_user_id);
-	ClassDB::bind_method(D_METHOD("get_relationships_count"), &Discord::get_relationships_count);
-	ClassDB::bind_method(D_METHOD("get_last_error"), &Discord::get_last_error);
-	ClassDB::bind_method(D_METHOD("get_default_presence_scopes"), &Discord::get_default_presence_scopes);
-	ClassDB::bind_method(D_METHOD("get_default_communication_scopes"), &Discord::get_default_communication_scopes);
-	ClassDB::bind_method(D_METHOD("get_requested_scopes"), &Discord::get_requested_scopes);
-	ClassDB::bind_method(D_METHOD("get_granted_scopes"), &Discord::get_granted_scopes);
-	ClassDB::bind_method(D_METHOD("get_game_activity"), &Discord::get_game_activity);
+	ClassDB::bind_method(D_METHOD("is_initialized"), &Discord::is_initialized);
+	ClassDB::bind_method(D_METHOD("is_presence_only_mode"), &Discord::is_presence_only_mode);
+	ClassDB::bind_method(D_METHOD("is_ready_for_presence"), &Discord::is_ready_for_presence);
+	ClassDB::bind_method(D_METHOD("refresh_relationships"), &Discord::refresh_relationships);
+	ClassDB::bind_method(D_METHOD("register_launch_command", "application_id", "command"), &Discord::register_launch_command);
+	ClassDB::bind_method(D_METHOD("register_launch_steam_application", "application_id", "steam_app_id"), &Discord::register_launch_steam_application);
+	ClassDB::bind_method(D_METHOD("reject_discord_friend_request", "user_id"), &Discord::reject_discord_friend_request);
+	ClassDB::bind_method(D_METHOD("reject_game_friend_request", "user_id"), &Discord::reject_game_friend_request);
+	ClassDB::bind_method(D_METHOD("remove_discord_and_game_friend", "user_id"), &Discord::remove_discord_and_game_friend);
+	ClassDB::bind_method(D_METHOD("remove_game_friend", "user_id"), &Discord::remove_game_friend);
+	ClassDB::bind_method(D_METHOD("run_callbacks"), &Discord::run_callbacks);
+	ClassDB::bind_method(D_METHOD("send_activity_invite", "user_id", "content"), &Discord::send_activity_invite, DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("send_activity_join_request", "user_id"), &Discord::send_activity_join_request);
+	ClassDB::bind_method(D_METHOD("send_activity_join_request_reply", "invite"), &Discord::send_activity_join_request_reply);
+	ClassDB::bind_method(D_METHOD("send_discord_friend_request", "username"), &Discord::send_discord_friend_request);
+	ClassDB::bind_method(D_METHOD("send_discord_friend_request_by_id", "user_id"), &Discord::send_discord_friend_request_by_id);
+	ClassDB::bind_method(D_METHOD("send_game_friend_request", "username"), &Discord::send_game_friend_request);
+	ClassDB::bind_method(D_METHOD("send_game_friend_request_by_id", "user_id"), &Discord::send_game_friend_request_by_id);
+	ClassDB::bind_method(D_METHOD("set_debug_logging", "enabled"), &Discord::set_debug_logging);
+	ClassDB::bind_method(D_METHOD("shutdown"), &Discord::shutdown);
+	ClassDB::bind_method(D_METHOD("unblock_user", "user_id"), &Discord::unblock_user);
 	ClassDB::bind_method(D_METHOD("update_rich_presence", "activity"), &Discord::update_rich_presence);
-	ClassDB::bind_method(D_METHOD("clear_rich_presence"), &Discord::clear_rich_presence);
-	ClassDB::bind_method(D_METHOD("authenticate_with_server", "url", "access_token", "client_id"), &Discord::authenticate_with_server);
-	ClassDB::bind_method(D_METHOD("get_version"), &Discord::get_version);
 
-	ADD_SIGNAL(MethodInfo("connection_state_changed", PropertyInfo(Variant::INT, "state"), PropertyInfo(Variant::INT, "error"), PropertyInfo(Variant::INT, "error_detail")));
+	ADD_SIGNAL(MethodInfo("activity_invite_accepted", PropertyInfo(Variant::STRING, "join_secret")));
+	ADD_SIGNAL(MethodInfo("activity_invite_created", PropertyInfo(Variant::DICTIONARY, "invite")));
+	ADD_SIGNAL(MethodInfo("activity_invite_sent"));
+	ADD_SIGNAL(MethodInfo("activity_invite_updated", PropertyInfo(Variant::DICTIONARY, "invite")));
+	ADD_SIGNAL(MethodInfo("activity_join_requested", PropertyInfo(Variant::STRING, "join_secret")));
+	ADD_SIGNAL(MethodInfo("authorization_failed", PropertyInfo(Variant::STRING, "error")));
 	ADD_SIGNAL(MethodInfo("authorization_started"));
 	ADD_SIGNAL(MethodInfo("authorized"));
-	ADD_SIGNAL(MethodInfo("authorization_failed", PropertyInfo(Variant::STRING, "error")));
+	ADD_SIGNAL(MethodInfo("connection_state_changed", PropertyInfo(Variant::INT, "state"), PropertyInfo(Variant::INT, "error"), PropertyInfo(Variant::INT, "error_detail")));
+	ADD_SIGNAL(MethodInfo("lobby_joined", PropertyInfo(Variant::INT, "lobby_id")));
 	ADD_SIGNAL(MethodInfo("ready"));
+	ADD_SIGNAL(MethodInfo("relationship_action_completed", PropertyInfo(Variant::STRING, "action"), PropertyInfo(Variant::INT, "user_id"), PropertyInfo(Variant::BOOL, "success"), PropertyInfo(Variant::STRING, "error")));
+	ADD_SIGNAL(MethodInfo("relationship_created", PropertyInfo(Variant::INT, "user_id"), PropertyInfo(Variant::BOOL, "is_discord")));
+	ADD_SIGNAL(MethodInfo("relationship_deleted", PropertyInfo(Variant::INT, "user_id"), PropertyInfo(Variant::BOOL, "is_discord")));
+	ADD_SIGNAL(MethodInfo("relationship_groups_updated", PropertyInfo(Variant::INT, "user_id")));
 	ADD_SIGNAL(MethodInfo("relationships_updated", PropertyInfo(Variant::INT, "count")));
 	ADD_SIGNAL(MethodInfo("rich_presence_updated", PropertyInfo(Variant::BOOL, "success"), PropertyInfo(Variant::STRING, "error")));
+	ADD_SIGNAL(MethodInfo("user_updated", PropertyInfo(Variant::INT, "user_id")));
 
 	BIND_ENUM_CONSTANT(STATE_DISCONNECTED);
 	BIND_ENUM_CONSTANT(STATE_CONNECTING);
@@ -106,6 +146,27 @@ void Discord::_bind_methods() {
 	BIND_ENUM_CONSTANT(AUTH_AUTHORIZED);
 	BIND_ENUM_CONSTANT(AUTH_READY);
 	BIND_ENUM_CONSTANT(AUTH_FAILED);
+
+	BIND_ENUM_CONSTANT(RELATIONSHIP_NONE);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_FRIEND);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_BLOCKED);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_PENDING_INCOMING);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_PENDING_OUTGOING);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_IMPLICIT);
+	BIND_ENUM_CONSTANT(RELATIONSHIP_SUGGESTION);
+
+	BIND_ENUM_CONSTANT(GROUP_ONLINE_PLAYING_GAME);
+	BIND_ENUM_CONSTANT(GROUP_ONLINE_ELSEWHERE);
+	BIND_ENUM_CONSTANT(GROUP_OFFLINE);
+
+	BIND_ENUM_CONSTANT(STATUS_ONLINE);
+	BIND_ENUM_CONSTANT(STATUS_OFFLINE);
+	BIND_ENUM_CONSTANT(STATUS_BLOCKED);
+	BIND_ENUM_CONSTANT(STATUS_IDLE);
+	BIND_ENUM_CONSTANT(STATUS_DND);
+	BIND_ENUM_CONSTANT(STATUS_INVISIBLE);
+	BIND_ENUM_CONSTANT(STATUS_STREAMING);
+	BIND_ENUM_CONSTANT(STATUS_UNKNOWN);
 }
 
 Discord *Discord::get_singleton() {
@@ -155,11 +216,25 @@ void Discord::_set_auth_state(AuthState p_state) {
 	_log_lifecycle(vformat("Auth state -> %d", (int)p_state));
 }
 
-Error Discord::_require_auth_ready(const char *p_operation) {
+Error Discord::_require_presence_ready(const char *p_operation) {
+	if (ready_for_presence && (presence_only_mode || auth_state == AUTH_READY)) {
+		return OK;
+	}
+	last_error = vformat("Discord is not ready for %s (presence_only=%s, auth_state=%d, connection=%d)",
+			p_operation, presence_only_mode ? "true" : "false", (int)auth_state, (int)connection_state);
+	return ERR_UNAUTHORIZED;
+}
+
+Error Discord::_require_oauth_ready(const char *p_operation) {
+	if (presence_only_mode) {
+		last_error = vformat("Discord OAuth is required for %s (presence-only mode active)", p_operation);
+		return ERR_UNAUTHORIZED;
+	}
 	if (ready_for_presence && auth_state == AUTH_READY) {
 		return OK;
 	}
-	last_error = vformat("Discord is not ready for %s (auth_state=%d, connection=%d)", p_operation, (int)auth_state, (int)connection_state);
+	last_error = vformat("Discord OAuth is not ready for %s (auth_state=%d, connection=%d)",
+			p_operation, (int)auth_state, (int)connection_state);
 	return ERR_UNAUTHORIZED;
 }
 
@@ -378,6 +453,15 @@ void Discord::_update_rich_presence_callback(Discord_ClientResult *result, void 
 	discord->emit_signal(SNAME("rich_presence_updated"), success, error);
 }
 
+void Discord::_emit_ready_once() {
+	if (ready_signal_emitted) {
+		return;
+	}
+	ready_signal_emitted = true;
+	_log_lifecycle("Client is ready for rich presence");
+	emit_signal(SNAME("ready"));
+}
+
 void Discord::_on_client_ready() {
 	if (ready_for_presence) {
 		return;
@@ -397,16 +481,11 @@ void Discord::_on_client_ready() {
 	}
 
 	_refresh_relationships();
-
-	if (!ready_signal_emitted) {
-		ready_signal_emitted = true;
-		_log_lifecycle("Client is ready for rich presence");
-		emit_signal(SNAME("ready"));
-	}
+	_emit_ready_once();
 
 	const bool had_pending = has_pending_presence;
 	_apply_pending_presence();
-	if (!had_pending && last_presence_sent.is_empty()) {
+	if (!had_pending && last_presence_sent.is_empty() && !presence_only_mode) {
 		Dictionary sample;
 		sample["type"] = DISCORD_ACTIVITY_TYPE_PLAYING;
 		sample["details"] = "Rank: Diamond II";
@@ -489,8 +568,11 @@ void Discord::_reset_session() {
 	initialized = false;
 	ready_for_presence = false;
 	ready_signal_emitted = false;
+	presence_only_mode = false;
 	log_callback_registered = false;
 	authorize_dismiss_callback_registered = false;
+	activity_callbacks_registered = false;
+	relationship_callbacks_registered = false;
 	has_pending_presence = false;
 	pending_presence = Dictionary();
 	last_presence_sent = Dictionary();
@@ -499,6 +581,8 @@ void Discord::_reset_session() {
 	last_emitted_error_detail = 0;
 	last_polled_status = -1;
 	auth_state = AUTH_NONE;
+	pending_relationship_action = String();
+	pending_relationship_user_id = 0;
 	client_id = 0;
 }
 
@@ -515,7 +599,7 @@ bool Discord::is_available() {
 	return dll_available;
 }
 
-Error Discord::_initialize_client(int64_t p_client_id) {
+Error Discord::_setup_client(int64_t p_client_id) {
 	if (client_active) {
 		return OK;
 	}
@@ -527,7 +611,14 @@ Error Discord::_initialize_client(int64_t p_client_id) {
 	_register_log_callback();
 	_register_authorize_dismiss_callback();
 	_register_platform_hooks();
+	_register_activity_callbacks();
+	if (!presence_only_mode) {
+		_register_relationship_callbacks();
+	}
+	return OK;
+}
 
+Error Discord::_initialize_client_oauth(int64_t p_client_id) {
 	Discord_AuthorizationCodeVerifier verifier;
 	loader.client_create_authorization_code_verifier(&client, &verifier);
 
@@ -580,7 +671,13 @@ Error Discord::initialize(int64_t p_client_id) {
 	discord_try_connect_frame_hook();
 
 	client_id = p_client_id;
-	Error err = _initialize_client(p_client_id);
+	presence_only_mode = false;
+	Error err = _setup_client(p_client_id);
+	if (err != OK) {
+		_reset_session();
+		return err;
+	}
+	err = _initialize_client_oauth(p_client_id);
 	if (err != OK) {
 		_reset_session();
 		return err;
@@ -588,6 +685,37 @@ Error Discord::initialize(int64_t p_client_id) {
 
 	initialized = true;
 	_log_lifecycle(vformat("Discord auth started (client_id=%s)", String::num_int64(p_client_id)));
+	return OK;
+}
+
+Error Discord::initialize_presence_only(int64_t p_client_id) {
+	if (!is_available()) {
+		last_error = "Discord Social SDK runtime library not available";
+		return ERR_UNAVAILABLE;
+	}
+	if (initialized) {
+		return OK;
+	}
+	if (p_client_id <= 0) {
+		last_error = "client_id must be a positive Discord application ID";
+		return ERR_INVALID_PARAMETER;
+	}
+
+	discord_try_connect_frame_hook();
+
+	client_id = p_client_id;
+	presence_only_mode = true;
+	Error err = _setup_client(p_client_id);
+	if (err != OK) {
+		_reset_session();
+		return err;
+	}
+
+	initialized = true;
+	ready_for_presence = true;
+	_emit_ready_once();
+	_apply_pending_presence();
+	_log_lifecycle(vformat("Discord presence-only RPC started (client_id=%s)", String::num_int64(p_client_id)));
 	return OK;
 }
 
@@ -692,7 +820,7 @@ String Discord::get_default_communication_scopes() const {
 }
 
 Error Discord::update_rich_presence(const Dictionary &p_activity) {
-	if (_require_auth_ready("update_rich_presence") != OK) {
+	if (_require_presence_ready("update_rich_presence") != OK) {
 		pending_presence = p_activity;
 		has_pending_presence = true;
 		return ERR_UNAUTHORIZED;
@@ -701,7 +829,7 @@ Error Discord::update_rich_presence(const Dictionary &p_activity) {
 }
 
 Error Discord::_send_rich_presence(const Dictionary &p_activity) {
-	if (_require_auth_ready("update_rich_presence") != OK) {
+	if (_require_presence_ready("update_rich_presence") != OK) {
 		return ERR_UNAUTHORIZED;
 	}
 
@@ -719,15 +847,36 @@ Error Discord::_send_rich_presence(const Dictionary &p_activity) {
 	const int activity_type = p_activity.has("type") ? (int)p_activity["type"] : DISCORD_ACTIVITY_TYPE_PLAYING;
 	loader.activity_set_type(&activity, (Discord_ActivityTypes)activity_type);
 
+	if (p_activity.has("name")) {
+		loader.activity_set_name(&activity, (String)p_activity["name"]);
+	}
 	if (p_activity.has("details")) {
 		loader.activity_set_details(&activity, (String)p_activity["details"]);
 	}
 	if (p_activity.has("state")) {
 		loader.activity_set_state(&activity, (String)p_activity["state"]);
 	}
+	if (p_activity.has("details_url")) {
+		loader.activity_set_details_url(&activity, (String)p_activity["details_url"]);
+	}
+	if (p_activity.has("state_url")) {
+		loader.activity_set_state_url(&activity, (String)p_activity["state_url"]);
+	}
+	if (p_activity.has("status_display_type")) {
+		const Discord_StatusDisplayTypes display_type = _parse_status_display_type((String)p_activity["status_display_type"]);
+		loader.activity_set_status_display_type(&activity, display_type);
+	}
+	if (p_activity.has("supported_platforms")) {
+		const Discord_ActivityGamePlatforms platforms = _parse_supported_platforms(p_activity["supported_platforms"]);
+		if (platforms != 0) {
+			loader.activity_set_supported_platforms(&activity, platforms);
+		}
+	}
 
 	const bool has_assets = p_activity.has("large_image") || p_activity.has("large_text") ||
-			p_activity.has("small_image") || p_activity.has("small_text");
+			p_activity.has("small_image") || p_activity.has("small_text") ||
+			p_activity.has("large_url") || p_activity.has("small_url") ||
+			p_activity.has("invite_cover_image");
 	if (has_assets) {
 		Discord_ActivityAssets assets;
 		loader.activity_assets_init(&assets);
@@ -737,11 +886,20 @@ Error Discord::_send_rich_presence(const Dictionary &p_activity) {
 		if (p_activity.has("large_text")) {
 			loader.activity_assets_set_large_text(&assets, (String)p_activity["large_text"]);
 		}
+		if (p_activity.has("large_url")) {
+			loader.activity_assets_set_large_url(&assets, (String)p_activity["large_url"]);
+		}
 		if (p_activity.has("small_image")) {
 			loader.activity_assets_set_small_image(&assets, (String)p_activity["small_image"]);
 		}
 		if (p_activity.has("small_text")) {
 			loader.activity_assets_set_small_text(&assets, (String)p_activity["small_text"]);
+		}
+		if (p_activity.has("small_url")) {
+			loader.activity_assets_set_small_url(&assets, (String)p_activity["small_url"]);
+		}
+		if (p_activity.has("invite_cover_image")) {
+			loader.activity_assets_set_invite_cover_image(&assets, (String)p_activity["invite_cover_image"]);
 		}
 		loader.activity_set_assets(&activity, &assets);
 		loader.activity_assets_drop(&assets);
@@ -761,13 +919,66 @@ Error Discord::_send_rich_presence(const Dictionary &p_activity) {
 		loader.activity_timestamps_drop(&timestamps);
 	}
 
+	const bool has_party = p_activity.has("party_id") || p_activity.has("party_current") || p_activity.has("party_max");
+	if (has_party && loader.has_activity_extensions()) {
+		Discord_ActivityParty party;
+		loader.activity_party_init(&party);
+		if (p_activity.has("party_id")) {
+			loader.activity_party_set_id(&party, (String)p_activity["party_id"]);
+		}
+		if (p_activity.has("party_current")) {
+			loader.activity_party_set_current_size(&party, (int32_t)(int)p_activity["party_current"]);
+		}
+		if (p_activity.has("party_max")) {
+			loader.activity_party_set_max_size(&party, (int32_t)(int)p_activity["party_max"]);
+		}
+		loader.activity_set_party(&activity, &party);
+		loader.activity_party_drop(&party);
+	}
+
+	const bool has_secrets = p_activity.has("join_secret") || p_activity.has("spectate_secret") || p_activity.has("match_secret");
+	if (has_secrets && loader.has_activity_extensions()) {
+		Discord_ActivitySecrets secrets;
+		loader.activity_secrets_init(&secrets);
+		if (p_activity.has("join_secret")) {
+			loader.activity_secrets_set_join(&secrets, (String)p_activity["join_secret"]);
+		}
+		if (p_activity.has("spectate_secret") || p_activity.has("match_secret")) {
+			_log_debug("spectate_secret/match_secret are not supported by the loaded Discord SDK; use join_secret");
+		}
+		loader.activity_set_secrets(&activity, &secrets);
+		loader.activity_secrets_drop(&secrets);
+	}
+
+	if (p_activity.has("buttons") && loader.has_activity_extensions()) {
+		const Variant buttons_variant = p_activity["buttons"];
+		if (buttons_variant.get_type() == Variant::ARRAY) {
+			const Array buttons = buttons_variant;
+			for (int i = 0; i < buttons.size(); i++) {
+				if (buttons[i].get_type() != Variant::DICTIONARY) {
+					continue;
+				}
+				const Dictionary button_dict = buttons[i];
+				if (!button_dict.has("label") || !button_dict.has("url")) {
+					continue;
+				}
+				Discord_ActivityButton button;
+				loader.activity_button_init(&button);
+				loader.activity_button_set_label(&button, (String)button_dict["label"]);
+				loader.activity_button_set_url(&button, (String)button_dict["url"]);
+				loader.activity_add_button(&activity, &button);
+				loader.activity_button_drop(&button);
+			}
+		}
+	}
+
 	loader.client_update_rich_presence(&client, &activity, Discord::_update_rich_presence_callback, this);
 	loader.activity_drop(&activity);
 	return OK;
 }
 
 void Discord::clear_rich_presence() {
-	if (_require_auth_ready("clear_rich_presence") != OK) {
+	if (_require_presence_ready("clear_rich_presence") != OK) {
 		return;
 	}
 	loader.client_clear_rich_presence(&client);
@@ -873,7 +1084,7 @@ Dictionary Discord::get_game_activity() {
 }
 
 Ref<DiscordAuthResult> Discord::authenticate_with_server(const String &p_url, const String &p_access_token, int64_t p_client_id) {
-	if (_require_auth_ready("authenticate_with_server") != OK) {
+	if (_require_oauth_ready("authenticate_with_server") != OK) {
 		Ref<DiscordAuthResult> result;
 		result.instantiate();
 		result->set_error_message(last_error);
@@ -906,4 +1117,524 @@ Dictionary Discord::get_version() const {
 	version["runtime_library"] = DiscordAPILoader::get_runtime_library_name();
 	version["runtime_present"] = DiscordAPILoader::is_runtime_library_present();
 	return version;
+}
+
+void Discord::_register_activity_callbacks() {
+	if (!client_active || activity_callbacks_registered) {
+		return;
+	}
+	loader.client_set_activity_invite_created_callback(&client, Discord::_activity_invite_created_callback, this);
+	loader.client_set_activity_invite_updated_callback(&client, Discord::_activity_invite_updated_callback, this);
+	loader.client_set_activity_join_callback(&client, Discord::_activity_join_callback, this);
+	loader.client_set_lobby_created_callback(&client, Discord::_lobby_created_callback, this);
+	activity_callbacks_registered = true;
+}
+
+void Discord::_register_relationship_callbacks() {
+	if (!client_active || relationship_callbacks_registered || !loader.has_relationship_api()) {
+		return;
+	}
+	loader.client_set_relationship_created_callback(&client, Discord::_relationship_created_callback, this);
+	loader.client_set_relationship_deleted_callback(&client, Discord::_relationship_deleted_callback, this);
+	loader.client_set_relationship_groups_updated_callback(&client, Discord::_relationship_groups_updated_callback, this);
+	loader.client_set_user_updated_callback(&client, Discord::_user_updated_callback, this);
+	relationship_callbacks_registered = true;
+}
+
+Discord_StatusDisplayTypes Discord::_parse_status_display_type(const String &p_value) const {
+	const String normalized = p_value.to_lower();
+	if (normalized == "state") {
+		return DISCORD_STATUS_DISPLAY_TYPE_STATE;
+	}
+	if (normalized == "details") {
+		return DISCORD_STATUS_DISPLAY_TYPE_DETAILS;
+	}
+	return DISCORD_STATUS_DISPLAY_TYPE_NAME;
+}
+
+Discord_ActivityGamePlatforms Discord::_parse_supported_platforms(const Variant &p_value) const {
+	if (p_value.get_type() == Variant::INT) {
+		return (Discord_ActivityGamePlatforms)(int)p_value;
+	}
+	if (p_value.get_type() != Variant::ARRAY) {
+		return (Discord_ActivityGamePlatforms)0;
+	}
+	int mask = 0;
+	const Array platforms = p_value;
+	for (int i = 0; i < platforms.size(); i++) {
+		const String platform = String(platforms[i]).to_lower();
+		if (platform == "desktop") {
+			mask |= DISCORD_ACTIVITY_GAME_PLATFORM_DESKTOP;
+		} else if (platform == "xbox") {
+			mask |= DISCORD_ACTIVITY_GAME_PLATFORM_XBOX;
+		} else if (platform == "ios") {
+			mask |= DISCORD_ACTIVITY_GAME_PLATFORM_IOS;
+		} else if (platform == "android") {
+			mask |= DISCORD_ACTIVITY_GAME_PLATFORM_ANDROID;
+		}
+	}
+	return (Discord_ActivityGamePlatforms)mask;
+}
+
+Dictionary Discord::_serialize_user(Discord_UserHandle *p_user) {
+	Dictionary out;
+	if (!p_user) {
+		return out;
+	}
+	out["id"] = (int64_t)loader.user_handle_id(p_user);
+	out["username"] = loader.user_handle_username(p_user);
+	out["display_name"] = loader.user_handle_display_name(p_user);
+	out["global_name"] = loader.user_handle_global_name(p_user);
+	out["is_provisional"] = loader.user_handle_is_provisional(p_user);
+	out["status"] = (int)loader.user_handle_status(p_user);
+	out["avatar_url"] = loader.user_handle_avatar_url(p_user);
+	Discord_Activity activity;
+	out["has_game_activity"] = loader.user_handle_game_activity(p_user, &activity);
+	if (out["has_game_activity"]) {
+		loader.activity_drop(&activity);
+	}
+	return out;
+}
+
+Dictionary Discord::_serialize_relationship(Discord_RelationshipHandle *p_relationship) {
+	Dictionary out;
+	if (!p_relationship) {
+		return out;
+	}
+	const uint64_t relationship_id = loader.relationship_handle_id(p_relationship);
+	out["user_id"] = (int64_t)relationship_id;
+	out["discord_relationship_type"] = (int)loader.relationship_handle_discord_relationship_type(p_relationship);
+	out["game_relationship_type"] = (int)loader.relationship_handle_game_relationship_type(p_relationship);
+	out["is_spam_request"] = loader.relationship_handle_is_spam_request(p_relationship);
+	Discord_UserHandle user;
+	if (loader.relationship_handle_user(p_relationship, &user)) {
+		out["user"] = _serialize_user(&user);
+		loader.user_handle_drop(&user);
+	}
+	return out;
+}
+
+Array Discord::_serialize_relationship_span(const Discord_RelationshipHandleSpan &p_span) {
+	Array out;
+	for (size_t i = 0; i < p_span.size; i++) {
+		out.push_back(_serialize_relationship(&p_span.ptr[i]));
+	}
+	return out;
+}
+
+bool Discord::_build_activity_invite(const Dictionary &p_invite, Discord_ActivityInvite *r_invite) const {
+	if (!r_invite || !loader.has_invite_api()) {
+		return false;
+	}
+	loader.activity_invite_init(r_invite);
+	if (p_invite.has("sender_id")) {
+		loader.activity_invite_set_sender_id(r_invite, (uint64_t)(int64_t)p_invite["sender_id"]);
+	}
+	if (p_invite.has("channel_id")) {
+		loader.activity_invite_set_channel_id(r_invite, (uint64_t)(int64_t)p_invite["channel_id"]);
+	}
+	if (p_invite.has("message_id")) {
+		loader.activity_invite_set_message_id(r_invite, (uint64_t)(int64_t)p_invite["message_id"]);
+	}
+	if (p_invite.has("type")) {
+		loader.activity_invite_set_type(r_invite, (Discord_ActivityActionTypes)(int)p_invite["type"]);
+	}
+	if (p_invite.has("application_id")) {
+		loader.activity_invite_set_application_id(r_invite, (uint64_t)(int64_t)p_invite["application_id"]);
+	}
+	if (p_invite.has("parent_application_id")) {
+		loader.activity_invite_set_parent_application_id(r_invite, (uint64_t)(int64_t)p_invite["parent_application_id"]);
+	}
+	if (p_invite.has("party_id")) {
+		loader.activity_invite_set_party_id(r_invite, (String)p_invite["party_id"]);
+	}
+	if (p_invite.has("session_id")) {
+		loader.activity_invite_set_session_id(r_invite, (String)p_invite["session_id"]);
+	}
+	if (p_invite.has("is_valid")) {
+		loader.activity_invite_set_is_valid(r_invite, (bool)p_invite["is_valid"]);
+	}
+	return true;
+}
+
+void Discord::_emit_relationship_action_completed(Discord_ClientResult *result, const String &p_action, uint64_t p_user_id) {
+	const bool success = result ? loader.client_result_successful(result) : false;
+	const String error = success ? String() : (result ? loader.client_result_error(result) : String("Discord SDK relationship API unavailable"));
+	if (result) {
+		loader.client_result_drop(result);
+	}
+	emit_signal(SNAME("relationship_action_completed"), p_action, (int64_t)p_user_id, success, error);
+}
+
+bool Discord::register_launch_command(int64_t p_application_id, const String &p_command) {
+	if (_require_presence_ready("register_launch_command") != OK) {
+		return false;
+	}
+	const int64_t app_id = p_application_id > 0 ? p_application_id : client_id;
+	return loader.client_register_launch_command(&client, (uint64_t)app_id, p_command);
+}
+
+bool Discord::register_launch_steam_application(int64_t p_application_id, int p_steam_app_id) {
+	if (_require_presence_ready("register_launch_steam_application") != OK) {
+		return false;
+	}
+	const int64_t app_id = p_application_id > 0 ? p_application_id : client_id;
+	return loader.client_register_launch_steam_application(&client, (uint64_t)app_id, (uint32_t)p_steam_app_id);
+}
+
+void Discord::send_activity_invite(uint64_t p_user_id, const String &p_content) {
+	if (_require_oauth_ready("send_activity_invite") != OK) {
+		return;
+	}
+	loader.client_send_activity_invite(&client, p_user_id, p_content, Discord::_send_activity_invite_callback, this);
+}
+
+void Discord::send_activity_join_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("send_activity_join_request") != OK) {
+		return;
+	}
+	loader.client_send_activity_join_request(&client, p_user_id, Discord::_send_activity_invite_callback, this);
+}
+
+void Discord::send_activity_join_request_reply(const Dictionary &p_invite) {
+	if (_require_oauth_ready("send_activity_join_request_reply") != OK) {
+		return;
+	}
+	Discord_ActivityInvite invite;
+	if (!_build_activity_invite(p_invite, &invite)) {
+		last_error = "Failed to build activity invite";
+		return;
+	}
+	loader.client_send_activity_join_request_reply(&client, &invite, Discord::_send_activity_invite_callback, this);
+	loader.activity_invite_drop(&invite);
+}
+
+void Discord::accept_activity_invite(const Dictionary &p_invite) {
+	if (_require_oauth_ready("accept_activity_invite") != OK) {
+		return;
+	}
+	Discord_ActivityInvite invite;
+	if (!_build_activity_invite(p_invite, &invite)) {
+		last_error = "Failed to build activity invite";
+		return;
+	}
+	loader.client_accept_activity_invite(&client, &invite, Discord::_accept_activity_invite_callback, this);
+	loader.activity_invite_drop(&invite);
+}
+
+void Discord::create_or_join_lobby(const String &p_secret) {
+	if (_require_oauth_ready("create_or_join_lobby") != OK) {
+		return;
+	}
+	loader.client_create_or_join_lobby(&client, p_secret, Discord::_create_or_join_lobby_callback, this);
+}
+
+Array Discord::get_relationships() {
+	Array out;
+	if (_require_oauth_ready("get_relationships") != OK) {
+		return out;
+	}
+	Discord_RelationshipHandleSpan span;
+	loader.client_get_relationships(&client, &span);
+	return _serialize_relationship_span(span);
+}
+
+Array Discord::get_relationships_by_group(RelationshipGroupType p_group) {
+	Array out;
+	if (_require_oauth_ready("get_relationships_by_group") != OK) {
+		return out;
+	}
+	Discord_RelationshipHandleSpan span;
+	loader.client_get_relationships_by_group(&client, (Discord_RelationshipGroupType)p_group, &span);
+	return _serialize_relationship_span(span);
+}
+
+Dictionary Discord::get_relationship(uint64_t p_user_id) {
+	Dictionary out;
+	if (_require_oauth_ready("get_relationship") != OK) {
+		return out;
+	}
+	Discord_RelationshipHandle relationship;
+	loader.client_get_relationship_handle(&client, p_user_id, &relationship);
+	out = _serialize_relationship(&relationship);
+	loader.relationship_handle_drop(&relationship);
+	return out;
+}
+
+Dictionary Discord::get_user(uint64_t p_user_id) {
+	Dictionary out;
+	if (_require_oauth_ready("get_user") != OK) {
+		return out;
+	}
+	Discord_UserHandle user;
+	if (!loader.client_get_user(&client, p_user_id, &user)) {
+		return out;
+	}
+	out = _serialize_user(&user);
+	loader.user_handle_drop(&user);
+	return out;
+}
+
+void Discord::refresh_relationships() {
+	if (_require_oauth_ready("refresh_relationships") != OK) {
+		return;
+	}
+	_refresh_relationships();
+}
+
+void Discord::send_game_friend_request(const String &p_username) {
+	if (_require_oauth_ready("send_game_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "send_game_friend_request";
+	pending_relationship_user_id = 0;
+	loader.client_send_game_friend_request(&client, p_username, Discord::_send_friend_request_callback, this);
+}
+
+void Discord::send_game_friend_request_by_id(uint64_t p_user_id) {
+	if (_require_oauth_ready("send_game_friend_request_by_id") != OK) {
+		return;
+	}
+	pending_relationship_action = "send_game_friend_request_by_id";
+	pending_relationship_user_id = p_user_id;
+	loader.client_send_game_friend_request_by_id(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::send_discord_friend_request(const String &p_username) {
+	if (_require_oauth_ready("send_discord_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "send_discord_friend_request";
+	pending_relationship_user_id = 0;
+	loader.client_send_discord_friend_request(&client, p_username, Discord::_send_friend_request_callback, this);
+}
+
+void Discord::send_discord_friend_request_by_id(uint64_t p_user_id) {
+	if (_require_oauth_ready("send_discord_friend_request_by_id") != OK) {
+		return;
+	}
+	pending_relationship_action = "send_discord_friend_request_by_id";
+	pending_relationship_user_id = p_user_id;
+	loader.client_send_discord_friend_request_by_id(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::accept_game_friend_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("accept_game_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "accept_game_friend_request";
+	pending_relationship_user_id = p_user_id;
+	loader.client_accept_game_friend_request(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::accept_discord_friend_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("accept_discord_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "accept_discord_friend_request";
+	pending_relationship_user_id = p_user_id;
+	loader.client_accept_discord_friend_request(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::reject_game_friend_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("reject_game_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "reject_game_friend_request";
+	pending_relationship_user_id = p_user_id;
+	loader.client_reject_game_friend_request(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::reject_discord_friend_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("reject_discord_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "reject_discord_friend_request";
+	pending_relationship_user_id = p_user_id;
+	loader.client_reject_discord_friend_request(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::cancel_game_friend_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("cancel_game_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "cancel_game_friend_request";
+	pending_relationship_user_id = p_user_id;
+	loader.client_cancel_game_friend_request(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::cancel_discord_friend_request(uint64_t p_user_id) {
+	if (_require_oauth_ready("cancel_discord_friend_request") != OK) {
+		return;
+	}
+	pending_relationship_action = "cancel_discord_friend_request";
+	pending_relationship_user_id = p_user_id;
+	loader.client_cancel_discord_friend_request(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::remove_game_friend(uint64_t p_user_id) {
+	if (_require_oauth_ready("remove_game_friend") != OK) {
+		return;
+	}
+	pending_relationship_action = "remove_game_friend";
+	pending_relationship_user_id = p_user_id;
+	loader.client_remove_game_friend(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::remove_discord_and_game_friend(uint64_t p_user_id) {
+	if (_require_oauth_ready("remove_discord_and_game_friend") != OK) {
+		return;
+	}
+	pending_relationship_action = "remove_discord_and_game_friend";
+	pending_relationship_user_id = p_user_id;
+	loader.client_remove_discord_and_game_friend(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::block_user(uint64_t p_user_id) {
+	if (_require_oauth_ready("block_user") != OK) {
+		return;
+	}
+	pending_relationship_action = "block_user";
+	pending_relationship_user_id = p_user_id;
+	loader.client_block_user(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::unblock_user(uint64_t p_user_id) {
+	if (_require_oauth_ready("unblock_user") != OK) {
+		return;
+	}
+	pending_relationship_action = "unblock_user";
+	pending_relationship_user_id = p_user_id;
+	loader.client_unblock_user(&client, p_user_id, Discord::_relationship_action_callback, this);
+}
+
+void Discord::_activity_invite_created_callback(Discord_ActivityInvite *invite, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord || !invite) {
+		return;
+	}
+	discord->emit_signal(SNAME("activity_invite_created"), discord->loader.activity_invite_to_dict(invite));
+}
+
+void Discord::_activity_invite_updated_callback(Discord_ActivityInvite *invite, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord || !invite) {
+		return;
+	}
+	discord->emit_signal(SNAME("activity_invite_updated"), discord->loader.activity_invite_to_dict(invite));
+}
+
+void Discord::_activity_join_callback(Discord_String join_secret, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->emit_signal(SNAME("activity_join_requested"), DiscordAPILoader::to_godot_string(join_secret));
+}
+
+void Discord::_accept_activity_invite_callback(Discord_ClientResult *result, Discord_String join_secret, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	const bool success = discord->loader.client_result_successful(result);
+	const String error = success ? String() : discord->loader.client_result_error(result);
+	discord->loader.client_result_drop(result);
+	if (success) {
+		discord->emit_signal(SNAME("activity_invite_accepted"), DiscordAPILoader::to_godot_string(join_secret));
+	} else if (!error.is_empty()) {
+		discord->_set_last_error(error);
+	}
+}
+
+void Discord::_send_activity_invite_callback(Discord_ClientResult *result, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	const bool success = discord->loader.client_result_successful(result);
+	const String error = success ? String() : discord->loader.client_result_error(result);
+	discord->loader.client_result_drop(result);
+	if (success) {
+		discord->emit_signal(SNAME("activity_invite_sent"));
+	} else if (!error.is_empty()) {
+		discord->_set_last_error(error);
+	}
+}
+
+void Discord::_create_or_join_lobby_callback(Discord_ClientResult *result, uint64_t lobby_id, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	const bool success = discord->loader.client_result_successful(result);
+	const String error = success ? String() : discord->loader.client_result_error(result);
+	discord->loader.client_result_drop(result);
+	if (success) {
+		discord->emit_signal(SNAME("lobby_joined"), (int64_t)lobby_id);
+	} else if (!error.is_empty()) {
+		discord->_set_last_error(error);
+	}
+}
+
+void Discord::_lobby_created_callback(uint64_t lobby_id, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->emit_signal(SNAME("lobby_joined"), (int64_t)lobby_id);
+}
+
+void Discord::_relationship_created_callback(uint64_t user_id, bool is_discord, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->emit_signal(SNAME("relationship_created"), (int64_t)user_id, is_discord);
+}
+
+void Discord::_relationship_deleted_callback(uint64_t user_id, bool is_discord, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->emit_signal(SNAME("relationship_deleted"), (int64_t)user_id, is_discord);
+}
+
+void Discord::_relationship_groups_updated_callback(uint64_t user_id, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->emit_signal(SNAME("relationship_groups_updated"), (int64_t)user_id);
+}
+
+void Discord::_user_updated_callback(uint64_t user_id, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	discord->emit_signal(SNAME("user_updated"), (int64_t)user_id);
+}
+
+void Discord::_relationship_action_callback(Discord_ClientResult *result, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	const String action = discord->pending_relationship_action;
+	const uint64_t user_id = discord->pending_relationship_user_id;
+	discord->pending_relationship_action = String();
+	discord->pending_relationship_user_id = 0;
+	discord->_emit_relationship_action_completed(result, action, user_id);
+}
+
+void Discord::_send_friend_request_callback(Discord_ClientResult *result, void *user_data) {
+	Discord *discord = (Discord *)user_data;
+	if (!discord) {
+		return;
+	}
+	const String action = discord->pending_relationship_action;
+	discord->pending_relationship_action = String();
+	discord->_emit_relationship_action_completed(result, action, 0);
 }

--- a/modules/discord_module/discord.h
+++ b/modules/discord_module/discord.h
@@ -61,6 +61,33 @@ public:
 		AUTH_FAILED,
 	};
 
+	enum RelationshipType {
+		RELATIONSHIP_NONE = DISCORD_RELATIONSHIP_TYPE_NONE,
+		RELATIONSHIP_FRIEND = DISCORD_RELATIONSHIP_TYPE_FRIEND,
+		RELATIONSHIP_BLOCKED = DISCORD_RELATIONSHIP_TYPE_BLOCKED,
+		RELATIONSHIP_PENDING_INCOMING = DISCORD_RELATIONSHIP_TYPE_PENDING_INCOMING,
+		RELATIONSHIP_PENDING_OUTGOING = DISCORD_RELATIONSHIP_TYPE_PENDING_OUTGOING,
+		RELATIONSHIP_IMPLICIT = DISCORD_RELATIONSHIP_TYPE_IMPLICIT,
+		RELATIONSHIP_SUGGESTION = DISCORD_RELATIONSHIP_TYPE_SUGGESTION,
+	};
+
+	enum RelationshipGroupType {
+		GROUP_ONLINE_PLAYING_GAME = DISCORD_RELATIONSHIP_GROUP_TYPE_ONLINE_PLAYING_GAME,
+		GROUP_ONLINE_ELSEWHERE = DISCORD_RELATIONSHIP_GROUP_TYPE_ONLINE_ELSEWHERE,
+		GROUP_OFFLINE = DISCORD_RELATIONSHIP_GROUP_TYPE_OFFLINE,
+	};
+
+	enum StatusType {
+		STATUS_ONLINE = DISCORD_STATUS_TYPE_ONLINE,
+		STATUS_OFFLINE = DISCORD_STATUS_TYPE_OFFLINE,
+		STATUS_BLOCKED = DISCORD_STATUS_TYPE_BLOCKED,
+		STATUS_IDLE = DISCORD_STATUS_TYPE_IDLE,
+		STATUS_DND = DISCORD_STATUS_TYPE_DND,
+		STATUS_INVISIBLE = DISCORD_STATUS_TYPE_INVISIBLE,
+		STATUS_STREAMING = DISCORD_STATUS_TYPE_STREAMING,
+		STATUS_UNKNOWN = DISCORD_STATUS_TYPE_UNKNOWN,
+	};
+
 private:
 	static Discord *singleton;
 
@@ -70,12 +97,15 @@ private:
 
 	bool dll_available = false;
 	bool initialized = false;
+	bool presence_only_mode = false;
 	bool ready_for_presence = false;
 	bool ready_signal_emitted = false;
 	bool debug_logging = false;
 	bool client_active = false;
 	bool log_callback_registered = false;
 	bool authorize_dismiss_callback_registered = false;
+	bool activity_callbacks_registered = false;
+	bool relationship_callbacks_registered = false;
 	bool has_pending_presence = false;
 	int64_t client_id = 0;
 	int relationships_count = -1;
@@ -89,6 +119,8 @@ private:
 	String requested_scopes;
 	String granted_scopes;
 	String oauth_scope_preset;
+	String pending_relationship_action;
+	uint64_t pending_relationship_user_id = 0;
 	uint64_t user_id = 0;
 	ConnectionState connection_state = STATE_DISCONNECTED;
 	String last_error;
@@ -104,11 +136,13 @@ private:
 	void _set_last_error(const String &p_error);
 	void _set_auth_state(AuthState p_state);
 	void _report_authorization_failed(const String &p_error);
-	Error _require_auth_ready(const char *p_operation);
+	Error _require_presence_ready(const char *p_operation);
+	Error _require_oauth_ready(const char *p_operation);
 	void _sync_connection_state(Discord_Client_Status p_status, int p_error, int p_error_detail, bool p_emit_signal);
 	void _reset_session();
 	void _clear_auth_flow();
 	void _on_client_ready();
+	void _emit_ready_once();
 	void _apply_pending_presence();
 	Error _send_rich_presence(const Dictionary &p_activity);
 	void _log_game_activity_readback();
@@ -122,11 +156,21 @@ private:
 	void _register_log_callback();
 	void _register_authorize_dismiss_callback();
 	void _register_platform_hooks();
+	void _register_activity_callbacks();
+	void _register_relationship_callbacks();
 	static ConnectionState _map_client_status(Discord_Client_Status p_status);
-	Error _initialize_client(int64_t p_client_id);
+	Error _setup_client(int64_t p_client_id);
+	Error _initialize_client_oauth(int64_t p_client_id);
 	void _run_client_callbacks();
 	void _disconnect_client();
 	void _start_token_exchange(DiscordAuthFlow *p_flow, const String &p_auth_code);
+	Dictionary _serialize_user(Discord_UserHandle *p_user);
+	Dictionary _serialize_relationship(Discord_RelationshipHandle *p_relationship);
+	Array _serialize_relationship_span(const Discord_RelationshipHandleSpan &p_span);
+	Discord_ActivityGamePlatforms _parse_supported_platforms(const Variant &p_value) const;
+	Discord_StatusDisplayTypes _parse_status_display_type(const String &p_value) const;
+	bool _build_activity_invite(const Dictionary &p_invite, Discord_ActivityInvite *r_invite) const;
+	void _emit_relationship_action_completed(Discord_ClientResult *result, const String &p_action, uint64_t p_user_id);
 
 	static void _authorize_callback(Discord_ClientResult *result, Discord_String code, Discord_String redirect_uri, void *user_data);
 	static void _token_exchange_callback(Discord_ClientResult *result,
@@ -141,6 +185,19 @@ private:
 	static void _log_callback(Discord_String message, Discord_LoggingSeverity severity, void *user_data);
 	static void _authorize_device_screen_closed_callback(void *user_data);
 	static void _update_rich_presence_callback(Discord_ClientResult *result, void *user_data);
+	static void _activity_invite_created_callback(Discord_ActivityInvite *invite, void *user_data);
+	static void _activity_invite_updated_callback(Discord_ActivityInvite *invite, void *user_data);
+	static void _activity_join_callback(Discord_String join_secret, void *user_data);
+	static void _accept_activity_invite_callback(Discord_ClientResult *result, Discord_String join_secret, void *user_data);
+	static void _send_activity_invite_callback(Discord_ClientResult *result, void *user_data);
+	static void _create_or_join_lobby_callback(Discord_ClientResult *result, uint64_t lobby_id, void *user_data);
+	static void _lobby_created_callback(uint64_t lobby_id, void *user_data);
+	static void _relationship_created_callback(uint64_t user_id, bool is_discord, void *user_data);
+	static void _relationship_deleted_callback(uint64_t user_id, bool is_discord, void *user_data);
+	static void _relationship_groups_updated_callback(uint64_t user_id, void *user_data);
+	static void _user_updated_callback(uint64_t user_id, void *user_data);
+	static void _relationship_action_callback(Discord_ClientResult *result, void *user_data);
+	static void _send_friend_request_callback(Discord_ClientResult *result, void *user_data);
 
 protected:
 	static void _bind_methods();
@@ -150,8 +207,10 @@ public:
 
 	bool is_available();
 	Error initialize(int64_t p_client_id = 0);
+	Error initialize_presence_only(int64_t p_client_id);
 	void shutdown();
 	bool is_initialized() const { return initialized; }
+	bool is_presence_only_mode() const { return presence_only_mode; }
 	bool is_client_active() const { return client_active; }
 	bool is_ready_for_presence() const { return ready_for_presence; }
 	AuthState get_auth_state() const { return auth_state; }
@@ -181,6 +240,35 @@ public:
 	Error update_rich_presence(const Dictionary &p_activity);
 	void clear_rich_presence();
 
+	bool register_launch_command(int64_t p_application_id, const String &p_command);
+	bool register_launch_steam_application(int64_t p_application_id, int p_steam_app_id);
+	void send_activity_invite(uint64_t p_user_id, const String &p_content = String());
+	void send_activity_join_request(uint64_t p_user_id);
+	void send_activity_join_request_reply(const Dictionary &p_invite);
+	void accept_activity_invite(const Dictionary &p_invite);
+	void create_or_join_lobby(const String &p_secret);
+
+	Array get_relationships();
+	Array get_relationships_by_group(RelationshipGroupType p_group);
+	Dictionary get_relationship(uint64_t p_user_id);
+	Dictionary get_user(uint64_t p_user_id);
+	void refresh_relationships();
+
+	void send_game_friend_request(const String &p_username);
+	void send_game_friend_request_by_id(uint64_t p_user_id);
+	void send_discord_friend_request(const String &p_username);
+	void send_discord_friend_request_by_id(uint64_t p_user_id);
+	void accept_game_friend_request(uint64_t p_user_id);
+	void accept_discord_friend_request(uint64_t p_user_id);
+	void reject_game_friend_request(uint64_t p_user_id);
+	void reject_discord_friend_request(uint64_t p_user_id);
+	void cancel_game_friend_request(uint64_t p_user_id);
+	void cancel_discord_friend_request(uint64_t p_user_id);
+	void remove_game_friend(uint64_t p_user_id);
+	void remove_discord_and_game_friend(uint64_t p_user_id);
+	void block_user(uint64_t p_user_id);
+	void unblock_user(uint64_t p_user_id);
+
 	Ref<DiscordAuthResult> authenticate_with_server(const String &p_url, const String &p_access_token, int64_t p_client_id);
 	Dictionary get_version() const;
 
@@ -190,3 +278,6 @@ public:
 
 VARIANT_ENUM_CAST(Discord::ConnectionState);
 VARIANT_ENUM_CAST(Discord::AuthState);
+VARIANT_ENUM_CAST(Discord::RelationshipType);
+VARIANT_ENUM_CAST(Discord::RelationshipGroupType);
+VARIANT_ENUM_CAST(Discord::StatusType);

--- a/modules/discord_module/discord_api_loader.cpp
+++ b/modules/discord_module/discord_api_loader.cpp
@@ -199,6 +199,91 @@ bool DiscordAPILoader::try_load() {
 			fn_client_set_authorize_device_screen_closed_callback);
 	LOAD_OPTIONAL("Discord_Client_SetGameWindowPid", fn_client_set_game_window_pid);
 	LOAD_OPTIONAL("Discord_Client_SetLogDir", fn_client_set_log_dir);
+	LOAD_OPTIONAL("Discord_Activity_SetName", fn_activity_set_name);
+	LOAD_OPTIONAL("Discord_Activity_SetStatusDisplayType", fn_activity_set_status_display_type);
+	LOAD_OPTIONAL("Discord_Activity_SetStateUrl", fn_activity_set_state_url);
+	LOAD_OPTIONAL("Discord_Activity_SetDetailsUrl", fn_activity_set_details_url);
+	LOAD_OPTIONAL("Discord_Activity_SetParty", fn_activity_set_party);
+	LOAD_OPTIONAL("Discord_Activity_SetSecrets", fn_activity_set_secrets);
+	LOAD_OPTIONAL("Discord_Activity_SetSupportedPlatforms", fn_activity_set_supported_platforms);
+	LOAD_OPTIONAL("Discord_Activity_AddButton", fn_activity_add_button);
+	LOAD_OPTIONAL("Discord_ActivityAssets_SetLargeUrl", fn_activity_assets_set_large_url);
+	LOAD_OPTIONAL("Discord_ActivityAssets_SetSmallUrl", fn_activity_assets_set_small_url);
+	LOAD_OPTIONAL("Discord_ActivityAssets_SetInviteCoverImage", fn_activity_assets_set_invite_cover_image);
+	LOAD_OPTIONAL("Discord_ActivityParty_Init", fn_activity_party_init);
+	LOAD_OPTIONAL("Discord_ActivityParty_Drop", fn_activity_party_drop);
+	LOAD_OPTIONAL("Discord_ActivityParty_SetId", fn_activity_party_set_id);
+	LOAD_OPTIONAL("Discord_ActivityParty_SetCurrentSize", fn_activity_party_set_current_size);
+	LOAD_OPTIONAL("Discord_ActivityParty_SetMaxSize", fn_activity_party_set_max_size);
+	LOAD_OPTIONAL("Discord_ActivitySecrets_Init", fn_activity_secrets_init);
+	LOAD_OPTIONAL("Discord_ActivitySecrets_Drop", fn_activity_secrets_drop);
+	LOAD_OPTIONAL("Discord_ActivitySecrets_SetJoin", fn_activity_secrets_set_join);
+	LOAD_OPTIONAL("Discord_ActivityButton_Init", fn_activity_button_init);
+	LOAD_OPTIONAL("Discord_ActivityButton_Drop", fn_activity_button_drop);
+	LOAD_OPTIONAL("Discord_ActivityButton_SetLabel", fn_activity_button_set_label);
+	LOAD_OPTIONAL("Discord_ActivityButton_SetUrl", fn_activity_button_set_url);
+	LOAD_OPTIONAL("Discord_ActivityInvite_Init", fn_activity_invite_init);
+	LOAD_OPTIONAL("Discord_ActivityInvite_Drop", fn_activity_invite_drop);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetSenderId", fn_activity_invite_set_sender_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetChannelId", fn_activity_invite_set_channel_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetMessageId", fn_activity_invite_set_message_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetType", fn_activity_invite_set_type);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetApplicationId", fn_activity_invite_set_application_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetParentApplicationId", fn_activity_invite_set_parent_application_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetPartyId", fn_activity_invite_set_party_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetSessionId", fn_activity_invite_set_session_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SetIsValid", fn_activity_invite_set_is_valid);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SenderId", fn_activity_invite_sender_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_ChannelId", fn_activity_invite_channel_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_MessageId", fn_activity_invite_message_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_Type", fn_activity_invite_type);
+	LOAD_OPTIONAL("Discord_ActivityInvite_ApplicationId", fn_activity_invite_application_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_ParentApplicationId", fn_activity_invite_parent_application_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_PartyId", fn_activity_invite_party_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_SessionId", fn_activity_invite_session_id);
+	LOAD_OPTIONAL("Discord_ActivityInvite_IsValid", fn_activity_invite_is_valid);
+	LOAD_OPTIONAL("Discord_Client_RegisterLaunchCommand", fn_client_register_launch_command);
+	LOAD_OPTIONAL("Discord_Client_RegisterLaunchSteamApplication", fn_client_register_launch_steam_application);
+	LOAD_OPTIONAL("Discord_Client_SendActivityInvite", fn_client_send_activity_invite);
+	LOAD_OPTIONAL("Discord_Client_SendActivityJoinRequest", fn_client_send_activity_join_request);
+	LOAD_OPTIONAL("Discord_Client_SendActivityJoinRequestReply", fn_client_send_activity_join_request_reply);
+	LOAD_OPTIONAL("Discord_Client_AcceptActivityInvite", fn_client_accept_activity_invite);
+	LOAD_OPTIONAL("Discord_Client_CreateOrJoinLobby", fn_client_create_or_join_lobby);
+	LOAD_OPTIONAL("Discord_Client_SetActivityInviteCreatedCallback", fn_client_set_activity_invite_created_callback);
+	LOAD_OPTIONAL("Discord_Client_SetActivityInviteUpdatedCallback", fn_client_set_activity_invite_updated_callback);
+	LOAD_OPTIONAL("Discord_Client_SetActivityJoinCallback", fn_client_set_activity_join_callback);
+	LOAD_OPTIONAL("Discord_Client_SetLobbyCreatedCallback", fn_client_set_lobby_created_callback);
+	LOAD_OPTIONAL("Discord_Client_GetRelationshipsByGroup", fn_client_get_relationships_by_group);
+	LOAD_OPTIONAL("Discord_Client_GetRelationshipHandle", fn_client_get_relationship_handle);
+	LOAD_OPTIONAL("Discord_Client_GetUser", fn_client_get_user);
+	LOAD_OPTIONAL("Discord_RelationshipHandle_DiscordRelationshipType", fn_relationship_handle_discord_relationship_type);
+	LOAD_OPTIONAL("Discord_RelationshipHandle_GameRelationshipType", fn_relationship_handle_game_relationship_type);
+	LOAD_OPTIONAL("Discord_RelationshipHandle_Id", fn_relationship_handle_id);
+	LOAD_OPTIONAL("Discord_RelationshipHandle_IsSpamRequest", fn_relationship_handle_is_spam_request);
+	LOAD_OPTIONAL("Discord_RelationshipHandle_User", fn_relationship_handle_user);
+	LOAD_OPTIONAL("Discord_RelationshipHandle_Drop", fn_relationship_handle_drop);
+	LOAD_OPTIONAL("Discord_UserHandle_GlobalName", fn_user_handle_global_name);
+	LOAD_OPTIONAL("Discord_UserHandle_Status", fn_user_handle_status);
+	LOAD_OPTIONAL("Discord_UserHandle_IsProvisional", fn_user_handle_is_provisional);
+	LOAD_OPTIONAL("Discord_UserHandle_AvatarUrl", fn_user_handle_avatar_url);
+	LOAD_OPTIONAL("Discord_Client_AcceptDiscordFriendRequest", fn_client_accept_discord_friend_request);
+	LOAD_OPTIONAL("Discord_Client_AcceptGameFriendRequest", fn_client_accept_game_friend_request);
+	LOAD_OPTIONAL("Discord_Client_BlockUser", fn_client_block_user);
+	LOAD_OPTIONAL("Discord_Client_CancelDiscordFriendRequest", fn_client_cancel_discord_friend_request);
+	LOAD_OPTIONAL("Discord_Client_CancelGameFriendRequest", fn_client_cancel_game_friend_request);
+	LOAD_OPTIONAL("Discord_Client_RejectDiscordFriendRequest", fn_client_reject_discord_friend_request);
+	LOAD_OPTIONAL("Discord_Client_RejectGameFriendRequest", fn_client_reject_game_friend_request);
+	LOAD_OPTIONAL("Discord_Client_RemoveDiscordAndGameFriend", fn_client_remove_discord_and_game_friend);
+	LOAD_OPTIONAL("Discord_Client_RemoveGameFriend", fn_client_remove_game_friend);
+	LOAD_OPTIONAL("Discord_Client_SendDiscordFriendRequest", fn_client_send_discord_friend_request);
+	LOAD_OPTIONAL("Discord_Client_SendDiscordFriendRequestById", fn_client_send_discord_friend_request_by_id);
+	LOAD_OPTIONAL("Discord_Client_SendGameFriendRequest", fn_client_send_game_friend_request);
+	LOAD_OPTIONAL("Discord_Client_SendGameFriendRequestById", fn_client_send_game_friend_request_by_id);
+	LOAD_OPTIONAL("Discord_Client_SetRelationshipCreatedCallback", fn_client_set_relationship_created_callback);
+	LOAD_OPTIONAL("Discord_Client_SetRelationshipDeletedCallback", fn_client_set_relationship_deleted_callback);
+	LOAD_OPTIONAL("Discord_Client_SetRelationshipGroupsUpdatedCallback", fn_client_set_relationship_groups_updated_callback);
+	LOAD_OPTIONAL("Discord_Client_SetUserUpdatedCallback", fn_client_set_user_updated_callback);
+	LOAD_OPTIONAL("Discord_Client_UnblockUser", fn_client_unblock_user);
 
 #undef LOAD_OPTIONAL
 
@@ -275,6 +360,91 @@ void DiscordAPILoader::unload() {
 	fn_client_get_version_patch = nullptr;
 	fn_client_set_game_window_pid = nullptr;
 	fn_client_set_log_dir = nullptr;
+	fn_activity_set_name = nullptr;
+	fn_activity_set_status_display_type = nullptr;
+	fn_activity_set_state_url = nullptr;
+	fn_activity_set_details_url = nullptr;
+	fn_activity_set_party = nullptr;
+	fn_activity_set_secrets = nullptr;
+	fn_activity_set_supported_platforms = nullptr;
+	fn_activity_add_button = nullptr;
+	fn_activity_assets_set_large_url = nullptr;
+	fn_activity_assets_set_small_url = nullptr;
+	fn_activity_assets_set_invite_cover_image = nullptr;
+	fn_activity_party_init = nullptr;
+	fn_activity_party_drop = nullptr;
+	fn_activity_party_set_id = nullptr;
+	fn_activity_party_set_current_size = nullptr;
+	fn_activity_party_set_max_size = nullptr;
+	fn_activity_secrets_init = nullptr;
+	fn_activity_secrets_drop = nullptr;
+	fn_activity_secrets_set_join = nullptr;
+	fn_activity_button_init = nullptr;
+	fn_activity_button_drop = nullptr;
+	fn_activity_button_set_label = nullptr;
+	fn_activity_button_set_url = nullptr;
+	fn_activity_invite_init = nullptr;
+	fn_activity_invite_drop = nullptr;
+	fn_activity_invite_set_sender_id = nullptr;
+	fn_activity_invite_set_channel_id = nullptr;
+	fn_activity_invite_set_message_id = nullptr;
+	fn_activity_invite_set_type = nullptr;
+	fn_activity_invite_set_application_id = nullptr;
+	fn_activity_invite_set_parent_application_id = nullptr;
+	fn_activity_invite_set_party_id = nullptr;
+	fn_activity_invite_set_session_id = nullptr;
+	fn_activity_invite_set_is_valid = nullptr;
+	fn_activity_invite_sender_id = nullptr;
+	fn_activity_invite_channel_id = nullptr;
+	fn_activity_invite_message_id = nullptr;
+	fn_activity_invite_type = nullptr;
+	fn_activity_invite_application_id = nullptr;
+	fn_activity_invite_parent_application_id = nullptr;
+	fn_activity_invite_party_id = nullptr;
+	fn_activity_invite_session_id = nullptr;
+	fn_activity_invite_is_valid = nullptr;
+	fn_client_register_launch_command = nullptr;
+	fn_client_register_launch_steam_application = nullptr;
+	fn_client_send_activity_invite = nullptr;
+	fn_client_send_activity_join_request = nullptr;
+	fn_client_send_activity_join_request_reply = nullptr;
+	fn_client_accept_activity_invite = nullptr;
+	fn_client_create_or_join_lobby = nullptr;
+	fn_client_set_activity_invite_created_callback = nullptr;
+	fn_client_set_activity_invite_updated_callback = nullptr;
+	fn_client_set_activity_join_callback = nullptr;
+	fn_client_set_lobby_created_callback = nullptr;
+	fn_client_get_relationships_by_group = nullptr;
+	fn_client_get_relationship_handle = nullptr;
+	fn_client_get_user = nullptr;
+	fn_relationship_handle_discord_relationship_type = nullptr;
+	fn_relationship_handle_game_relationship_type = nullptr;
+	fn_relationship_handle_id = nullptr;
+	fn_relationship_handle_is_spam_request = nullptr;
+	fn_relationship_handle_user = nullptr;
+	fn_relationship_handle_drop = nullptr;
+	fn_user_handle_global_name = nullptr;
+	fn_user_handle_status = nullptr;
+	fn_user_handle_is_provisional = nullptr;
+	fn_user_handle_avatar_url = nullptr;
+	fn_client_accept_discord_friend_request = nullptr;
+	fn_client_accept_game_friend_request = nullptr;
+	fn_client_block_user = nullptr;
+	fn_client_cancel_discord_friend_request = nullptr;
+	fn_client_cancel_game_friend_request = nullptr;
+	fn_client_reject_discord_friend_request = nullptr;
+	fn_client_reject_game_friend_request = nullptr;
+	fn_client_remove_discord_and_game_friend = nullptr;
+	fn_client_remove_game_friend = nullptr;
+	fn_client_send_discord_friend_request = nullptr;
+	fn_client_send_discord_friend_request_by_id = nullptr;
+	fn_client_send_game_friend_request = nullptr;
+	fn_client_send_game_friend_request_by_id = nullptr;
+	fn_client_set_relationship_created_callback = nullptr;
+	fn_client_set_relationship_deleted_callback = nullptr;
+	fn_client_set_relationship_groups_updated_callback = nullptr;
+	fn_client_set_user_updated_callback = nullptr;
+	fn_client_unblock_user = nullptr;
 }
 
 void DiscordAPILoader::run_callbacks() const {
@@ -647,5 +817,530 @@ void DiscordAPILoader::fill_version_dict(Dictionary &p_version) const {
 		p_version["hash"] = to_godot_string(hash);
 	} else {
 		p_version["hash"] = String();
+	}
+}
+
+#define DISCORD_LOADER_STRING_PTR(setter, fn_member)            \
+	void DiscordAPILoader::setter(Discord_ActivityAssets *self, \
+			const String &p_value) const {                      \
+		if (!fn_member) {                                       \
+			return;                                             \
+		}                                                       \
+		CharString utf8 = p_value.utf8();                       \
+		Discord_String str;                                     \
+		str.ptr = (uint8_t *)utf8.ptr();                        \
+		str.size = utf8.length();                               \
+		fn_member(self, &str);                                  \
+	}
+
+DISCORD_LOADER_STRING_PTR(activity_assets_set_large_url, fn_activity_assets_set_large_url)
+DISCORD_LOADER_STRING_PTR(activity_assets_set_small_url, fn_activity_assets_set_small_url)
+DISCORD_LOADER_STRING_PTR(activity_assets_set_invite_cover_image, fn_activity_assets_set_invite_cover_image)
+
+#undef DISCORD_LOADER_STRING_PTR
+
+void DiscordAPILoader::activity_set_name(Discord_Activity *self, const String &p_value) const {
+	if (!fn_activity_set_name) {
+		return;
+	}
+	Discord_String str = make_string(p_value);
+	fn_activity_set_name(self, str);
+}
+
+void DiscordAPILoader::activity_set_status_display_type(Discord_Activity *self, Discord_StatusDisplayTypes value) const {
+	if (!fn_activity_set_status_display_type) {
+		return;
+	}
+	fn_activity_set_status_display_type(self, &value);
+}
+
+void DiscordAPILoader::activity_set_state_url(Discord_Activity *self, const String &p_value) const {
+	if (!fn_activity_set_state_url) {
+		return;
+	}
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_set_state_url(self, &str);
+}
+
+void DiscordAPILoader::activity_set_details_url(Discord_Activity *self, const String &p_value) const {
+	if (!fn_activity_set_details_url) {
+		return;
+	}
+	CharString utf8 = p_value.utf8();
+	Discord_String str;
+	str.ptr = (uint8_t *)utf8.ptr();
+	str.size = utf8.length();
+	fn_activity_set_details_url(self, &str);
+}
+
+void DiscordAPILoader::activity_set_party(Discord_Activity *self, Discord_ActivityParty *value) const {
+	if (fn_activity_set_party) {
+		fn_activity_set_party(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_set_secrets(Discord_Activity *self, Discord_ActivitySecrets *value) const {
+	if (fn_activity_set_secrets) {
+		fn_activity_set_secrets(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_set_supported_platforms(Discord_Activity *self, Discord_ActivityGamePlatforms value) const {
+	if (fn_activity_set_supported_platforms) {
+		fn_activity_set_supported_platforms(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_add_button(Discord_Activity *self, Discord_ActivityButton const *button) const {
+	if (fn_activity_add_button) {
+		fn_activity_add_button(self, button);
+	}
+}
+
+void DiscordAPILoader::activity_party_init(Discord_ActivityParty *self) const {
+	if (fn_activity_party_init) {
+		fn_activity_party_init(self);
+	}
+}
+
+void DiscordAPILoader::activity_party_drop(Discord_ActivityParty *self) const {
+	if (fn_activity_party_drop) {
+		fn_activity_party_drop(self);
+	}
+}
+
+void DiscordAPILoader::activity_party_set_id(Discord_ActivityParty *self, const String &p_value) const {
+	if (fn_activity_party_set_id) {
+		fn_activity_party_set_id(self, make_string(p_value));
+	}
+}
+
+void DiscordAPILoader::activity_party_set_current_size(Discord_ActivityParty *self, int32_t value) const {
+	if (fn_activity_party_set_current_size) {
+		fn_activity_party_set_current_size(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_party_set_max_size(Discord_ActivityParty *self, int32_t value) const {
+	if (fn_activity_party_set_max_size) {
+		fn_activity_party_set_max_size(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_secrets_init(Discord_ActivitySecrets *self) const {
+	if (fn_activity_secrets_init) {
+		fn_activity_secrets_init(self);
+	}
+}
+
+void DiscordAPILoader::activity_secrets_drop(Discord_ActivitySecrets *self) const {
+	if (fn_activity_secrets_drop) {
+		fn_activity_secrets_drop(self);
+	}
+}
+
+void DiscordAPILoader::activity_secrets_set_join(Discord_ActivitySecrets *self, const String &p_value) const {
+	if (fn_activity_secrets_set_join) {
+		fn_activity_secrets_set_join(self, make_string(p_value));
+	}
+}
+
+void DiscordAPILoader::activity_button_init(Discord_ActivityButton *self) const {
+	if (fn_activity_button_init) {
+		fn_activity_button_init(self);
+	}
+}
+
+void DiscordAPILoader::activity_button_drop(Discord_ActivityButton *self) const {
+	if (fn_activity_button_drop) {
+		fn_activity_button_drop(self);
+	}
+}
+
+void DiscordAPILoader::activity_button_set_label(Discord_ActivityButton *self, const String &p_value) const {
+	if (fn_activity_button_set_label) {
+		fn_activity_button_set_label(self, make_string(p_value));
+	}
+}
+
+void DiscordAPILoader::activity_button_set_url(Discord_ActivityButton *self, const String &p_value) const {
+	if (fn_activity_button_set_url) {
+		fn_activity_button_set_url(self, make_string(p_value));
+	}
+}
+
+void DiscordAPILoader::activity_invite_init(Discord_ActivityInvite *self) const {
+	if (fn_activity_invite_init) {
+		fn_activity_invite_init(self);
+	}
+}
+
+void DiscordAPILoader::activity_invite_drop(Discord_ActivityInvite *self) const {
+	if (fn_activity_invite_drop) {
+		fn_activity_invite_drop(self);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_sender_id(Discord_ActivityInvite *self, uint64_t value) const {
+	if (fn_activity_invite_set_sender_id) {
+		fn_activity_invite_set_sender_id(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_channel_id(Discord_ActivityInvite *self, uint64_t value) const {
+	if (fn_activity_invite_set_channel_id) {
+		fn_activity_invite_set_channel_id(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_message_id(Discord_ActivityInvite *self, uint64_t value) const {
+	if (fn_activity_invite_set_message_id) {
+		fn_activity_invite_set_message_id(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_type(Discord_ActivityInvite *self, Discord_ActivityActionTypes value) const {
+	if (fn_activity_invite_set_type) {
+		fn_activity_invite_set_type(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_application_id(Discord_ActivityInvite *self, uint64_t value) const {
+	if (fn_activity_invite_set_application_id) {
+		fn_activity_invite_set_application_id(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_parent_application_id(Discord_ActivityInvite *self, uint64_t value) const {
+	if (fn_activity_invite_set_parent_application_id) {
+		fn_activity_invite_set_parent_application_id(self, value);
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_party_id(Discord_ActivityInvite *self, const String &p_value) const {
+	if (fn_activity_invite_set_party_id) {
+		fn_activity_invite_set_party_id(self, make_string(p_value));
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_session_id(Discord_ActivityInvite *self, const String &p_value) const {
+	if (fn_activity_invite_set_session_id) {
+		fn_activity_invite_set_session_id(self, make_string(p_value));
+	}
+}
+
+void DiscordAPILoader::activity_invite_set_is_valid(Discord_ActivityInvite *self, bool value) const {
+	if (fn_activity_invite_set_is_valid) {
+		fn_activity_invite_set_is_valid(self, value);
+	}
+}
+
+Dictionary DiscordAPILoader::activity_invite_to_dict(Discord_ActivityInvite *self) const {
+	Dictionary out;
+	if (!self) {
+		return out;
+	}
+	if (fn_activity_invite_sender_id) {
+		out["sender_id"] = (int64_t)fn_activity_invite_sender_id(self);
+	}
+	if (fn_activity_invite_channel_id) {
+		out["channel_id"] = (int64_t)fn_activity_invite_channel_id(self);
+	}
+	if (fn_activity_invite_message_id) {
+		out["message_id"] = (int64_t)fn_activity_invite_message_id(self);
+	}
+	if (fn_activity_invite_type) {
+		out["type"] = (int)fn_activity_invite_type(self);
+	}
+	if (fn_activity_invite_application_id) {
+		out["application_id"] = (int64_t)fn_activity_invite_application_id(self);
+	}
+	if (fn_activity_invite_parent_application_id) {
+		out["parent_application_id"] = (int64_t)fn_activity_invite_parent_application_id(self);
+	}
+	if (fn_activity_invite_party_id) {
+		Discord_String party_id;
+		fn_activity_invite_party_id(self, &party_id);
+		out["party_id"] = to_godot_string(party_id);
+	}
+	if (fn_activity_invite_session_id) {
+		Discord_String session_id;
+		fn_activity_invite_session_id(self, &session_id);
+		out["session_id"] = to_godot_string(session_id);
+	}
+	if (fn_activity_invite_is_valid) {
+		out["is_valid"] = fn_activity_invite_is_valid(self);
+	}
+	return out;
+}
+
+bool DiscordAPILoader::client_register_launch_command(Discord_Client *self, uint64_t application_id, const String &p_command) const {
+	if (!fn_client_register_launch_command) {
+		return false;
+	}
+	return fn_client_register_launch_command(self, application_id, make_string(p_command));
+}
+
+bool DiscordAPILoader::client_register_launch_steam_application(Discord_Client *self, uint64_t application_id, uint32_t steam_app_id) const {
+	if (!fn_client_register_launch_steam_application) {
+		return false;
+	}
+	return fn_client_register_launch_steam_application(self, application_id, steam_app_id);
+}
+
+void DiscordAPILoader::client_send_activity_invite(Discord_Client *self,
+		uint64_t user_id,
+		const String &p_content,
+		Discord_Client_SendActivityInviteCallback callback,
+		void *user_data) const {
+	if (fn_client_send_activity_invite) {
+		fn_client_send_activity_invite(self, user_id, make_string(p_content), callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_send_activity_join_request(Discord_Client *self,
+		uint64_t user_id,
+		Discord_Client_SendActivityInviteCallback callback,
+		void *user_data) const {
+	if (fn_client_send_activity_join_request) {
+		fn_client_send_activity_join_request(self, user_id, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_send_activity_join_request_reply(Discord_Client *self,
+		Discord_ActivityInvite *invite,
+		Discord_Client_SendActivityInviteCallback callback,
+		void *user_data) const {
+	if (fn_client_send_activity_join_request_reply) {
+		fn_client_send_activity_join_request_reply(self, invite, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_accept_activity_invite(Discord_Client *self,
+		Discord_ActivityInvite *invite,
+		Discord_Client_AcceptActivityInviteCallback callback,
+		void *user_data) const {
+	if (fn_client_accept_activity_invite) {
+		fn_client_accept_activity_invite(self, invite, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_create_or_join_lobby(Discord_Client *self,
+		const String &p_secret,
+		Discord_Client_CreateOrJoinLobbyCallback callback,
+		void *user_data) const {
+	if (fn_client_create_or_join_lobby) {
+		fn_client_create_or_join_lobby(self, make_string(p_secret), callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_activity_invite_created_callback(Discord_Client *self,
+		Discord_Client_ActivityInviteCallback callback,
+		void *user_data) const {
+	if (fn_client_set_activity_invite_created_callback) {
+		fn_client_set_activity_invite_created_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_activity_invite_updated_callback(Discord_Client *self,
+		Discord_Client_ActivityInviteCallback callback,
+		void *user_data) const {
+	if (fn_client_set_activity_invite_updated_callback) {
+		fn_client_set_activity_invite_updated_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_activity_join_callback(Discord_Client *self,
+		Discord_Client_ActivityJoinCallback callback,
+		void *user_data) const {
+	if (fn_client_set_activity_join_callback) {
+		fn_client_set_activity_join_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_lobby_created_callback(Discord_Client *self,
+		Discord_Client_LobbyCreatedCallback callback,
+		void *user_data) const {
+	if (fn_client_set_lobby_created_callback) {
+		fn_client_set_lobby_created_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_get_relationships_by_group(Discord_Client *self,
+		Discord_RelationshipGroupType group_type,
+		Discord_RelationshipHandleSpan *return_value) const {
+	if (fn_client_get_relationships_by_group) {
+		fn_client_get_relationships_by_group(self, group_type, return_value);
+	}
+}
+
+void DiscordAPILoader::client_get_relationship_handle(Discord_Client *self,
+		uint64_t user_id,
+		Discord_RelationshipHandle *return_value) const {
+	if (fn_client_get_relationship_handle) {
+		fn_client_get_relationship_handle(self, user_id, return_value);
+	}
+}
+
+bool DiscordAPILoader::client_get_user(Discord_Client *self, uint64_t user_id, Discord_UserHandle *return_value) const {
+	if (!fn_client_get_user) {
+		return false;
+	}
+	return fn_client_get_user(self, user_id, return_value);
+}
+
+void DiscordAPILoader::relationship_handle_drop(Discord_RelationshipHandle *self) const {
+	if (fn_relationship_handle_drop) {
+		fn_relationship_handle_drop(self);
+	}
+}
+
+Discord_RelationshipType DiscordAPILoader::relationship_handle_discord_relationship_type(Discord_RelationshipHandle *self) const {
+	if (!fn_relationship_handle_discord_relationship_type) {
+		return DISCORD_RELATIONSHIP_TYPE_NONE;
+	}
+	return fn_relationship_handle_discord_relationship_type(self);
+}
+
+Discord_RelationshipType DiscordAPILoader::relationship_handle_game_relationship_type(Discord_RelationshipHandle *self) const {
+	if (!fn_relationship_handle_game_relationship_type) {
+		return DISCORD_RELATIONSHIP_TYPE_NONE;
+	}
+	return fn_relationship_handle_game_relationship_type(self);
+}
+
+uint64_t DiscordAPILoader::relationship_handle_id(Discord_RelationshipHandle *self) const {
+	if (!fn_relationship_handle_id) {
+		return 0;
+	}
+	return fn_relationship_handle_id(self);
+}
+
+bool DiscordAPILoader::relationship_handle_is_spam_request(Discord_RelationshipHandle *self) const {
+	if (!fn_relationship_handle_is_spam_request) {
+		return false;
+	}
+	return fn_relationship_handle_is_spam_request(self);
+}
+
+bool DiscordAPILoader::relationship_handle_user(Discord_RelationshipHandle *self, Discord_UserHandle *return_value) const {
+	if (!fn_relationship_handle_user) {
+		return false;
+	}
+	return fn_relationship_handle_user(self, return_value);
+}
+
+String DiscordAPILoader::user_handle_global_name(Discord_UserHandle *self) const {
+	if (!fn_user_handle_global_name) {
+		return String();
+	}
+	Discord_String name;
+	if (!fn_user_handle_global_name(self, &name)) {
+		return String();
+	}
+	return to_godot_string(name);
+}
+
+Discord_StatusType DiscordAPILoader::user_handle_status(Discord_UserHandle *self) const {
+	if (!fn_user_handle_status) {
+		return DISCORD_STATUS_TYPE_UNKNOWN;
+	}
+	return fn_user_handle_status(self);
+}
+
+bool DiscordAPILoader::user_handle_is_provisional(Discord_UserHandle *self) const {
+	if (!fn_user_handle_is_provisional) {
+		return false;
+	}
+	return fn_user_handle_is_provisional(self);
+}
+
+String DiscordAPILoader::user_handle_avatar_url(Discord_UserHandle *self) const {
+	if (!fn_user_handle_avatar_url) {
+		return String();
+	}
+	Discord_String url;
+	fn_user_handle_avatar_url(self,
+			DISCORD_USER_HANDLE_AVATAR_TYPE_GIF,
+			DISCORD_USER_HANDLE_AVATAR_TYPE_PNG,
+			&url);
+	return to_godot_string(url);
+}
+
+#define DISCORD_LOADER_RELATIONSHIP_ACTION(name, fn_member)         \
+	void DiscordAPILoader::name(Discord_Client *self,               \
+			uint64_t user_id,                                       \
+			Discord_Client_UpdateRelationshipCallback callback,     \
+			void *user_data) const {                                \
+		if (fn_member) {                                            \
+			fn_member(self, user_id, callback, nullptr, user_data); \
+		}                                                           \
+	}
+
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_accept_discord_friend_request, fn_client_accept_discord_friend_request)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_accept_game_friend_request, fn_client_accept_game_friend_request)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_block_user, fn_client_block_user)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_cancel_discord_friend_request, fn_client_cancel_discord_friend_request)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_cancel_game_friend_request, fn_client_cancel_game_friend_request)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_reject_discord_friend_request, fn_client_reject_discord_friend_request)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_reject_game_friend_request, fn_client_reject_game_friend_request)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_remove_discord_and_game_friend, fn_client_remove_discord_and_game_friend)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_remove_game_friend, fn_client_remove_game_friend)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_send_discord_friend_request_by_id, fn_client_send_discord_friend_request_by_id)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_send_game_friend_request_by_id, fn_client_send_game_friend_request_by_id)
+DISCORD_LOADER_RELATIONSHIP_ACTION(client_unblock_user, fn_client_unblock_user)
+
+#undef DISCORD_LOADER_RELATIONSHIP_ACTION
+
+void DiscordAPILoader::client_send_discord_friend_request(Discord_Client *self,
+		const String &p_username,
+		Discord_Client_SendFriendRequestCallback callback,
+		void *user_data) const {
+	if (fn_client_send_discord_friend_request) {
+		fn_client_send_discord_friend_request(self, make_string(p_username), callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_send_game_friend_request(Discord_Client *self,
+		const String &p_username,
+		Discord_Client_SendFriendRequestCallback callback,
+		void *user_data) const {
+	if (fn_client_send_game_friend_request) {
+		fn_client_send_game_friend_request(self, make_string(p_username), callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_relationship_created_callback(Discord_Client *self,
+		Discord_Client_RelationshipCreatedCallback callback,
+		void *user_data) const {
+	if (fn_client_set_relationship_created_callback) {
+		fn_client_set_relationship_created_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_relationship_deleted_callback(Discord_Client *self,
+		Discord_Client_RelationshipDeletedCallback callback,
+		void *user_data) const {
+	if (fn_client_set_relationship_deleted_callback) {
+		fn_client_set_relationship_deleted_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_relationship_groups_updated_callback(Discord_Client *self,
+		Discord_Client_RelationshipGroupsUpdatedCallback callback,
+		void *user_data) const {
+	if (fn_client_set_relationship_groups_updated_callback) {
+		fn_client_set_relationship_groups_updated_callback(self, callback, nullptr, user_data);
+	}
+}
+
+void DiscordAPILoader::client_set_user_updated_callback(Discord_Client *self,
+		Discord_Client_UserUpdatedCallback callback,
+		void *user_data) const {
+	if (fn_client_set_user_updated_callback) {
+		fn_client_set_user_updated_callback(self, callback, nullptr, user_data);
 	}
 }

--- a/modules/discord_module/discord_api_loader.h
+++ b/modules/discord_module/discord_api_loader.h
@@ -140,6 +140,199 @@ private:
 	typedef int32_t (*Discord_Client_GetVersionPatchFn)();
 	typedef void (*Discord_Client_SetGameWindowPidFn)(Discord_Client *self, int32_t pid);
 	typedef bool (*Discord_Client_SetLogDirFn)(Discord_Client *self, Discord_String path, Discord_LoggingSeverity min_severity);
+	typedef void (*Discord_Activity_SetNameFn)(Discord_Activity *self, Discord_String value);
+	typedef void (*Discord_Activity_SetStatusDisplayTypeFn)(Discord_Activity *self, Discord_StatusDisplayTypes *value);
+	typedef void (*Discord_Activity_SetStateUrlFn)(Discord_Activity *self, Discord_String *value);
+	typedef void (*Discord_Activity_SetDetailsUrlFn)(Discord_Activity *self, Discord_String *value);
+	typedef void (*Discord_Activity_SetPartyFn)(Discord_Activity *self, Discord_ActivityParty *value);
+	typedef void (*Discord_Activity_SetSecretsFn)(Discord_Activity *self, Discord_ActivitySecrets *value);
+	typedef void (*Discord_Activity_SetSupportedPlatformsFn)(Discord_Activity *self, Discord_ActivityGamePlatforms value);
+	typedef void (*Discord_Activity_AddButtonFn)(Discord_Activity *self, Discord_ActivityButton const *button);
+	typedef void (*Discord_ActivityAssets_SetLargeUrlFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityAssets_SetSmallUrlFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityAssets_SetInviteCoverImageFn)(Discord_ActivityAssets *self, Discord_String *value);
+	typedef void (*Discord_ActivityParty_InitFn)(Discord_ActivityParty *self);
+	typedef void (*Discord_ActivityParty_DropFn)(Discord_ActivityParty *self);
+	typedef void (*Discord_ActivityParty_SetIdFn)(Discord_ActivityParty *self, Discord_String value);
+	typedef void (*Discord_ActivityParty_SetCurrentSizeFn)(Discord_ActivityParty *self, int32_t value);
+	typedef void (*Discord_ActivityParty_SetMaxSizeFn)(Discord_ActivityParty *self, int32_t value);
+	typedef void (*Discord_ActivitySecrets_InitFn)(Discord_ActivitySecrets *self);
+	typedef void (*Discord_ActivitySecrets_DropFn)(Discord_ActivitySecrets *self);
+	typedef void (*Discord_ActivitySecrets_SetJoinFn)(Discord_ActivitySecrets *self, Discord_String value);
+	typedef void (*Discord_ActivityButton_InitFn)(Discord_ActivityButton *self);
+	typedef void (*Discord_ActivityButton_DropFn)(Discord_ActivityButton *self);
+	typedef void (*Discord_ActivityButton_SetLabelFn)(Discord_ActivityButton *self, Discord_String value);
+	typedef void (*Discord_ActivityButton_SetUrlFn)(Discord_ActivityButton *self, Discord_String value);
+	typedef void (*Discord_ActivityInvite_InitFn)(Discord_ActivityInvite *self);
+	typedef void (*Discord_ActivityInvite_DropFn)(Discord_ActivityInvite *self);
+	typedef void (*Discord_ActivityInvite_SetSenderIdFn)(Discord_ActivityInvite *self, uint64_t value);
+	typedef void (*Discord_ActivityInvite_SetChannelIdFn)(Discord_ActivityInvite *self, uint64_t value);
+	typedef void (*Discord_ActivityInvite_SetMessageIdFn)(Discord_ActivityInvite *self, uint64_t value);
+	typedef void (*Discord_ActivityInvite_SetTypeFn)(Discord_ActivityInvite *self, Discord_ActivityActionTypes value);
+	typedef void (*Discord_ActivityInvite_SetApplicationIdFn)(Discord_ActivityInvite *self, uint64_t value);
+	typedef void (*Discord_ActivityInvite_SetParentApplicationIdFn)(Discord_ActivityInvite *self, uint64_t value);
+	typedef void (*Discord_ActivityInvite_SetPartyIdFn)(Discord_ActivityInvite *self, Discord_String value);
+	typedef void (*Discord_ActivityInvite_SetSessionIdFn)(Discord_ActivityInvite *self, Discord_String value);
+	typedef void (*Discord_ActivityInvite_SetIsValidFn)(Discord_ActivityInvite *self, bool value);
+	typedef uint64_t (*Discord_ActivityInvite_SenderIdFn)(Discord_ActivityInvite *self);
+	typedef uint64_t (*Discord_ActivityInvite_ChannelIdFn)(Discord_ActivityInvite *self);
+	typedef uint64_t (*Discord_ActivityInvite_MessageIdFn)(Discord_ActivityInvite *self);
+	typedef Discord_ActivityActionTypes (*Discord_ActivityInvite_TypeFn)(Discord_ActivityInvite *self);
+	typedef uint64_t (*Discord_ActivityInvite_ApplicationIdFn)(Discord_ActivityInvite *self);
+	typedef uint64_t (*Discord_ActivityInvite_ParentApplicationIdFn)(Discord_ActivityInvite *self);
+	typedef void (*Discord_ActivityInvite_PartyIdFn)(Discord_ActivityInvite *self, Discord_String *return_value);
+	typedef void (*Discord_ActivityInvite_SessionIdFn)(Discord_ActivityInvite *self, Discord_String *return_value);
+	typedef bool (*Discord_ActivityInvite_IsValidFn)(Discord_ActivityInvite *self);
+	typedef bool (*Discord_Client_RegisterLaunchCommandFn)(Discord_Client *self, uint64_t application_id, Discord_String command);
+	typedef bool (*Discord_Client_RegisterLaunchSteamApplicationFn)(Discord_Client *self, uint64_t application_id, uint32_t steam_app_id);
+	typedef void (*Discord_Client_SendActivityInviteFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_String content,
+			Discord_Client_SendActivityInviteCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_SendActivityJoinRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_SendActivityInviteCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_SendActivityJoinRequestReplyFn)(Discord_Client *self,
+			Discord_ActivityInvite *invite,
+			Discord_Client_SendActivityInviteCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_AcceptActivityInviteFn)(Discord_Client *self,
+			Discord_ActivityInvite *invite,
+			Discord_Client_AcceptActivityInviteCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_CreateOrJoinLobbyFn)(Discord_Client *self,
+			Discord_String secret,
+			Discord_Client_CreateOrJoinLobbyCallback callback,
+			Discord_FreeFn callback_user_data_free,
+			void *callback_user_data);
+	typedef void (*Discord_Client_SetActivityInviteCreatedCallbackFn)(Discord_Client *self,
+			Discord_Client_ActivityInviteCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetActivityInviteUpdatedCallbackFn)(Discord_Client *self,
+			Discord_Client_ActivityInviteCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetActivityJoinCallbackFn)(Discord_Client *self,
+			Discord_Client_ActivityJoinCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetLobbyCreatedCallbackFn)(Discord_Client *self,
+			Discord_Client_LobbyCreatedCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_GetRelationshipsByGroupFn)(Discord_Client *self,
+			Discord_RelationshipGroupType group_type,
+			Discord_RelationshipHandleSpan *return_value);
+	typedef void (*Discord_Client_GetRelationshipHandleFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_RelationshipHandle *return_value);
+	typedef bool (*Discord_Client_GetUserFn)(Discord_Client *self, uint64_t user_id, Discord_UserHandle *return_value);
+	typedef Discord_RelationshipType (*Discord_RelationshipHandle_DiscordRelationshipTypeFn)(Discord_RelationshipHandle *self);
+	typedef Discord_RelationshipType (*Discord_RelationshipHandle_GameRelationshipTypeFn)(Discord_RelationshipHandle *self);
+	typedef uint64_t (*Discord_RelationshipHandle_IdFn)(Discord_RelationshipHandle *self);
+	typedef bool (*Discord_RelationshipHandle_IsSpamRequestFn)(Discord_RelationshipHandle *self);
+	typedef bool (*Discord_RelationshipHandle_UserFn)(Discord_RelationshipHandle *self, Discord_UserHandle *return_value);
+	typedef void (*Discord_RelationshipHandle_DropFn)(Discord_RelationshipHandle *self);
+	typedef bool (*Discord_UserHandle_GlobalNameFn)(Discord_UserHandle *self, Discord_String *return_value);
+	typedef Discord_StatusType (*Discord_UserHandle_StatusFn)(Discord_UserHandle *self);
+	typedef bool (*Discord_UserHandle_IsProvisionalFn)(Discord_UserHandle *self);
+	typedef void (*Discord_UserHandle_AvatarUrlFn)(Discord_UserHandle *self,
+			Discord_UserHandle_AvatarType animated_type,
+			Discord_UserHandle_AvatarType static_type,
+			Discord_String *return_value);
+	typedef void (*Discord_Client_AcceptDiscordFriendRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_AcceptGameFriendRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_BlockUserFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_CancelDiscordFriendRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_CancelGameFriendRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_RejectDiscordFriendRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_RejectGameFriendRequestFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_RemoveDiscordAndGameFriendFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_RemoveGameFriendFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SendDiscordFriendRequestFn)(Discord_Client *self,
+			Discord_String username,
+			Discord_Client_SendFriendRequestCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SendDiscordFriendRequestByIdFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SendGameFriendRequestFn)(Discord_Client *self,
+			Discord_String username,
+			Discord_Client_SendFriendRequestCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SendGameFriendRequestByIdFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetRelationshipCreatedCallbackFn)(Discord_Client *self,
+			Discord_Client_RelationshipCreatedCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetRelationshipDeletedCallbackFn)(Discord_Client *self,
+			Discord_Client_RelationshipDeletedCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetRelationshipGroupsUpdatedCallbackFn)(Discord_Client *self,
+			Discord_Client_RelationshipGroupsUpdatedCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_SetUserUpdatedCallbackFn)(Discord_Client *self,
+			Discord_Client_UserUpdatedCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
+	typedef void (*Discord_Client_UnblockUserFn)(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback cb,
+			Discord_FreeFn cb_user_data_free,
+			void *cb_user_data);
 
 	Discord_RunCallbacksFn fn_run_callbacks = nullptr;
 	Discord_Client_InitFn fn_client_init = nullptr;
@@ -203,6 +396,91 @@ private:
 	Discord_Client_GetVersionPatchFn fn_client_get_version_patch = nullptr;
 	Discord_Client_SetGameWindowPidFn fn_client_set_game_window_pid = nullptr;
 	Discord_Client_SetLogDirFn fn_client_set_log_dir = nullptr;
+	Discord_Activity_SetNameFn fn_activity_set_name = nullptr;
+	Discord_Activity_SetStatusDisplayTypeFn fn_activity_set_status_display_type = nullptr;
+	Discord_Activity_SetStateUrlFn fn_activity_set_state_url = nullptr;
+	Discord_Activity_SetDetailsUrlFn fn_activity_set_details_url = nullptr;
+	Discord_Activity_SetPartyFn fn_activity_set_party = nullptr;
+	Discord_Activity_SetSecretsFn fn_activity_set_secrets = nullptr;
+	Discord_Activity_SetSupportedPlatformsFn fn_activity_set_supported_platforms = nullptr;
+	Discord_Activity_AddButtonFn fn_activity_add_button = nullptr;
+	Discord_ActivityAssets_SetLargeUrlFn fn_activity_assets_set_large_url = nullptr;
+	Discord_ActivityAssets_SetSmallUrlFn fn_activity_assets_set_small_url = nullptr;
+	Discord_ActivityAssets_SetInviteCoverImageFn fn_activity_assets_set_invite_cover_image = nullptr;
+	Discord_ActivityParty_InitFn fn_activity_party_init = nullptr;
+	Discord_ActivityParty_DropFn fn_activity_party_drop = nullptr;
+	Discord_ActivityParty_SetIdFn fn_activity_party_set_id = nullptr;
+	Discord_ActivityParty_SetCurrentSizeFn fn_activity_party_set_current_size = nullptr;
+	Discord_ActivityParty_SetMaxSizeFn fn_activity_party_set_max_size = nullptr;
+	Discord_ActivitySecrets_InitFn fn_activity_secrets_init = nullptr;
+	Discord_ActivitySecrets_DropFn fn_activity_secrets_drop = nullptr;
+	Discord_ActivitySecrets_SetJoinFn fn_activity_secrets_set_join = nullptr;
+	Discord_ActivityButton_InitFn fn_activity_button_init = nullptr;
+	Discord_ActivityButton_DropFn fn_activity_button_drop = nullptr;
+	Discord_ActivityButton_SetLabelFn fn_activity_button_set_label = nullptr;
+	Discord_ActivityButton_SetUrlFn fn_activity_button_set_url = nullptr;
+	Discord_ActivityInvite_InitFn fn_activity_invite_init = nullptr;
+	Discord_ActivityInvite_DropFn fn_activity_invite_drop = nullptr;
+	Discord_ActivityInvite_SetSenderIdFn fn_activity_invite_set_sender_id = nullptr;
+	Discord_ActivityInvite_SetChannelIdFn fn_activity_invite_set_channel_id = nullptr;
+	Discord_ActivityInvite_SetMessageIdFn fn_activity_invite_set_message_id = nullptr;
+	Discord_ActivityInvite_SetTypeFn fn_activity_invite_set_type = nullptr;
+	Discord_ActivityInvite_SetApplicationIdFn fn_activity_invite_set_application_id = nullptr;
+	Discord_ActivityInvite_SetParentApplicationIdFn fn_activity_invite_set_parent_application_id = nullptr;
+	Discord_ActivityInvite_SetPartyIdFn fn_activity_invite_set_party_id = nullptr;
+	Discord_ActivityInvite_SetSessionIdFn fn_activity_invite_set_session_id = nullptr;
+	Discord_ActivityInvite_SetIsValidFn fn_activity_invite_set_is_valid = nullptr;
+	Discord_ActivityInvite_SenderIdFn fn_activity_invite_sender_id = nullptr;
+	Discord_ActivityInvite_ChannelIdFn fn_activity_invite_channel_id = nullptr;
+	Discord_ActivityInvite_MessageIdFn fn_activity_invite_message_id = nullptr;
+	Discord_ActivityInvite_TypeFn fn_activity_invite_type = nullptr;
+	Discord_ActivityInvite_ApplicationIdFn fn_activity_invite_application_id = nullptr;
+	Discord_ActivityInvite_ParentApplicationIdFn fn_activity_invite_parent_application_id = nullptr;
+	Discord_ActivityInvite_PartyIdFn fn_activity_invite_party_id = nullptr;
+	Discord_ActivityInvite_SessionIdFn fn_activity_invite_session_id = nullptr;
+	Discord_ActivityInvite_IsValidFn fn_activity_invite_is_valid = nullptr;
+	Discord_Client_RegisterLaunchCommandFn fn_client_register_launch_command = nullptr;
+	Discord_Client_RegisterLaunchSteamApplicationFn fn_client_register_launch_steam_application = nullptr;
+	Discord_Client_SendActivityInviteFn fn_client_send_activity_invite = nullptr;
+	Discord_Client_SendActivityJoinRequestFn fn_client_send_activity_join_request = nullptr;
+	Discord_Client_SendActivityJoinRequestReplyFn fn_client_send_activity_join_request_reply = nullptr;
+	Discord_Client_AcceptActivityInviteFn fn_client_accept_activity_invite = nullptr;
+	Discord_Client_CreateOrJoinLobbyFn fn_client_create_or_join_lobby = nullptr;
+	Discord_Client_SetActivityInviteCreatedCallbackFn fn_client_set_activity_invite_created_callback = nullptr;
+	Discord_Client_SetActivityInviteUpdatedCallbackFn fn_client_set_activity_invite_updated_callback = nullptr;
+	Discord_Client_SetActivityJoinCallbackFn fn_client_set_activity_join_callback = nullptr;
+	Discord_Client_SetLobbyCreatedCallbackFn fn_client_set_lobby_created_callback = nullptr;
+	Discord_Client_GetRelationshipsByGroupFn fn_client_get_relationships_by_group = nullptr;
+	Discord_Client_GetRelationshipHandleFn fn_client_get_relationship_handle = nullptr;
+	Discord_Client_GetUserFn fn_client_get_user = nullptr;
+	Discord_RelationshipHandle_DiscordRelationshipTypeFn fn_relationship_handle_discord_relationship_type = nullptr;
+	Discord_RelationshipHandle_GameRelationshipTypeFn fn_relationship_handle_game_relationship_type = nullptr;
+	Discord_RelationshipHandle_IdFn fn_relationship_handle_id = nullptr;
+	Discord_RelationshipHandle_IsSpamRequestFn fn_relationship_handle_is_spam_request = nullptr;
+	Discord_RelationshipHandle_UserFn fn_relationship_handle_user = nullptr;
+	Discord_RelationshipHandle_DropFn fn_relationship_handle_drop = nullptr;
+	Discord_UserHandle_GlobalNameFn fn_user_handle_global_name = nullptr;
+	Discord_UserHandle_StatusFn fn_user_handle_status = nullptr;
+	Discord_UserHandle_IsProvisionalFn fn_user_handle_is_provisional = nullptr;
+	Discord_UserHandle_AvatarUrlFn fn_user_handle_avatar_url = nullptr;
+	Discord_Client_AcceptDiscordFriendRequestFn fn_client_accept_discord_friend_request = nullptr;
+	Discord_Client_AcceptGameFriendRequestFn fn_client_accept_game_friend_request = nullptr;
+	Discord_Client_BlockUserFn fn_client_block_user = nullptr;
+	Discord_Client_CancelDiscordFriendRequestFn fn_client_cancel_discord_friend_request = nullptr;
+	Discord_Client_CancelGameFriendRequestFn fn_client_cancel_game_friend_request = nullptr;
+	Discord_Client_RejectDiscordFriendRequestFn fn_client_reject_discord_friend_request = nullptr;
+	Discord_Client_RejectGameFriendRequestFn fn_client_reject_game_friend_request = nullptr;
+	Discord_Client_RemoveDiscordAndGameFriendFn fn_client_remove_discord_and_game_friend = nullptr;
+	Discord_Client_RemoveGameFriendFn fn_client_remove_game_friend = nullptr;
+	Discord_Client_SendDiscordFriendRequestFn fn_client_send_discord_friend_request = nullptr;
+	Discord_Client_SendDiscordFriendRequestByIdFn fn_client_send_discord_friend_request_by_id = nullptr;
+	Discord_Client_SendGameFriendRequestFn fn_client_send_game_friend_request = nullptr;
+	Discord_Client_SendGameFriendRequestByIdFn fn_client_send_game_friend_request_by_id = nullptr;
+	Discord_Client_SetRelationshipCreatedCallbackFn fn_client_set_relationship_created_callback = nullptr;
+	Discord_Client_SetRelationshipDeletedCallbackFn fn_client_set_relationship_deleted_callback = nullptr;
+	Discord_Client_SetRelationshipGroupsUpdatedCallbackFn fn_client_set_relationship_groups_updated_callback = nullptr;
+	Discord_Client_SetUserUpdatedCallbackFn fn_client_set_user_updated_callback = nullptr;
+	Discord_Client_UnblockUserFn fn_client_unblock_user = nullptr;
 
 	bool _load_symbol(const char *p_name, void *&r_symbol);
 
@@ -309,6 +587,166 @@ public:
 	void client_set_game_window_pid(Discord_Client *self, int32_t pid) const;
 	bool client_set_log_dir(Discord_Client *self, const String &p_path, Discord_LoggingSeverity min_severity) const;
 	void fill_version_dict(Dictionary &p_version) const;
+
+	bool has_activity_extensions() const { return fn_activity_set_name != nullptr; }
+	bool has_invite_api() const { return fn_client_register_launch_command != nullptr; }
+	bool has_relationship_api() const { return fn_client_get_relationships_by_group != nullptr; }
+
+	void activity_set_name(Discord_Activity *self, const String &p_value) const;
+	void activity_set_status_display_type(Discord_Activity *self, Discord_StatusDisplayTypes value) const;
+	void activity_set_state_url(Discord_Activity *self, const String &p_value) const;
+	void activity_set_details_url(Discord_Activity *self, const String &p_value) const;
+	void activity_set_party(Discord_Activity *self, Discord_ActivityParty *value) const;
+	void activity_set_secrets(Discord_Activity *self, Discord_ActivitySecrets *value) const;
+	void activity_set_supported_platforms(Discord_Activity *self, Discord_ActivityGamePlatforms value) const;
+	void activity_add_button(Discord_Activity *self, Discord_ActivityButton const *button) const;
+	void activity_assets_set_large_url(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_assets_set_small_url(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_assets_set_invite_cover_image(Discord_ActivityAssets *self, const String &p_value) const;
+	void activity_party_init(Discord_ActivityParty *self) const;
+	void activity_party_drop(Discord_ActivityParty *self) const;
+	void activity_party_set_id(Discord_ActivityParty *self, const String &p_value) const;
+	void activity_party_set_current_size(Discord_ActivityParty *self, int32_t value) const;
+	void activity_party_set_max_size(Discord_ActivityParty *self, int32_t value) const;
+	void activity_secrets_init(Discord_ActivitySecrets *self) const;
+	void activity_secrets_drop(Discord_ActivitySecrets *self) const;
+	void activity_secrets_set_join(Discord_ActivitySecrets *self, const String &p_value) const;
+	void activity_button_init(Discord_ActivityButton *self) const;
+	void activity_button_drop(Discord_ActivityButton *self) const;
+	void activity_button_set_label(Discord_ActivityButton *self, const String &p_value) const;
+	void activity_button_set_url(Discord_ActivityButton *self, const String &p_value) const;
+	void activity_invite_init(Discord_ActivityInvite *self) const;
+	void activity_invite_drop(Discord_ActivityInvite *self) const;
+	void activity_invite_set_sender_id(Discord_ActivityInvite *self, uint64_t value) const;
+	void activity_invite_set_channel_id(Discord_ActivityInvite *self, uint64_t value) const;
+	void activity_invite_set_message_id(Discord_ActivityInvite *self, uint64_t value) const;
+	void activity_invite_set_type(Discord_ActivityInvite *self, Discord_ActivityActionTypes value) const;
+	void activity_invite_set_application_id(Discord_ActivityInvite *self, uint64_t value) const;
+	void activity_invite_set_parent_application_id(Discord_ActivityInvite *self, uint64_t value) const;
+	void activity_invite_set_party_id(Discord_ActivityInvite *self, const String &p_value) const;
+	void activity_invite_set_session_id(Discord_ActivityInvite *self, const String &p_value) const;
+	void activity_invite_set_is_valid(Discord_ActivityInvite *self, bool value) const;
+	Dictionary activity_invite_to_dict(Discord_ActivityInvite *self) const;
+	bool client_register_launch_command(Discord_Client *self, uint64_t application_id, const String &p_command) const;
+	bool client_register_launch_steam_application(Discord_Client *self, uint64_t application_id, uint32_t steam_app_id) const;
+	void client_send_activity_invite(Discord_Client *self,
+			uint64_t user_id,
+			const String &p_content,
+			Discord_Client_SendActivityInviteCallback callback,
+			void *user_data) const;
+	void client_send_activity_join_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_SendActivityInviteCallback callback,
+			void *user_data) const;
+	void client_send_activity_join_request_reply(Discord_Client *self,
+			Discord_ActivityInvite *invite,
+			Discord_Client_SendActivityInviteCallback callback,
+			void *user_data) const;
+	void client_accept_activity_invite(Discord_Client *self,
+			Discord_ActivityInvite *invite,
+			Discord_Client_AcceptActivityInviteCallback callback,
+			void *user_data) const;
+	void client_create_or_join_lobby(Discord_Client *self,
+			const String &p_secret,
+			Discord_Client_CreateOrJoinLobbyCallback callback,
+			void *user_data) const;
+	void client_set_activity_invite_created_callback(Discord_Client *self,
+			Discord_Client_ActivityInviteCallback callback,
+			void *user_data) const;
+	void client_set_activity_invite_updated_callback(Discord_Client *self,
+			Discord_Client_ActivityInviteCallback callback,
+			void *user_data) const;
+	void client_set_activity_join_callback(Discord_Client *self,
+			Discord_Client_ActivityJoinCallback callback,
+			void *user_data) const;
+	void client_set_lobby_created_callback(Discord_Client *self,
+			Discord_Client_LobbyCreatedCallback callback,
+			void *user_data) const;
+	void client_get_relationships_by_group(Discord_Client *self,
+			Discord_RelationshipGroupType group_type,
+			Discord_RelationshipHandleSpan *return_value) const;
+	void client_get_relationship_handle(Discord_Client *self,
+			uint64_t user_id,
+			Discord_RelationshipHandle *return_value) const;
+	bool client_get_user(Discord_Client *self, uint64_t user_id, Discord_UserHandle *return_value) const;
+	void relationship_handle_drop(Discord_RelationshipHandle *self) const;
+	Discord_RelationshipType relationship_handle_discord_relationship_type(Discord_RelationshipHandle *self) const;
+	Discord_RelationshipType relationship_handle_game_relationship_type(Discord_RelationshipHandle *self) const;
+	uint64_t relationship_handle_id(Discord_RelationshipHandle *self) const;
+	bool relationship_handle_is_spam_request(Discord_RelationshipHandle *self) const;
+	bool relationship_handle_user(Discord_RelationshipHandle *self, Discord_UserHandle *return_value) const;
+	String user_handle_global_name(Discord_UserHandle *self) const;
+	Discord_StatusType user_handle_status(Discord_UserHandle *self) const;
+	bool user_handle_is_provisional(Discord_UserHandle *self) const;
+	String user_handle_avatar_url(Discord_UserHandle *self) const;
+	void client_accept_discord_friend_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_accept_game_friend_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_block_user(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_cancel_discord_friend_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_cancel_game_friend_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_reject_discord_friend_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_reject_game_friend_request(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_remove_discord_and_game_friend(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_remove_game_friend(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_send_discord_friend_request(Discord_Client *self,
+			const String &p_username,
+			Discord_Client_SendFriendRequestCallback callback,
+			void *user_data) const;
+	void client_send_discord_friend_request_by_id(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_send_game_friend_request(Discord_Client *self,
+			const String &p_username,
+			Discord_Client_SendFriendRequestCallback callback,
+			void *user_data) const;
+	void client_send_game_friend_request_by_id(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
+	void client_set_relationship_created_callback(Discord_Client *self,
+			Discord_Client_RelationshipCreatedCallback callback,
+			void *user_data) const;
+	void client_set_relationship_deleted_callback(Discord_Client *self,
+			Discord_Client_RelationshipDeletedCallback callback,
+			void *user_data) const;
+	void client_set_relationship_groups_updated_callback(Discord_Client *self,
+			Discord_Client_RelationshipGroupsUpdatedCallback callback,
+			void *user_data) const;
+	void client_set_user_updated_callback(Discord_Client *self,
+			Discord_Client_UserUpdatedCallback callback,
+			void *user_data) const;
+	void client_unblock_user(Discord_Client *self,
+			uint64_t user_id,
+			Discord_Client_UpdateRelationshipCallback callback,
+			void *user_data) const;
 
 	static Discord_String make_string(const String &p_value);
 	static String to_godot_string(const Discord_String &p_value);

--- a/modules/discord_module/discord_types.h
+++ b/modules/discord_module/discord_types.h
@@ -63,6 +63,68 @@ typedef enum Discord_IntegrationType {
 	DISCORD_INTEGRATION_TYPE_USER_INSTALL = 1,
 } Discord_IntegrationType;
 
+typedef enum Discord_ActivityActionTypes {
+	DISCORD_ACTIVITY_ACTION_TYPE_INVALID = 0,
+	DISCORD_ACTIVITY_ACTION_TYPE_JOIN = 1,
+	DISCORD_ACTIVITY_ACTION_TYPE_JOIN_REQUEST = 5,
+} Discord_ActivityActionTypes;
+
+typedef enum Discord_ActivityPartyPrivacy {
+	DISCORD_ACTIVITY_PARTY_PRIVACY_PRIVATE = 0,
+	DISCORD_ACTIVITY_PARTY_PRIVACY_PUBLIC = 1,
+} Discord_ActivityPartyPrivacy;
+
+typedef enum Discord_StatusDisplayTypes {
+	DISCORD_STATUS_DISPLAY_TYPE_NAME = 0,
+	DISCORD_STATUS_DISPLAY_TYPE_STATE = 1,
+	DISCORD_STATUS_DISPLAY_TYPE_DETAILS = 2,
+} Discord_StatusDisplayTypes;
+
+typedef enum Discord_ActivityGamePlatforms {
+	DISCORD_ACTIVITY_GAME_PLATFORM_DESKTOP = 1,
+	DISCORD_ACTIVITY_GAME_PLATFORM_XBOX = 2,
+	DISCORD_ACTIVITY_GAME_PLATFORM_SAMSUNG = 4,
+	DISCORD_ACTIVITY_GAME_PLATFORM_IOS = 8,
+	DISCORD_ACTIVITY_GAME_PLATFORM_ANDROID = 16,
+	DISCORD_ACTIVITY_GAME_PLATFORM_EMBEDDED = 32,
+	DISCORD_ACTIVITY_GAME_PLATFORM_PS4 = 64,
+	DISCORD_ACTIVITY_GAME_PLATFORM_PS5 = 128,
+} Discord_ActivityGamePlatforms;
+
+typedef enum Discord_RelationshipType {
+	DISCORD_RELATIONSHIP_TYPE_NONE = 0,
+	DISCORD_RELATIONSHIP_TYPE_FRIEND = 1,
+	DISCORD_RELATIONSHIP_TYPE_BLOCKED = 2,
+	DISCORD_RELATIONSHIP_TYPE_PENDING_INCOMING = 3,
+	DISCORD_RELATIONSHIP_TYPE_PENDING_OUTGOING = 4,
+	DISCORD_RELATIONSHIP_TYPE_IMPLICIT = 5,
+	DISCORD_RELATIONSHIP_TYPE_SUGGESTION = 6,
+} Discord_RelationshipType;
+
+typedef enum Discord_RelationshipGroupType {
+	DISCORD_RELATIONSHIP_GROUP_TYPE_ONLINE_PLAYING_GAME = 0,
+	DISCORD_RELATIONSHIP_GROUP_TYPE_ONLINE_ELSEWHERE = 1,
+	DISCORD_RELATIONSHIP_GROUP_TYPE_OFFLINE = 2,
+} Discord_RelationshipGroupType;
+
+typedef enum Discord_StatusType {
+	DISCORD_STATUS_TYPE_ONLINE = 0,
+	DISCORD_STATUS_TYPE_OFFLINE = 1,
+	DISCORD_STATUS_TYPE_BLOCKED = 2,
+	DISCORD_STATUS_TYPE_IDLE = 3,
+	DISCORD_STATUS_TYPE_DND = 4,
+	DISCORD_STATUS_TYPE_INVISIBLE = 5,
+	DISCORD_STATUS_TYPE_STREAMING = 6,
+	DISCORD_STATUS_TYPE_UNKNOWN = 7,
+} Discord_StatusType;
+
+typedef enum Discord_UserHandle_AvatarType {
+	DISCORD_USER_HANDLE_AVATAR_TYPE_GIF = 0,
+	DISCORD_USER_HANDLE_AVATAR_TYPE_WEBP = 1,
+	DISCORD_USER_HANDLE_AVATAR_TYPE_PNG = 2,
+	DISCORD_USER_HANDLE_AVATAR_TYPE_JPEG = 3,
+} Discord_UserHandle_AvatarType;
+
 typedef struct Discord_Client {
 	void *opaque;
 } Discord_Client;
@@ -86,6 +148,48 @@ typedef struct Discord_AuthorizationArgs {
 typedef struct Discord_UserHandle {
 	void *opaque;
 } Discord_UserHandle;
+
+typedef struct Discord_Activity {
+	void *opaque;
+} Discord_Activity;
+
+typedef struct Discord_ActivityAssets {
+	void *opaque;
+} Discord_ActivityAssets;
+
+typedef struct Discord_ActivityTimestamps {
+	void *opaque;
+} Discord_ActivityTimestamps;
+
+typedef struct Discord_ActivityParty {
+	void *opaque;
+} Discord_ActivityParty;
+
+typedef struct Discord_ActivitySecrets {
+	void *opaque;
+} Discord_ActivitySecrets;
+
+typedef struct Discord_ActivityButton {
+	void *opaque;
+} Discord_ActivityButton;
+
+typedef struct Discord_ActivityInvite {
+	void *opaque;
+} Discord_ActivityInvite;
+
+typedef struct Discord_RelationshipHandle {
+	void *opaque;
+} Discord_RelationshipHandle;
+
+typedef struct Discord_RelationshipHandleSpan {
+	Discord_RelationshipHandle *ptr;
+	size_t size;
+} Discord_RelationshipHandleSpan;
+
+typedef struct Discord_ActivityButtonSpan {
+	Discord_ActivityButton *ptr;
+	size_t size;
+} Discord_ActivityButtonSpan;
 
 typedef void (*Discord_FreeFn)(void *ptr);
 
@@ -127,27 +231,6 @@ typedef enum Discord_LoggingSeverity {
 	DISCORD_LOGGING_SEVERITY_NONE = 5,
 } Discord_LoggingSeverity;
 
-typedef struct Discord_Activity {
-	void *opaque;
-} Discord_Activity;
-
-typedef struct Discord_ActivityAssets {
-	void *opaque;
-} Discord_ActivityAssets;
-
-typedef struct Discord_ActivityTimestamps {
-	void *opaque;
-} Discord_ActivityTimestamps;
-
-typedef struct Discord_RelationshipHandle {
-	void *opaque;
-} Discord_RelationshipHandle;
-
-typedef struct Discord_RelationshipHandleSpan {
-	Discord_RelationshipHandle *ptr;
-	size_t size;
-} Discord_RelationshipHandleSpan;
-
 typedef void (*Discord_Client_LogCallback)(Discord_String message,
 		Discord_LoggingSeverity severity,
 		void *user_data);
@@ -156,3 +239,39 @@ typedef void (*Discord_Client_UpdateRichPresenceCallback)(Discord_ClientResult *
 		void *user_data);
 
 typedef void (*Discord_Client_AuthorizeDeviceScreenClosedCallback)(void *user_data);
+
+typedef void (*Discord_Client_CreateOrJoinLobbyCallback)(Discord_ClientResult *result,
+		uint64_t lobby_id,
+		void *user_data);
+
+typedef void (*Discord_Client_AcceptActivityInviteCallback)(Discord_ClientResult *result,
+		Discord_String join_secret,
+		void *user_data);
+
+typedef void (*Discord_Client_SendActivityInviteCallback)(Discord_ClientResult *result,
+		void *user_data);
+
+typedef void (*Discord_Client_ActivityInviteCallback)(Discord_ActivityInvite *invite,
+		void *user_data);
+
+typedef void (*Discord_Client_ActivityJoinCallback)(Discord_String join_secret, void *user_data);
+
+typedef void (*Discord_Client_UpdateRelationshipCallback)(Discord_ClientResult *result,
+		void *user_data);
+
+typedef void (*Discord_Client_SendFriendRequestCallback)(Discord_ClientResult *result,
+		void *user_data);
+
+typedef void (*Discord_Client_RelationshipCreatedCallback)(uint64_t user_id,
+		bool is_discord_relationship_update,
+		void *user_data);
+
+typedef void (*Discord_Client_RelationshipDeletedCallback)(uint64_t user_id,
+		bool is_discord_relationship_update,
+		void *user_data);
+
+typedef void (*Discord_Client_RelationshipGroupsUpdatedCallback)(uint64_t user_id, void *user_data);
+
+typedef void (*Discord_Client_UserUpdatedCallback)(uint64_t user_id, void *user_data);
+
+typedef void (*Discord_Client_LobbyCreatedCallback)(uint64_t lobby_id, void *user_data);

--- a/modules/discord_module/doc_classes/Discord.xml
+++ b/modules/discord_module/doc_classes/Discord.xml
@@ -1,15 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Discord" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		Discord Social SDK integration for OAuth authentication and backend JWT exchange.
+		Discord Social SDK integration for RPC rich presence, OAuth, invites, and relationships.
 	</brief_description>
 	<description>
-		The Discord singleton dynamically loads the Discord Partner SDK library at runtime. If the library is not found beside the executable, all methods fail gracefully without crashing.
-		Call [method initialize] with your Discord application client ID to start the OAuth flow, pump [method run_callbacks] (or rely on the engine frame hook), then use [method get_access_token] and [method authenticate_with_server] to exchange the token for a JWT from your backend.
+		The Discord singleton dynamically loads the Discord Partner SDK library at runtime. Use [method initialize_presence_only] for auth-less RPC rich presence, or [method initialize] for the full OAuth social layer (friends, invites, server auth).
+		Pump [method run_callbacks] each frame (or rely on the engine frame hook) while the client is active.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="accept_activity_invite">
+			<return type="void" />
+			<param index="0" name="invite" type="Dictionary" />
+			<description>
+				Accepts an activity invite built from [signal activity_invite_created] / [signal activity_invite_updated] payload fields. Requires OAuth ([constant AUTH_READY]).
+			</description>
+		</method>
+		<method name="accept_discord_friend_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Accepts a pending Discord-wide friend request. OAuth only. Emits [signal relationship_action_completed].
+			</description>
+		</method>
+		<method name="accept_game_friend_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Accepts a pending game-scoped friend request. OAuth only. Emits [signal relationship_action_completed].
+			</description>
+		</method>
 		<method name="authenticate_with_server">
 			<return type="DiscordAuthResult" />
 			<param index="0" name="url" type="String" />
@@ -17,6 +38,27 @@
 			<param index="2" name="client_id" type="int" />
 			<description>
 				POSTs the OAuth access token to the auth server and returns the parsed response. Requires [constant AUTH_READY] and a non-empty access token.
+			</description>
+		</method>
+		<method name="block_user">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Blocks a user. OAuth only. Emits [signal relationship_action_completed].
+			</description>
+		</method>
+		<method name="cancel_discord_friend_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Cancels an outgoing Discord friend request. OAuth only.
+			</description>
+		</method>
+		<method name="cancel_game_friend_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Cancels an outgoing game friend request. OAuth only.
 			</description>
 		</method>
 		<method name="clear_debug_log">
@@ -28,7 +70,14 @@
 		<method name="clear_rich_presence">
 			<return type="void" />
 			<description>
-				Clears the player's Discord rich presence. Requires [constant AUTH_READY].
+				Clears the player's Discord rich presence. Requires presence readiness ([method is_ready_for_presence]).
+			</description>
+		</method>
+		<method name="create_or_join_lobby">
+			<return type="void" />
+			<param index="0" name="secret" type="String" />
+			<description>
+				Creates or joins a Discord lobby by secret. OAuth only. Emits [signal lobby_joined] on success.
 			</description>
 		</method>
 		<method name="get_access_token" qualifiers="const">
@@ -52,25 +101,25 @@
 		<method name="get_debug_log" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns recent lifecycle and SDK log lines (always populated for auth/connect/presence steps; verbose SDK detail when debug logging is enabled).
+				Returns recent lifecycle and SDK log lines.
 			</description>
 		</method>
 		<method name="get_default_communication_scopes" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the default OAuth scopes for communication features ([code]openid[/code] and [code]sdk.social_layer[/code]).
+				Returns the default OAuth scopes for communication features.
 			</description>
 		</method>
 		<method name="get_default_presence_scopes" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the default OAuth scopes for rich presence ([code]openid[/code] and [code]sdk.social_layer_presence[/code]).
+				Returns the default OAuth scopes for rich presence and friends list.
 			</description>
 		</method>
 		<method name="get_game_activity">
 			<return type="Dictionary" />
 			<description>
-				Returns the current user's game-associated activity from the SDK readback ([code]type[/code], [code]details[/code], [code]state[/code]), or an empty dictionary when unavailable.
+				Returns the current user's game-associated activity readback, or an empty dictionary when unavailable.
 			</description>
 		</method>
 		<method name="get_granted_scopes" qualifiers="const">
@@ -82,13 +131,33 @@
 		<method name="get_last_error" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the most recent error message from Discord initialization or auth.
+				Returns the most recent error message.
+			</description>
+		</method>
+		<method name="get_relationship">
+			<return type="Dictionary" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Returns a relationship dictionary for [param user_id], or empty when unavailable. OAuth only.
+			</description>
+		</method>
+		<method name="get_relationships">
+			<return type="Array" />
+			<description>
+				Returns all relationships as an array of dictionaries. OAuth only.
+			</description>
+		</method>
+		<method name="get_relationships_by_group">
+			<return type="Array" />
+			<param index="0" name="group" type="int" enum="Discord.RelationshipGroupType" />
+			<description>
+				Returns relationships for a unified friends list group. OAuth only.
 			</description>
 		</method>
 		<method name="get_relationships_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the cached Discord relationships count after [constant AUTH_READY], or [code]-1[/code] when unavailable.
+				Returns the cached relationships count after [constant AUTH_READY], or [code]-1[/code] when unavailable.
 			</description>
 		</method>
 		<method name="get_requested_scopes" qualifiers="const">
@@ -97,16 +166,23 @@
 				Returns the OAuth scopes requested during the current auth flow.
 			</description>
 		</method>
+		<method name="get_user">
+			<return type="Dictionary" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Returns a user dictionary for [param user_id]. OAuth only.
+			</description>
+		</method>
 		<method name="get_user_id" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the connected Discord user snowflake ID after [constant AUTH_READY], or [code]0[/code] when unavailable.
+				Returns the connected Discord user snowflake ID after [constant AUTH_READY], or [code]0[/code].
 			</description>
 		</method>
 		<method name="get_username" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the connected Discord display or username after [constant AUTH_READY], or an empty string when unavailable.
+				Returns the connected Discord display or username after [constant AUTH_READY].
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">
@@ -119,31 +195,38 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="client_id" type="int" default="0" />
 			<description>
-				Initializes the Discord Social SDK and starts the OAuth authorization flow for the given application client ID.
+				Initializes the Discord Social SDK and starts the OAuth authorization flow.
+			</description>
+		</method>
+		<method name="initialize_presence_only">
+			<return type="int" enum="Error" />
+			<param index="0" name="client_id" type="int" />
+			<description>
+				Initializes RPC rich presence without OAuth or [method initialize]'s connect step. Sets [method is_presence_only_mode] and emits [signal ready] immediately.
 			</description>
 		</method>
 		<method name="is_authorization_pending" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] while waiting for the user to complete OAuth ([constant AUTH_PENDING]).
+				Returns [code]true[/code] while waiting for OAuth ([constant AUTH_PENDING]).
 			</description>
 		</method>
 		<method name="is_authorized" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] after token exchange succeeds ([constant AUTH_AUTHORIZED] or [constant AUTH_READY]).
+				Returns [code]true[/code] after token exchange succeeds.
 			</description>
 		</method>
 		<method name="is_available">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] when the Discord Partner SDK runtime library is present beside the executable.
+				Returns [code]true[/code] when the Discord Partner SDK runtime library is present.
 			</description>
 		</method>
 		<method name="is_client_active" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] while the SDK client session is active (including during OAuth).
+				Returns [code]true[/code] while the SDK client session is active.
 			</description>
 		</method>
 		<method name="is_debug_logging_enabled" qualifiers="const">
@@ -155,18 +238,75 @@
 		<method name="is_frame_hook_connected" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Returns whether the engine frame hook is connected for automatic callback pumping.
 			</description>
 		</method>
 		<method name="is_initialized" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] after a successful [method initialize].
+				Returns [code]true[/code] after a successful [method initialize] or [method initialize_presence_only].
+			</description>
+		</method>
+		<method name="is_presence_only_mode" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when initialized via [method initialize_presence_only] (RPC, no OAuth).
 			</description>
 		</method>
 		<method name="is_ready_for_presence" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] when the client has reached [constant STATE_READY] and rich presence can be updated.
+				Returns [code]true[/code] when rich presence can be updated (RPC mode or [constant AUTH_READY]).
+			</description>
+		</method>
+		<method name="refresh_relationships">
+			<return type="void" />
+			<description>
+				Refreshes the cached relationship count and emits [signal relationships_updated]. OAuth only.
+			</description>
+		</method>
+		<method name="register_launch_command">
+			<return type="bool" />
+			<param index="0" name="application_id" type="int" />
+			<param index="1" name="command" type="String" />
+			<description>
+				Registers a custom launch command for Discord deep links. Works in RPC and OAuth modes.
+			</description>
+		</method>
+		<method name="register_launch_steam_application">
+			<return type="bool" />
+			<param index="0" name="application_id" type="int" />
+			<param index="1" name="steam_app_id" type="int" />
+			<description>
+				Registers Steam launch integration for Discord join flows. Works in RPC and OAuth modes.
+			</description>
+		</method>
+		<method name="reject_discord_friend_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Rejects a pending Discord friend request. OAuth only.
+			</description>
+		</method>
+		<method name="reject_game_friend_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Rejects a pending game friend request. OAuth only.
+			</description>
+		</method>
+		<method name="remove_discord_and_game_friend">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Removes both Discord and game friendship. OAuth only.
+			</description>
+		</method>
+		<method name="remove_game_friend">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Removes a game-scoped friend. OAuth only.
 			</description>
 		</method>
 		<method name="run_callbacks">
@@ -175,11 +315,61 @@
 				Pumps Discord SDK callbacks. Also invoked automatically each frame when initialized.
 			</description>
 		</method>
+		<method name="send_activity_invite">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<param index="1" name="content" type="String" default="&quot;&quot;" />
+			<description>
+				Sends an activity invite with optional message text. OAuth only. Emits [signal activity_invite_sent].
+			</description>
+		</method>
+		<method name="send_activity_join_request">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Sends a join request to another user. OAuth only.
+			</description>
+		</method>
+		<method name="send_activity_join_request_reply">
+			<return type="void" />
+			<param index="0" name="invite" type="Dictionary" />
+			<description>
+				Replies to an activity join request invite. OAuth only.
+			</description>
+		</method>
+		<method name="send_discord_friend_request">
+			<return type="void" />
+			<param index="0" name="username" type="String" />
+			<description>
+				Sends a Discord-wide friend request by username. OAuth only.
+			</description>
+		</method>
+		<method name="send_discord_friend_request_by_id">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Sends a Discord-wide friend request by user ID. OAuth only.
+			</description>
+		</method>
+		<method name="send_game_friend_request">
+			<return type="void" />
+			<param index="0" name="username" type="String" />
+			<description>
+				Sends a game-scoped friend request by username. OAuth only.
+			</description>
+		</method>
+		<method name="send_game_friend_request_by_id">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Sends a game-scoped friend request by user ID. OAuth only.
+			</description>
+		</method>
 		<method name="set_debug_logging">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
-				Enables verbose SDK file logging ([code]discord.log[/code] in user data) in addition to always-on lifecycle logs.
+				Enables verbose SDK file logging in user data.
 			</description>
 		</method>
 		<method name="shutdown">
@@ -188,29 +378,65 @@
 				Shuts down the Discord SDK session and releases resources.
 			</description>
 		</method>
+		<method name="unblock_user">
+			<return type="void" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Unblocks a user. OAuth only.
+			</description>
+		</method>
 		<method name="update_rich_presence">
 			<return type="int" enum="Error" />
 			<param index="0" name="activity" type="Dictionary" />
 			<description>
-				Updates Discord rich presence. Dictionary keys: [code]type[/code], [code]details[/code], [code]state[/code], [code]large_image[/code], [code]large_text[/code], [code]small_image[/code], [code]small_text[/code], [code]start_timestamp[/code], [code]end_timestamp[/code]. Requires [constant AUTH_READY]; if called earlier, the activity is cached and applied when [signal ready] fires. Returns [constant ERR_UNAUTHORIZED] when not ready.
+				Updates Discord rich presence. Keys include [code]type[/code], [code]name[/code], [code]details[/code], [code]state[/code], [code]details_url[/code], [code]state_url[/code], asset fields, [code]invite_cover_image[/code], [code]status_display_type[/code] ([code]name[/code]/[code]state[/code]/[code]details[/code]), [code]supported_platforms[/code] (array or bitmask), [code]party_id[/code], [code]party_current[/code], [code]party_max[/code], [code]join_secret[/code], [code]buttons[/code] ([code]{label,url}[/code]), and timestamps. Cached if called before ready.
 			</description>
 		</method>
 	</methods>
 	<signals>
+		<signal name="activity_invite_accepted">
+			<param index="0" name="join_secret" type="String" />
+			<description>
+				Emitted when the local user accepts an activity invite.
+			</description>
+		</signal>
+		<signal name="activity_invite_created">
+			<param index="0" name="invite" type="Dictionary" />
+			<description>
+				Emitted when a new activity invite is received.
+			</description>
+		</signal>
+		<signal name="activity_invite_sent">
+			<description>
+				Emitted after [method send_activity_invite] completes successfully.
+			</description>
+		</signal>
+		<signal name="activity_invite_updated">
+			<param index="0" name="invite" type="Dictionary" />
+			<description>
+				Emitted when an existing activity invite is updated.
+			</description>
+		</signal>
+		<signal name="activity_join_requested">
+			<param index="0" name="join_secret" type="String" />
+			<description>
+				Emitted when another user requests to join via the Discord client Join button.
+			</description>
+		</signal>
 		<signal name="authorization_failed">
 			<param index="0" name="error" type="String" />
 			<description>
-				Emitted when OAuth authorization fails or the user dismisses the auth UI.
+				Emitted when OAuth authorization fails.
 			</description>
 		</signal>
 		<signal name="authorization_started">
 			<description>
-				Emitted when the OAuth authorization flow begins (auth popup shown).
+				Emitted when OAuth authorization begins and the user must approve access.
 			</description>
 		</signal>
 		<signal name="authorized">
 			<description>
-				Emitted after the access token is stored and [method initialize]'s connect step begins.
+				Emitted when OAuth authorization succeeds before the client reaches ready state.
 			</description>
 		</signal>
 		<signal name="connection_state_changed">
@@ -218,25 +444,66 @@
 			<param index="1" name="error" type="int" />
 			<param index="2" name="error_detail" type="int" />
 			<description>
-				Emitted when the SDK connection state changes. [param state] uses [enum ConnectionState].
+				Emitted when the Discord client connection state changes.
+			</description>
+		</signal>
+		<signal name="lobby_joined">
+			<param index="0" name="lobby_id" type="int" />
+			<description>
+				Emitted when [method create_or_join_lobby] succeeds.
 			</description>
 		</signal>
 		<signal name="ready">
 			<description>
-				Emitted once when the client reaches [constant STATE_READY] and rich presence can be updated.
+				Emitted when Discord is ready for rich presence updates.
+			</description>
+		</signal>
+		<signal name="relationship_action_completed">
+			<param index="0" name="action" type="String" />
+			<param index="1" name="user_id" type="int" />
+			<param index="2" name="success" type="bool" />
+			<param index="3" name="error" type="String" />
+			<description>
+				Emitted when an OAuth relationship action completes.
+			</description>
+		</signal>
+		<signal name="relationship_created">
+			<param index="0" name="user_id" type="int" />
+			<param index="1" name="is_discord" type="bool" />
+			<description>
+				Emitted when a new relationship is created. OAuth only.
+			</description>
+		</signal>
+		<signal name="relationship_deleted">
+			<param index="0" name="user_id" type="int" />
+			<param index="1" name="is_discord" type="bool" />
+			<description>
+				Emitted when a relationship is removed. OAuth only.
+			</description>
+		</signal>
+		<signal name="relationship_groups_updated">
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Emitted when unified friends list groups should be refreshed. OAuth only.
 			</description>
 		</signal>
 		<signal name="relationships_updated">
 			<param index="0" name="count" type="int" />
 			<description>
-				Emitted after relationships are fetched on ready.
+				Emitted when the relationship count is refreshed after connect.
 			</description>
 		</signal>
 		<signal name="rich_presence_updated">
 			<param index="0" name="success" type="bool" />
 			<param index="1" name="error" type="String" />
 			<description>
-				Emitted when [method update_rich_presence] completes asynchronously.
+				Emitted when a rich presence update completes.
+			</description>
+		</signal>
+		<signal name="user_updated">
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Emitted when a Discord user's profile or status changes. OAuth only.
 			</description>
 		</signal>
 	</signals>
@@ -256,19 +523,50 @@
 		<constant name="STATE_HTTP_WAIT" value="6" enum="ConnectionState">
 		</constant>
 		<constant name="AUTH_NONE" value="0" enum="AuthState">
-			No auth flow started.
 		</constant>
 		<constant name="AUTH_PENDING" value="1" enum="AuthState">
-			OAuth popup shown; waiting for user authorization.
 		</constant>
 		<constant name="AUTH_AUTHORIZED" value="2" enum="AuthState">
-			Access token stored; connecting to Discord.
 		</constant>
 		<constant name="AUTH_READY" value="3" enum="AuthState">
-			Client ready; social APIs including rich presence are available.
 		</constant>
 		<constant name="AUTH_FAILED" value="4" enum="AuthState">
-			Authorization failed or was dismissed.
+		</constant>
+		<constant name="RELATIONSHIP_NONE" value="0" enum="RelationshipType">
+		</constant>
+		<constant name="RELATIONSHIP_FRIEND" value="1" enum="RelationshipType">
+		</constant>
+		<constant name="RELATIONSHIP_BLOCKED" value="2" enum="RelationshipType">
+		</constant>
+		<constant name="RELATIONSHIP_PENDING_INCOMING" value="3" enum="RelationshipType">
+		</constant>
+		<constant name="RELATIONSHIP_PENDING_OUTGOING" value="4" enum="RelationshipType">
+		</constant>
+		<constant name="RELATIONSHIP_IMPLICIT" value="5" enum="RelationshipType">
+		</constant>
+		<constant name="RELATIONSHIP_SUGGESTION" value="6" enum="RelationshipType">
+		</constant>
+		<constant name="GROUP_ONLINE_PLAYING_GAME" value="0" enum="RelationshipGroupType">
+		</constant>
+		<constant name="GROUP_ONLINE_ELSEWHERE" value="1" enum="RelationshipGroupType">
+		</constant>
+		<constant name="GROUP_OFFLINE" value="2" enum="RelationshipGroupType">
+		</constant>
+		<constant name="STATUS_ONLINE" value="0" enum="StatusType">
+		</constant>
+		<constant name="STATUS_OFFLINE" value="1" enum="StatusType">
+		</constant>
+		<constant name="STATUS_BLOCKED" value="2" enum="StatusType">
+		</constant>
+		<constant name="STATUS_IDLE" value="3" enum="StatusType">
+		</constant>
+		<constant name="STATUS_DND" value="4" enum="StatusType">
+		</constant>
+		<constant name="STATUS_INVISIBLE" value="5" enum="StatusType">
+		</constant>
+		<constant name="STATUS_STREAMING" value="6" enum="StatusType">
+		</constant>
+		<constant name="STATUS_UNKNOWN" value="7" enum="StatusType">
 		</constant>
 	</constants>
 </class>

--- a/modules/discord_module/tests/test_discord_module.h
+++ b/modules/discord_module/tests/test_discord_module.h
@@ -145,4 +145,42 @@ TEST_CASE("[DiscordModule] version dictionary") {
 	CHECK(version.has("sdk_enabled"));
 }
 
+TEST_CASE("[DiscordModule] presence only mode defaults false") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK_FALSE(discord->is_presence_only_mode());
+}
+
+TEST_CASE("[DiscordModule] initialize_presence_only unavailable without runtime library") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	if (DiscordAPILoader::is_runtime_library_present()) {
+		return;
+	}
+	CHECK(discord->initialize_presence_only(123456789) == ERR_UNAVAILABLE);
+	CHECK_FALSE(discord->is_presence_only_mode());
+}
+
+TEST_CASE("[DiscordModule] presence only signals registered") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK(discord->has_signal("activity_join_requested"));
+	CHECK(discord->has_signal("relationship_groups_updated"));
+	CHECK(discord->has_signal("relationship_action_completed"));
+}
+
+TEST_CASE("[DiscordModule] relationship enums exposed") {
+	CHECK(int(Discord::RELATIONSHIP_FRIEND) == 1);
+	CHECK(int(Discord::GROUP_OFFLINE) == 2);
+	CHECK(int(Discord::STATUS_ONLINE) == 0);
+}
+
+TEST_CASE("[DiscordModule] oauth relationship queries gated") {
+	Discord *discord = Discord::get_singleton();
+	REQUIRE(discord != nullptr);
+	CHECK(discord->get_relationships().is_empty());
+	CHECK(discord->get_relationship(1).is_empty());
+	CHECK(discord->get_user(1).is_empty());
+}
+
 } //namespace TestDiscordModule


### PR DESCRIPTION
## Summary
- Add `initialize_presence_only()` for Rich Presence without OAuth, with `is_presence_only_mode()` and relaxed `_require_presence_ready` guards.
- Extend `update_rich_presence()` to support full Activity fields (URLs, buttons, party, join secrets, platforms, invite cover, timestamps).
- Add game invite APIs (launch registration, send/accept/reply, join callbacks, `create_or_join_lobby`) and OAuth-only unified friends list + relationship management APIs with signals and enums.
- Update `Discord.xml`, API loader optional symbols, and Discord module tests.

## Test plan
- [x] `python -m SCons module_discord_module_enabled=yes target=editor -j8`
- [x] Run `--test --test-case=*DiscordModule*` with `tests=yes` build
- [x] Verify RPC presence updates without OAuth popup (Discord desktop running)
- [ ] Verify OAuth paths: UFL groups, friend requests, activity invites (two accounts)
