### PR TITLE
opt-in GDScript style guide

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -226,6 +226,7 @@ public:
 		int code;
 		String string_code;
 		String message;
+		bool is_style = false;
 	};
 
 	struct ScriptError {

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1688,6 +1688,39 @@
 			Specifies the maximum number of log files allowed (used for rotation). Set to [code]1[/code] to disable log file rotation.
 			If the [code]--log-file &lt;file&gt;[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url] is used, log rotation is always disabled.
 		</member>
+		<member name="debug/gdscript/style_checks/class_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a class name is not written in [code]PascalCase[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/constant_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a constant name is not written in [code]CONSTANT_CASE[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. Names in [code]PascalCase[/code] are also accepted, for example a [code]const[/code] that holds a preloaded script or scene. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/enum_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a enum name is not written in [code]PascalCase[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/enum_value_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a enum value is not written in [code]CONSTANT_CASE[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/file_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a script file name is not written in [code]snake_case[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. Built-in scripts are never reported, as they have no file name of their own. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/function_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function name is not written in [code]snake_case[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/hexadecimal_case" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a hexadecimal number uses lowercase letters, for example [code]0xfb8c0b[/code] instead of [code]0xFB8C0B[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/parameter_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function or signal parameter name is not written in [code]snake_case[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/signal_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a signal name is not written in [code]snake_case[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/trailing_comma" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the last element of an array, dictionary or enum is not followed by a trailing comma while the closing bracket is on its own line, or is followed by one while the closing bracket is on the same line, as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
+		<member name="debug/gdscript/style_checks/variable_naming_convention" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a variable name is not written in [code]snake_case[/code], as recommended by the [url=https://docs.blazium.app/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]. This check is disabled by default.
+		</member>
 		<member name="debug/gdscript/warnings/assert_always_false" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an [code]assert[/code] call always evaluates to [code]false[/code].
 		</member>

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -338,6 +338,10 @@ void ScriptEditorDebugger::_select_thread(int p_index) {
 	_thread_debug_enter(debugging_thread_id);
 }
 
+static bool _is_style_warning_name(const String &p_name) {
+	return p_name.ends_with("_NAMING_CONVENTION") || p_name.ends_with("_TRAILING_COMMA") || p_name == "HEXADECIMAL_CASE";
+}
+
 void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data) {
 	emit_signal(SNAME("debug_data"), p_msg, p_data);
 	if (p_msg == "debug_enter") {
@@ -587,8 +591,12 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 		String tooltip = oe.warning ? TTR("Warning:") : TTR("Error:");
 
 		TreeItem *error = error_tree->create_item(r);
+		const bool is_style_warning = oe.warning && _is_style_warning_name(oe.error);
 		if (oe.warning) {
 			error->set_meta("_is_warning", true);
+			if (is_style_warning) {
+				error->set_meta("_is_style_warning", true);
+			}
 		} else {
 			error->set_meta("_is_error", true);
 		}
@@ -598,7 +606,14 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 		error->set_text(0, time);
 		error->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
 
-		const Color color = get_theme_color(oe.warning ? SNAME("warning_color") : SNAME("error_color"), EditorStringName(Editor));
+		Color color;
+		if (is_style_warning) {
+			color = has_theme_color(SNAME("style_warning_color"), EditorStringName(Editor))
+					? get_theme_color(SNAME("style_warning_color"), EditorStringName(Editor))
+					: Color(0.68, 0.5, 0.93);
+		} else {
+			color = get_theme_color(oe.warning ? SNAME("warning_color") : SNAME("error_color"), EditorStringName(Editor));
+		}
 		error->set_custom_color(0, color);
 		error->set_custom_color(1, color);
 
@@ -931,7 +946,14 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			if (error_root) {
 				TreeItem *error = error_root->get_first_child();
 				while (error) {
-					if (error->has_meta("_is_warning")) {
+					if (error->has_meta("_is_style_warning")) {
+						const Color sc = has_theme_color(SNAME("style_warning_color"), EditorStringName(Editor))
+								? get_theme_color(SNAME("style_warning_color"), EditorStringName(Editor))
+								: Color(0.68, 0.5, 0.93);
+						error->set_icon(0, get_editor_theme_icon(SNAME("Warning")));
+						error->set_custom_color(0, sc);
+						error->set_custom_color(1, sc);
+					} else if (error->has_meta("_is_warning")) {
 						error->set_icon(0, get_editor_theme_icon(SNAME("Warning")));
 						error->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 						error->set_custom_color(1, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -644,6 +644,8 @@ void ScriptTextEditor::_update_background_color() {
 
 	// Set the warning background.
 	if (warning_line_color.a != 0.0) {
+		Color style_line_color = Color(0.68, 0.5, 0.93);
+		style_line_color.a = warning_line_color.a;
 		for (const ScriptLanguage::Warning &warning : warnings) {
 			int warning_start_line = CLAMP(warning.start_line - 1, 0, te->get_line_count() - 1);
 			int warning_end_line = CLAMP(warning.end_line - 1, 0, te->get_line_count() - 1);
@@ -652,10 +654,11 @@ void ScriptTextEditor::_update_background_color() {
 			// If the warning highlight is too long, only highlight the start line.
 			const int warning_max_lines = 20;
 
-			te->set_line_background_color(folded_line_header, warning_line_color);
+			const Color line_color = warning.is_style ? style_line_color : warning_line_color;
+			te->set_line_background_color(folded_line_header, line_color);
 			if (warning_end_line - warning_start_line < warning_max_lines) {
 				for (int i = warning_start_line + 1; i <= warning_end_line; i++) {
-					te->set_line_background_color(i, warning_line_color);
+					te->set_line_background_color(i, line_color);
 				}
 			}
 		}
@@ -914,6 +917,9 @@ void ScriptTextEditor::_update_warnings() {
 	}
 
 	// Add script warnings.
+	const Color style_warning_color = warnings_panel->has_theme_color(SNAME("style_warning_color"), EditorStringName(Editor))
+			? warnings_panel->get_theme_color(SNAME("style_warning_color"), EditorStringName(Editor))
+			: Color(0.68, 0.5, 0.93);
 	warnings_panel->push_table(3);
 	for (const ScriptLanguage::Warning &w : warnings) {
 		Dictionary ignore_meta;
@@ -930,14 +936,20 @@ void ScriptTextEditor::_update_warnings() {
 
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(w.start_line - 1);
-		warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		warnings_panel->push_color(w.is_style ? style_warning_color : warnings_panel->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 		warnings_panel->add_text(vformat(TTR("Line %d (%s):"), w.start_line, w.string_code));
 		warnings_panel->pop(); // Color.
 		warnings_panel->pop(); // Meta goto.
 		warnings_panel->pop(); // Cell.
 
 		warnings_panel->push_cell();
-		warnings_panel->add_text(w.message);
+		if (w.is_style) {
+			warnings_panel->push_color(style_warning_color);
+			warnings_panel->add_text(w.message);
+			warnings_panel->pop();
+		} else {
+			warnings_panel->add_text(w.message);
+		}
 		warnings_panel->add_newline();
 		warnings_panel->pop(); // Cell.
 	}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -148,6 +148,7 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 			w.rightmost_column = warn.rightmost_column;
 			w.code = (int)warn.code;
 			w.string_code = GDScriptWarning::get_name_from_code(warn.code);
+			w.is_style = GDScriptWarning::is_style_warning(warn.code);
 			w.message = warn.get_message();
 			r_warnings->push_back(w);
 		}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -213,6 +213,141 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	pending_warnings.push_back(pw);
 }
 
+static bool _style_strip(const String &p_name, String &r_core) {
+	int begin = 0;
+	int end = p_name.length();
+	while (begin < end && p_name[begin] == '_') {
+		begin++;
+	}
+	while (end > begin && p_name[end - 1] == '_') {
+		end--;
+	}
+	if (begin >= end) {
+		return false;
+	}
+	r_core = p_name.substr(begin, end - begin);
+	const char32_t first = r_core[0];
+	if (first >= '0' && first <= '9') {
+		return false;
+	}
+	return true;
+}
+
+static bool _style_is_snake_case(const String &p_name) {
+	String core;
+	if (!_style_strip(p_name, core)) {
+		return true;
+	}
+	for (int i = 0; i < core.length(); i++) {
+		const char32_t c = core[i];
+		if (c >= 'A' && c <= 'Z') {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool _style_is_constant_case(const String &p_name) {
+	String core;
+	if (!_style_strip(p_name, core)) {
+		return true;
+	}
+	for (int i = 0; i < core.length(); i++) {
+		const char32_t c = core[i];
+		if (c >= 'a' && c <= 'z') {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool _style_is_pascal_case(const String &p_name) {
+	String core;
+	if (!_style_strip(p_name, core)) {
+		return true;
+	}
+	const char32_t first = core[0];
+	if (first < 'A' || first > 'Z') {
+		return false;
+	}
+	if (core.find_char('_') != -1) {
+		return false;
+	}
+	return true;
+}
+
+void GDScriptParser::check_identifier_style(const IdentifierNode *p_identifier, GDScriptWarning::Code p_code) {
+	if (p_identifier == nullptr || p_identifier->name == StringName()) {
+		return;
+	}
+	const String name = String(p_identifier->name);
+	bool ok = true;
+	switch (p_code) {
+		case GDScriptWarning::CLASS_NAMING_CONVENTION:
+		case GDScriptWarning::ENUM_NAMING_CONVENTION:
+			ok = _style_is_pascal_case(name);
+			break;
+		case GDScriptWarning::FUNCTION_NAMING_CONVENTION:
+		case GDScriptWarning::VARIABLE_NAMING_CONVENTION:
+		case GDScriptWarning::SIGNAL_NAMING_CONVENTION:
+		case GDScriptWarning::PARAMETER_NAMING_CONVENTION:
+			ok = _style_is_snake_case(name);
+			break;
+		case GDScriptWarning::CONSTANT_NAMING_CONVENTION:
+			ok = _style_is_constant_case(name) || _style_is_pascal_case(name);
+			break;
+		case GDScriptWarning::ENUM_VALUE_NAMING_CONVENTION:
+			ok = _style_is_constant_case(name);
+			break;
+		default:
+			return;
+	}
+	if (!ok) {
+		push_warning(p_identifier, p_code, name);
+	}
+}
+
+void GDScriptParser::check_file_style() {
+	if (script_path.is_empty() || script_path.contains("::")) {
+		return;
+	}
+	const String file_name = script_path.get_file();
+	if (_style_is_snake_case(file_name.get_basename())) {
+		return;
+	}
+	Node *nd = alloc_node<PassNode>();
+	nd->start_line = 1;
+	nd->start_column = 0;
+	nd->end_line = 1;
+	nd->leftmost_column = 0;
+	nd->rightmost_column = 0;
+	push_warning(nd, GDScriptWarning::FILE_NAMING_CONVENTION, file_name);
+}
+
+void GDScriptParser::check_trailing_comma(const Node *p_list, const Node *p_last_element, bool p_has_trailing_comma, const String &p_kind) {
+	if (p_last_element == nullptr) {
+		return;
+	}
+	const bool comma_expected = p_list->end_line > p_last_element->end_line;
+	if (comma_expected && !p_has_trailing_comma) {
+		push_warning(p_last_element, GDScriptWarning::MISSING_TRAILING_COMMA, p_kind);
+	} else if (!comma_expected && p_has_trailing_comma) {
+		push_warning(p_last_element, GDScriptWarning::UNNECESSARY_TRAILING_COMMA, p_kind);
+	}
+}
+
+void GDScriptParser::check_hexadecimal_case(const Node *p_source, const String &p_text) {
+	if (!p_text.begins_with("0x") && !p_text.begins_with("0X")) {
+		return;
+	}
+	for (int i = 2; i < p_text.length(); i++) {
+		if (p_text[i] >= 'a' && p_text[i] <= 'f') {
+			push_warning(p_source, GDScriptWarning::HEXADECIMAL_CASE, p_text);
+			return;
+		}
+	}
+}
+
 void GDScriptParser::apply_pending_warnings() {
 	for (const PendingWarning &pw : pending_warnings) {
 		if (warning_ignored_lines[pw.code].has(pw.source->start_line)) {
@@ -410,6 +545,8 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 		nd->rightmost_column = 0;
 		push_warning(nd, GDScriptWarning::EMPTY_FILE);
 	}
+
+	check_file_style();
 #endif
 
 	push_multiline(false); // Keep one for the whole parsing.
@@ -846,6 +983,9 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class(bool p_is_static) {
 
 	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the class name after "class".)")) {
 		n_class->identifier = parse_identifier();
+#ifdef DEBUG_ENABLED
+		check_identifier_style(n_class->identifier, GDScriptWarning::CLASS_NAMING_CONVENTION);
+#endif
 		if (n_class->outer) {
 			String fqcn = n_class->outer->fqcn;
 			if (fqcn.is_empty()) {
@@ -894,6 +1034,9 @@ void GDScriptParser::parse_class_name() {
 	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the global class name after "class_name".)")) {
 		current_class->identifier = parse_identifier();
 		current_class->fqcn = String(current_class->identifier->name);
+#ifdef DEBUG_ENABLED
+		check_identifier_style(current_class->identifier, GDScriptWarning::CLASS_NAMING_CONVENTION);
+#endif
 	}
 
 	if (match(GDScriptTokenizer::Token::EXTENDS)) {
@@ -1116,6 +1259,9 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 
 	variable->identifier = parse_identifier();
 	variable->export_info.name = variable->identifier->name;
+#ifdef DEBUG_ENABLED
+	check_identifier_style(variable->identifier, GDScriptWarning::VARIABLE_NAMING_CONVENTION);
+#endif
 	variable->is_static = p_is_static;
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
@@ -1351,6 +1497,9 @@ GDScriptParser::ConstantNode *GDScriptParser::parse_constant(bool p_is_static) {
 	}
 
 	constant->identifier = parse_identifier();
+#ifdef DEBUG_ENABLED
+	check_identifier_style(constant->identifier, GDScriptWarning::CONSTANT_NAMING_CONVENTION);
+#endif
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
 		if (check((GDScriptTokenizer::Token::EQUAL))) {
@@ -1389,6 +1538,9 @@ GDScriptParser::ParameterNode *GDScriptParser::parse_parameter() {
 
 	ParameterNode *parameter = alloc_node<ParameterNode>();
 	parameter->identifier = parse_identifier();
+#ifdef DEBUG_ENABLED
+	check_identifier_style(parameter->identifier, GDScriptWarning::PARAMETER_NAMING_CONVENTION);
+#endif
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
 		if (check((GDScriptTokenizer::Token::EQUAL))) {
@@ -1419,6 +1571,9 @@ GDScriptParser::SignalNode *GDScriptParser::parse_signal(bool p_is_static) {
 	}
 
 	signal->identifier = parse_identifier();
+#ifdef DEBUG_ENABLED
+	check_identifier_style(signal->identifier, GDScriptWarning::SIGNAL_NAMING_CONVENTION);
+#endif
 
 	if (check(GDScriptTokenizer::Token::PARENTHESIS_OPEN)) {
 		push_multiline(true);
@@ -1462,6 +1617,9 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 	if (match(GDScriptTokenizer::Token::IDENTIFIER)) {
 		enum_node->identifier = parse_identifier();
 		named = true;
+#ifdef DEBUG_ENABLED
+		check_identifier_style(enum_node->identifier, GDScriptWarning::ENUM_NAMING_CONVENTION);
+#endif
 	}
 
 	push_multiline(true);
@@ -1477,8 +1635,15 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 	GDScriptLanguage::get_singleton()->get_public_functions(&gdscript_funcs);
 #endif
 
+#ifdef DEBUG_ENABLED
+	bool has_trailing_comma = false;
+#endif
+
 	do {
 		if (check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
+#ifdef DEBUG_ENABLED
+			has_trailing_comma = !enum_node->values.is_empty();
+#endif
 			break; // Allow trailing comma.
 		}
 		if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for enum key.)")) {
@@ -1487,6 +1652,9 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 			EnumNode::Value item;
 			item.identifier = identifier;
 			item.parent_enum = enum_node;
+#ifdef DEBUG_ENABLED
+			check_identifier_style(item.identifier, GDScriptWarning::ENUM_VALUE_NAMING_CONVENTION);
+#endif
 			item.line = previous.start_line;
 			item.leftmost_column = previous.leftmost_column;
 			item.rightmost_column = previous.rightmost_column;
@@ -1548,6 +1716,14 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACE_CLOSE, R"(Expected closing "}" for enum.)");
 	complete_extents(enum_node);
+#ifdef DEBUG_ENABLED
+	const Node *last_enum_element = nullptr;
+	if (!enum_node->values.is_empty()) {
+		const EnumNode::Value &last_value = enum_node->values[enum_node->values.size() - 1];
+		last_enum_element = last_value.custom_value != nullptr ? last_value.custom_value : last_value.identifier;
+	}
+	check_trailing_comma(enum_node, last_enum_element, has_trailing_comma, "enum");
+#endif
 	end_statement("enum");
 
 	return enum_node;
@@ -1623,6 +1799,9 @@ GDScriptParser::FunctionNode *GDScriptParser::parse_function(bool p_is_static) {
 
 	function->identifier = parse_identifier();
 	function->is_static = p_is_static;
+#ifdef DEBUG_ENABLED
+	check_identifier_style(function->identifier, GDScriptWarning::FUNCTION_NAMING_CONVENTION);
+#endif
 
 	SuiteNode *body = alloc_node<SuiteNode>();
 
@@ -2707,6 +2886,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_literal(ExpressionNode *p_
 	update_extents(literal);
 	make_completion_context(COMPLETION_NONE, literal, -1);
 	complete_extents(literal);
+#ifdef DEBUG_ENABLED
+	check_hexadecimal_case(literal, previous.source);
+#endif
 	return literal;
 }
 
@@ -3070,10 +3252,17 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_await(ExpressionNode *p_pr
 GDScriptParser::ExpressionNode *GDScriptParser::parse_array(ExpressionNode *p_previous_operand, bool p_can_assign) {
 	ArrayNode *array = alloc_node<ArrayNode>();
 
+#ifdef DEBUG_ENABLED
+	bool has_trailing_comma = false;
+#endif
+
 	if (!check(GDScriptTokenizer::Token::BRACKET_CLOSE)) {
 		do {
 			if (check(GDScriptTokenizer::Token::BRACKET_CLOSE)) {
 				// Allow for trailing comma.
+#ifdef DEBUG_ENABLED
+				has_trailing_comma = true;
+#endif
 				break;
 			}
 
@@ -3088,6 +3277,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_array(ExpressionNode *p_pr
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACKET_CLOSE, R"(Expected closing "]" after array elements.)");
 	complete_extents(array);
+#ifdef DEBUG_ENABLED
+	check_trailing_comma(array, array->elements.is_empty() ? nullptr : array->elements[array->elements.size() - 1], has_trailing_comma, "array");
+#endif
 
 	return array;
 }
@@ -3096,10 +3288,17 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 	DictionaryNode *dictionary = alloc_node<DictionaryNode>();
 
 	bool decided_style = false;
+#ifdef DEBUG_ENABLED
+	bool has_trailing_comma = false;
+#endif
+
 	if (!check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
 		do {
 			if (check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
 				// Allow for trailing comma.
+#ifdef DEBUG_ENABLED
+				has_trailing_comma = true;
+#endif
 				break;
 			}
 
@@ -3193,6 +3392,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACE_CLOSE, R"(Expected closing "}" after dictionary elements.)");
 	complete_extents(dictionary);
+#ifdef DEBUG_ENABLED
+	check_trailing_comma(dictionary, dictionary->elements.is_empty() ? nullptr : dictionary->elements[dictionary->elements.size() - 1].value, has_trailing_comma, "dictionary");
+#endif
 
 	return dictionary;
 }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1455,6 +1455,10 @@ private:
 		push_warning(p_source, p_code, Vector<String>{ p_symbols... });
 	}
 	void apply_pending_warnings();
+	void check_identifier_style(const IdentifierNode *p_identifier, GDScriptWarning::Code p_code);
+	void check_file_style();
+	void check_trailing_comma(const Node *p_list, const Node *p_last_element, bool p_has_trailing_comma, const String &p_kind);
+	void check_hexadecimal_case(const Node *p_source, const String &p_text);
 #endif
 	// Setting p_force to false will prevent the completion context from being update if a context was already set before.
 	// This should only be done when we push context before we consumed any tokens for the corresponding structure.

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -162,6 +162,42 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case FUNCTION_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(The function name "%s" does not follow the GDScript style guide (expected snake_case).)*", symbols[0]);
+		case CLASS_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The class name "%s" does not follow the GDScript style guide (expected PascalCase).)", symbols[0]);
+		case VARIABLE_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The variable name "%s" does not follow the GDScript style guide (expected snake_case).)", symbols[0]);
+		case CONSTANT_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The constant name "%s" does not follow the GDScript style guide (expected CONSTANT_CASE).)", symbols[0]);
+		case SIGNAL_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The signal name "%s" does not follow the GDScript style guide (expected snake_case).)", symbols[0]);
+		case ENUM_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The enum name "%s" does not follow the GDScript style guide (expected PascalCase).)", symbols[0]);
+		case ENUM_VALUE_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The enum value "%s" does not follow the GDScript style guide (expected CONSTANT_CASE).)", symbols[0]);
+		case PARAMETER_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The parameter name "%s" does not follow the GDScript style guide (expected snake_case).)", symbols[0]);
+		case FILE_NAMING_CONVENTION:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The file name "%s" does not follow the GDScript style guide (expected snake_case).)", symbols[0]);
+		case MISSING_TRAILING_COMMA:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(Missing trailing comma after the last element of this %s, as recommended by the GDScript style guide when the closing bracket is on its own line.)", symbols[0]);
+		case UNNECESSARY_TRAILING_COMMA:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(Unnecessary trailing comma after the last element of this %s, as the GDScript style guide only recommends one when the closing bracket is on its own line.)", symbols[0]);
+		case HEXADECIMAL_CASE:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The hexadecimal number "%s" does not follow the GDScript style guide (expected uppercase letters).)", symbols[0]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -238,6 +274,18 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",
 		"ONREADY_WITH_EXPORT",
+		"FUNCTION_NAMING_CONVENTION",
+		"CLASS_NAMING_CONVENTION",
+		"VARIABLE_NAMING_CONVENTION",
+		"CONSTANT_NAMING_CONVENTION",
+		"SIGNAL_NAMING_CONVENTION",
+		"ENUM_NAMING_CONVENTION",
+		"ENUM_VALUE_NAMING_CONVENTION",
+		"PARAMETER_NAMING_CONVENTION",
+		"FILE_NAMING_CONVENTION",
+		"MISSING_TRAILING_COMMA",
+		"UNNECESSARY_TRAILING_COMMA",
+		"HEXADECIMAL_CASE",
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",
@@ -251,6 +299,12 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 }
 
 String GDScriptWarning::get_settings_path_from_code(Code p_code) {
+	if (is_style_warning(p_code)) {
+		if (p_code == MISSING_TRAILING_COMMA || p_code == UNNECESSARY_TRAILING_COMMA) {
+			return "debug/gdscript/style_checks/trailing_comma";
+		}
+		return "debug/gdscript/style_checks/" + get_name_from_code(p_code).to_lower();
+	}
 	return "debug/gdscript/warnings/" + get_name_from_code(p_code).to_lower();
 }
 

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -89,6 +89,18 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		FUNCTION_NAMING_CONVENTION,
+		CLASS_NAMING_CONVENTION,
+		VARIABLE_NAMING_CONVENTION,
+		CONSTANT_NAMING_CONVENTION,
+		SIGNAL_NAMING_CONVENTION,
+		ENUM_NAMING_CONVENTION,
+		ENUM_VALUE_NAMING_CONVENTION,
+		PARAMETER_NAMING_CONVENTION,
+		FILE_NAMING_CONVENTION,
+		MISSING_TRAILING_COMMA,
+		UNNECESSARY_TRAILING_COMMA,
+		HEXADECIMAL_CASE,
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -146,6 +158,18 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		IGNORE, // FUNCTION_NAMING_CONVENTION
+		IGNORE, // CLASS_NAMING_CONVENTION
+		IGNORE, // VARIABLE_NAMING_CONVENTION
+		IGNORE, // CONSTANT_NAMING_CONVENTION
+		IGNORE, // SIGNAL_NAMING_CONVENTION
+		IGNORE, // ENUM_NAMING_CONVENTION
+		IGNORE, // ENUM_VALUE_NAMING_CONVENTION
+		IGNORE, // PARAMETER_NAMING_CONVENTION
+		IGNORE, // FILE_NAMING_CONVENTION
+		IGNORE, // MISSING_TRAILING_COMMA
+		IGNORE, // UNNECESSARY_TRAILING_COMMA
+		IGNORE, // HEXADECIMAL_CASE
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION
@@ -165,6 +189,9 @@ public:
 	static int get_default_value(Code p_code);
 	static PropertyInfo get_property_info(Code p_code);
 	static String get_name_from_code(Code p_code);
+	static bool is_style_warning(Code p_code) {
+		return p_code >= FUNCTION_NAMING_CONVENTION && p_code <= HEXADECIMAL_CASE;
+	}
 	static String get_settings_path_from_code(Code p_code);
 	static Code get_code_from_name(const String &p_name);
 };

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -149,7 +149,7 @@ GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_l
 	// Set all warning levels to "Warn" in order to test them properly, even the ones that default to error.
 	ProjectSettings::get_singleton()->set_setting("debug/gdscript/warnings/enable", true);
 	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
-		if (i == GDScriptWarning::UNTYPED_DECLARATION || i == GDScriptWarning::INFERRED_DECLARATION) {
+		if (i == GDScriptWarning::UNTYPED_DECLARATION || i == GDScriptWarning::INFERRED_DECLARATION || GDScriptWarning::is_style_warning((GDScriptWarning::Code)i)) {
 			// TODO: Add ability for test scripts to specify which warnings to enable/disable for testing.
 			continue;
 		}
@@ -526,7 +526,47 @@ String GDScriptTest::get_text_for_status(GDScriptTest::TestStatus p_status) cons
 	return "";
 }
 
+#ifdef DEBUG_ENABLED
+namespace {
+class StyleWarningTestScope {
+	// Keyed by settings path, not by warning code: several warnings can share a
+	// single setting, and saving one level per code would capture a level that an
+	// earlier code already changed, then restore that wrong level afterwards.
+	HashMap<String, int> saved_levels;
+	bool active = false;
+
+public:
+	explicit StyleWarningTestScope(const String &p_path) {
+		active = p_path.contains("style_checks");
+		if (!active) {
+			return;
+		}
+		for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
+			GDScriptWarning::Code code = (GDScriptWarning::Code)i;
+			String path = GDScriptWarning::get_settings_path_from_code(code);
+			if (!saved_levels.has(path)) {
+				saved_levels[path] = (int)ProjectSettings::get_singleton()->get_setting(path);
+			}
+			ProjectSettings::get_singleton()->set_setting(path, (int)(GDScriptWarning::is_style_warning(code) ? GDScriptWarning::WARN : GDScriptWarning::IGNORE));
+		}
+	}
+
+	~StyleWarningTestScope() {
+		if (!active) {
+			return;
+		}
+		for (const KeyValue<String, int> &E : saved_levels) {
+			ProjectSettings::get_singleton()->set_setting(E.key, E.value);
+		}
+	}
+};
+} // namespace
+#endif
+
 GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
+#ifdef DEBUG_ENABLED
+	StyleWarningTestScope _style_warning_test_scope(source_file);
+#endif
 	disable_stdout();
 
 	TestResult result;

--- a/modules/gdscript/tests/scripts/analyzer/style_checks/FileNamingConvention.norun.gd
+++ b/modules/gdscript/tests/scripts/analyzer/style_checks/FileNamingConvention.norun.gd
@@ -1,0 +1,5 @@
+# The name of this file is intentionally not snake_case, to check
+# FILE_NAMING_CONVENTION. Everything inside the file follows the style guide,
+# so the file name is the only thing reported.
+func do_nothing():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/style_checks/FileNamingConvention.norun.out
+++ b/modules/gdscript/tests/scripts/analyzer/style_checks/FileNamingConvention.norun.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+~~ WARNING at line 1: (FILE_NAMING_CONVENTION) The file name "FileNamingConvention.norun.gd" does not follow the GDScript style guide (expected snake_case).

--- a/modules/gdscript/tests/scripts/analyzer/style_checks/naming_conventions.norun.gd
+++ b/modules/gdscript/tests/scripts/analyzer/style_checks/naming_conventions.norun.gd
@@ -1,0 +1,69 @@
+signal HealthChanged
+
+enum player_state {
+	idle,
+	Running,
+}
+
+const maxHealth = 100
+
+var currentHealth = 100
+
+class inventory_slot:
+	var slot_id = 0
+
+func TakeDamage(Amount):
+	pass
+
+# A trailing comma is expected after the last element when the closing bracket is
+# on its own line, and not expected when it shares the last element's line.
+
+enum Ok {
+	ONE,
+	TWO,
+}
+
+enum Missing {
+	ONE,
+	TWO # <- MISSING_TRAILING_COMMA (enum)
+}
+
+enum Unnecessary { ONE, TWO, } # <- UNNECESSARY_TRAILING_COMMA (enum)
+
+const OK_ARRAY = [1, 2]
+const BAD_ARRAY = [1, 2,] # <- UNNECESSARY_TRAILING_COMMA (array)
+const OK_DICT = {"a": 1}
+const BAD_DICT = {"a": 1,} # <- UNNECESSARY_TRAILING_COMMA (dictionary)
+
+func check_multiline():
+	var ok_array = [
+		1,
+		2,
+	]
+	var missing_array = [
+		1,
+		2 # <- MISSING_TRAILING_COMMA (array)
+	]
+	var ok_dict = {
+		"a": 1,
+	}
+	var missing_dict = {
+		"a": 1 # <- MISSING_TRAILING_COMMA (dictionary)
+	}
+	print(ok_array, missing_array, ok_dict, missing_dict)
+
+# Hexadecimal numbers use uppercase letters for their digits. The "0x" prefix and
+# "_" separators are not affected, and numbers without letters have nothing to check.
+
+const OK_COLOR = 0xFB8C0B
+const BAD_COLOR = 0xfb8c0b # <- HEXADECIMAL_CASE
+const OK_MASK = 0xFFFF_F8F8_0000
+const BAD_MASK = 0xffff_f8f8_0000 # <- HEXADECIMAL_CASE
+const OK_NO_LETTERS = 0x1234
+const OK_DECIMAL = 1_234_567_890
+const OK_BINARY = 0b1101_0010_1010
+
+func check_locals():
+	var mixed_case = 0xDEADbeef # <- HEXADECIMAL_CASE
+	var not_a_number = "0xfb8c0b"
+	print(mixed_case, not_a_number)

--- a/modules/gdscript/tests/scripts/analyzer/style_checks/naming_conventions.norun.out
+++ b/modules/gdscript/tests/scripts/analyzer/style_checks/naming_conventions.norun.out
@@ -1,0 +1,19 @@
+GDTEST_OK
+~~ WARNING at line 1: (SIGNAL_NAMING_CONVENTION) The signal name "HealthChanged" does not follow the GDScript style guide (expected snake_case).
+~~ WARNING at line 3: (ENUM_NAMING_CONVENTION) The enum name "player_state" does not follow the GDScript style guide (expected PascalCase).
+~~ WARNING at line 4: (ENUM_VALUE_NAMING_CONVENTION) The enum value "idle" does not follow the GDScript style guide (expected CONSTANT_CASE).
+~~ WARNING at line 5: (ENUM_VALUE_NAMING_CONVENTION) The enum value "Running" does not follow the GDScript style guide (expected CONSTANT_CASE).
+~~ WARNING at line 8: (CONSTANT_NAMING_CONVENTION) The constant name "maxHealth" does not follow the GDScript style guide (expected CONSTANT_CASE).
+~~ WARNING at line 10: (VARIABLE_NAMING_CONVENTION) The variable name "currentHealth" does not follow the GDScript style guide (expected snake_case).
+~~ WARNING at line 12: (CLASS_NAMING_CONVENTION) The class name "inventory_slot" does not follow the GDScript style guide (expected PascalCase).
+~~ WARNING at line 15: (FUNCTION_NAMING_CONVENTION) The function name "TakeDamage" does not follow the GDScript style guide (expected snake_case).
+~~ WARNING at line 15: (PARAMETER_NAMING_CONVENTION) The parameter name "Amount" does not follow the GDScript style guide (expected snake_case).
+~~ WARNING at line 28: (MISSING_TRAILING_COMMA) Missing trailing comma after the last element of this enum, as recommended by the GDScript style guide when the closing bracket is on its own line.
+~~ WARNING at line 31: (UNNECESSARY_TRAILING_COMMA) Unnecessary trailing comma after the last element of this enum, as the GDScript style guide only recommends one when the closing bracket is on its own line.
+~~ WARNING at line 34: (UNNECESSARY_TRAILING_COMMA) Unnecessary trailing comma after the last element of this array, as the GDScript style guide only recommends one when the closing bracket is on its own line.
+~~ WARNING at line 36: (UNNECESSARY_TRAILING_COMMA) Unnecessary trailing comma after the last element of this dictionary, as the GDScript style guide only recommends one when the closing bracket is on its own line.
+~~ WARNING at line 45: (MISSING_TRAILING_COMMA) Missing trailing comma after the last element of this array, as recommended by the GDScript style guide when the closing bracket is on its own line.
+~~ WARNING at line 51: (MISSING_TRAILING_COMMA) Missing trailing comma after the last element of this dictionary, as recommended by the GDScript style guide when the closing bracket is on its own line.
+~~ WARNING at line 59: (HEXADECIMAL_CASE) The hexadecimal number "0xfb8c0b" does not follow the GDScript style guide (expected uppercase letters).
+~~ WARNING at line 61: (HEXADECIMAL_CASE) The hexadecimal number "0xffff_f8f8_0000" does not follow the GDScript style guide (expected uppercase letters).
+~~ WARNING at line 67: (HEXADECIMAL_CASE) The hexadecimal number "0xDEADbeef" does not follow the GDScript style guide (expected uppercase letters).


### PR DESCRIPTION
attempt at godotengine/godot-proposals#14895
style warnings are purple, to enable them its Project Settings Debug GDScript  Style Checks
here is a gd script to trigger the style warnings. its a .txt due to uploading limits
[style_warnings_example.txt](https://github.com/user-attachments/files/29946510/style_warnings_example.txt)

