### PR TITLE
mask_parent on Sprite2D

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -600,6 +600,11 @@
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.
 		</member>
+		<member name="mask_parent" type="int" setter="set_mask_parent" getter="get_mask_parent" enum="CanvasItem.MaskParentMode" default="0">
+			If not [constant MASK_PARENT_DISABLED], this [CanvasItem] is not drawn on its own. Instead, its opaque pixels are used as an alpha mask for its parent [CanvasItem]. With [constant MASK_PARENT_INTERSECT] the parent is only visible where this node is opaque; with [constant MASK_PARENT_SUBTRACT] the parent is hidden where this node is opaque. This is the inverse of [member clip_children], and lets a child (for example a [Sprite2D]) mask its parent without any [BackBufferCopy] setup.
+			[b]Note:[/b] The parent must itself draw something (for example a [Sprite2D], [TextureRect] or [Polygon2D]) for the mask to have a visible effect. Masking a non-drawing parent such as a plain [Node2D] produces no visible result, since there is nothing for the mask to shape. Also has no effect if the parent is not a [CanvasItem], or when set on a [CanvasGroup].
+			[b]Note:[/b] On the Compatibility rendering method, soft (anti-aliased or gradient) mask edges require [member ProjectSettings.rendering/viewport/hdr_2d] to be enabled, or the Forward+ rendering method, to render smoothly. Without one of these, the back buffer only has 2 bits of alpha precision and soft edges appear dithered.
+		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material applied to this [CanvasItem].
 		</member>
@@ -744,6 +749,18 @@
 		</constant>
 		<constant name="CLIP_CHILDREN_MAX" value="3" enum="ClipChildrenMode">
 			Represents the size of the [enum ClipChildrenMode] enum.
+		</constant>
+		<constant name="MASK_PARENT_DISABLED" value="0" enum="MaskParentMode">
+			The node is drawn normally and does not mask its parent.
+		</constant>
+		<constant name="MASK_PARENT_INTERSECT" value="1" enum="MaskParentMode">
+			The node is not drawn; the parent is only visible where this node is opaque.
+		</constant>
+		<constant name="MASK_PARENT_SUBTRACT" value="2" enum="MaskParentMode">
+			The node is not drawn; the parent is hidden where this node is opaque (cuts a hole).
+		</constant>
+		<constant name="MASK_PARENT_MAX" value="3" enum="MaskParentMode">
+			Represents the size of the [enum MaskParentMode] enum.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -540,6 +540,15 @@
 				Sets the light [param mask] for the canvas item specified by the [param item] RID. Equivalent to [member CanvasItem.light_mask].
 			</description>
 		</method>
+		<method name="canvas_item_set_mask_parent">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="mode" type="int" enum="RenderingServer.CanvasGroupMode" />
+			<description>
+				Marks the canvas item specified by the [param item] RID as a mask for its parent: it is not drawn itself, but its opaque pixels define where the parent remains visible. [param mode] must be [constant CANVAS_GROUP_MODE_DISABLED] (off), [constant CANVAS_GROUP_MODE_MASK_PARENT] (parent kept where this item is opaque) or [constant CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT] (parent hidden where this item is opaque). The parent is promoted to the matching group automatically, so no [BackBufferCopy] is required.
+				[b]Note:[/b] The equivalent node functionality is found in [member CanvasItem.mask_parent].
+			</description>
+		</method>
 		<method name="canvas_item_set_material">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
@@ -5654,6 +5663,12 @@
 			Parent is used for clipping child, but parent is also drawn underneath child as normal before clipping child to its visible area.
 		</constant>
 		<constant name="CANVAS_GROUP_MODE_TRANSPARENT" value="3" enum="CanvasGroupMode">
+		</constant>
+		<constant name="CANVAS_GROUP_MODE_MASK_PARENT" value="4" enum="CanvasGroupMode">
+			Applied automatically to the parent of a [CanvasItem] that has [member CanvasItem.mask_parent] enabled. The parent becomes the group owner: it is routed through the back buffer and remains visible only where the masking child's pixels are opaque. Not meant to be set directly.
+		</constant>
+		<constant name="CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT" value="5" enum="CanvasGroupMode">
+			Like [constant CANVAS_GROUP_MODE_MASK_PARENT], but the parent is hidden where the masking child is opaque instead of kept.
 		</constant>
 		<constant name="CANVAS_LIGHT_MODE_POINT" value="0" enum="CanvasLightMode">
 			2D point light (see [PointLight2D]).

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -451,7 +451,12 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 				_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used, false, r_render_info, material_screen_texture_mipmaps_cached);
 				item_count = 0;
 
-				if (ci->canvas_group_owner->canvas_group->mode != RS::CANVAS_GROUP_MODE_TRANSPARENT) {
+				const bool owner_uses_clear =
+						ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_TRANSPARENT ||
+						ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT ||
+						ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT;
+
+				if (!owner_uses_clear) {
 					Rect2i group_rect = ci->canvas_group_owner->global_rect_cache;
 					texture_storage->render_target_copy_to_back_buffer(p_to_render_target, group_rect, false);
 					if (ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_CLIP_AND_DRAW) {
@@ -589,6 +594,10 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 		if (ci->use_canvas_group) {
 			if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_CLIP_AND_DRAW) {
 				material = default_clip_children_material;
+			} else if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT) {
+				material = default_mask_parent_material;
+			} else if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT) {
+				material = default_mask_parent_subtract_material;
 			} else {
 				if (material.is_null()) {
 					if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_CLIP_ONLY) {
@@ -2838,6 +2847,48 @@ void fragment() {
 		material_storage->material_set_shader(default_clip_children_material, default_clip_children_shader);
 	}
 
+	{
+		default_mask_parent_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(default_mask_parent_shader);
+
+		material_storage->shader_set_code(default_mask_parent_shader, R"(
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+void fragment() {
+	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
+	COLOR.a *= c.a;
+}
+)");
+		default_mask_parent_material = material_storage->material_allocate();
+		material_storage->material_initialize(default_mask_parent_material);
+
+		material_storage->material_set_shader(default_mask_parent_material, default_mask_parent_shader);
+	}
+
+	{
+		default_mask_parent_subtract_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(default_mask_parent_subtract_shader);
+
+		material_storage->shader_set_code(default_mask_parent_subtract_shader, R"(
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+void fragment() {
+	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
+	COLOR.a *= 1.0 - c.a;
+}
+)");
+		default_mask_parent_subtract_material = material_storage->material_allocate();
+		material_storage->material_initialize(default_mask_parent_subtract_material);
+
+		material_storage->material_set_shader(default_mask_parent_subtract_material, default_mask_parent_subtract_shader);
+	}
+
 	default_canvas_texture = texture_storage->canvas_texture_allocate();
 	texture_storage->canvas_texture_initialize(default_canvas_texture);
 
@@ -2854,6 +2905,10 @@ RasterizerCanvasGLES3::~RasterizerCanvasGLES3() {
 	material_storage->shader_free(default_canvas_group_shader);
 	material_storage->material_free(default_clip_children_material);
 	material_storage->shader_free(default_clip_children_shader);
+	material_storage->material_free(default_mask_parent_material);
+	material_storage->shader_free(default_mask_parent_shader);
+	material_storage->material_free(default_mask_parent_subtract_material);
+	material_storage->shader_free(default_mask_parent_subtract_shader);
 	singleton = nullptr;
 
 	glDeleteBuffers(1, &data.canvas_quad_vertices);

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -335,6 +335,10 @@ public:
 	RID default_canvas_group_shader;
 	RID default_clip_children_material;
 	RID default_clip_children_shader;
+	RID default_mask_parent_material;
+	RID default_mask_parent_shader;
+	RID default_mask_parent_subtract_material;
+	RID default_mask_parent_subtract_shader;
 
 	typedef void Texture;
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -343,6 +343,10 @@ void CanvasItem::_notification(int p_what) {
 			_set_global_invalid(true);
 			_enter_canvas();
 
+			if (mask_parent_mode != MASK_PARENT_DISABLED) {
+				_refresh_mask_parent();
+			}
+
 			RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, is_visible_in_tree()); // The visibility of the parent may change.
 			if (is_visible_in_tree()) {
 				notification(NOTIFICATION_VISIBILITY_CHANGED); // Considered invisible until entered.
@@ -378,6 +382,10 @@ void CanvasItem::_notification(int p_what) {
 
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
+			}
+
+			if (mask_parent_mode != MASK_PARENT_DISABLED) {
+				_refresh_mask_parent(true);
 			}
 			_exit_canvas();
 
@@ -1326,6 +1334,8 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_clip_children_mode", "mode"), &CanvasItem::set_clip_children_mode);
 	ClassDB::bind_method(D_METHOD("get_clip_children_mode"), &CanvasItem::get_clip_children_mode);
+	ClassDB::bind_method(D_METHOD("set_mask_parent", "enabled"), &CanvasItem::set_mask_parent);
+	ClassDB::bind_method(D_METHOD("get_mask_parent"), &CanvasItem::get_mask_parent);
 
 	GDVIRTUAL_BIND(_draw);
 
@@ -1336,6 +1346,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_behind_parent"), "set_draw_behind_parent", "is_draw_behind_parent_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "clip_children", PROPERTY_HINT_ENUM, "Disabled,Clip Only,Clip + Draw"), "set_clip_children_mode", "get_clip_children_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mask_parent", PROPERTY_HINT_ENUM, "Disabled,Intersect,Subtract"), "set_mask_parent", "get_mask_parent");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_light_mask", "get_light_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visibility_layer", PROPERTY_HINT_LAYERS_2D_RENDER), "set_visibility_layer", "get_visibility_layer");
 
@@ -1385,6 +1396,11 @@ void CanvasItem::_bind_methods() {
 	BIND_ENUM_CONSTANT(CLIP_CHILDREN_ONLY);
 	BIND_ENUM_CONSTANT(CLIP_CHILDREN_AND_DRAW);
 	BIND_ENUM_CONSTANT(CLIP_CHILDREN_MAX);
+
+	BIND_ENUM_CONSTANT(MASK_PARENT_DISABLED);
+	BIND_ENUM_CONSTANT(MASK_PARENT_INTERSECT);
+	BIND_ENUM_CONSTANT(MASK_PARENT_SUBTRACT);
+	BIND_ENUM_CONSTANT(MASK_PARENT_MAX);
 }
 
 Transform2D CanvasItem::get_canvas_transform() const {
@@ -1621,6 +1637,54 @@ void CanvasItem::set_clip_children_mode(ClipChildrenMode p_clip_mode) {
 CanvasItem::ClipChildrenMode CanvasItem::get_clip_children_mode() const {
 	ERR_READ_THREAD_GUARD_V(CLIP_CHILDREN_DISABLED);
 	return clip_children_mode;
+}
+
+void CanvasItem::_refresh_mask_parent(bool p_force_disable) {
+	if (Object::cast_to<CanvasGroup>(this) != nullptr) {
+		return;
+	}
+
+	RS::CanvasGroupMode rs_mode = RS::CANVAS_GROUP_MODE_DISABLED;
+	if (!p_force_disable) {
+		switch (mask_parent_mode) {
+			case MASK_PARENT_INTERSECT:
+				rs_mode = RS::CANVAS_GROUP_MODE_MASK_PARENT;
+				break;
+			case MASK_PARENT_SUBTRACT:
+				rs_mode = RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT;
+				break;
+			default:
+				rs_mode = RS::CANVAS_GROUP_MODE_DISABLED;
+				break;
+		}
+	}
+
+	RS::get_singleton()->canvas_item_set_mask_parent(get_canvas_item(), rs_mode);
+}
+
+void CanvasItem::set_mask_parent(MaskParentMode p_mode) {
+	ERR_THREAD_GUARD;
+	ERR_FAIL_INDEX(p_mode, MASK_PARENT_MAX);
+
+	if (mask_parent_mode == p_mode) {
+		return;
+	}
+
+	if (Object::cast_to<CanvasGroup>(this) != nullptr) {
+		return;
+	}
+
+	mask_parent_mode = p_mode;
+
+	if (is_inside_tree()) {
+		_refresh_mask_parent();
+	}
+	queue_redraw();
+}
+
+CanvasItem::MaskParentMode CanvasItem::get_mask_parent() const {
+	ERR_READ_THREAD_GUARD_V(MASK_PARENT_DISABLED);
+	return mask_parent_mode;
 }
 
 CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -71,6 +71,13 @@ public:
 		CLIP_CHILDREN_MAX,
 	};
 
+	enum MaskParentMode {
+		MASK_PARENT_DISABLED,
+		MASK_PARENT_INTERSECT, // Parent kept where this node is opaque (clip mask).
+		MASK_PARENT_SUBTRACT, // Parent hidden where this node is opaque (cut a hole).
+		MASK_PARENT_MAX,
+	};
+
 private:
 	mutable SelfList<Node>
 			xform_change;
@@ -113,6 +120,8 @@ private:
 
 	ClipChildrenMode clip_children_mode = CLIP_CHILDREN_DISABLED;
 
+	MaskParentMode mask_parent_mode = MASK_PARENT_DISABLED;
+
 	mutable RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	mutable RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
 	TextureFilter texture_filter = TEXTURE_FILTER_PARENT_NODE;
@@ -138,6 +147,7 @@ private:
 
 	void _enter_canvas();
 	void _exit_canvas();
+	void _refresh_mask_parent(bool p_force_disable = false);
 
 	void _window_visibility_changed();
 
@@ -256,6 +266,9 @@ public:
 
 	void set_clip_children_mode(ClipChildrenMode p_clip_mode);
 	ClipChildrenMode get_clip_children_mode() const;
+
+	void set_mask_parent(MaskParentMode p_mode);
+	MaskParentMode get_mask_parent() const;
 
 	virtual void set_light_mask(int p_light_mask);
 	int get_light_mask() const;
@@ -400,7 +413,7 @@ public:
 VARIANT_ENUM_CAST(CanvasItem::TextureFilter)
 VARIANT_ENUM_CAST(CanvasItem::TextureRepeat)
 VARIANT_ENUM_CAST(CanvasItem::ClipChildrenMode)
-
+VARIANT_ENUM_CAST(CanvasItem::MaskParentMode)
 class CanvasTexture : public Texture2D {
 	GDCLASS(CanvasTexture, Texture2D);
 	OBJ_SAVE_TYPE(Texture2D); // Saves derived classes with common type so they can be interchanged.

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -88,7 +88,7 @@ void RendererCanvasCull::_collect_ysort_children(RendererCanvasCull::Item *p_can
 	int child_item_count = p_canvas_item->child_items.size();
 	RendererCanvasCull::Item **child_items = p_canvas_item->child_items.ptrw();
 	for (int i = 0; i < child_item_count; i++) {
-		if (child_items[i]->visible) {
+		if (child_items[i]->visible && !child_items[i]->mask_parent) {
 			// To y-sort according to the item's final position, physics interpolation
 			// and transform snapping need to be applied before y-sorting.
 			Transform2D child_xform;
@@ -138,7 +138,7 @@ int RendererCanvasCull::_count_ysort_children(RendererCanvasCull::Item *p_canvas
 	int child_item_count = p_canvas_item->child_items.size();
 	RendererCanvasCull::Item *const *child_items = p_canvas_item->child_items.ptr();
 	for (int i = 0; i < child_item_count; i++) {
-		if (child_items[i]->visible) {
+		if (child_items[i]->visible && !child_items[i]->mask_parent) {
 			ysort_children_count++;
 			if (child_items[i]->sort_y) {
 				ysort_children_count += _count_ysort_children(child_items[i]);
@@ -427,9 +427,23 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		} else {
 			RendererCanvasRender::Item *canvas_group_from = nullptr;
 			bool use_canvas_group = ci->canvas_group != nullptr && (ci->canvas_group->fit_empty || ci->commands != nullptr);
+			bool mask_parent_group = use_canvas_group &&
+					(ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT ||
+							ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT);
 			if (use_canvas_group) {
 				int zidx = p_z - RS::CANVAS_ITEM_Z_MIN;
 				canvas_group_from = r_z_last_list[zidx];
+			}
+
+			if (mask_parent_group) {
+				int mask_child_count = ci->child_items.size();
+				Item **mask_child_items = ci->child_items.ptrw();
+				for (int i = 0; i < mask_child_count; i++) {
+					if (!mask_child_items[i]->mask_parent) {
+						continue;
+					}
+					_cull_canvas_item(mask_child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+				}
 			}
 
 			_attach_canvas_item_for_draw(ci, p_canvas_clip, r_z_list, r_z_last_list, final_xform, p_clip_rect, global_rect, modulate, p_z, p_material_owner, use_canvas_group, canvas_group_from);
@@ -437,23 +451,57 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	} else {
 		RendererCanvasRender::Item *canvas_group_from = nullptr;
 		bool use_canvas_group = ci->canvas_group != nullptr && (ci->canvas_group->fit_empty || ci->commands != nullptr);
-		if (use_canvas_group) {
-			int zidx = p_z - RS::CANVAS_ITEM_Z_MIN;
-			canvas_group_from = r_z_last_list[zidx];
-		}
 
-		for (int i = 0; i < child_item_count; i++) {
-			if (!child_items[i]->behind && !use_canvas_group) {
-				continue;
+		bool mask_parent_group = use_canvas_group &&
+				(ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT ||
+						ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT);
+
+		if (mask_parent_group) {
+			int zidx = p_z - RS::CANVAS_ITEM_Z_MIN;
+
+			for (int i = 0; i < child_item_count; i++) {
+				if (child_items[i]->mask_parent || !child_items[i]->behind) {
+					continue;
+				}
+				_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
 			}
-			_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
-		}
-		_attach_canvas_item_for_draw(ci, p_canvas_clip, r_z_list, r_z_last_list, final_xform, p_clip_rect, global_rect, modulate, p_z, p_material_owner, use_canvas_group, canvas_group_from);
-		for (int i = 0; i < child_item_count; i++) {
-			if (child_items[i]->behind || use_canvas_group) {
-				continue;
+
+			canvas_group_from = r_z_last_list[zidx];
+
+			for (int i = 0; i < child_item_count; i++) {
+				if (!child_items[i]->mask_parent) {
+					continue;
+				}
+				_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
 			}
-			_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+
+			_attach_canvas_item_for_draw(ci, p_canvas_clip, r_z_list, r_z_last_list, final_xform, p_clip_rect, global_rect, modulate, p_z, p_material_owner, use_canvas_group, canvas_group_from);
+
+			for (int i = 0; i < child_item_count; i++) {
+				if (child_items[i]->mask_parent || child_items[i]->behind) {
+					continue;
+				}
+				_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+			}
+		} else {
+			if (use_canvas_group) {
+				int zidx = p_z - RS::CANVAS_ITEM_Z_MIN;
+				canvas_group_from = r_z_last_list[zidx];
+			}
+
+			for (int i = 0; i < child_item_count; i++) {
+				if (!child_items[i]->behind && !use_canvas_group) {
+					continue;
+				}
+				_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+			}
+			_attach_canvas_item_for_draw(ci, p_canvas_clip, r_z_list, r_z_last_list, final_xform, p_clip_rect, global_rect, modulate, p_z, p_material_owner, use_canvas_group, canvas_group_from);
+			for (int i = 0; i < child_item_count; i++) {
+				if (child_items[i]->behind || use_canvas_group) {
+					continue;
+				}
+				_cull_canvas_item(child_items[i], final_xform, p_clip_rect, modulate, p_z, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, p_material_owner, false, p_canvas_cull_mask, repeat_size, repeat_times, repeat_source_item);
+			}
 		}
 	}
 }
@@ -1972,6 +2020,56 @@ void RendererCanvasCull::canvas_item_set_canvas_group_mode(RID p_item, RS::Canva
 		canvas_item->canvas_group->fit_margin = p_fit_margin;
 		canvas_item->canvas_group->blur_mipmaps = p_blur_mipmaps;
 		canvas_item->canvas_group->clear_margin = p_clear_margin;
+	}
+}
+
+void RendererCanvasCull::canvas_item_set_mask_parent(RID p_item, RS::CanvasGroupMode p_mode) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	const bool enabled = p_mode == RS::CANVAS_GROUP_MODE_MASK_PARENT || p_mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT;
+
+	if (canvas_item->mask_parent == enabled && !enabled) {
+		return;
+	}
+	canvas_item->mask_parent = enabled;
+
+	_mark_ysort_dirty(canvas_item);
+
+	if (!canvas_item_owner.owns(canvas_item->parent)) {
+		return;
+	}
+	Item *parent = canvas_item_owner.get_or_null(canvas_item->parent);
+
+	if (enabled) {
+		if (parent->canvas_group == nullptr) {
+			parent->canvas_group = memnew(RendererCanvasRender::Item::CanvasGroup);
+			parent->canvas_group->fit_empty = false;
+			parent->canvas_group->fit_margin = 0.0;
+			parent->canvas_group->blur_mipmaps = false;
+			parent->canvas_group->clear_margin = 5.0;
+		}
+		if (parent->canvas_group->mode == RS::CANVAS_GROUP_MODE_DISABLED ||
+				parent->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT ||
+				parent->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT) {
+			parent->canvas_group->mode = p_mode;
+		}
+	} else {
+		if (parent->canvas_group != nullptr &&
+				(parent->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT ||
+						parent->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT)) {
+			bool still_masked = false;
+			for (int i = 0; i < parent->child_items.size(); i++) {
+				if (parent->child_items[i]->mask_parent) {
+					still_masked = true;
+					break;
+				}
+			}
+			if (!still_masked) {
+				memdelete(parent->canvas_group);
+				parent->canvas_group = nullptr;
+			}
+		}
 	}
 }
 

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -272,6 +272,7 @@ public:
 	void canvas_item_set_visibility_notifier(RID p_item, bool p_enable, const Rect2 &p_area, const Callable &p_enter_callable, const Callable &p_exit_callable);
 
 	void canvas_item_set_canvas_group_mode(RID p_item, RS::CanvasGroupMode p_mode, float p_clear_margin = 5.0, bool p_fit_empty = false, float p_fit_margin = 0.0, bool p_blur_mipmaps = false);
+	void canvas_item_set_mask_parent(RID p_item, RS::CanvasGroupMode p_mode);
 
 	void canvas_item_set_debug_redraw(bool p_enabled);
 	bool canvas_item_get_debug_redraw() const;

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -323,15 +323,16 @@ public:
 		bool use_identity_transform : 1;
 
 		struct CanvasGroup {
-			RS::CanvasGroupMode mode;
-			bool fit_empty;
-			float fit_margin;
-			bool blur_mipmaps;
-			float clear_margin;
+			RS::CanvasGroupMode mode = RS::CANVAS_GROUP_MODE_DISABLED;
+			bool fit_empty = false;
+			float fit_margin = 0.0;
+			bool blur_mipmaps = false;
+			float clear_margin = 5.0;
 		};
 
 		CanvasGroup *canvas_group = nullptr;
 		bool use_canvas_group = false;
+		bool mask_parent = false;
 		int light_mask;
 		int z_final;
 
@@ -476,6 +477,7 @@ public:
 			material_owner = nullptr;
 			copy_back_buffer = nullptr;
 			distance_field = false;
+			mask_parent = false;
 			light_masked = false;
 			update_when_visible = false;
 			z_final = 0;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1214,6 +1214,10 @@ void RendererCanvasRenderRD::_render_items(RID p_to_render_target, int p_item_co
 		if (ci->use_canvas_group) {
 			if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_CLIP_AND_DRAW) {
 				material = default_clip_children_material;
+			} else if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT) {
+				material = default_mask_parent_material;
+			} else if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT) {
+				material = default_mask_parent_subtract_material;
 			} else {
 				if (material.is_null()) {
 					if (ci->canvas_group->mode == RS::CANVAS_GROUP_MODE_CLIP_ONLY) {
@@ -1578,7 +1582,12 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 				_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used, false, r_render_info);
 				item_count = 0;
 
-				if (ci->canvas_group_owner->canvas_group->mode != RS::CANVAS_GROUP_MODE_TRANSPARENT) {
+				const bool owner_uses_clear =
+						ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_TRANSPARENT ||
+						ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT ||
+						ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT;
+
+				if (!owner_uses_clear) {
 					Rect2i group_rect = ci->canvas_group_owner->global_rect_cache;
 					texture_storage->render_target_copy_to_back_buffer(p_to_render_target, group_rect, false);
 					if (ci->canvas_group_owner->canvas_group->mode == RS::CANVAS_GROUP_MODE_CLIP_AND_DRAW) {
@@ -2844,6 +2853,48 @@ void fragment() {
 		material_storage->material_set_shader(default_clip_children_material, default_clip_children_shader);
 	}
 
+	{
+		default_mask_parent_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(default_mask_parent_shader);
+
+		material_storage->shader_set_code(default_mask_parent_shader, R"(
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+void fragment() {
+	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
+	COLOR.a *= c.a;
+}
+)");
+		default_mask_parent_material = material_storage->material_allocate();
+		material_storage->material_initialize(default_mask_parent_material);
+
+		material_storage->material_set_shader(default_mask_parent_material, default_mask_parent_shader);
+	}
+
+	{
+		default_mask_parent_subtract_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(default_mask_parent_subtract_shader);
+
+		material_storage->shader_set_code(default_mask_parent_subtract_shader, R"(
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+void fragment() {
+	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
+	COLOR.a *= 1.0 - c.a;
+}
+)");
+		default_mask_parent_subtract_material = material_storage->material_allocate();
+		material_storage->material_initialize(default_mask_parent_subtract_material);
+
+		material_storage->material_set_shader(default_mask_parent_subtract_material, default_mask_parent_subtract_shader);
+	}
+
 	static_assert(sizeof(PushConstant) == 128);
 }
 
@@ -2900,6 +2951,10 @@ RendererCanvasRenderRD::~RendererCanvasRenderRD() {
 
 	material_storage->material_free(default_canvas_group_material);
 	material_storage->shader_free(default_canvas_group_shader);
+	material_storage->material_free(default_mask_parent_material);
+	material_storage->shader_free(default_mask_parent_shader);
+	material_storage->material_free(default_mask_parent_subtract_material);
+	material_storage->shader_free(default_mask_parent_subtract_shader);
 
 	material_storage->material_free(default_clip_children_material);
 	material_storage->shader_free(default_clip_children_shader);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -411,6 +411,10 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	RID default_canvas_group_material;
 	RID default_clip_children_material;
 	RID default_clip_children_shader;
+	RID default_mask_parent_material;
+	RID default_mask_parent_shader;
+	RID default_mask_parent_subtract_material;
+	RID default_mask_parent_subtract_shader;
 
 	RS::CanvasItemTextureFilter default_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	RS::CanvasItemTextureRepeat default_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -951,6 +951,7 @@ public:
 	FUNC5(canvas_item_set_visibility_notifier, RID, bool, const Rect2 &, const Callable &, const Callable &)
 
 	FUNC6(canvas_item_set_canvas_group_mode, RID, CanvasGroupMode, float, bool, float, bool)
+	FUNC2(canvas_item_set_mask_parent, RID, CanvasGroupMode)
 
 	FUNC1(canvas_item_set_debug_redraw, bool)
 	FUNC0RC(bool, canvas_item_get_debug_redraw)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3303,6 +3303,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("canvas_item_set_visibility_notifier", "item", "enable", "area", "enter_callable", "exit_callable"), &RenderingServer::canvas_item_set_visibility_notifier);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_canvas_group_mode", "item", "mode", "clear_margin", "fit_empty", "fit_margin", "blur_mipmaps"), &RenderingServer::canvas_item_set_canvas_group_mode, DEFVAL(5.0), DEFVAL(false), DEFVAL(0.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("canvas_item_set_mask_parent", "item", "mode"), &RenderingServer::canvas_item_set_mask_parent);
 
 	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_rect", "item"), &RenderingServer::debug_canvas_item_get_rect);
 
@@ -3329,6 +3330,8 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(CANVAS_GROUP_MODE_CLIP_ONLY);
 	BIND_ENUM_CONSTANT(CANVAS_GROUP_MODE_CLIP_AND_DRAW);
 	BIND_ENUM_CONSTANT(CANVAS_GROUP_MODE_TRANSPARENT);
+	BIND_ENUM_CONSTANT(CANVAS_GROUP_MODE_MASK_PARENT);
+	BIND_ENUM_CONSTANT(CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT);
 
 	/* CANVAS LIGHT */
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1540,9 +1540,13 @@ public:
 		CANVAS_GROUP_MODE_CLIP_ONLY,
 		CANVAS_GROUP_MODE_CLIP_AND_DRAW,
 		CANVAS_GROUP_MODE_TRANSPARENT,
+		CANVAS_GROUP_MODE_MASK_PARENT,
+		CANVAS_GROUP_MODE_MASK_PARENT_SUBTRACT,
 	};
 
 	virtual void canvas_item_set_canvas_group_mode(RID p_item, CanvasGroupMode p_mode, float p_clear_margin = 5.0, bool p_fit_empty = false, float p_fit_margin = 0.0, bool p_blur_mipmaps = false) = 0;
+
+	virtual void canvas_item_set_mask_parent(RID p_item, CanvasGroupMode p_mode) = 0;
 
 	virtual void canvas_item_set_debug_redraw(bool p_enabled) = 0;
 	virtual bool canvas_item_get_debug_redraw() const = 0;


### PR DESCRIPTION
attempt at godotengine/godot-proposals#4282
Technically, this is the CanvasGroup / clip mechanism automated and inverted. unlike godotengine/godot#74859 siblings are individuals, they can not clip or clip too. If you want smooth masks on Compatibility you need to use HDR 2D [not doing an engine change to alter that as that would affect all of Compatibility]
