### PR TITLE
Add dddbrowser module for DDD page export and preview

### DIFF
--- a/modules/dddbrowser/SCsub
+++ b/modules/dddbrowser/SCsub
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_dddbrowser = env_modules.Clone()
+
+env_dddbrowser.add_source_files(env.modules_sources, "*.cpp")
+
+if env.editor_build:
+    env_dddbrowser.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/dddbrowser/config.py
+++ b/modules/dddbrowser/config.py
@@ -1,0 +1,29 @@
+def can_build(env, platform):
+    # Soft deps: preview uses httpserver; DDD Luau compile-check uses luau_module when present.
+    env.module_add_dependencies("dddbrowser", ["httpserver", "luau_module"], True)
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "DDDBrowserLevel",
+        "DDDBrowserSpawn",
+        "DDDBrowserPortal",
+        "DDDBrowserVolume",
+        "DDDBrowserModel",
+        "DDDBrowserTextbox",
+        "DDDBrowserPicturebox",
+        "DDDBrowserAudio",
+        "DDDBrowserFont",
+        "DDDBrowserScript",
+        "DDDBrowserExporter",
+        "DDDBrowserPreviewServer",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/dddbrowser/ddd_luau_check.cpp
+++ b/modules/dddbrowser/ddd_luau_check.cpp
@@ -1,0 +1,195 @@
+/**************************************************************************/
+/*  ddd_luau_check.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "ddd_luau_check.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/file_access.h"
+
+#ifdef MODULE_LUAU_MODULE_ENABLED
+#include "modules/luau_module/luau.h"
+#endif
+
+String DDDLuauCheck::stub_preamble() {
+	return R"LUAU(-- DDDBrowser API stubs (editor check only; stripped at export)
+local Engine = {
+	getActionState = function(_name) return false end,
+	consumeAction = function(_name) return false end,
+	setEntityPosition = function(_id, _x, _y, _z) end,
+	getEntityPosition = function(_id) return { x = 0, y = 0, z = 0 } end,
+	setEntityRotation = function(_id, _x, _y, _z) end,
+	getEntityRotation = function(_id) return { x = 0, y = 0, z = 0 } end,
+	setEntityScale = function(_id, _x, _y, _z) end,
+	getEntityScale = function(_id) return { x = 1, y = 1, z = 1 } end,
+	setEntityVisible = function(_id, _v) end,
+	getEntityVisible = function(_id) return true end,
+	getCamera = function() return { position = { x = 0, y = 0, z = 0 }, forward = { x = 0, y = 0, z = -1 } } end,
+	setCamera = function(_pos, _fwd) end,
+	triggerPortal = function(_id) return false end,
+	spawnEntity = function(_req) return nil end,
+	destroyEntity = function(_id) return false end,
+	raycast = function(_o, _d, _max) return { hit = false } end,
+	sphereOverlap = function(_c, _r) return {} end,
+	httpRequest = function(_url, _cb) end,
+	openTextBox = function(_id, _title, _text, _buttons, _checks, _cb) end,
+	closeTextBox = function(_id) end,
+	openImGuiTextBox = function(_title, _text, _buttons, _checks, _cb) end,
+	closeImGuiTextBox = function() end,
+	playAudio = function(_id, _asset, _pos, _ambient, _loop, _vol) end,
+	stopAudio = function(_id) end,
+	openExternalUrl = function(_url, _cb) end,
+	setLightColor = function(_id, _r, _g, _b) end,
+	getLightColor = function(_id) return { x = 1, y = 1, z = 1 } end,
+	setLightIntensity = function(_id, _v) end,
+	getLightIntensity = function(_id) return 1 end,
+	setLightEnabled = function(_id, _v) end,
+	getLightEnabled = function(_id) return true end,
+	setLightRange = function(_id, _v) end,
+	getLightRange = function(_id) return 10 end,
+}
+local Scene = {
+	getId = function() return "" end,
+	getName = function() return "" end,
+	getDescription = function() return "" end,
+	getAuthor = function() return "" end,
+	getRating = function() return "GENERAL" end,
+	getThumbnail = function() return "" end,
+	getManifestUrl = function() return "" end,
+	getWorldId = function() return "" end,
+	getWorldPosition = function() return { x = 0, y = 0, z = 0 } end,
+	TravelTo = function(_url) end,
+}
+local Gamemode = {
+	getState = function(_k) return nil end,
+	setState = function(_k, _v) end,
+	triggerEvent = function(_name, _payload) end,
+	onEvent = function(_name, _cb) end,
+	saveGame = function() return false end,
+}
+local localStorage = {
+	get = function(_k) return nil end,
+	set = function(_k, _v) end,
+	remove = function(_k) end,
+	clear = function() end,
+	getAll = function() return {} end,
+}
+)LUAU";
+}
+
+String DDDLuauCheck::entity_template() {
+	return R"LUAU(-- DDDBrowser entity script (not a Blazium gdclass / LuauScript).
+-- Lifecycle table returned below runs in DDDBrowser with Engine/Scene/Gamemode/localStorage.
+-- Tunables from the instance script.data field are available as self.data.
+
+local Script = {}
+
+function Script:on_start()
+	-- self.entity (number), self.asset_id (string), self.data (table)
+end
+
+function Script:on_update(dt)
+end
+
+function Script:on_interact(actorId)
+end
+
+function Script:on_save()
+	return {}
+end
+
+function Script:on_load(state)
+end
+
+function Script:on_shutdown()
+end
+
+return Script
+)LUAU";
+}
+
+String DDDLuauCheck::gamemode_template() {
+	return R"LUAU(-- DDDBrowser gamemode script (scene-wide). Declared via Level.gamemode_file.
+-- Export emits gamemode.file as this .luau basename (not an asset id).
+
+local GamemodeScript = {}
+
+function GamemodeScript:on_start()
+end
+
+function GamemodeScript:on_update(dt)
+end
+
+function GamemodeScript:on_save()
+	return {}
+end
+
+function GamemodeScript:on_load(state)
+end
+
+return GamemodeScript
+)LUAU";
+}
+
+Dictionary DDDLuauCheck::check_source(const String &p_source) {
+	Dictionary result;
+#ifdef MODULE_LUAU_MODULE_ENABLED
+	const String wrapped = stub_preamble() + "\n" + p_source;
+	const luau_module::LuauCompileResult compile = luau_module::Luau::compile_with_diagnostics(wrapped);
+	if (compile.succeeded()) {
+		result["ok"] = true;
+		result["message"] = "DDD Luau compile check passed.";
+	} else {
+		result["ok"] = false;
+		String msg = compile.error_message;
+		if (compile.error_line >= 0) {
+			msg = vformat("Line %d: %s", compile.error_line, compile.error_message);
+		}
+		result["message"] = msg;
+	}
+#else
+	result["ok"] = false;
+	result["message"] = "luau_module is disabled; cannot compile-check DDD Luau.";
+#endif
+	return result;
+}
+
+Dictionary DDDLuauCheck::check_file(const String &p_path) {
+	String path = p_path;
+	if (path.begins_with("res://") || path.begins_with("user://")) {
+		path = ProjectSettings::get_singleton()->globalize_path(path);
+	}
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::READ);
+	Dictionary result;
+	if (f.is_null()) {
+		result["ok"] = false;
+		result["message"] = vformat("Cannot read script: %s", p_path);
+		return result;
+	}
+	return check_source(f->get_as_text());
+}

--- a/modules/dddbrowser/ddd_luau_check.h
+++ b/modules/dddbrowser/ddd_luau_check.h
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  ddd_luau_check.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+
+class DDDLuauCheck {
+public:
+	static String stub_preamble();
+	static String entity_template();
+	static String gamemode_template();
+
+	static Dictionary check_source(const String &p_source);
+	static Dictionary check_file(const String &p_path);
+};

--- a/modules/dddbrowser/dddbrowser_audio.cpp
+++ b/modules/dddbrowser/dddbrowser_audio.cpp
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  dddbrowser_audio.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_audio.h"
+
+void DDDBrowserAudio::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_source_path", "path"), &DDDBrowserAudio::set_source_path);
+	ClassDB::bind_method(D_METHOD("get_source_path"), &DDDBrowserAudio::get_source_path);
+	ClassDB::bind_method(D_METHOD("set_format", "format"), &DDDBrowserAudio::set_format);
+	ClassDB::bind_method(D_METHOD("get_format"), &DDDBrowserAudio::get_format);
+	ClassDB::bind_method(D_METHOD("set_ambient", "ambient"), &DDDBrowserAudio::set_ambient);
+	ClassDB::bind_method(D_METHOD("get_ambient"), &DDDBrowserAudio::get_ambient);
+	ClassDB::bind_method(D_METHOD("set_loop", "loop"), &DDDBrowserAudio::set_loop);
+	ClassDB::bind_method(D_METHOD("get_loop"), &DDDBrowserAudio::get_loop);
+	ClassDB::bind_method(D_METHOD("set_volume", "volume"), &DDDBrowserAudio::set_volume);
+	ClassDB::bind_method(D_METHOD("get_volume"), &DDDBrowserAudio::get_volume);
+	ClassDB::bind_method(D_METHOD("set_auto_play", "auto_play"), &DDDBrowserAudio::set_auto_play);
+	ClassDB::bind_method(D_METHOD("get_auto_play"), &DDDBrowserAudio::get_auto_play);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_path", PROPERTY_HINT_FILE, "*.wav,*.ogg"), "set_source_path", "get_source_path");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "format", PROPERTY_HINT_ENUM, "WAV,Ogg"), "set_format", "get_format");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ambient"), "set_ambient", "get_ambient");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "get_loop");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_volume", "get_volume");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_play"), "set_auto_play", "get_auto_play");
+
+	BIND_ENUM_CONSTANT(FORMAT_WAV);
+	BIND_ENUM_CONSTANT(FORMAT_OGG);
+}
+
+void DDDBrowserAudio::set_source_path(const String &p_path) {
+	source_path = p_path;
+}
+String DDDBrowserAudio::get_source_path() const {
+	return source_path;
+}
+void DDDBrowserAudio::set_format(Format p_format) {
+	format = p_format;
+}
+DDDBrowserAudio::Format DDDBrowserAudio::get_format() const {
+	return format;
+}
+void DDDBrowserAudio::set_ambient(bool p_ambient) {
+	ambient = p_ambient;
+}
+bool DDDBrowserAudio::get_ambient() const {
+	return ambient;
+}
+void DDDBrowserAudio::set_loop(bool p_loop) {
+	loop = p_loop;
+}
+bool DDDBrowserAudio::get_loop() const {
+	return loop;
+}
+void DDDBrowserAudio::set_volume(float p_volume) {
+	volume = p_volume;
+}
+float DDDBrowserAudio::get_volume() const {
+	return volume;
+}
+void DDDBrowserAudio::set_auto_play(bool p_auto) {
+	auto_play = p_auto;
+}
+bool DDDBrowserAudio::get_auto_play() const {
+	return auto_play;
+}

--- a/modules/dddbrowser/dddbrowser_audio.h
+++ b/modules/dddbrowser/dddbrowser_audio.h
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  dddbrowser_audio.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserAudio : public Node3D {
+	GDCLASS(DDDBrowserAudio, Node3D);
+
+public:
+	enum Format {
+		FORMAT_WAV,
+		FORMAT_OGG,
+	};
+
+private:
+	String source_path;
+	Format format = FORMAT_WAV;
+	bool ambient = false;
+	bool loop = false;
+	float volume = 1.0f;
+	bool auto_play = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_source_path(const String &p_path);
+	String get_source_path() const;
+	void set_format(Format p_format);
+	Format get_format() const;
+	void set_ambient(bool p_ambient);
+	bool get_ambient() const;
+	void set_loop(bool p_loop);
+	bool get_loop() const;
+	void set_volume(float p_volume);
+	float get_volume() const;
+	void set_auto_play(bool p_auto);
+	bool get_auto_play() const;
+};
+
+VARIANT_ENUM_CAST(DDDBrowserAudio::Format);

--- a/modules/dddbrowser/dddbrowser_export_convert.cpp
+++ b/modules/dddbrowser/dddbrowser_export_convert.cpp
@@ -1,0 +1,361 @@
+/**************************************************************************/
+/*  dddbrowser_export_convert.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_export_convert.h"
+#include "dddbrowser_exporter.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/file_access.h"
+#include "core/io/image.h"
+#include "core/io/resource_loader.h"
+#include "core/object/script_language.h"
+#include "scene/3d/audio_stream_player_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/world_environment.h"
+#include "scene/resources/3d/box_shape_3d.h"
+#include "scene/resources/3d/capsule_shape_3d.h"
+#include "scene/resources/3d/cylinder_shape_3d.h"
+#include "scene/resources/3d/sphere_shape_3d.h"
+#include "scene/resources/environment.h"
+#include "scene/resources/material.h"
+#include "scene/resources/mesh.h"
+#include "scene/resources/sky.h"
+#include "scene/resources/texture.h"
+#include "servers/audio/audio_stream.h"
+
+#ifdef MODULE_LUAU_MODULE_ENABLED
+#include "modules/luau_module/luau_script.h"
+#endif
+
+Dictionary DDDBrowserExportConvert::collider_from_shape_node(CollisionShape3D *p_shape, String *r_warning) {
+	Dictionary out;
+	if (!p_shape) {
+		return out;
+	}
+	Ref<Shape3D> shape = p_shape->get_shape();
+	if (shape.is_null()) {
+		return out;
+	}
+	if (const BoxShape3D *box = Object::cast_to<BoxShape3D>(shape.ptr())) {
+		out["type"] = "box";
+		Dictionary box_props;
+		Dictionary size;
+		Vector3 s = box->get_size();
+		size["x"] = MAX(0.01, s.x);
+		size["y"] = MAX(0.01, s.y);
+		size["z"] = MAX(0.01, s.z);
+		box_props["size"] = size;
+		out["box"] = box_props;
+	} else if (const SphereShape3D *sphere = Object::cast_to<SphereShape3D>(shape.ptr())) {
+		out["type"] = "sphere";
+		Dictionary sphere_props;
+		sphere_props["radius"] = MAX(0.01, sphere->get_radius());
+		out["sphere"] = sphere_props;
+	} else if (const CapsuleShape3D *capsule = Object::cast_to<CapsuleShape3D>(shape.ptr())) {
+		out["type"] = "capsule";
+		Dictionary capsule_props;
+		capsule_props["radius"] = MAX(0.01, capsule->get_radius());
+		capsule_props["halfHeight"] = MAX(0.01, capsule->get_height() * 0.5);
+		out["capsule"] = capsule_props;
+	} else if (const CylinderShape3D *cylinder = Object::cast_to<CylinderShape3D>(shape.ptr())) {
+		out["type"] = "cylinder";
+		Dictionary cylinder_props;
+		cylinder_props["radius"] = MAX(0.01, cylinder->get_radius());
+		cylinder_props["halfHeight"] = MAX(0.01, cylinder->get_height() * 0.5);
+		out["cylinder"] = cylinder_props;
+	} else if (r_warning) {
+		*r_warning = vformat("Unsupported collision shape '%s' on '%s' (use box/sphere/capsule/cylinder)", shape->get_class(), p_shape->get_name());
+	}
+	return out;
+}
+
+Dictionary DDDBrowserExportConvert::collider_from_mesh_node(MeshInstance3D *p_mi, String *r_warning) {
+	Dictionary out;
+	if (!p_mi) {
+		return out;
+	}
+	String local_warn;
+
+	for (int i = 0; i < p_mi->get_child_count(); i++) {
+		if (CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(p_mi->get_child(i))) {
+			local_warn = String();
+			out = collider_from_shape_node(cs, &local_warn);
+			if (!out.is_empty()) {
+				return out;
+			}
+			if (!local_warn.is_empty() && r_warning && r_warning->is_empty()) {
+				*r_warning = local_warn;
+			}
+		}
+	}
+	Node *parent = p_mi->get_parent();
+	if (parent) {
+		for (int i = 0; i < parent->get_child_count(); i++) {
+			if (CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(parent->get_child(i))) {
+				local_warn = String();
+				out = collider_from_shape_node(cs, &local_warn);
+				if (!out.is_empty()) {
+					return out;
+				}
+				if (!local_warn.is_empty() && r_warning && r_warning->is_empty()) {
+					*r_warning = local_warn;
+				}
+			}
+		}
+	}
+	return out;
+}
+
+Error DDDBrowserExportConvert::export_mesh_with_mtl(DDDBrowserExporter *p_exporter, MeshInstance3D *p_mi, const String &p_obj_path, const String &p_base_url, const String &p_export_dir, String *r_warning) {
+	ERR_FAIL_NULL_V(p_exporter, ERR_INVALID_PARAMETER);
+	ERR_FAIL_NULL_V(p_mi, ERR_INVALID_PARAMETER);
+	Ref<Mesh> mesh = p_mi->get_mesh();
+	ERR_FAIL_COND_V(mesh.is_null(), ERR_INVALID_DATA);
+
+	const String id_base = p_obj_path.get_file().get_basename();
+	const String mtl_name = id_base + ".mtl";
+	const String mtl_path = p_obj_path.get_base_dir().path_join(mtl_name);
+
+	String body;
+	body += "# DDDBrowser OBJ export\n";
+	body += "mtllib " + mtl_name + "\n";
+
+	String mtl_body;
+	mtl_body += "# DDDBrowser MTL export\n";
+
+	int vertex_offset = 1;
+	const int surfaces = mesh->get_surface_count();
+	for (int s = 0; s < surfaces; s++) {
+		Array arrays = mesh->surface_get_arrays(s);
+		PackedVector3Array vertices = arrays[Mesh::ARRAY_VERTEX];
+		PackedVector3Array normals = arrays[Mesh::ARRAY_NORMAL];
+		PackedVector2Array uvs = arrays[Mesh::ARRAY_TEX_UV];
+		PackedInt32Array indices = arrays[Mesh::ARRAY_INDEX];
+
+		String mat_name = "mat_" + itos(s);
+		body += "usemtl " + mat_name + "\n";
+		mtl_body += "newmtl " + mat_name + "\n";
+
+		Ref<Material> mat = p_mi->get_active_material(s);
+		Color albedo(1, 1, 1, 1);
+		Ref<Texture2D> albedo_tex;
+		if (mat.is_valid()) {
+			if (BaseMaterial3D *base = Object::cast_to<BaseMaterial3D>(mat.ptr())) {
+				albedo = base->get_albedo();
+				albedo_tex = base->get_texture(BaseMaterial3D::TEXTURE_ALBEDO);
+			}
+		}
+		mtl_body += vformat("Kd %.6f %.6f %.6f\n", albedo.r, albedo.g, albedo.b);
+
+		if (albedo_tex.is_valid()) {
+			String tex_path = albedo_tex->get_path();
+			String dest_name = id_base + "_albedo_" + itos(s);
+			String dest_rel;
+			if (!tex_path.is_empty() && (tex_path.begins_with("res://") || tex_path.begins_with("user://"))) {
+				String src = ProjectSettings::get_singleton()->globalize_path(tex_path);
+				String ext = src.get_extension().to_lower();
+				if (ext.is_empty()) {
+					ext = "png";
+				}
+				dest_rel = "textures/" + dest_name + "." + ext;
+				String dest_abs = p_export_dir.path_join(dest_rel);
+				if (FileAccess::exists(src)) {
+					p_exporter->_copy_file(src, dest_abs);
+					mtl_body += "map_Kd ../" + dest_rel.replace("\\", "/") + "\n";
+				} else if (r_warning) {
+					*r_warning = vformat("Missing albedo texture file: %s", tex_path);
+				}
+			} else {
+				Ref<Image> img = albedo_tex->get_image();
+				if (img.is_valid() && !img->is_empty()) {
+					dest_rel = "textures/" + dest_name + ".png";
+					String dest_abs = p_export_dir.path_join(dest_rel);
+					img->save_png(dest_abs);
+					mtl_body += "map_Kd ../" + dest_rel.replace("\\", "/") + "\n";
+				}
+			}
+		}
+
+		for (int i = 0; i < vertices.size(); i++) {
+			const Vector3 &v = vertices[i];
+			body += vformat("v %.6f %.6f %.6f\n", v.x, v.y, v.z);
+		}
+		if (uvs.size() == vertices.size()) {
+			for (int i = 0; i < uvs.size(); i++) {
+				body += vformat("vt %.6f %.6f\n", uvs[i].x, uvs[i].y);
+			}
+		}
+		if (normals.size() == vertices.size()) {
+			for (int i = 0; i < normals.size(); i++) {
+				const Vector3 &n = normals[i];
+				body += vformat("vn %.6f %.6f %.6f\n", n.x, n.y, n.z);
+			}
+		}
+
+		body += "o " + id_base + "\n";
+		const bool has_uv = uvs.size() == vertices.size();
+		const bool has_n = normals.size() == vertices.size();
+		if (indices.size()) {
+			for (int i = 0; i + 2 < indices.size(); i += 3) {
+				int a = indices[i] + vertex_offset;
+				int b = indices[i + 1] + vertex_offset;
+				int c = indices[i + 2] + vertex_offset;
+				if (has_uv && has_n) {
+					body += vformat("f %d/%d/%d %d/%d/%d %d/%d/%d\n", a, a, a, b, b, b, c, c, c);
+				} else if (has_n) {
+					body += vformat("f %d//%d %d//%d %d//%d\n", a, a, b, b, c, c);
+				} else {
+					body += vformat("f %d %d %d\n", a, b, c);
+				}
+			}
+		} else {
+			for (int i = 0; i + 2 < vertices.size(); i += 3) {
+				int a = i + vertex_offset;
+				int b = i + 1 + vertex_offset;
+				int c = i + 2 + vertex_offset;
+				body += vformat("f %d %d %d\n", a, b, c);
+			}
+		}
+		vertex_offset += vertices.size();
+	}
+
+	Error err = p_exporter->_write_text(p_obj_path, body);
+	if (err != OK) {
+		return err;
+	}
+	return p_exporter->_write_text(mtl_path, mtl_body);
+}
+
+String DDDBrowserExportConvert::resolve_audio_stream_path(Node *p_node) {
+	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_node);
+	if (!player) {
+		return String();
+	}
+	Ref<AudioStream> stream = player->get_stream();
+	if (stream.is_null()) {
+		return String();
+	}
+	return stream->get_path();
+}
+
+String DDDBrowserExportConvert::resolve_luau_script_path(Node *p_node) {
+	ERR_FAIL_NULL_V(p_node, String());
+	Ref<Script> script = p_node->get_script();
+	if (script.is_null()) {
+		return String();
+	}
+#ifdef MODULE_LUAU_MODULE_ENABLED
+	if (Object::cast_to<LuauScript>(script.ptr())) {
+		String path = script->get_path();
+		if (!path.is_empty()) {
+			return path;
+		}
+
+		return String();
+	}
+#endif
+	String path = script->get_path();
+	if (path.ends_with(".luau") || path.ends_with(".lua")) {
+		return path;
+	}
+	return String();
+}
+
+Dictionary DDDBrowserExportConvert::collect_script_export_data(Node *p_node) {
+	Dictionary data;
+	ERR_FAIL_NULL_V(p_node, data);
+	Ref<Script> script = p_node->get_script();
+	if (script.is_null()) {
+		return data;
+	}
+	List<PropertyInfo> props;
+	p_node->get_property_list(&props);
+	for (const PropertyInfo &pi : props) {
+		if (!(pi.usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
+			continue;
+		}
+		Variant v = p_node->get(pi.name);
+		switch (v.get_type()) {
+			case Variant::BOOL:
+			case Variant::INT:
+			case Variant::FLOAT:
+			case Variant::STRING:
+			case Variant::STRING_NAME:
+			case Variant::DICTIONARY:
+			case Variant::ARRAY:
+				data[String(pi.name)] = v;
+				break;
+			default:
+				break;
+		}
+	}
+	return data;
+}
+
+bool DDDBrowserExportConvert::try_skybox_from_world_environment(Node *p_root, Dictionary &r_skybox) {
+	ERR_FAIL_NULL_V(p_root, false);
+	Vector<Node *> nodes;
+	nodes.push_back(p_root);
+	for (int i = 0; i < nodes.size(); i++) {
+		for (int c = 0; c < nodes[i]->get_child_count(); c++) {
+			nodes.push_back(nodes[i]->get_child(c));
+		}
+	}
+	for (int i = 0; i < nodes.size(); i++) {
+		WorldEnvironment *we = Object::cast_to<WorldEnvironment>(nodes[i]);
+		if (!we) {
+			continue;
+		}
+		Ref<Environment> env = we->get_environment();
+		if (env.is_null()) {
+			continue;
+		}
+		Ref<Sky> sky = env->get_sky();
+		if (sky.is_null()) {
+			continue;
+		}
+
+		Variant panorama = sky->get("sky_material");
+		if (panorama.get_type() == Variant::OBJECT) {
+			Object *mat_obj = panorama;
+			if (mat_obj) {
+				Variant tex_v = mat_obj->get("panorama");
+				if (tex_v.get_type() == Variant::OBJECT) {
+					Ref<Texture2D> tex = tex_v;
+					if (tex.is_valid() && !tex->get_path().is_empty()) {
+						r_skybox["uri"] = tex->get_path();
+						return true;
+					}
+				}
+			}
+		}
+	}
+	return false;
+}

--- a/modules/dddbrowser/dddbrowser_export_convert.h
+++ b/modules/dddbrowser/dddbrowser_export_convert.h
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  dddbrowser_export_convert.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/typed_array.h"
+
+class Node;
+class Node3D;
+class MeshInstance3D;
+class CollisionShape3D;
+class DDDBrowserExporter;
+
+struct DDDBrowserExportContext {
+	String base_url;
+	String export_dir;
+	Array *assets = nullptr;
+	Array *instances = nullptr;
+	HashSet<String> *used_asset_ids = nullptr;
+	HashMap<String, String> *script_path_to_asset_id = nullptr;
+	HashSet<String> *used_script_filenames = nullptr;
+	HashSet<ObjectID> *exported_mesh_ids = nullptr;
+	bool has_spawn = false;
+	PackedStringArray warnings;
+};
+
+class DDDBrowserExportConvert {
+public:
+	static Dictionary collider_from_shape_node(CollisionShape3D *p_shape, String *r_warning = nullptr);
+	static Dictionary collider_from_mesh_node(MeshInstance3D *p_mi, String *r_warning = nullptr);
+	static Error export_mesh_with_mtl(DDDBrowserExporter *p_exporter, MeshInstance3D *p_mi, const String &p_obj_path, const String &p_base_url, const String &p_export_dir, String *r_warning = nullptr);
+	static String resolve_audio_stream_path(Node *p_node);
+	static String resolve_luau_script_path(Node *p_node);
+	static Dictionary collect_script_export_data(Node *p_node);
+	static bool try_skybox_from_world_environment(Node *p_root, Dictionary &r_skybox);
+};

--- a/modules/dddbrowser/dddbrowser_exporter.cpp
+++ b/modules/dddbrowser/dddbrowser_exporter.cpp
@@ -1,0 +1,1370 @@
+/**************************************************************************/
+/*  dddbrowser_exporter.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_exporter.h"
+
+#include "dddbrowser_audio.h"
+#include "dddbrowser_export_convert.h"
+#include "dddbrowser_font.h"
+#include "dddbrowser_level.h"
+#include "dddbrowser_model.h"
+#include "dddbrowser_picturebox.h"
+#include "dddbrowser_portal.h"
+#include "dddbrowser_script.h"
+#include "dddbrowser_spawn.h"
+#include "dddbrowser_textbox.h"
+#include "dddbrowser_volume.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/io/image.h"
+#include "core/io/json.h"
+#include "core/math/math_funcs.h"
+#include "core/templates/hash_map.h"
+#include "scene/3d/audio_stream_player_3d.h"
+#include "scene/3d/camera_3d.h"
+#include "scene/3d/label_3d.h"
+#include "scene/3d/light_3d.h"
+#include "scene/3d/marker_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/3d/sprite_3d.h"
+#include "scene/resources/mesh.h"
+#include "scene/resources/texture.h"
+
+void DDDBrowserExporter::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("export_scene", "root", "export_dir", "generate_html"), &DDDBrowserExporter::export_scene, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("build_scene_dictionary", "root", "export_dir"), &DDDBrowserExporter::build_scene_dictionary);
+	ClassDB::bind_method(D_METHOD("validate_scene_dictionary", "scene"), &DDDBrowserExporter::validate_scene_dictionary);
+	ClassDB::bind_method(D_METHOD("get_validation_errors", "scene"), &DDDBrowserExporter::get_validation_errors);
+	ClassDB::bind_method(D_METHOD("get_last_error"), &DDDBrowserExporter::get_last_error);
+	ClassDB::bind_method(D_METHOD("get_last_warning"), &DDDBrowserExporter::get_last_warning);
+}
+
+String DDDBrowserExporter::_sanitize_id(const String &p_name) {
+	String out;
+	for (int i = 0; i < p_name.length(); i++) {
+		char32_t c = p_name[i];
+		if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+			out += c;
+		} else {
+			out += '_';
+		}
+	}
+	if (out.is_empty()) {
+		out = "node";
+	}
+	return out;
+}
+
+String DDDBrowserExporter::_unique_id(const String &p_base, HashSet<String> &r_used) {
+	String id = _sanitize_id(p_base);
+	if (!r_used.has(id)) {
+		r_used.insert(id);
+		return id;
+	}
+	int n = 2;
+	while (true) {
+		String candidate = id + "_" + itos(n);
+		if (!r_used.has(candidate)) {
+			r_used.insert(candidate);
+			return candidate;
+		}
+		n++;
+	}
+}
+
+Dictionary DDDBrowserExporter::_vec3(const Vector3 &p_v) {
+	Dictionary d;
+	d["x"] = p_v.x;
+	d["y"] = p_v.y;
+	d["z"] = p_v.z;
+	return d;
+}
+
+Dictionary DDDBrowserExporter::_safe_scale(const Vector3 &p_s) {
+	Dictionary d;
+	d["x"] = MAX(1e-6, Math::abs(p_s.x) < 1e-6 ? 1.0 : p_s.x);
+	d["y"] = MAX(1e-6, Math::abs(p_s.y) < 1e-6 ? 1.0 : p_s.y);
+	d["z"] = MAX(1e-6, Math::abs(p_s.z) < 1e-6 ? 1.0 : p_s.z);
+	return d;
+}
+
+Dictionary DDDBrowserExporter::_color_vec3(const Color &p_c) {
+	return _vec3(Vector3(p_c.r, p_c.g, p_c.b));
+}
+
+Dictionary DDDBrowserExporter::_transform_fields(Node3D *p_node) {
+	Dictionary inst;
+	Transform3D xf = p_node->get_global_transform();
+	inst["position"] = _vec3(xf.origin);
+	Vector3 euler = xf.basis.get_euler();
+	inst["rotation"] = _vec3(Vector3(Math::rad_to_deg(euler.x), Math::rad_to_deg(euler.y), Math::rad_to_deg(euler.z)));
+	inst["scale"] = _safe_scale(xf.basis.get_scale());
+	return inst;
+}
+
+String DDDBrowserExporter::_build_uri(const String &p_base_url, const String &p_export_dir, const String &p_filepath) {
+	String rel = p_filepath;
+	if (rel.begins_with(p_export_dir)) {
+		rel = rel.substr(p_export_dir.length());
+		while (rel.begins_with("/") || rel.begins_with("\\")) {
+			rel = rel.substr(1);
+		}
+	}
+	rel = rel.replace("\\", "/");
+	if (p_base_url.is_empty()) {
+		return rel;
+	}
+	return p_base_url.path_join(rel);
+}
+
+bool DDDBrowserExporter::_is_remote_uri(const String &p_path) {
+	return p_path.begins_with("http://") || p_path.begins_with("https://") || p_path.begins_with("data:");
+}
+
+String DDDBrowserExporter::_resolve_source_path(const String &p_path) {
+	if (p_path.is_empty()) {
+		return p_path;
+	}
+	if (p_path.begins_with("res://") || p_path.begins_with("user://")) {
+		return ProjectSettings::get_singleton()->globalize_path(p_path);
+	}
+	return p_path;
+}
+
+String DDDBrowserExporter::_script_filename_from_path(const String &p_path) {
+	String name = p_path.get_file();
+	if (name.is_empty()) {
+		name = "script.luau";
+	}
+	if (!name.to_lower().ends_with(".luau")) {
+		name = _sanitize_id(name.get_basename()) + ".luau";
+	}
+	return name;
+}
+
+String DDDBrowserExporter::_media_type_for_extension(const String &p_ext) {
+	String e = p_ext.to_lower();
+	if (e == "obj") {
+		return "model/obj";
+	}
+	if (e == "luau" || e == "lua") {
+		return "application/x-luau";
+	}
+	if (e == "wav") {
+		return "audio/wav";
+	}
+	if (e == "ogg") {
+		return "audio/ogg";
+	}
+	if (e == "ttf") {
+		return "font/ttf";
+	}
+	if (e == "otf") {
+		return "font/otf";
+	}
+	if (e == "png") {
+		return "image/png";
+	}
+	if (e == "jpg" || e == "jpeg") {
+		return "image/jpeg";
+	}
+	if (e == "tga") {
+		return "image/tga";
+	}
+	return "application/octet-stream";
+}
+
+Error DDDBrowserExporter::_write_text(const String &p_path, const String &p_text) const {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_CREATE, vformat("Cannot write %s", p_path));
+	f->store_string(p_text);
+	return OK;
+}
+
+Error DDDBrowserExporter::_copy_file(const String &p_from, const String &p_to) const {
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	ERR_FAIL_COND_V(da.is_null(), ERR_CANT_CREATE);
+	return da->copy(p_from, p_to);
+}
+
+Error DDDBrowserExporter::_export_mesh_obj(MeshInstance3D *p_mi, const String &p_path) const {
+	ERR_FAIL_NULL_V(p_mi, ERR_INVALID_PARAMETER);
+	Ref<Mesh> mesh = p_mi->get_mesh();
+	ERR_FAIL_COND_V(mesh.is_null(), ERR_INVALID_DATA);
+
+	String body;
+	body += "# DDDBrowser OBJ export\n";
+	int vertex_offset = 1;
+	const int surfaces = mesh->get_surface_count();
+	for (int s = 0; s < surfaces; s++) {
+		Array arrays = mesh->surface_get_arrays(s);
+		PackedVector3Array vertices = arrays[Mesh::ARRAY_VERTEX];
+		PackedVector3Array normals = arrays[Mesh::ARRAY_NORMAL];
+		PackedVector2Array uvs = arrays[Mesh::ARRAY_TEX_UV];
+		PackedInt32Array indices = arrays[Mesh::ARRAY_INDEX];
+
+		for (int i = 0; i < vertices.size(); i++) {
+			const Vector3 &v = vertices[i];
+			body += vformat("v %.6f %.6f %.6f\n", v.x, v.y, v.z);
+		}
+		if (uvs.size() == vertices.size()) {
+			for (int i = 0; i < uvs.size(); i++) {
+				body += vformat("vt %.6f %.6f\n", uvs[i].x, uvs[i].y);
+			}
+		}
+		if (normals.size() == vertices.size()) {
+			for (int i = 0; i < normals.size(); i++) {
+				const Vector3 &n = normals[i];
+				body += vformat("vn %.6f %.6f %.6f\n", n.x, n.y, n.z);
+			}
+		}
+
+		body += "o " + _sanitize_id(p_mi->get_name()) + "\n";
+		const bool has_uv = uvs.size() == vertices.size();
+		const bool has_n = normals.size() == vertices.size();
+		if (indices.size()) {
+			for (int i = 0; i + 2 < indices.size(); i += 3) {
+				int a = indices[i] + vertex_offset;
+				int b = indices[i + 1] + vertex_offset;
+				int c = indices[i + 2] + vertex_offset;
+				if (has_uv && has_n) {
+					body += vformat("f %d/%d/%d %d/%d/%d %d/%d/%d\n", a, a, a, b, b, b, c, c, c);
+				} else if (has_n) {
+					body += vformat("f %d//%d %d//%d %d//%d\n", a, a, b, b, c, c);
+				} else {
+					body += vformat("f %d %d %d\n", a, b, c);
+				}
+			}
+		} else {
+			for (int i = 0; i + 2 < vertices.size(); i += 3) {
+				int a = i + vertex_offset;
+				int b = i + 1 + vertex_offset;
+				int c = i + 2 + vertex_offset;
+				body += vformat("f %d %d %d\n", a, b, c);
+			}
+		}
+		vertex_offset += vertices.size();
+	}
+	return _write_text(p_path, body);
+}
+
+Dictionary DDDBrowserExporter::_light_instance(Light3D *p_light) const {
+	Dictionary inst = _transform_fields(p_light);
+	inst["id"] = _sanitize_id(p_light->get_name());
+
+	Dictionary light;
+	Color c = p_light->get_color();
+	light["color"] = _vec3(Vector3(c.r, c.g, c.b));
+	light["intensity"] = MAX(0.1, p_light->get_param(Light3D::PARAM_ENERGY));
+	light["enabled"] = p_light->is_visible();
+	light["shadowEnabled"] = p_light->has_shadow();
+
+	Transform3D xf = p_light->get_global_transform();
+	if (Object::cast_to<DirectionalLight3D>(p_light)) {
+		inst["type"] = "directionalLight";
+		Vector3 dir = -xf.basis.get_column(2).normalized();
+		light["direction"] = _vec3(dir);
+	} else if (Object::cast_to<SpotLight3D>(p_light)) {
+		inst["type"] = "spotLight";
+		SpotLight3D *spot = Object::cast_to<SpotLight3D>(p_light);
+		light["range"] = MAX(0.1, spot->get_param(Light3D::PARAM_RANGE));
+		light["cutoff"] = CLAMP(Math::rad_to_deg(spot->get_param(Light3D::PARAM_SPOT_ANGLE)) * 0.8, 0.0, 90.0);
+		light["outerCutoff"] = CLAMP(Math::rad_to_deg(spot->get_param(Light3D::PARAM_SPOT_ANGLE)), 0.0, 90.0);
+		Vector3 dir = -xf.basis.get_column(2).normalized();
+		light["direction"] = _vec3(dir);
+		Dictionary att;
+		att["constant"] = 1.0;
+		att["linear"] = 0.09;
+		att["quadratic"] = 0.032;
+		light["attenuation"] = att;
+	} else {
+		inst["type"] = "pointLight";
+		light["range"] = MAX(0.1, p_light->get_param(Light3D::PARAM_RANGE));
+		Dictionary att;
+		att["constant"] = 1.0;
+		att["linear"] = 0.09;
+		att["quadratic"] = 0.032;
+		light["attenuation"] = att;
+	}
+	inst["light"] = light;
+	return inst;
+}
+
+String DDDBrowserExporter::_ensure_script_asset(const String &p_source_path, bool p_pin_sha256, const String &p_preferred_id, const String &p_base_url, const String &p_export_dir, Array &r_assets, HashSet<String> &r_used_ids, HashMap<String, String> &r_path_to_asset_id, HashSet<String> &r_used_filenames, String *r_exported_filename) const {
+	if (p_source_path.is_empty()) {
+		last_error = "Script path is empty";
+		return String();
+	}
+
+	const String dedupe_key = _is_remote_uri(p_source_path) ? p_source_path : _resolve_source_path(p_source_path);
+	if (r_path_to_asset_id.has(dedupe_key)) {
+		const String existing_id = r_path_to_asset_id[dedupe_key];
+		if (r_exported_filename) {
+			for (int i = 0; i < r_assets.size(); i++) {
+				Dictionary a = r_assets[i];
+				if (String(a.get("id", "")) == existing_id) {
+					*r_exported_filename = _script_filename_from_path(String(a.get("uri", "")));
+					break;
+				}
+			}
+		}
+		return existing_id;
+	}
+
+	String id = _unique_id(p_preferred_id.is_empty() ? p_source_path.get_file().get_basename() : p_preferred_id, r_used_ids);
+	Dictionary asset;
+	asset["id"] = id;
+	asset["type"] = "script";
+	asset["mediaType"] = "application/x-luau";
+
+	String exported_filename = _script_filename_from_path(p_source_path);
+	if (_is_remote_uri(p_source_path)) {
+		asset["uri"] = p_source_path;
+		r_used_filenames.insert(exported_filename);
+	} else {
+		String src = dedupe_key;
+		if (!FileAccess::exists(src)) {
+			last_error = vformat("Script file not found: %s", p_source_path);
+			return String();
+		}
+
+		if (r_used_filenames.has(exported_filename)) {
+			exported_filename = id + ".luau";
+		}
+		int suffix = 2;
+		while (r_used_filenames.has(exported_filename)) {
+			exported_filename = id + "_" + itos(suffix) + ".luau";
+			suffix++;
+		}
+		r_used_filenames.insert(exported_filename);
+		String dest = p_export_dir.path_join("scripts").path_join(exported_filename);
+		if (_copy_file(src, dest) != OK) {
+			last_error = vformat("Failed copying script: %s", p_source_path);
+			return String();
+		}
+		asset["uri"] = _build_uri(p_base_url, p_export_dir, dest);
+		if (p_pin_sha256) {
+			String hash = FileAccess::get_sha256(dest);
+			if (!hash.is_empty()) {
+				asset["sha256"] = hash;
+			}
+		}
+	}
+
+	r_assets.push_back(asset);
+	r_path_to_asset_id[dedupe_key] = id;
+	if (r_exported_filename) {
+		*r_exported_filename = exported_filename;
+	}
+	return id;
+}
+
+String DDDBrowserExporter::_ensure_font_asset(DDDBrowserFont *p_font, const String &p_base_url, const String &p_export_dir, Array &r_assets, HashSet<String> &r_used_ids) const {
+	ERR_FAIL_NULL_V(p_font, String());
+	String preferred = p_font->get_asset_id().is_empty() ? String(p_font->get_name()) : p_font->get_asset_id();
+	String id = _unique_id(preferred, r_used_ids);
+	Dictionary asset;
+	asset["id"] = id;
+	asset["type"] = "font";
+
+	String path = p_font->get_source_path();
+	if (path.is_empty()) {
+		return String();
+	}
+	if (_is_remote_uri(path)) {
+		asset["uri"] = path;
+		asset["mediaType"] = path.to_lower().ends_with(".otf") ? "font/otf" : "font/ttf";
+	} else {
+		String src = _resolve_source_path(path);
+		if (!FileAccess::exists(src)) {
+			return String();
+		}
+		String ext = src.get_extension().to_lower();
+		if (ext.is_empty()) {
+			ext = "ttf";
+		}
+		String dest = p_export_dir.path_join("fonts").path_join(id + "." + ext);
+		if (_copy_file(src, dest) != OK) {
+			return String();
+		}
+		asset["uri"] = _build_uri(p_base_url, p_export_dir, dest);
+		asset["mediaType"] = _media_type_for_extension(ext);
+	}
+	Dictionary font_props;
+	font_props["size"] = MAX(0.01, p_font->get_size());
+	font_props["style"] = p_font->style_string();
+	asset["font"] = font_props;
+	r_assets.push_back(asset);
+	return id;
+}
+
+Dictionary DDDBrowserExporter::build_scene_dictionary(Node *p_root, const String &p_export_dir) {
+	last_error = String();
+	last_warning = String();
+	export_warnings.clear();
+	Dictionary scene;
+	DDDBrowserLevel *level = Object::cast_to<DDDBrowserLevel>(p_root);
+	String base_url;
+	String scene_name = "Exported Scene";
+	String schema_version = "1.0";
+	String version = "1.0";
+
+	if (level) {
+		scene_name = level->get_scene_name();
+		version = level->get_version();
+		schema_version = level->get_schema_version();
+		base_url = level->get_base_url();
+		scene["name"] = scene_name;
+		scene["version"] = version;
+		scene["schemaVersion"] = schema_version;
+		if (!level->get_scene_id().is_empty()) {
+			scene["id"] = level->get_scene_id();
+		} else {
+			scene["id"] = _sanitize_id(scene_name).to_lower();
+		}
+		if (!level->get_author().is_empty()) {
+			scene["author"] = level->get_author();
+		}
+		if (!level->get_description().is_empty()) {
+			scene["description"] = level->get_description();
+		}
+		scene["rating"] = level->rating_string();
+		if (!level->get_thumbnail_url().is_empty()) {
+			scene["thumbnail"] = level->get_thumbnail_url();
+		}
+		if (!level->get_manifest_url().is_empty()) {
+			scene["manifestUrl"] = level->get_manifest_url();
+		}
+		Dictionary sky = level->build_skybox_dictionary();
+		if (!sky.is_empty()) {
+			scene["skybox"] = sky;
+		}
+		if (level->get_export_movement_bounds()) {
+			Dictionary bounds;
+			bounds["min"] = _vec3(level->get_bounds_min());
+			bounds["max"] = _vec3(level->get_bounds_max());
+			scene["movementBounds"] = bounds;
+		}
+		if (!level->get_world_id().is_empty()) {
+			Dictionary world;
+			world["id"] = level->get_world_id();
+			world["position"] = _vec3(level->get_world_position());
+			scene["world"] = world;
+		}
+		scene["gameType"] = level->game_type_string();
+		Dictionary autosave = level->build_autosave_notification_dictionary();
+		if (!autosave.is_empty()) {
+			scene["autosaveNotification"] = autosave;
+		}
+	} else {
+		scene["name"] = scene_name;
+		scene["version"] = version;
+		scene["schemaVersion"] = schema_version;
+		String fallback_name = p_root ? String(p_root->get_name()) : scene_name;
+		scene["id"] = _sanitize_id(fallback_name).to_lower();
+	}
+
+	Array assets;
+	Array instances;
+	HashSet<String> used_asset_ids;
+	HashMap<ObjectID, String> font_node_to_asset;
+	HashMap<String, String> script_path_to_asset_id;
+	HashSet<String> used_script_filenames;
+	HashSet<ObjectID> exported_mesh_ids;
+	bool has_spawn = false;
+	Camera3D *first_camera = nullptr;
+	Marker3D *spawn_marker = nullptr;
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(p_export_dir.path_join("meshes"));
+	da->make_dir_recursive(p_export_dir.path_join("scripts"));
+	da->make_dir_recursive(p_export_dir.path_join("audio"));
+	da->make_dir_recursive(p_export_dir.path_join("fonts"));
+	da->make_dir_recursive(p_export_dir.path_join("textures"));
+
+	Vector<Node *> nodes;
+	nodes.push_back(p_root);
+	for (int i = 0; i < nodes.size(); i++) {
+		Node *n = nodes[i];
+		for (int c = 0; c < n->get_child_count(); c++) {
+			nodes.push_back(n->get_child(c));
+		}
+	}
+
+	auto attach_node_script = [&](Node *n, Dictionary &inst, const String &preferred_id) -> bool {
+		String path = DDDBrowserExportConvert::resolve_luau_script_path(n);
+		if (path.is_empty()) {
+			return true;
+		}
+		String script_id = _ensure_script_asset(path, true, preferred_id, base_url, p_export_dir, assets, used_asset_ids, script_path_to_asset_id, used_script_filenames);
+		if (script_id.is_empty()) {
+			return false;
+		}
+		Dictionary script_props;
+		script_props["file"] = script_id;
+		Dictionary data = DDDBrowserExportConvert::collect_script_export_data(n);
+		if (!data.is_empty()) {
+			script_props["data"] = data;
+		}
+		inst["script"] = script_props;
+		return true;
+	};
+
+	auto export_model_from_mi = [&](MeshInstance3D *mi, Dictionary collider_override) -> bool {
+		if (!mi || mi->get_mesh().is_null() || exported_mesh_ids.has(mi->get_instance_id())) {
+			return true;
+		}
+		exported_mesh_ids.insert(mi->get_instance_id());
+		String id = _unique_id(mi->get_name(), used_asset_ids);
+		String obj_path = p_export_dir.path_join("meshes").path_join(id + ".obj");
+		String warn;
+		if (DDDBrowserExportConvert::export_mesh_with_mtl(this, mi, obj_path, base_url, p_export_dir, &warn) != OK) {
+			export_warnings.push_back(vformat("Failed exporting mesh '%s'", mi->get_name()));
+			return true;
+		}
+		if (!warn.is_empty()) {
+			export_warnings.push_back(warn);
+		}
+		Dictionary asset;
+		asset["id"] = id;
+		asset["type"] = "model";
+		asset["uri"] = _build_uri(base_url, p_export_dir, obj_path);
+		asset["mediaType"] = "model/obj";
+		Dictionary collider = collider_override;
+		if (collider.is_empty()) {
+			if (DDDBrowserModel *model = Object::cast_to<DDDBrowserModel>(mi)) {
+				collider = model->build_collider_dictionary();
+			}
+			if (collider.is_empty()) {
+				String collider_warn;
+				collider = DDDBrowserExportConvert::collider_from_mesh_node(mi, &collider_warn);
+				if (!collider_warn.is_empty()) {
+					export_warnings.push_back(collider_warn);
+				}
+			}
+		}
+		if (!collider.is_empty()) {
+			asset["collider"] = collider;
+		}
+		assets.push_back(asset);
+
+		Dictionary inst = _transform_fields(mi);
+		inst["id"] = id;
+		inst["type"] = "model";
+		inst["asset"] = id;
+		if (!collider.is_empty()) {
+			inst["collider"] = collider;
+		}
+
+		bool has_luau = !DDDBrowserExportConvert::resolve_luau_script_path(mi).is_empty();
+		if (DDDBrowserModel *model = Object::cast_to<DDDBrowserModel>(mi)) {
+			if (has_luau && !model->get_script_path().is_empty()) {
+				export_warnings.push_back(vformat("Model '%s': preferring attached LuauScript over script_path", model->get_name()));
+			}
+			if (has_luau) {
+				if (!attach_node_script(mi, inst, id + "_script")) {
+					return false;
+				}
+			} else if (!model->get_script_path().is_empty()) {
+				String script_id = _ensure_script_asset(model->get_script_path(), model->get_pin_script_sha256(), id + "_script", base_url, p_export_dir, assets, used_asset_ids, script_path_to_asset_id, used_script_filenames);
+				if (script_id.is_empty()) {
+					return false;
+				}
+				Dictionary script_props;
+				script_props["file"] = script_id;
+				if (!model->get_script_data().is_empty()) {
+					script_props["data"] = model->get_script_data();
+				}
+				inst["script"] = script_props;
+			}
+		} else if (!attach_node_script(mi, inst, id + "_script")) {
+			return false;
+		}
+		instances.push_back(inst);
+		return true;
+	};
+
+	for (int i = 0; i < nodes.size(); i++) {
+		Node *n = nodes[i];
+		if (DDDBrowserFont *font = Object::cast_to<DDDBrowserFont>(n)) {
+			String id = _ensure_font_asset(font, base_url, p_export_dir, assets, used_asset_ids);
+			if (!id.is_empty()) {
+				font_node_to_asset[font->get_instance_id()] = id;
+			}
+			continue;
+		}
+		if (DDDBrowserScript *script_node = Object::cast_to<DDDBrowserScript>(n)) {
+			if (script_node->get_source_path().is_empty()) {
+				last_error = vformat("DDDBrowserScript '%s' has empty source_path", script_node->get_name());
+				return scene;
+			}
+			String preferred = script_node->get_asset_id().is_empty() ? String(script_node->get_name()) : script_node->get_asset_id();
+			String id = _ensure_script_asset(script_node->get_source_path(), script_node->get_pin_sha256(), preferred, base_url, p_export_dir, assets, used_asset_ids, script_path_to_asset_id, used_script_filenames);
+			if (id.is_empty()) {
+				return scene;
+			}
+		}
+	}
+
+	if (level && !level->get_gamemode_file().is_empty()) {
+		String gm_filename;
+		String gm_id = _ensure_script_asset(level->get_gamemode_file(), true, "gamemode", base_url, p_export_dir, assets, used_asset_ids, script_path_to_asset_id, used_script_filenames, &gm_filename);
+		if (gm_id.is_empty() || gm_filename.is_empty()) {
+			if (last_error.is_empty()) {
+				last_error = vformat("Failed to export gamemode script: %s", level->get_gamemode_file());
+			}
+			return scene;
+		}
+		Dictionary gm;
+		gm["file"] = gm_filename;
+		scene["gamemode"] = gm;
+	}
+
+	for (int i = 0; i < nodes.size(); i++) {
+		Node *n = nodes[i];
+		if (Object::cast_to<DDDBrowserFont>(n) || Object::cast_to<DDDBrowserScript>(n)) {
+			continue;
+		}
+		if (n->is_class("RigidBody3D") || n->is_class("CharacterBody3D")) {
+			export_warnings.push_back(vformat("Skipping physics body '%s' (%s); use StaticBody3D/MeshInstance3D for DDD export", n->get_name(), n->get_class()));
+			continue;
+		}
+		if (n->is_class("AnimationPlayer")) {
+			export_warnings.push_back(vformat("Skipping AnimationPlayer '%s' (unsupported in DDD export)", n->get_name()));
+			continue;
+		}
+		if (n->is_class("CSGShape3D") || n->is_class("CSGCombiner3D") || n->is_class("CSGPrimitive3D")) {
+			export_warnings.push_back(vformat("Skipping CSG node '%s'; bake to MeshInstance3D first", n->get_name()));
+			continue;
+		}
+		if (DDDBrowserSpawn *spawn = Object::cast_to<DDDBrowserSpawn>(n)) {
+			scene["spawn"] = _vec3(spawn->get_global_transform().origin);
+			has_spawn = true;
+			continue;
+		}
+		if (Camera3D *cam = Object::cast_to<Camera3D>(n)) {
+			if (!first_camera) {
+				first_camera = cam;
+			}
+			continue;
+		}
+		if (Marker3D *marker = Object::cast_to<Marker3D>(n)) {
+			if (String(marker->get_name()).to_lower() == "spawn") {
+				spawn_marker = marker;
+			}
+			continue;
+		}
+		if (MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(n)) {
+			Node *parent = mi->get_parent();
+			if (parent && (parent->is_class("StaticBody3D") || parent->is_class("AnimatableBody3D"))) {
+				continue;
+			}
+			if (parent && (parent->is_class("RigidBody3D") || parent->is_class("CharacterBody3D"))) {
+				export_warnings.push_back(vformat("Skipping mesh '%s' under %s '%s' (rigid/character physics not exported)", mi->get_name(), parent->get_class(), parent->get_name()));
+				continue;
+			}
+			if (!export_model_from_mi(mi, Dictionary())) {
+				return scene;
+			}
+			continue;
+		}
+		if (n->is_class("StaticBody3D") || n->is_class("AnimatableBody3D")) {
+			MeshInstance3D *child_mi = nullptr;
+			Dictionary body_collider;
+			for (int c = 0; c < n->get_child_count(); c++) {
+				Node *child = n->get_child(c);
+				if (!child_mi) {
+					child_mi = Object::cast_to<MeshInstance3D>(child);
+				}
+				if (CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(child)) {
+					String collider_warn;
+					Dictionary col = DDDBrowserExportConvert::collider_from_shape_node(cs, &collider_warn);
+					if (!col.is_empty() && body_collider.is_empty()) {
+						body_collider = col;
+					} else if (!collider_warn.is_empty()) {
+						export_warnings.push_back(collider_warn);
+					}
+				}
+			}
+			if (child_mi) {
+				if (!export_model_from_mi(child_mi, body_collider)) {
+					return scene;
+				}
+			} else {
+				export_warnings.push_back(vformat("Static/Animatable body '%s' has no MeshInstance3D child", n->get_name()));
+			}
+			continue;
+		}
+		if (Light3D *light = Object::cast_to<Light3D>(n)) {
+			Dictionary inst = _light_instance(light);
+			inst["id"] = _unique_id(light->get_name(), used_asset_ids);
+			if (!attach_node_script(light, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+		if (DDDBrowserPortal *portal = Object::cast_to<DDDBrowserPortal>(n)) {
+			if (portal->get_destination_url().is_empty()) {
+				continue;
+			}
+			Dictionary inst = _transform_fields(portal);
+			inst["id"] = _unique_id(portal->get_name(), used_asset_ids);
+			inst["type"] = "portal";
+			Dictionary p;
+			p["destinationUrl"] = portal->get_destination_url();
+			p["radius"] = portal->get_radius();
+			const bool auto_t = portal->get_trigger_mode() == DDDBrowserPortal::TRIGGER_AUTO;
+			const bool manual_t = portal->get_trigger_mode() == DDDBrowserPortal::TRIGGER_MANUAL;
+			const bool script_t = portal->get_trigger_mode() == DDDBrowserPortal::TRIGGER_SCRIPT;
+			p["autoTrigger"] = auto_t;
+			p["manualTrigger"] = manual_t;
+			p["scriptTrigger"] = script_t;
+			inst["portal"] = p;
+			instances.push_back(inst);
+			continue;
+		}
+		if (DDDBrowserVolume *vol = Object::cast_to<DDDBrowserVolume>(n)) {
+			Dictionary inst = _transform_fields(vol);
+			inst["id"] = _unique_id(vol->get_name(), used_asset_ids);
+			inst["type"] = vol->type_string();
+			inst[vol->properties_key()] = vol->build_properties_dictionary();
+			instances.push_back(inst);
+			continue;
+		}
+		if (DDDBrowserTextbox *tb = Object::cast_to<DDDBrowserTextbox>(n)) {
+			String asset_id = _unique_id(String(tb->get_name()) + "_asset", used_asset_ids);
+			Dictionary asset;
+			asset["id"] = asset_id;
+			asset["type"] = "textbox";
+			asset["uri"] = "data:text/plain," + asset_id;
+			asset["mediaType"] = "application/json";
+			Dictionary tb_props;
+			tb_props["text"] = tb->get_text();
+			if (!tb->get_title().is_empty()) {
+				tb_props["title"] = tb->get_title();
+			}
+			tb_props["size"] = MAX(0.01, tb->get_font_size());
+			tb_props["color"] = _color_vec3(tb->get_color());
+
+			String font_id = tb->get_font_asset_id();
+			if (font_id.is_empty()) {
+				for (int c = 0; c < tb->get_child_count(); c++) {
+					if (DDDBrowserFont *child_font = Object::cast_to<DDDBrowserFont>(tb->get_child(c))) {
+						if (font_node_to_asset.has(child_font->get_instance_id())) {
+							font_id = font_node_to_asset[child_font->get_instance_id()];
+							break;
+						}
+					}
+				}
+			}
+			if (!font_id.is_empty()) {
+				tb_props["font"] = font_id;
+			}
+			asset["textbox"] = tb_props;
+			assets.push_back(asset);
+
+			Dictionary inst = _transform_fields(tb);
+			inst["id"] = _unique_id(tb->get_name(), used_asset_ids);
+			inst["type"] = "textbox";
+			Dictionary inst_tb;
+			inst_tb["asset"] = asset_id;
+			if (!font_id.is_empty()) {
+				inst_tb["font"] = font_id;
+			}
+			inst["textbox"] = inst_tb;
+			if (!attach_node_script(tb, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+		if (Label3D *label = Object::cast_to<Label3D>(n)) {
+			String asset_id = _unique_id(String(label->get_name()) + "_asset", used_asset_ids);
+			Dictionary asset;
+			asset["id"] = asset_id;
+			asset["type"] = "textbox";
+			asset["uri"] = "data:text/plain," + asset_id;
+			asset["mediaType"] = "application/json";
+			Dictionary tb_props;
+			tb_props["text"] = label->get_text();
+			tb_props["size"] = MAX(0.01, label->get_font_size() / 32.0);
+			tb_props["color"] = _color_vec3(label->get_modulate());
+			asset["textbox"] = tb_props;
+			assets.push_back(asset);
+
+			Dictionary inst = _transform_fields(label);
+			inst["id"] = _unique_id(label->get_name(), used_asset_ids);
+			inst["type"] = "textbox";
+			Dictionary inst_tb;
+			inst_tb["asset"] = asset_id;
+			inst["textbox"] = inst_tb;
+			if (!attach_node_script(label, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+		if (DDDBrowserPicturebox *pb = Object::cast_to<DDDBrowserPicturebox>(n)) {
+			String tex_path = pb->get_texture_path();
+			if (tex_path.is_empty()) {
+				continue;
+			}
+			String tex_asset_id = _unique_id(String(pb->get_name()) + "_texture", used_asset_ids);
+			Dictionary tex_asset;
+			tex_asset["id"] = tex_asset_id;
+			tex_asset["type"] = "texture";
+			if (_is_remote_uri(tex_path)) {
+				tex_asset["uri"] = tex_path;
+				tex_asset["mediaType"] = _media_type_for_extension(tex_path.get_extension());
+			} else {
+				String src = _resolve_source_path(tex_path);
+				if (!FileAccess::exists(src)) {
+					continue;
+				}
+				String ext = src.get_extension().to_lower();
+				if (ext.is_empty()) {
+					ext = "png";
+				}
+				String dest = p_export_dir.path_join("textures").path_join(tex_asset_id + "." + ext);
+				if (_copy_file(src, dest) != OK) {
+					continue;
+				}
+				tex_asset["uri"] = _build_uri(base_url, p_export_dir, dest);
+				tex_asset["mediaType"] = _media_type_for_extension(ext);
+			}
+			assets.push_back(tex_asset);
+
+			String pb_asset_id = _unique_id(String(pb->get_name()) + "_asset", used_asset_ids);
+			Dictionary pb_asset;
+			pb_asset["id"] = pb_asset_id;
+			pb_asset["type"] = "picturebox";
+			pb_asset["uri"] = "data:text/plain," + pb_asset_id;
+			pb_asset["mediaType"] = "application/json";
+			Dictionary pb_props;
+			pb_props["texture"] = tex_asset_id;
+			pb_props["width"] = MAX(0.01, pb->get_width());
+			pb_props["height"] = MAX(0.01, pb->get_height());
+			pb_asset["picturebox"] = pb_props;
+			assets.push_back(pb_asset);
+
+			Dictionary inst = _transform_fields(pb);
+			inst["id"] = _unique_id(pb->get_name(), used_asset_ids);
+			inst["type"] = "picturebox";
+			Dictionary inst_pb;
+			inst_pb["asset"] = pb_asset_id;
+			inst["picturebox"] = inst_pb;
+			if (!attach_node_script(pb, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+		if (Sprite3D *sprite = Object::cast_to<Sprite3D>(n)) {
+			Ref<Texture2D> tex = sprite->get_texture();
+			if (tex.is_null()) {
+				export_warnings.push_back(vformat("Sprite3D '%s' has no texture", sprite->get_name()));
+				continue;
+			}
+			String tex_path = tex->get_path();
+			String tex_asset_id = _unique_id(String(sprite->get_name()) + "_texture", used_asset_ids);
+			Dictionary tex_asset;
+			tex_asset["id"] = tex_asset_id;
+			tex_asset["type"] = "texture";
+			bool tex_ok = false;
+			if (!tex_path.is_empty() && _is_remote_uri(tex_path)) {
+				tex_asset["uri"] = tex_path;
+				tex_asset["mediaType"] = _media_type_for_extension(tex_path.get_extension());
+				tex_ok = true;
+			} else if (!tex_path.is_empty()) {
+				String src = _resolve_source_path(tex_path);
+				if (FileAccess::exists(src)) {
+					String ext = src.get_extension().to_lower();
+					if (ext.is_empty()) {
+						ext = "png";
+					}
+					String dest = p_export_dir.path_join("textures").path_join(tex_asset_id + "." + ext);
+					if (_copy_file(src, dest) == OK) {
+						tex_asset["uri"] = _build_uri(base_url, p_export_dir, dest);
+						tex_asset["mediaType"] = _media_type_for_extension(ext);
+						tex_ok = true;
+					}
+				}
+			}
+			if (!tex_ok) {
+				Ref<Image> img = tex->get_image();
+				if (img.is_valid() && !img->is_empty()) {
+					String dest = p_export_dir.path_join("textures").path_join(tex_asset_id + ".png");
+					if (img->save_png(dest) == OK) {
+						tex_asset["uri"] = _build_uri(base_url, p_export_dir, dest);
+						tex_asset["mediaType"] = "image/png";
+						tex_ok = true;
+					}
+				}
+			}
+			if (!tex_ok) {
+				export_warnings.push_back(vformat("Sprite3D '%s' texture could not be exported", sprite->get_name()));
+				continue;
+			}
+			assets.push_back(tex_asset);
+
+			String pb_asset_id = _unique_id(String(sprite->get_name()) + "_asset", used_asset_ids);
+			Dictionary pb_asset;
+			pb_asset["id"] = pb_asset_id;
+			pb_asset["type"] = "picturebox";
+			pb_asset["uri"] = "data:text/plain," + pb_asset_id;
+			pb_asset["mediaType"] = "application/json";
+			Dictionary pb_props;
+			pb_props["texture"] = tex_asset_id;
+			const float pixel = sprite->get_pixel_size();
+			pb_props["width"] = MAX(0.01, pixel * float(tex->get_width()));
+			pb_props["height"] = MAX(0.01, pixel * float(tex->get_height()));
+			pb_asset["picturebox"] = pb_props;
+			assets.push_back(pb_asset);
+
+			Dictionary inst = _transform_fields(sprite);
+			inst["id"] = _unique_id(sprite->get_name(), used_asset_ids);
+			inst["type"] = "picturebox";
+			Dictionary inst_pb;
+			inst_pb["asset"] = pb_asset_id;
+			inst["picturebox"] = inst_pb;
+			if (!attach_node_script(sprite, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+		if (DDDBrowserAudio *audio = Object::cast_to<DDDBrowserAudio>(n)) {
+			String src_path = audio->get_source_path();
+			if (src_path.is_empty()) {
+				continue;
+			}
+			String asset_id = _unique_id(String(audio->get_name()) + "_asset", used_asset_ids);
+			Dictionary asset;
+			asset["id"] = asset_id;
+			asset["type"] = "audio";
+
+			String format_str = audio->get_format() == DDDBrowserAudio::FORMAT_OGG ? "ogg" : "wav";
+			if (_is_remote_uri(src_path)) {
+				asset["uri"] = src_path;
+				if (src_path.to_lower().ends_with(".ogg")) {
+					format_str = "ogg";
+				} else if (src_path.to_lower().ends_with(".wav")) {
+					format_str = "wav";
+				}
+				asset["mediaType"] = format_str == "ogg" ? "audio/ogg" : "audio/wav";
+			} else {
+				String src = _resolve_source_path(src_path);
+				if (!FileAccess::exists(src)) {
+					continue;
+				}
+				String ext = src.get_extension().to_lower();
+				if (ext == "ogg") {
+					format_str = "ogg";
+				} else if (ext == "wav") {
+					format_str = "wav";
+				} else {
+					ext = format_str;
+				}
+				String dest = p_export_dir.path_join("audio").path_join(asset_id + "." + ext);
+				if (_copy_file(src, dest) != OK) {
+					continue;
+				}
+				asset["uri"] = _build_uri(base_url, p_export_dir, dest);
+				asset["mediaType"] = format_str == "ogg" ? "audio/ogg" : "audio/wav";
+			}
+			Dictionary audio_asset_props;
+			audio_asset_props["format"] = format_str;
+			audio_asset_props["ambient"] = audio->get_ambient();
+			asset["audio"] = audio_asset_props;
+			assets.push_back(asset);
+
+			Dictionary inst = _transform_fields(audio);
+			inst["id"] = _unique_id(audio->get_name(), used_asset_ids);
+			inst["type"] = "audio";
+			Dictionary inst_audio;
+			inst_audio["asset"] = asset_id;
+			inst_audio["loop"] = audio->get_loop();
+			inst_audio["volume"] = CLAMP(audio->get_volume(), 0.0f, 1.0f);
+			inst_audio["autoPlay"] = audio->get_auto_play();
+			inst["audio"] = inst_audio;
+			if (!attach_node_script(audio, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+		if (AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(n)) {
+			String src_path = DDDBrowserExportConvert::resolve_audio_stream_path(player);
+			if (src_path.is_empty()) {
+				export_warnings.push_back(vformat("AudioStreamPlayer3D '%s' has no stream path (wav/ogg required)", player->get_name()));
+				continue;
+			}
+			String asset_id = _unique_id(String(player->get_name()) + "_asset", used_asset_ids);
+			Dictionary asset;
+			asset["id"] = asset_id;
+			asset["type"] = "audio";
+			String format_str = "wav";
+			if (_is_remote_uri(src_path)) {
+				asset["uri"] = src_path;
+				if (src_path.to_lower().ends_with(".ogg")) {
+					format_str = "ogg";
+				}
+				asset["mediaType"] = format_str == "ogg" ? "audio/ogg" : "audio/wav";
+			} else {
+				String src = _resolve_source_path(src_path);
+				if (!FileAccess::exists(src)) {
+					export_warnings.push_back(vformat("Missing audio stream file for '%s': %s", player->get_name(), src_path));
+					continue;
+				}
+				String ext = src.get_extension().to_lower();
+				if (ext == "ogg") {
+					format_str = "ogg";
+				} else if (ext == "wav") {
+					format_str = "wav";
+				} else {
+					export_warnings.push_back(vformat("Unsupported audio format for '%s' (.%s); need wav/ogg", player->get_name(), ext));
+					continue;
+				}
+				String dest = p_export_dir.path_join("audio").path_join(asset_id + "." + ext);
+				if (_copy_file(src, dest) != OK) {
+					export_warnings.push_back(vformat("Failed copying audio for '%s'", player->get_name()));
+					continue;
+				}
+				asset["uri"] = _build_uri(base_url, p_export_dir, dest);
+				asset["mediaType"] = format_str == "ogg" ? "audio/ogg" : "audio/wav";
+			}
+			Dictionary audio_asset_props;
+			audio_asset_props["format"] = format_str;
+			audio_asset_props["ambient"] = false;
+			asset["audio"] = audio_asset_props;
+			assets.push_back(asset);
+
+			Dictionary inst = _transform_fields(player);
+			inst["id"] = _unique_id(player->get_name(), used_asset_ids);
+			inst["type"] = "audio";
+			Dictionary inst_audio;
+			inst_audio["asset"] = asset_id;
+			inst_audio["loop"] = true;
+			inst_audio["volume"] = CLAMP(float(Math::db_to_linear(player->get_volume_db())), 0.0f, 1.0f);
+			inst_audio["autoPlay"] = player->is_autoplay_enabled();
+			inst["audio"] = inst_audio;
+			if (!attach_node_script(player, inst, String(inst["id"]) + "_script")) {
+				return scene;
+			}
+			instances.push_back(inst);
+			continue;
+		}
+	}
+
+	if (!has_spawn) {
+		if (spawn_marker) {
+			scene["spawn"] = _vec3(spawn_marker->get_global_transform().origin);
+			has_spawn = true;
+		} else if (first_camera) {
+			scene["spawn"] = _vec3(first_camera->get_global_transform().origin);
+			has_spawn = true;
+		}
+	}
+
+	if (!scene.has("skybox")) {
+		Dictionary sky;
+		if (DDDBrowserExportConvert::try_skybox_from_world_environment(p_root, sky)) {
+			String uri = sky.get("uri", "");
+			if (!uri.is_empty() && !_is_remote_uri(uri)) {
+				String src = _resolve_source_path(uri);
+				if (FileAccess::exists(src)) {
+					String ext = src.get_extension().to_lower();
+					if (ext.is_empty()) {
+						ext = "png";
+					}
+					String dest = p_export_dir.path_join("textures").path_join("skybox." + ext);
+					if (_copy_file(src, dest) == OK) {
+						sky["uri"] = _build_uri(base_url, p_export_dir, dest);
+						scene["skybox"] = sky;
+					} else {
+						export_warnings.push_back("Failed copying WorldEnvironment skybox texture");
+					}
+				} else {
+					export_warnings.push_back(vformat("WorldEnvironment skybox texture missing: %s", uri));
+				}
+			} else if (!uri.is_empty()) {
+				scene["skybox"] = sky;
+			}
+		}
+	}
+
+	scene["assets"] = assets;
+	if (!instances.is_empty()) {
+		scene["instances"] = instances;
+	}
+	if (!export_warnings.is_empty()) {
+		last_warning = String("\n").join(export_warnings);
+	}
+	return scene;
+}
+
+PackedStringArray DDDBrowserExporter::get_validation_errors(const Dictionary &p_scene) const {
+	PackedStringArray errors;
+	if (!p_scene.has("name") || String(p_scene["name"]).is_empty()) {
+		errors.push_back("missing name");
+	}
+	if (!p_scene.has("version")) {
+		errors.push_back("missing version");
+	}
+	if (!p_scene.has("schemaVersion")) {
+		errors.push_back("missing schemaVersion");
+	}
+	if (!p_scene.has("assets") || p_scene["assets"].get_type() != Variant::ARRAY) {
+		errors.push_back("missing assets array");
+	}
+	if (p_scene.has("instances") && p_scene["instances"].get_type() == Variant::ARRAY) {
+		Array insts = p_scene["instances"];
+		for (int i = 0; i < insts.size(); i++) {
+			Dictionary inst = insts[i];
+			if (!inst.has("type")) {
+				errors.push_back(vformat("instances/%d missing type", i));
+			}
+			if (!inst.has("id") || !inst.has("position") || !inst.has("rotation") || !inst.has("scale")) {
+				errors.push_back(vformat("instances/%d missing transform fields", i));
+			}
+			String t = inst.get("type", "");
+			if (t == "model" && !inst.has("asset")) {
+				errors.push_back(vformat("instances/%d model missing asset", i));
+			}
+			if ((t == "pointLight" || t == "directionalLight" || t == "spotLight") && !inst.has("light")) {
+				errors.push_back(vformat("instances/%d light missing light props", i));
+			}
+			if (t == "portal" && !inst.has("portal")) {
+				errors.push_back(vformat("instances/%d portal missing portal props", i));
+			}
+			if (t == "textbox") {
+				if (!inst.has("textbox")) {
+					errors.push_back(vformat("instances/%d textbox missing textbox props", i));
+				} else {
+					Dictionary tb = inst["textbox"];
+					if (!tb.has("asset")) {
+						errors.push_back(vformat("instances/%d textbox missing textbox.asset", i));
+					}
+				}
+			}
+			if (t == "picturebox") {
+				if (!inst.has("picturebox")) {
+					errors.push_back(vformat("instances/%d picturebox missing picturebox props", i));
+				} else {
+					Dictionary pb = inst["picturebox"];
+					if (!pb.has("asset")) {
+						errors.push_back(vformat("instances/%d picturebox missing picturebox.asset", i));
+					}
+				}
+			}
+			if (t == "audio") {
+				if (!inst.has("audio")) {
+					errors.push_back(vformat("instances/%d audio missing audio props", i));
+				} else {
+					Dictionary a = inst["audio"];
+					if (!a.has("asset")) {
+						errors.push_back(vformat("instances/%d audio missing audio.asset", i));
+					}
+				}
+			}
+			if (t.ends_with("Volume") || t == "teleportVolume" || t == "interactionVolume" || t == "autosaveVolume") {
+				if (!inst.has(t)) {
+					errors.push_back(vformat("instances/%d volume missing %s props", i, t));
+				} else {
+					Dictionary props = inst[t];
+					if ((t == "singleTriggerVolume" || t == "exitTriggerVolume" || t == "lookAtVolume" || t == "multiTriggerVolume" || t == "cooldownTriggerVolume" || t == "stayTriggerVolume" || t == "timedEntryTriggerVolume" || t == "interactionVolume") && !props.has("eventName")) {
+						errors.push_back(vformat("instances/%d %s missing eventName", i, t));
+					}
+					if (t == "lookedAtVolume" && (!props.has("eventName") || !props.has("targetInstanceId"))) {
+						errors.push_back(vformat("instances/%d lookedAtVolume missing required fields", i));
+					}
+					if (t == "cooldownTriggerVolume" && !props.has("cooldownSeconds")) {
+						errors.push_back(vformat("instances/%d cooldownTriggerVolume missing cooldownSeconds", i));
+					}
+					if (t == "stayTriggerVolume" && !props.has("stayInterval")) {
+						errors.push_back(vformat("instances/%d stayTriggerVolume missing stayInterval", i));
+					}
+					if (t == "timedEntryTriggerVolume" && !props.has("requiredStayTime")) {
+						errors.push_back(vformat("instances/%d timedEntryTriggerVolume missing requiredStayTime", i));
+					}
+					if (t == "counterTriggerVolume" && (!props.has("counter_word") || !props.has("required_count"))) {
+						errors.push_back(vformat("instances/%d counterTriggerVolume missing counter fields", i));
+					}
+					if (t == "sequenceTriggerVolume" && (!props.has("sequence_group_id") || !props.has("sequence_index"))) {
+						errors.push_back(vformat("instances/%d sequenceTriggerVolume missing sequence fields", i));
+					}
+					if (t == "teleportVolume" && !props.has("target_position")) {
+						errors.push_back(vformat("instances/%d teleportVolume missing target_position", i));
+					}
+					if (t == "interactionVolume" && !props.has("action")) {
+						errors.push_back(vformat("instances/%d interactionVolume missing action", i));
+					}
+				}
+			}
+		}
+	}
+	HashSet<String> script_asset_ids;
+	HashSet<String> script_filenames;
+	if (p_scene.has("assets") && p_scene["assets"].get_type() == Variant::ARRAY) {
+		Array asset_list = p_scene["assets"];
+		for (int i = 0; i < asset_list.size(); i++) {
+			Dictionary asset = asset_list[i];
+			if (!asset.has("id") || !asset.has("type") || !asset.has("uri") || !asset.has("mediaType")) {
+				errors.push_back(vformat("assets/%d missing required fields", i));
+			}
+			String t = asset.get("type", "");
+			if (t == "textbox" && !asset.has("textbox")) {
+				errors.push_back(vformat("assets/%d textbox missing textbox props", i));
+			}
+			if (t == "picturebox" && !asset.has("picturebox")) {
+				errors.push_back(vformat("assets/%d picturebox missing picturebox props", i));
+			}
+			if (t == "audio" && !asset.has("audio")) {
+				errors.push_back(vformat("assets/%d audio missing audio props", i));
+			}
+			if (t == "script") {
+				String aid = asset.get("id", "");
+				if (!aid.is_empty()) {
+					script_asset_ids.insert(aid);
+				}
+				String uri = asset.get("uri", "");
+				String fname = _script_filename_from_path(uri);
+				if (!fname.is_empty()) {
+					script_filenames.insert(fname);
+				}
+				String mt = asset.get("mediaType", "");
+				if (mt != "application/x-luau") {
+					errors.push_back(vformat("assets/%d script mediaType must be application/x-luau", i));
+				}
+			}
+		}
+	}
+	if (p_scene.has("instances") && p_scene["instances"].get_type() == Variant::ARRAY) {
+		Array insts = p_scene["instances"];
+		for (int i = 0; i < insts.size(); i++) {
+			Dictionary inst = insts[i];
+			if (!inst.has("script")) {
+				continue;
+			}
+			Dictionary script_props = inst["script"];
+			String file = script_props.get("file", "");
+			if (file.is_empty() || !script_asset_ids.has(file)) {
+				errors.push_back(vformat("instances/%d script.file must reference a script asset id", i));
+			}
+		}
+	}
+	if (p_scene.has("gamemode")) {
+		Dictionary gm = p_scene["gamemode"];
+		String file = gm.get("file", "");
+		if (file.is_empty() || !file.to_lower().ends_with(".luau")) {
+			errors.push_back("gamemode.file must be a .luau filename");
+		} else if (!script_filenames.has(file)) {
+			errors.push_back(vformat("gamemode.file '%s' does not match an exported script filename", file));
+		}
+	}
+	return errors;
+}
+
+bool DDDBrowserExporter::validate_scene_dictionary(const Dictionary &p_scene) const {
+	return get_validation_errors(p_scene).is_empty();
+}
+
+Error DDDBrowserExporter::export_scene(Node *p_root, const String &p_export_dir, bool p_generate_html) {
+	last_error = String();
+	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	Error err = da->make_dir_recursive(p_export_dir);
+	if (err != OK && err != ERR_ALREADY_EXISTS) {
+		last_error = "Cannot create export directory";
+		return err;
+	}
+
+	Dictionary scene = build_scene_dictionary(p_root, p_export_dir);
+	if (!last_error.is_empty()) {
+		return ERR_INVALID_DATA;
+	}
+	PackedStringArray errors = get_validation_errors(scene);
+	if (!errors.is_empty()) {
+		last_error = errors[0];
+		return ERR_INVALID_DATA;
+	}
+
+	String json_text = JSON::stringify(scene, "\t", false);
+	String json_path = p_export_dir.path_join("scene.json");
+	err = _write_text(json_path, json_text);
+	if (err != OK) {
+		last_error = "Failed writing scene.json";
+		return err;
+	}
+
+	if (p_generate_html) {
+		String name = scene.get("name", "Exported Scene");
+		String id = scene.get("id", "exported_scene");
+		String author = scene.get("author", "");
+		String rating = scene.get("rating", "GENERAL");
+		String desc = scene.get("description", "");
+		String thumb = scene.get("thumbnail", "");
+		String html;
+		html += "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n";
+		html += "    <meta charset=\"utf-8\">\n";
+		html += "    <title>" + name.xml_escape() + "</title>\n\n";
+		html += "    <meta name=\"scene:id\" content=\"" + id.xml_escape() + "\">\n";
+		html += "    <meta name=\"scene:name\" content=\"" + name.xml_escape() + "\">\n";
+		html += "    <meta name=\"scene:author\" content=\"" + author.xml_escape() + "\">\n";
+		html += "    <meta name=\"scene:rating\" content=\"" + rating.xml_escape() + "\">\n";
+		if (!thumb.is_empty()) {
+			html += "    <meta name=\"scene:thumbnail\" content=\"" + thumb.xml_escape() + "\">\n";
+		}
+		html += "\n    <script id=\"blazium-scene\" type=\"application/vnd.blazium.scene+json\">\n";
+		html += json_text + "\n";
+		html += "    </script>\n</head>\n<body>\n";
+		html += "    <h1>" + name.xml_escape() + "</h1>\n";
+		if (!desc.is_empty()) {
+			html += "    <p>" + desc.xml_escape() + "</p>\n";
+		}
+		html += "</body>\n</html>\n";
+		err = _write_text(p_export_dir.path_join("index.html"), html);
+		if (err != OK) {
+			last_error = "Failed writing index.html";
+			return err;
+		}
+	}
+	return OK;
+}
+
+String DDDBrowserExporter::get_last_error() const {
+	return last_error;
+}
+String DDDBrowserExporter::get_last_warning() const {
+	return last_warning;
+}

--- a/modules/dddbrowser/dddbrowser_exporter.h
+++ b/modules/dddbrowser/dddbrowser_exporter.h
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  dddbrowser_exporter.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
+#include "core/variant/dictionary.h"
+
+class Node;
+class Node3D;
+class MeshInstance3D;
+class Light3D;
+class DDDBrowserModel;
+class DDDBrowserFont;
+class DDDBrowserScript;
+class DDDBrowserExportConvert;
+
+class DDDBrowserExporter : public RefCounted {
+	GDCLASS(DDDBrowserExporter, RefCounted);
+	friend class DDDBrowserExportConvert;
+
+	mutable String last_error;
+	mutable String last_warning;
+	mutable PackedStringArray export_warnings;
+
+	static String _sanitize_id(const String &p_name);
+	static String _unique_id(const String &p_base, HashSet<String> &r_used);
+	static Dictionary _vec3(const Vector3 &p_v);
+	static Dictionary _safe_scale(const Vector3 &p_s);
+	static Dictionary _color_vec3(const Color &p_c);
+	static Dictionary _transform_fields(Node3D *p_node);
+	static String _build_uri(const String &p_base_url, const String &p_export_dir, const String &p_filepath);
+	static bool _is_remote_uri(const String &p_path);
+	static String _resolve_source_path(const String &p_path);
+	static String _media_type_for_extension(const String &p_ext);
+	static String _script_filename_from_path(const String &p_path);
+	Error _export_mesh_obj(MeshInstance3D *p_mi, const String &p_path) const;
+	Dictionary _light_instance(Light3D *p_light) const;
+	Error _write_text(const String &p_path, const String &p_text) const;
+	Error _copy_file(const String &p_from, const String &p_to) const;
+	String _ensure_script_asset(const String &p_source_path, bool p_pin_sha256, const String &p_preferred_id, const String &p_base_url, const String &p_export_dir, Array &r_assets, HashSet<String> &r_used_ids, HashMap<String, String> &r_path_to_asset_id, HashSet<String> &r_used_filenames, String *r_exported_filename = nullptr) const;
+	String _ensure_font_asset(DDDBrowserFont *p_font, const String &p_base_url, const String &p_export_dir, Array &r_assets, HashSet<String> &r_used_ids) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Error export_scene(Node *p_root, const String &p_export_dir, bool p_generate_html = true);
+	Dictionary build_scene_dictionary(Node *p_root, const String &p_export_dir);
+	bool validate_scene_dictionary(const Dictionary &p_scene) const;
+	PackedStringArray get_validation_errors(const Dictionary &p_scene) const;
+	String get_last_error() const;
+	String get_last_warning() const;
+};

--- a/modules/dddbrowser/dddbrowser_font.cpp
+++ b/modules/dddbrowser/dddbrowser_font.cpp
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  dddbrowser_font.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_font.h"
+
+void DDDBrowserFont::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_asset_id", "id"), &DDDBrowserFont::set_asset_id);
+	ClassDB::bind_method(D_METHOD("get_asset_id"), &DDDBrowserFont::get_asset_id);
+	ClassDB::bind_method(D_METHOD("set_source_path", "path"), &DDDBrowserFont::set_source_path);
+	ClassDB::bind_method(D_METHOD("get_source_path"), &DDDBrowserFont::get_source_path);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &DDDBrowserFont::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &DDDBrowserFont::get_size);
+	ClassDB::bind_method(D_METHOD("set_style", "style"), &DDDBrowserFont::set_style);
+	ClassDB::bind_method(D_METHOD("get_style"), &DDDBrowserFont::get_style);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "asset_id"), "set_asset_id", "get_asset_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_path", PROPERTY_HINT_FILE, "*.ttf,*.otf"), "set_source_path", "get_source_path");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size", PROPERTY_HINT_RANGE, "1,512,0.1"), "set_size", "get_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "style", PROPERTY_HINT_ENUM, "Normal,Bold,Italic"), "set_style", "get_style");
+
+	BIND_ENUM_CONSTANT(STYLE_NORMAL);
+	BIND_ENUM_CONSTANT(STYLE_BOLD);
+	BIND_ENUM_CONSTANT(STYLE_ITALIC);
+}
+
+void DDDBrowserFont::set_asset_id(const String &p_id) {
+	asset_id = p_id;
+}
+String DDDBrowserFont::get_asset_id() const {
+	return asset_id;
+}
+void DDDBrowserFont::set_source_path(const String &p_path) {
+	source_path = p_path;
+}
+String DDDBrowserFont::get_source_path() const {
+	return source_path;
+}
+void DDDBrowserFont::set_size(float p_size) {
+	size = p_size;
+}
+float DDDBrowserFont::get_size() const {
+	return size;
+}
+void DDDBrowserFont::set_style(Style p_style) {
+	style = p_style;
+}
+DDDBrowserFont::Style DDDBrowserFont::get_style() const {
+	return style;
+}
+
+String DDDBrowserFont::style_string() const {
+	switch (style) {
+		case STYLE_BOLD:
+			return "bold";
+		case STYLE_ITALIC:
+			return "italic";
+		default:
+			return "normal";
+	}
+}

--- a/modules/dddbrowser/dddbrowser_font.h
+++ b/modules/dddbrowser/dddbrowser_font.h
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  dddbrowser_font.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserFont : public Node3D {
+	GDCLASS(DDDBrowserFont, Node3D);
+
+public:
+	enum Style {
+		STYLE_NORMAL,
+		STYLE_BOLD,
+		STYLE_ITALIC,
+	};
+
+private:
+	String asset_id;
+	String source_path;
+	float size = 16.0f;
+	Style style = STYLE_NORMAL;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_asset_id(const String &p_id);
+	String get_asset_id() const;
+	void set_source_path(const String &p_path);
+	String get_source_path() const;
+	void set_size(float p_size);
+	float get_size() const;
+	void set_style(Style p_style);
+	Style get_style() const;
+	String style_string() const;
+};
+
+VARIANT_ENUM_CAST(DDDBrowserFont::Style);

--- a/modules/dddbrowser/dddbrowser_level.cpp
+++ b/modules/dddbrowser/dddbrowser_level.cpp
@@ -1,0 +1,387 @@
+/**************************************************************************/
+/*  dddbrowser_level.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_level.h"
+
+void DDDBrowserLevel::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_scene_name", "name"), &DDDBrowserLevel::set_scene_name);
+	ClassDB::bind_method(D_METHOD("get_scene_name"), &DDDBrowserLevel::get_scene_name);
+	ClassDB::bind_method(D_METHOD("set_scene_id", "id"), &DDDBrowserLevel::set_scene_id);
+	ClassDB::bind_method(D_METHOD("get_scene_id"), &DDDBrowserLevel::get_scene_id);
+	ClassDB::bind_method(D_METHOD("set_author", "author"), &DDDBrowserLevel::set_author);
+	ClassDB::bind_method(D_METHOD("get_author"), &DDDBrowserLevel::get_author);
+	ClassDB::bind_method(D_METHOD("set_description", "description"), &DDDBrowserLevel::set_description);
+	ClassDB::bind_method(D_METHOD("get_description"), &DDDBrowserLevel::get_description);
+	ClassDB::bind_method(D_METHOD("set_version", "version"), &DDDBrowserLevel::set_version);
+	ClassDB::bind_method(D_METHOD("get_version"), &DDDBrowserLevel::get_version);
+	ClassDB::bind_method(D_METHOD("set_schema_version", "version"), &DDDBrowserLevel::set_schema_version);
+	ClassDB::bind_method(D_METHOD("get_schema_version"), &DDDBrowserLevel::get_schema_version);
+	ClassDB::bind_method(D_METHOD("set_rating", "rating"), &DDDBrowserLevel::set_rating);
+	ClassDB::bind_method(D_METHOD("get_rating"), &DDDBrowserLevel::get_rating);
+	ClassDB::bind_method(D_METHOD("set_thumbnail_url", "url"), &DDDBrowserLevel::set_thumbnail_url);
+	ClassDB::bind_method(D_METHOD("get_thumbnail_url"), &DDDBrowserLevel::get_thumbnail_url);
+	ClassDB::bind_method(D_METHOD("set_manifest_url", "url"), &DDDBrowserLevel::set_manifest_url);
+	ClassDB::bind_method(D_METHOD("get_manifest_url"), &DDDBrowserLevel::get_manifest_url);
+	ClassDB::bind_method(D_METHOD("set_skybox_uri", "uri"), &DDDBrowserLevel::set_skybox_uri);
+	ClassDB::bind_method(D_METHOD("get_skybox_uri"), &DDDBrowserLevel::get_skybox_uri);
+	ClassDB::bind_method(D_METHOD("set_skybox_px", "uri"), &DDDBrowserLevel::set_skybox_px);
+	ClassDB::bind_method(D_METHOD("get_skybox_px"), &DDDBrowserLevel::get_skybox_px);
+	ClassDB::bind_method(D_METHOD("set_skybox_nx", "uri"), &DDDBrowserLevel::set_skybox_nx);
+	ClassDB::bind_method(D_METHOD("get_skybox_nx"), &DDDBrowserLevel::get_skybox_nx);
+	ClassDB::bind_method(D_METHOD("set_skybox_py", "uri"), &DDDBrowserLevel::set_skybox_py);
+	ClassDB::bind_method(D_METHOD("get_skybox_py"), &DDDBrowserLevel::get_skybox_py);
+	ClassDB::bind_method(D_METHOD("set_skybox_ny", "uri"), &DDDBrowserLevel::set_skybox_ny);
+	ClassDB::bind_method(D_METHOD("get_skybox_ny"), &DDDBrowserLevel::get_skybox_ny);
+	ClassDB::bind_method(D_METHOD("set_skybox_pz", "uri"), &DDDBrowserLevel::set_skybox_pz);
+	ClassDB::bind_method(D_METHOD("get_skybox_pz"), &DDDBrowserLevel::get_skybox_pz);
+	ClassDB::bind_method(D_METHOD("set_skybox_nz", "uri"), &DDDBrowserLevel::set_skybox_nz);
+	ClassDB::bind_method(D_METHOD("get_skybox_nz"), &DDDBrowserLevel::get_skybox_nz);
+	ClassDB::bind_method(D_METHOD("set_skybox_rotation", "rotation"), &DDDBrowserLevel::set_skybox_rotation);
+	ClassDB::bind_method(D_METHOD("get_skybox_rotation"), &DDDBrowserLevel::get_skybox_rotation);
+	ClassDB::bind_method(D_METHOD("set_base_url", "url"), &DDDBrowserLevel::set_base_url);
+	ClassDB::bind_method(D_METHOD("get_base_url"), &DDDBrowserLevel::get_base_url);
+	ClassDB::bind_method(D_METHOD("set_export_movement_bounds", "enable"), &DDDBrowserLevel::set_export_movement_bounds);
+	ClassDB::bind_method(D_METHOD("get_export_movement_bounds"), &DDDBrowserLevel::get_export_movement_bounds);
+	ClassDB::bind_method(D_METHOD("set_bounds_min", "min"), &DDDBrowserLevel::set_bounds_min);
+	ClassDB::bind_method(D_METHOD("get_bounds_min"), &DDDBrowserLevel::get_bounds_min);
+	ClassDB::bind_method(D_METHOD("set_bounds_max", "max"), &DDDBrowserLevel::set_bounds_max);
+	ClassDB::bind_method(D_METHOD("get_bounds_max"), &DDDBrowserLevel::get_bounds_max);
+	ClassDB::bind_method(D_METHOD("set_gamemode_file", "file"), &DDDBrowserLevel::set_gamemode_file);
+	ClassDB::bind_method(D_METHOD("get_gamemode_file"), &DDDBrowserLevel::get_gamemode_file);
+	ClassDB::bind_method(D_METHOD("set_world_id", "id"), &DDDBrowserLevel::set_world_id);
+	ClassDB::bind_method(D_METHOD("get_world_id"), &DDDBrowserLevel::get_world_id);
+	ClassDB::bind_method(D_METHOD("set_world_position", "position"), &DDDBrowserLevel::set_world_position);
+	ClassDB::bind_method(D_METHOD("get_world_position"), &DDDBrowserLevel::get_world_position);
+	ClassDB::bind_method(D_METHOD("set_game_type", "type"), &DDDBrowserLevel::set_game_type);
+	ClassDB::bind_method(D_METHOD("get_game_type"), &DDDBrowserLevel::get_game_type);
+	ClassDB::bind_method(D_METHOD("set_use_autosave_notification", "use"), &DDDBrowserLevel::set_use_autosave_notification);
+	ClassDB::bind_method(D_METHOD("get_use_autosave_notification"), &DDDBrowserLevel::get_use_autosave_notification);
+	ClassDB::bind_method(D_METHOD("set_autosave_text", "text"), &DDDBrowserLevel::set_autosave_text);
+	ClassDB::bind_method(D_METHOD("get_autosave_text"), &DDDBrowserLevel::get_autosave_text);
+	ClassDB::bind_method(D_METHOD("set_autosave_x", "x"), &DDDBrowserLevel::set_autosave_x);
+	ClassDB::bind_method(D_METHOD("get_autosave_x"), &DDDBrowserLevel::get_autosave_x);
+	ClassDB::bind_method(D_METHOD("set_autosave_y", "y"), &DDDBrowserLevel::set_autosave_y);
+	ClassDB::bind_method(D_METHOD("get_autosave_y"), &DDDBrowserLevel::get_autosave_y);
+	ClassDB::bind_method(D_METHOD("set_autosave_font", "font"), &DDDBrowserLevel::set_autosave_font);
+	ClassDB::bind_method(D_METHOD("get_autosave_font"), &DDDBrowserLevel::get_autosave_font);
+	ClassDB::bind_method(D_METHOD("set_autosave_color", "color"), &DDDBrowserLevel::set_autosave_color);
+	ClassDB::bind_method(D_METHOD("get_autosave_color"), &DDDBrowserLevel::get_autosave_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "scene_name"), "set_scene_name", "get_scene_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "scene_id"), "set_scene_id", "get_scene_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "author"), "set_author", "get_author");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "description", PROPERTY_HINT_MULTILINE_TEXT), "set_description", "get_description");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version"), "set_version", "get_version");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "schema_version"), "set_schema_version", "get_schema_version");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rating", PROPERTY_HINT_ENUM, "General,Moderate,Adult"), "set_rating", "get_rating");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "thumbnail_url"), "set_thumbnail_url", "get_thumbnail_url");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "manifest_url"), "set_manifest_url", "get_manifest_url");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "base_url"), "set_base_url", "get_base_url");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "game_type", PROPERTY_HINT_ENUM, "None,FPS"), "set_game_type", "get_game_type");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "gamemode_file", PROPERTY_HINT_FILE, "*.luau"), "set_gamemode_file", "get_gamemode_file");
+
+	ADD_GROUP("World", "world_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "world_id"), "set_world_id", "get_world_id");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "world_position"), "set_world_position", "get_world_position");
+
+	ADD_GROUP("Skybox", "skybox_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_uri"), "set_skybox_uri", "get_skybox_uri");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_px"), "set_skybox_px", "get_skybox_px");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_nx"), "set_skybox_nx", "get_skybox_nx");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_py"), "set_skybox_py", "get_skybox_py");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_ny"), "set_skybox_ny", "get_skybox_ny");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_pz"), "set_skybox_pz", "get_skybox_pz");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "skybox_nz"), "set_skybox_nz", "get_skybox_nz");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "skybox_rotation"), "set_skybox_rotation", "get_skybox_rotation");
+
+	ADD_GROUP("Movement Bounds", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "export_movement_bounds"), "set_export_movement_bounds", "get_export_movement_bounds");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "bounds_min"), "set_bounds_min", "get_bounds_min");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "bounds_max"), "set_bounds_max", "get_bounds_max");
+
+	ADD_GROUP("Autosave Notification", "autosave_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_autosave_notification"), "set_use_autosave_notification", "get_use_autosave_notification");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "autosave_text"), "set_autosave_text", "get_autosave_text");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "autosave_x"), "set_autosave_x", "get_autosave_x");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "autosave_y"), "set_autosave_y", "get_autosave_y");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "autosave_font"), "set_autosave_font", "get_autosave_font");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "autosave_color"), "set_autosave_color", "get_autosave_color");
+
+	BIND_ENUM_CONSTANT(RATING_GENERAL);
+	BIND_ENUM_CONSTANT(RATING_MODERATE);
+	BIND_ENUM_CONSTANT(RATING_ADULT);
+	BIND_ENUM_CONSTANT(GAME_TYPE_NONE);
+	BIND_ENUM_CONSTANT(GAME_TYPE_FPS);
+}
+
+void DDDBrowserLevel::set_scene_name(const String &p_name) {
+	scene_name = p_name;
+}
+String DDDBrowserLevel::get_scene_name() const {
+	return scene_name;
+}
+void DDDBrowserLevel::set_scene_id(const String &p_id) {
+	scene_id = p_id;
+}
+String DDDBrowserLevel::get_scene_id() const {
+	return scene_id;
+}
+void DDDBrowserLevel::set_author(const String &p_author) {
+	author = p_author;
+}
+String DDDBrowserLevel::get_author() const {
+	return author;
+}
+void DDDBrowserLevel::set_description(const String &p_description) {
+	description = p_description;
+}
+String DDDBrowserLevel::get_description() const {
+	return description;
+}
+void DDDBrowserLevel::set_version(const String &p_version) {
+	version = p_version;
+}
+String DDDBrowserLevel::get_version() const {
+	return version;
+}
+void DDDBrowserLevel::set_schema_version(const String &p_version) {
+	schema_version = p_version;
+}
+String DDDBrowserLevel::get_schema_version() const {
+	return schema_version;
+}
+void DDDBrowserLevel::set_rating(Rating p_rating) {
+	rating = p_rating;
+}
+DDDBrowserLevel::Rating DDDBrowserLevel::get_rating() const {
+	return rating;
+}
+void DDDBrowserLevel::set_thumbnail_url(const String &p_url) {
+	thumbnail_url = p_url;
+}
+String DDDBrowserLevel::get_thumbnail_url() const {
+	return thumbnail_url;
+}
+void DDDBrowserLevel::set_manifest_url(const String &p_url) {
+	manifest_url = p_url;
+}
+String DDDBrowserLevel::get_manifest_url() const {
+	return manifest_url;
+}
+void DDDBrowserLevel::set_skybox_uri(const String &p_uri) {
+	skybox_uri = p_uri;
+}
+String DDDBrowserLevel::get_skybox_uri() const {
+	return skybox_uri;
+}
+void DDDBrowserLevel::set_skybox_px(const String &p_uri) {
+	skybox_px = p_uri;
+}
+String DDDBrowserLevel::get_skybox_px() const {
+	return skybox_px;
+}
+void DDDBrowserLevel::set_skybox_nx(const String &p_uri) {
+	skybox_nx = p_uri;
+}
+String DDDBrowserLevel::get_skybox_nx() const {
+	return skybox_nx;
+}
+void DDDBrowserLevel::set_skybox_py(const String &p_uri) {
+	skybox_py = p_uri;
+}
+String DDDBrowserLevel::get_skybox_py() const {
+	return skybox_py;
+}
+void DDDBrowserLevel::set_skybox_ny(const String &p_uri) {
+	skybox_ny = p_uri;
+}
+String DDDBrowserLevel::get_skybox_ny() const {
+	return skybox_ny;
+}
+void DDDBrowserLevel::set_skybox_pz(const String &p_uri) {
+	skybox_pz = p_uri;
+}
+String DDDBrowserLevel::get_skybox_pz() const {
+	return skybox_pz;
+}
+void DDDBrowserLevel::set_skybox_nz(const String &p_uri) {
+	skybox_nz = p_uri;
+}
+String DDDBrowserLevel::get_skybox_nz() const {
+	return skybox_nz;
+}
+void DDDBrowserLevel::set_skybox_rotation(const Vector3 &p_rot) {
+	skybox_rotation = p_rot;
+}
+Vector3 DDDBrowserLevel::get_skybox_rotation() const {
+	return skybox_rotation;
+}
+void DDDBrowserLevel::set_base_url(const String &p_url) {
+	base_url = p_url;
+}
+String DDDBrowserLevel::get_base_url() const {
+	return base_url;
+}
+void DDDBrowserLevel::set_export_movement_bounds(bool p_enable) {
+	export_movement_bounds = p_enable;
+}
+bool DDDBrowserLevel::get_export_movement_bounds() const {
+	return export_movement_bounds;
+}
+void DDDBrowserLevel::set_bounds_min(const Vector3 &p_min) {
+	bounds_min = p_min;
+}
+Vector3 DDDBrowserLevel::get_bounds_min() const {
+	return bounds_min;
+}
+void DDDBrowserLevel::set_bounds_max(const Vector3 &p_max) {
+	bounds_max = p_max;
+}
+Vector3 DDDBrowserLevel::get_bounds_max() const {
+	return bounds_max;
+}
+void DDDBrowserLevel::set_gamemode_file(const String &p_file) {
+	gamemode_file = p_file;
+}
+String DDDBrowserLevel::get_gamemode_file() const {
+	return gamemode_file;
+}
+void DDDBrowserLevel::set_world_id(const String &p_id) {
+	world_id = p_id;
+}
+String DDDBrowserLevel::get_world_id() const {
+	return world_id;
+}
+void DDDBrowserLevel::set_world_position(const Vector3 &p_pos) {
+	world_position = p_pos;
+}
+Vector3 DDDBrowserLevel::get_world_position() const {
+	return world_position;
+}
+void DDDBrowserLevel::set_game_type(GameType p_type) {
+	game_type = p_type;
+}
+DDDBrowserLevel::GameType DDDBrowserLevel::get_game_type() const {
+	return game_type;
+}
+void DDDBrowserLevel::set_use_autosave_notification(bool p_use) {
+	use_autosave_notification = p_use;
+}
+bool DDDBrowserLevel::get_use_autosave_notification() const {
+	return use_autosave_notification;
+}
+void DDDBrowserLevel::set_autosave_text(const String &p_text) {
+	autosave_text = p_text;
+}
+String DDDBrowserLevel::get_autosave_text() const {
+	return autosave_text;
+}
+void DDDBrowserLevel::set_autosave_x(float p_x) {
+	autosave_x = p_x;
+}
+float DDDBrowserLevel::get_autosave_x() const {
+	return autosave_x;
+}
+void DDDBrowserLevel::set_autosave_y(float p_y) {
+	autosave_y = p_y;
+}
+float DDDBrowserLevel::get_autosave_y() const {
+	return autosave_y;
+}
+void DDDBrowserLevel::set_autosave_font(const String &p_font) {
+	autosave_font = p_font;
+}
+String DDDBrowserLevel::get_autosave_font() const {
+	return autosave_font;
+}
+void DDDBrowserLevel::set_autosave_color(const Color &p_color) {
+	autosave_color = p_color;
+}
+Color DDDBrowserLevel::get_autosave_color() const {
+	return autosave_color;
+}
+
+String DDDBrowserLevel::rating_string() const {
+	switch (rating) {
+		case RATING_MODERATE:
+			return "MODERATE";
+		case RATING_ADULT:
+			return "ADULT";
+		default:
+			return "GENERAL";
+	}
+}
+
+String DDDBrowserLevel::game_type_string() const {
+	return game_type == GAME_TYPE_FPS ? "FPS" : "NONE";
+}
+
+Dictionary DDDBrowserLevel::build_skybox_dictionary() const {
+	Dictionary sky;
+	const bool has_faces = !skybox_px.is_empty() && !skybox_nx.is_empty() && !skybox_py.is_empty() && !skybox_ny.is_empty() && !skybox_pz.is_empty() && !skybox_nz.is_empty();
+	if (has_faces) {
+		Dictionary faces;
+		faces["px"] = skybox_px;
+		faces["nx"] = skybox_nx;
+		faces["py"] = skybox_py;
+		faces["ny"] = skybox_ny;
+		faces["pz"] = skybox_pz;
+		faces["nz"] = skybox_nz;
+		sky["faces"] = faces;
+	} else if (!skybox_uri.is_empty()) {
+		sky["uri"] = skybox_uri;
+	} else {
+		return Dictionary();
+	}
+	Dictionary rot;
+	rot["x"] = skybox_rotation.x;
+	rot["y"] = skybox_rotation.y;
+	rot["z"] = skybox_rotation.z;
+	sky["rotation"] = rot;
+	return sky;
+}
+
+Dictionary DDDBrowserLevel::build_autosave_notification_dictionary() const {
+	if (!use_autosave_notification) {
+		return Dictionary();
+	}
+	Dictionary d;
+	d["text"] = autosave_text;
+	d["x"] = autosave_x;
+	d["y"] = autosave_y;
+	if (!autosave_font.is_empty()) {
+		d["font"] = autosave_font;
+	}
+	Dictionary color;
+	color["x"] = autosave_color.r;
+	color["y"] = autosave_color.g;
+	color["z"] = autosave_color.b;
+	d["color"] = color;
+	return d;
+}

--- a/modules/dddbrowser/dddbrowser_level.h
+++ b/modules/dddbrowser/dddbrowser_level.h
@@ -1,0 +1,156 @@
+/**************************************************************************/
+/*  dddbrowser_level.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserLevel : public Node3D {
+	GDCLASS(DDDBrowserLevel, Node3D);
+
+public:
+	enum Rating {
+		RATING_GENERAL,
+		RATING_MODERATE,
+		RATING_ADULT,
+	};
+
+	enum GameType {
+		GAME_TYPE_NONE,
+		GAME_TYPE_FPS,
+	};
+
+private:
+	String scene_name = "Exported Scene";
+	String scene_id;
+	String author;
+	String description;
+	String version = "1.0";
+	String schema_version = "1.0";
+	Rating rating = RATING_GENERAL;
+	String thumbnail_url;
+	String manifest_url;
+	String skybox_uri;
+	String skybox_px;
+	String skybox_nx;
+	String skybox_py;
+	String skybox_ny;
+	String skybox_pz;
+	String skybox_nz;
+	Vector3 skybox_rotation;
+	String base_url;
+	bool export_movement_bounds = false;
+	Vector3 bounds_min = Vector3(-100, -100, -100);
+	Vector3 bounds_max = Vector3(100, 100, 100);
+	String gamemode_file;
+	String world_id;
+	Vector3 world_position;
+	GameType game_type = GAME_TYPE_NONE;
+	bool use_autosave_notification = false;
+	String autosave_text = "Game Saved";
+	float autosave_x = 0.0f;
+	float autosave_y = 0.0f;
+	String autosave_font;
+	Color autosave_color = Color(1, 1, 1);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_scene_name(const String &p_name);
+	String get_scene_name() const;
+	void set_scene_id(const String &p_id);
+	String get_scene_id() const;
+	void set_author(const String &p_author);
+	String get_author() const;
+	void set_description(const String &p_description);
+	String get_description() const;
+	void set_version(const String &p_version);
+	String get_version() const;
+	void set_schema_version(const String &p_version);
+	String get_schema_version() const;
+	void set_rating(Rating p_rating);
+	Rating get_rating() const;
+	void set_thumbnail_url(const String &p_url);
+	String get_thumbnail_url() const;
+	void set_manifest_url(const String &p_url);
+	String get_manifest_url() const;
+	void set_skybox_uri(const String &p_uri);
+	String get_skybox_uri() const;
+	void set_skybox_px(const String &p_uri);
+	String get_skybox_px() const;
+	void set_skybox_nx(const String &p_uri);
+	String get_skybox_nx() const;
+	void set_skybox_py(const String &p_uri);
+	String get_skybox_py() const;
+	void set_skybox_ny(const String &p_uri);
+	String get_skybox_ny() const;
+	void set_skybox_pz(const String &p_uri);
+	String get_skybox_pz() const;
+	void set_skybox_nz(const String &p_uri);
+	String get_skybox_nz() const;
+	void set_skybox_rotation(const Vector3 &p_rot);
+	Vector3 get_skybox_rotation() const;
+	void set_base_url(const String &p_url);
+	String get_base_url() const;
+	void set_export_movement_bounds(bool p_enable);
+	bool get_export_movement_bounds() const;
+	void set_bounds_min(const Vector3 &p_min);
+	Vector3 get_bounds_min() const;
+	void set_bounds_max(const Vector3 &p_max);
+	Vector3 get_bounds_max() const;
+	void set_gamemode_file(const String &p_file);
+	String get_gamemode_file() const;
+	void set_world_id(const String &p_id);
+	String get_world_id() const;
+	void set_world_position(const Vector3 &p_pos);
+	Vector3 get_world_position() const;
+	void set_game_type(GameType p_type);
+	GameType get_game_type() const;
+	void set_use_autosave_notification(bool p_use);
+	bool get_use_autosave_notification() const;
+	void set_autosave_text(const String &p_text);
+	String get_autosave_text() const;
+	void set_autosave_x(float p_x);
+	float get_autosave_x() const;
+	void set_autosave_y(float p_y);
+	float get_autosave_y() const;
+	void set_autosave_font(const String &p_font);
+	String get_autosave_font() const;
+	void set_autosave_color(const Color &p_color);
+	Color get_autosave_color() const;
+
+	String rating_string() const;
+	String game_type_string() const;
+	Dictionary build_skybox_dictionary() const;
+	Dictionary build_autosave_notification_dictionary() const;
+};
+
+VARIANT_ENUM_CAST(DDDBrowserLevel::Rating);
+VARIANT_ENUM_CAST(DDDBrowserLevel::GameType);

--- a/modules/dddbrowser/dddbrowser_model.cpp
+++ b/modules/dddbrowser/dddbrowser_model.cpp
@@ -1,0 +1,146 @@
+/**************************************************************************/
+/*  dddbrowser_model.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_model.h"
+
+void DDDBrowserModel::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_collider_type", "type"), &DDDBrowserModel::set_collider_type);
+	ClassDB::bind_method(D_METHOD("get_collider_type"), &DDDBrowserModel::get_collider_type);
+	ClassDB::bind_method(D_METHOD("set_collider_box_size", "size"), &DDDBrowserModel::set_collider_box_size);
+	ClassDB::bind_method(D_METHOD("get_collider_box_size"), &DDDBrowserModel::get_collider_box_size);
+	ClassDB::bind_method(D_METHOD("set_collider_radius", "radius"), &DDDBrowserModel::set_collider_radius);
+	ClassDB::bind_method(D_METHOD("get_collider_radius"), &DDDBrowserModel::get_collider_radius);
+	ClassDB::bind_method(D_METHOD("set_collider_half_height", "half_height"), &DDDBrowserModel::set_collider_half_height);
+	ClassDB::bind_method(D_METHOD("get_collider_half_height"), &DDDBrowserModel::get_collider_half_height);
+	ClassDB::bind_method(D_METHOD("set_script_path", "path"), &DDDBrowserModel::set_script_path);
+	ClassDB::bind_method(D_METHOD("get_script_path"), &DDDBrowserModel::get_script_path);
+	ClassDB::bind_method(D_METHOD("set_script_data", "data"), &DDDBrowserModel::set_script_data);
+	ClassDB::bind_method(D_METHOD("get_script_data"), &DDDBrowserModel::get_script_data);
+	ClassDB::bind_method(D_METHOD("set_pin_script_sha256", "pin"), &DDDBrowserModel::set_pin_script_sha256);
+	ClassDB::bind_method(D_METHOD("get_pin_script_sha256"), &DDDBrowserModel::get_pin_script_sha256);
+
+	ADD_GROUP("Collider", "collider_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_type", PROPERTY_HINT_ENUM, "None,Box,Sphere,Capsule,Cylinder"), "set_collider_type", "get_collider_type");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collider_box_size"), "set_collider_box_size", "get_collider_box_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collider_radius", PROPERTY_HINT_RANGE, "0.01,100,0.01"), "set_collider_radius", "get_collider_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collider_half_height", PROPERTY_HINT_RANGE, "0.01,100,0.01"), "set_collider_half_height", "get_collider_half_height");
+	ADD_GROUP("Script", "script_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "script_path", PROPERTY_HINT_FILE, "*.luau"), "set_script_path", "get_script_path");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "script_data"), "set_script_data", "get_script_data");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pin_script_sha256"), "set_pin_script_sha256", "get_pin_script_sha256");
+
+	BIND_ENUM_CONSTANT(COLLIDER_NONE);
+	BIND_ENUM_CONSTANT(COLLIDER_BOX);
+	BIND_ENUM_CONSTANT(COLLIDER_SPHERE);
+	BIND_ENUM_CONSTANT(COLLIDER_CAPSULE);
+	BIND_ENUM_CONSTANT(COLLIDER_CYLINDER);
+}
+
+void DDDBrowserModel::set_collider_type(ColliderType p_type) {
+	collider_type = p_type;
+}
+DDDBrowserModel::ColliderType DDDBrowserModel::get_collider_type() const {
+	return collider_type;
+}
+void DDDBrowserModel::set_collider_box_size(const Vector3 &p_size) {
+	collider_box_size = p_size;
+}
+Vector3 DDDBrowserModel::get_collider_box_size() const {
+	return collider_box_size;
+}
+void DDDBrowserModel::set_collider_radius(float p_radius) {
+	collider_radius = p_radius;
+}
+float DDDBrowserModel::get_collider_radius() const {
+	return collider_radius;
+}
+void DDDBrowserModel::set_collider_half_height(float p_half_height) {
+	collider_half_height = p_half_height;
+}
+float DDDBrowserModel::get_collider_half_height() const {
+	return collider_half_height;
+}
+void DDDBrowserModel::set_script_path(const String &p_path) {
+	script_path = p_path;
+}
+String DDDBrowserModel::get_script_path() const {
+	return script_path;
+}
+void DDDBrowserModel::set_script_data(const Dictionary &p_data) {
+	script_data = p_data;
+}
+Dictionary DDDBrowserModel::get_script_data() const {
+	return script_data;
+}
+void DDDBrowserModel::set_pin_script_sha256(bool p_pin) {
+	pin_script_sha256 = p_pin;
+}
+bool DDDBrowserModel::get_pin_script_sha256() const {
+	return pin_script_sha256;
+}
+
+Dictionary DDDBrowserModel::build_collider_dictionary() const {
+	Dictionary out;
+	switch (collider_type) {
+		case COLLIDER_BOX: {
+			out["type"] = "box";
+			Dictionary box;
+			box["size"] = Dictionary();
+			Dictionary size;
+			size["x"] = MAX(0.01, collider_box_size.x);
+			size["y"] = MAX(0.01, collider_box_size.y);
+			size["z"] = MAX(0.01, collider_box_size.z);
+			box["size"] = size;
+			out["box"] = box;
+		} break;
+		case COLLIDER_SPHERE: {
+			out["type"] = "sphere";
+			Dictionary sphere;
+			sphere["radius"] = MAX(0.01, collider_radius);
+			out["sphere"] = sphere;
+		} break;
+		case COLLIDER_CAPSULE: {
+			out["type"] = "capsule";
+			Dictionary capsule;
+			capsule["halfHeight"] = MAX(0.01, collider_half_height);
+			capsule["radius"] = MAX(0.01, collider_radius);
+			out["capsule"] = capsule;
+		} break;
+		case COLLIDER_CYLINDER: {
+			out["type"] = "cylinder";
+			Dictionary cylinder;
+			cylinder["halfHeight"] = MAX(0.01, collider_half_height);
+			cylinder["radius"] = MAX(0.01, collider_radius);
+			out["cylinder"] = cylinder;
+		} break;
+		default:
+			break;
+	}
+	return out;
+}

--- a/modules/dddbrowser/dddbrowser_model.h
+++ b/modules/dddbrowser/dddbrowser_model.h
@@ -1,0 +1,77 @@
+/**************************************************************************/
+/*  dddbrowser_model.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/mesh_instance_3d.h"
+
+class DDDBrowserModel : public MeshInstance3D {
+	GDCLASS(DDDBrowserModel, MeshInstance3D);
+
+public:
+	enum ColliderType {
+		COLLIDER_NONE,
+		COLLIDER_BOX,
+		COLLIDER_SPHERE,
+		COLLIDER_CAPSULE,
+		COLLIDER_CYLINDER,
+	};
+
+private:
+	ColliderType collider_type = COLLIDER_NONE;
+	Vector3 collider_box_size = Vector3(1, 1, 1);
+	float collider_radius = 0.5f;
+	float collider_half_height = 1.0f;
+	String script_path;
+	Dictionary script_data;
+	bool pin_script_sha256 = true;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_collider_type(ColliderType p_type);
+	ColliderType get_collider_type() const;
+	void set_collider_box_size(const Vector3 &p_size);
+	Vector3 get_collider_box_size() const;
+	void set_collider_radius(float p_radius);
+	float get_collider_radius() const;
+	void set_collider_half_height(float p_half_height);
+	float get_collider_half_height() const;
+	void set_script_path(const String &p_path);
+	String get_script_path() const;
+	void set_script_data(const Dictionary &p_data);
+	Dictionary get_script_data() const;
+	void set_pin_script_sha256(bool p_pin);
+	bool get_pin_script_sha256() const;
+
+	Dictionary build_collider_dictionary() const;
+};
+
+VARIANT_ENUM_CAST(DDDBrowserModel::ColliderType);

--- a/modules/dddbrowser/dddbrowser_picturebox.cpp
+++ b/modules/dddbrowser/dddbrowser_picturebox.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  dddbrowser_picturebox.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_picturebox.h"
+
+void DDDBrowserPicturebox::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_texture_path", "path"), &DDDBrowserPicturebox::set_texture_path);
+	ClassDB::bind_method(D_METHOD("get_texture_path"), &DDDBrowserPicturebox::get_texture_path);
+	ClassDB::bind_method(D_METHOD("set_width", "width"), &DDDBrowserPicturebox::set_width);
+	ClassDB::bind_method(D_METHOD("get_width"), &DDDBrowserPicturebox::get_width);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &DDDBrowserPicturebox::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &DDDBrowserPicturebox::get_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "texture_path", PROPERTY_HINT_FILE, "*.png,*.jpg,*.jpeg,*.tga"), "set_texture_path", "get_texture_path");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_RANGE, "0.01,10000,0.01"), "set_width", "get_width");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.01,10000,0.01"), "set_height", "get_height");
+}
+
+void DDDBrowserPicturebox::set_texture_path(const String &p_path) {
+	texture_path = p_path;
+}
+String DDDBrowserPicturebox::get_texture_path() const {
+	return texture_path;
+}
+void DDDBrowserPicturebox::set_width(float p_width) {
+	width = p_width;
+}
+float DDDBrowserPicturebox::get_width() const {
+	return width;
+}
+void DDDBrowserPicturebox::set_height(float p_height) {
+	height = p_height;
+}
+float DDDBrowserPicturebox::get_height() const {
+	return height;
+}

--- a/modules/dddbrowser/dddbrowser_picturebox.h
+++ b/modules/dddbrowser/dddbrowser_picturebox.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  dddbrowser_picturebox.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserPicturebox : public Node3D {
+	GDCLASS(DDDBrowserPicturebox, Node3D);
+
+	String texture_path;
+	float width = 1.0f;
+	float height = 1.0f;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_texture_path(const String &p_path);
+	String get_texture_path() const;
+	void set_width(float p_width);
+	float get_width() const;
+	void set_height(float p_height);
+	float get_height() const;
+};

--- a/modules/dddbrowser/dddbrowser_portal.cpp
+++ b/modules/dddbrowser/dddbrowser_portal.cpp
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  dddbrowser_portal.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_portal.h"
+
+void DDDBrowserPortal::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_destination_url", "url"), &DDDBrowserPortal::set_destination_url);
+	ClassDB::bind_method(D_METHOD("get_destination_url"), &DDDBrowserPortal::get_destination_url);
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &DDDBrowserPortal::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &DDDBrowserPortal::get_radius);
+	ClassDB::bind_method(D_METHOD("set_trigger_mode", "mode"), &DDDBrowserPortal::set_trigger_mode);
+	ClassDB::bind_method(D_METHOD("get_trigger_mode"), &DDDBrowserPortal::get_trigger_mode);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "destination_url"), "set_destination_url", "get_destination_url");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "trigger_mode", PROPERTY_HINT_ENUM, "Auto,Manual,Script"), "set_trigger_mode", "get_trigger_mode");
+
+	BIND_ENUM_CONSTANT(TRIGGER_AUTO);
+	BIND_ENUM_CONSTANT(TRIGGER_MANUAL);
+	BIND_ENUM_CONSTANT(TRIGGER_SCRIPT);
+}
+
+void DDDBrowserPortal::set_destination_url(const String &p_url) {
+	destination_url = p_url;
+}
+String DDDBrowserPortal::get_destination_url() const {
+	return destination_url;
+}
+void DDDBrowserPortal::set_radius(float p_radius) {
+	radius = p_radius;
+}
+float DDDBrowserPortal::get_radius() const {
+	return radius;
+}
+void DDDBrowserPortal::set_trigger_mode(TriggerMode p_mode) {
+	trigger_mode = p_mode;
+}
+DDDBrowserPortal::TriggerMode DDDBrowserPortal::get_trigger_mode() const {
+	return trigger_mode;
+}

--- a/modules/dddbrowser/dddbrowser_portal.h
+++ b/modules/dddbrowser/dddbrowser_portal.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  dddbrowser_portal.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserPortal : public Node3D {
+	GDCLASS(DDDBrowserPortal, Node3D);
+
+public:
+	enum TriggerMode {
+		TRIGGER_AUTO,
+		TRIGGER_MANUAL,
+		TRIGGER_SCRIPT,
+	};
+
+private:
+	String destination_url;
+	float radius = 1.0f;
+	TriggerMode trigger_mode = TRIGGER_MANUAL;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_destination_url(const String &p_url);
+	String get_destination_url() const;
+	void set_radius(float p_radius);
+	float get_radius() const;
+	void set_trigger_mode(TriggerMode p_mode);
+	TriggerMode get_trigger_mode() const;
+};
+
+VARIANT_ENUM_CAST(DDDBrowserPortal::TriggerMode);

--- a/modules/dddbrowser/dddbrowser_preview_server.cpp
+++ b/modules/dddbrowser/dddbrowser_preview_server.cpp
@@ -1,0 +1,116 @@
+/**************************************************************************/
+/*  dddbrowser_preview_server.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_preview_server.h"
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "modules/httpserver/http_request_context.h"
+#include "modules/httpserver/http_response.h"
+#include "modules/httpserver/http_server.h"
+
+void DDDBrowserPreviewServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("start", "root_dir", "port"), &DDDBrowserPreviewServer::start, DEFVAL(8081));
+	ClassDB::bind_method(D_METHOD("stop"), &DDDBrowserPreviewServer::stop);
+	ClassDB::bind_method(D_METHOD("is_running"), &DDDBrowserPreviewServer::is_running);
+	ClassDB::bind_method(D_METHOD("get_port"), &DDDBrowserPreviewServer::get_port);
+	ClassDB::bind_method(D_METHOD("get_root_dir"), &DDDBrowserPreviewServer::get_root_dir);
+	ClassDB::bind_method(D_METHOD("get_index_url"), &DDDBrowserPreviewServer::get_index_url);
+}
+
+void DDDBrowserPreviewServer::_serve_file(const Ref<HTTPRequestContext> &p_req, const Ref<HTTPResponse> &p_res) {
+	String path = p_req->get_path();
+	if (path.is_empty() || path == "/") {
+		path = "/index.html";
+	}
+	while (path.begins_with("/")) {
+		path = path.substr(1);
+	}
+	path = path.replace("..", "");
+	String full = root_dir.path_join(path);
+	if (!FileAccess::exists(full)) {
+		p_res->set_status(404);
+		p_res->set_body("Not Found");
+		return;
+	}
+	p_res->set_file(full);
+}
+
+Error DDDBrowserPreviewServer::start(const String &p_root_dir, int p_port) {
+	HTTPServer *server = HTTPServer::get_singleton();
+	ERR_FAIL_NULL_V(server, ERR_UNAVAILABLE);
+	if (server->is_listening()) {
+		server->stop();
+		server->clear_routes();
+	}
+	root_dir = p_root_dir.replace("\\", "/");
+	port = p_port;
+	server->set_cors_enabled(true);
+	server->set_static_directory(root_dir);
+
+	Callable cb = callable_mp(this, &DDDBrowserPreviewServer::_serve_file);
+	server->register_route("GET", "/", cb);
+	server->register_route("GET", "/index.html", cb);
+	server->register_route("GET", "/scene.json", cb);
+	server->register_route("GET", "/meshes/{name}", cb);
+	server->register_route("GET", "/scripts/{name}", cb);
+	server->register_route("GET", "/audio/{name}", cb);
+	server->register_route("GET", "/fonts/{name}", cb);
+	server->register_route("GET", "/textures/{name}", cb);
+	server->register_route("GET", "/{name}", cb);
+
+	Error err = server->listen(port, "127.0.0.1", false, "", "");
+	listening = err == OK;
+	return err;
+}
+
+void DDDBrowserPreviewServer::stop() {
+	HTTPServer *server = HTTPServer::get_singleton();
+	if (server && server->is_listening()) {
+		server->stop();
+		server->clear_routes();
+	}
+	listening = false;
+}
+
+bool DDDBrowserPreviewServer::is_running() const {
+	HTTPServer *server = HTTPServer::get_singleton();
+	return listening && server && server->is_listening();
+}
+
+int DDDBrowserPreviewServer::get_port() const {
+	return port;
+}
+String DDDBrowserPreviewServer::get_root_dir() const {
+	return root_dir;
+}
+
+String DDDBrowserPreviewServer::get_index_url() const {
+	return vformat("http://127.0.0.1:%d/index.html", port);
+}

--- a/modules/dddbrowser/dddbrowser_preview_server.h
+++ b/modules/dddbrowser/dddbrowser_preview_server.h
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*  dddbrowser_preview_server.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+
+class HTTPRequestContext;
+class HTTPResponse;
+
+class DDDBrowserPreviewServer : public RefCounted {
+	GDCLASS(DDDBrowserPreviewServer, RefCounted);
+
+	String root_dir;
+	int port = 8081;
+	bool listening = false;
+
+	void _serve_file(const Ref<HTTPRequestContext> &p_req, const Ref<HTTPResponse> &p_res);
+
+protected:
+	static void _bind_methods();
+
+public:
+	Error start(const String &p_root_dir, int p_port = 8081);
+	void stop();
+	bool is_running() const;
+	int get_port() const;
+	String get_root_dir() const;
+	String get_index_url() const;
+};

--- a/modules/dddbrowser/dddbrowser_script.cpp
+++ b/modules/dddbrowser/dddbrowser_script.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  dddbrowser_script.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_script.h"
+
+void DDDBrowserScript::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_asset_id", "id"), &DDDBrowserScript::set_asset_id);
+	ClassDB::bind_method(D_METHOD("get_asset_id"), &DDDBrowserScript::get_asset_id);
+	ClassDB::bind_method(D_METHOD("set_source_path", "path"), &DDDBrowserScript::set_source_path);
+	ClassDB::bind_method(D_METHOD("get_source_path"), &DDDBrowserScript::get_source_path);
+	ClassDB::bind_method(D_METHOD("set_pin_sha256", "pin"), &DDDBrowserScript::set_pin_sha256);
+	ClassDB::bind_method(D_METHOD("get_pin_sha256"), &DDDBrowserScript::get_pin_sha256);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "asset_id"), "set_asset_id", "get_asset_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_path", PROPERTY_HINT_FILE, "*.luau"), "set_source_path", "get_source_path");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pin_sha256"), "set_pin_sha256", "get_pin_sha256");
+}
+
+void DDDBrowserScript::set_asset_id(const String &p_id) {
+	asset_id = p_id;
+}
+String DDDBrowserScript::get_asset_id() const {
+	return asset_id;
+}
+void DDDBrowserScript::set_source_path(const String &p_path) {
+	source_path = p_path;
+}
+String DDDBrowserScript::get_source_path() const {
+	return source_path;
+}
+void DDDBrowserScript::set_pin_sha256(bool p_pin) {
+	pin_sha256 = p_pin;
+}
+bool DDDBrowserScript::get_pin_sha256() const {
+	return pin_sha256;
+}

--- a/modules/dddbrowser/dddbrowser_script.h
+++ b/modules/dddbrowser/dddbrowser_script.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  dddbrowser_script.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserScript : public Node3D {
+	GDCLASS(DDDBrowserScript, Node3D);
+
+	String asset_id;
+	String source_path;
+	bool pin_sha256 = true;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_asset_id(const String &p_id);
+	String get_asset_id() const;
+	void set_source_path(const String &p_path);
+	String get_source_path() const;
+	void set_pin_sha256(bool p_pin);
+	bool get_pin_sha256() const;
+};

--- a/modules/dddbrowser/dddbrowser_spawn.cpp
+++ b/modules/dddbrowser/dddbrowser_spawn.cpp
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  dddbrowser_spawn.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_spawn.h"
+
+void DDDBrowserSpawn::_bind_methods() {
+}
+
+PackedStringArray DDDBrowserSpawn::get_configuration_warnings() const {
+	PackedStringArray warnings = Node3D::get_configuration_warnings();
+	warnings.push_back("DDDBrowserSpawn marks the player spawn position for DDDBrowser export.");
+	return warnings;
+}

--- a/modules/dddbrowser/dddbrowser_spawn.h
+++ b/modules/dddbrowser/dddbrowser_spawn.h
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*  dddbrowser_spawn.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserSpawn : public Node3D {
+	GDCLASS(DDDBrowserSpawn, Node3D);
+
+protected:
+	static void _bind_methods();
+
+public:
+	PackedStringArray get_configuration_warnings() const override;
+};

--- a/modules/dddbrowser/dddbrowser_textbox.cpp
+++ b/modules/dddbrowser/dddbrowser_textbox.cpp
@@ -1,0 +1,80 @@
+/**************************************************************************/
+/*  dddbrowser_textbox.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_textbox.h"
+
+void DDDBrowserTextbox::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_text", "text"), &DDDBrowserTextbox::set_text);
+	ClassDB::bind_method(D_METHOD("get_text"), &DDDBrowserTextbox::get_text);
+	ClassDB::bind_method(D_METHOD("set_title", "title"), &DDDBrowserTextbox::set_title);
+	ClassDB::bind_method(D_METHOD("get_title"), &DDDBrowserTextbox::get_title);
+	ClassDB::bind_method(D_METHOD("set_font_asset_id", "id"), &DDDBrowserTextbox::set_font_asset_id);
+	ClassDB::bind_method(D_METHOD("get_font_asset_id"), &DDDBrowserTextbox::get_font_asset_id);
+	ClassDB::bind_method(D_METHOD("set_font_size", "size"), &DDDBrowserTextbox::set_font_size);
+	ClassDB::bind_method(D_METHOD("get_font_size"), &DDDBrowserTextbox::get_font_size);
+	ClassDB::bind_method(D_METHOD("set_color", "color"), &DDDBrowserTextbox::set_color);
+	ClassDB::bind_method(D_METHOD("get_color"), &DDDBrowserTextbox::get_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "font_asset_id"), "set_font_asset_id", "get_font_asset_id");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "font_size", PROPERTY_HINT_RANGE, "1,512,0.1"), "set_font_size", "get_font_size");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
+}
+
+void DDDBrowserTextbox::set_text(const String &p_text) {
+	text = p_text;
+}
+String DDDBrowserTextbox::get_text() const {
+	return text;
+}
+void DDDBrowserTextbox::set_title(const String &p_title) {
+	title = p_title;
+}
+String DDDBrowserTextbox::get_title() const {
+	return title;
+}
+void DDDBrowserTextbox::set_font_asset_id(const String &p_id) {
+	font_asset_id = p_id;
+}
+String DDDBrowserTextbox::get_font_asset_id() const {
+	return font_asset_id;
+}
+void DDDBrowserTextbox::set_font_size(float p_size) {
+	font_size = p_size;
+}
+float DDDBrowserTextbox::get_font_size() const {
+	return font_size;
+}
+void DDDBrowserTextbox::set_color(const Color &p_color) {
+	color = p_color;
+}
+Color DDDBrowserTextbox::get_color() const {
+	return color;
+}

--- a/modules/dddbrowser/dddbrowser_textbox.h
+++ b/modules/dddbrowser/dddbrowser_textbox.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  dddbrowser_textbox.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserTextbox : public Node3D {
+	GDCLASS(DDDBrowserTextbox, Node3D);
+
+	String text = "Hello";
+	String title;
+	String font_asset_id;
+	float font_size = 16.0f;
+	Color color = Color(1, 1, 1);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_text(const String &p_text);
+	String get_text() const;
+	void set_title(const String &p_title);
+	String get_title() const;
+	void set_font_asset_id(const String &p_id);
+	String get_font_asset_id() const;
+	void set_font_size(float p_size);
+	float get_font_size() const;
+	void set_color(const Color &p_color);
+	Color get_color() const;
+};

--- a/modules/dddbrowser/dddbrowser_volume.cpp
+++ b/modules/dddbrowser/dddbrowser_volume.cpp
@@ -1,0 +1,446 @@
+/**************************************************************************/
+/*  dddbrowser_volume.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dddbrowser_volume.h"
+
+void DDDBrowserVolume::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_volume_type", "type"), &DDDBrowserVolume::set_volume_type);
+	ClassDB::bind_method(D_METHOD("get_volume_type"), &DDDBrowserVolume::get_volume_type);
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &DDDBrowserVolume::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &DDDBrowserVolume::get_radius);
+	ClassDB::bind_method(D_METHOD("set_event_name", "name"), &DDDBrowserVolume::set_event_name);
+	ClassDB::bind_method(D_METHOD("get_event_name"), &DDDBrowserVolume::get_event_name);
+	ClassDB::bind_method(D_METHOD("set_single_use", "v"), &DDDBrowserVolume::set_single_use);
+	ClassDB::bind_method(D_METHOD("get_single_use"), &DDDBrowserVolume::get_single_use);
+	ClassDB::bind_method(D_METHOD("set_cooldown_seconds", "v"), &DDDBrowserVolume::set_cooldown_seconds);
+	ClassDB::bind_method(D_METHOD("get_cooldown_seconds"), &DDDBrowserVolume::get_cooldown_seconds);
+	ClassDB::bind_method(D_METHOD("set_fov_degrees", "v"), &DDDBrowserVolume::set_fov_degrees);
+	ClassDB::bind_method(D_METHOD("get_fov_degrees"), &DDDBrowserVolume::get_fov_degrees);
+	ClassDB::bind_method(D_METHOD("set_target_instance_id", "id"), &DDDBrowserVolume::set_target_instance_id);
+	ClassDB::bind_method(D_METHOD("get_target_instance_id"), &DDDBrowserVolume::get_target_instance_id);
+	ClassDB::bind_method(D_METHOD("set_max_fires", "v"), &DDDBrowserVolume::set_max_fires);
+	ClassDB::bind_method(D_METHOD("get_max_fires"), &DDDBrowserVolume::get_max_fires);
+	ClassDB::bind_method(D_METHOD("set_auto_remove_on_fire", "v"), &DDDBrowserVolume::set_auto_remove_on_fire);
+	ClassDB::bind_method(D_METHOD("get_auto_remove_on_fire"), &DDDBrowserVolume::get_auto_remove_on_fire);
+	ClassDB::bind_method(D_METHOD("set_stay_interval", "v"), &DDDBrowserVolume::set_stay_interval);
+	ClassDB::bind_method(D_METHOD("get_stay_interval"), &DDDBrowserVolume::get_stay_interval);
+	ClassDB::bind_method(D_METHOD("set_required_stay_time", "v"), &DDDBrowserVolume::set_required_stay_time);
+	ClassDB::bind_method(D_METHOD("get_required_stay_time"), &DDDBrowserVolume::get_required_stay_time);
+	ClassDB::bind_method(D_METHOD("set_counter_word", "v"), &DDDBrowserVolume::set_counter_word);
+	ClassDB::bind_method(D_METHOD("get_counter_word"), &DDDBrowserVolume::get_counter_word);
+	ClassDB::bind_method(D_METHOD("set_required_count", "v"), &DDDBrowserVolume::set_required_count);
+	ClassDB::bind_method(D_METHOD("get_required_count"), &DDDBrowserVolume::get_required_count);
+	ClassDB::bind_method(D_METHOD("set_auto_reset_after_fire", "v"), &DDDBrowserVolume::set_auto_reset_after_fire);
+	ClassDB::bind_method(D_METHOD("get_auto_reset_after_fire"), &DDDBrowserVolume::get_auto_reset_after_fire);
+	ClassDB::bind_method(D_METHOD("set_fire_once_when_reached", "v"), &DDDBrowserVolume::set_fire_once_when_reached);
+	ClassDB::bind_method(D_METHOD("get_fire_once_when_reached"), &DDDBrowserVolume::get_fire_once_when_reached);
+	ClassDB::bind_method(D_METHOD("set_sequence_group_id", "v"), &DDDBrowserVolume::set_sequence_group_id);
+	ClassDB::bind_method(D_METHOD("get_sequence_group_id"), &DDDBrowserVolume::get_sequence_group_id);
+	ClassDB::bind_method(D_METHOD("set_sequence_index", "v"), &DDDBrowserVolume::set_sequence_index);
+	ClassDB::bind_method(D_METHOD("get_sequence_index"), &DDDBrowserVolume::get_sequence_index);
+	ClassDB::bind_method(D_METHOD("set_reset_if_wrong", "v"), &DDDBrowserVolume::set_reset_if_wrong);
+	ClassDB::bind_method(D_METHOD("get_reset_if_wrong"), &DDDBrowserVolume::get_reset_if_wrong);
+	ClassDB::bind_method(D_METHOD("set_is_on", "v"), &DDDBrowserVolume::set_is_on);
+	ClassDB::bind_method(D_METHOD("get_is_on"), &DDDBrowserVolume::get_is_on);
+	ClassDB::bind_method(D_METHOD("set_on_activate_event", "v"), &DDDBrowserVolume::set_on_activate_event);
+	ClassDB::bind_method(D_METHOD("get_on_activate_event"), &DDDBrowserVolume::get_on_activate_event);
+	ClassDB::bind_method(D_METHOD("set_on_deactivate_event", "v"), &DDDBrowserVolume::set_on_deactivate_event);
+	ClassDB::bind_method(D_METHOD("get_on_deactivate_event"), &DDDBrowserVolume::get_on_deactivate_event);
+	ClassDB::bind_method(D_METHOD("set_action", "v"), &DDDBrowserVolume::set_action);
+	ClassDB::bind_method(D_METHOD("get_action"), &DDDBrowserVolume::get_action);
+	ClassDB::bind_method(D_METHOD("set_target_position", "v"), &DDDBrowserVolume::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &DDDBrowserVolume::get_target_position);
+	ClassDB::bind_method(D_METHOD("set_keep_velocity", "v"), &DDDBrowserVolume::set_keep_velocity);
+	ClassDB::bind_method(D_METHOD("get_keep_velocity"), &DDDBrowserVolume::get_keep_velocity);
+	ClassDB::bind_method(D_METHOD("set_extra_props", "props"), &DDDBrowserVolume::set_extra_props);
+	ClassDB::bind_method(D_METHOD("get_extra_props"), &DDDBrowserVolume::get_extra_props);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "volume_type", PROPERTY_HINT_ENUM, "Autosave,LookAt,LookedAt,SingleTrigger,MultiTrigger,CooldownTrigger,ExitTrigger,StayTrigger,TimedEntryTrigger,CounterTrigger,SequenceTrigger,ToggleTrigger,Teleport,Interaction"), "set_volume_type", "get_volume_type");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "event_name"), "set_event_name", "get_event_name");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "single_use"), "set_single_use", "get_single_use");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cooldown_seconds", PROPERTY_HINT_RANGE, "0,3600,0.01"), "set_cooldown_seconds", "get_cooldown_seconds");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fov_degrees", PROPERTY_HINT_RANGE, "0,180,0.1"), "set_fov_degrees", "get_fov_degrees");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "target_instance_id"), "set_target_instance_id", "get_target_instance_id");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fires", PROPERTY_HINT_RANGE, "0,100000,1"), "set_max_fires", "get_max_fires");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_remove_on_fire"), "set_auto_remove_on_fire", "get_auto_remove_on_fire");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "stay_interval", PROPERTY_HINT_RANGE, "0.01,3600,0.01"), "set_stay_interval", "get_stay_interval");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "required_stay_time", PROPERTY_HINT_RANGE, "0.01,3600,0.01"), "set_required_stay_time", "get_required_stay_time");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "counter_word"), "set_counter_word", "get_counter_word");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "required_count", PROPERTY_HINT_RANGE, "1,100000,1"), "set_required_count", "get_required_count");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_reset_after_fire"), "set_auto_reset_after_fire", "get_auto_reset_after_fire");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fire_once_when_reached"), "set_fire_once_when_reached", "get_fire_once_when_reached");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "sequence_group_id"), "set_sequence_group_id", "get_sequence_group_id");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sequence_index", PROPERTY_HINT_RANGE, "0,100000,1"), "set_sequence_index", "get_sequence_index");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_if_wrong"), "set_reset_if_wrong", "get_reset_if_wrong");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_on"), "set_is_on", "get_is_on");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "on_activate_event"), "set_on_activate_event", "get_on_activate_event");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "on_deactivate_event"), "set_on_deactivate_event", "get_on_deactivate_event");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "action"), "set_action", "get_action");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position"), "set_target_position", "get_target_position");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_velocity"), "set_keep_velocity", "get_keep_velocity");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "extra_props"), "set_extra_props", "get_extra_props");
+
+	BIND_ENUM_CONSTANT(VOLUME_AUTOSAVE);
+	BIND_ENUM_CONSTANT(VOLUME_LOOK_AT);
+	BIND_ENUM_CONSTANT(VOLUME_LOOKED_AT);
+	BIND_ENUM_CONSTANT(VOLUME_SINGLE_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_MULTI_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_COOLDOWN_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_EXIT_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_STAY_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_TIMED_ENTRY_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_COUNTER_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_SEQUENCE_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_TOGGLE_TRIGGER);
+	BIND_ENUM_CONSTANT(VOLUME_TELEPORT);
+	BIND_ENUM_CONSTANT(VOLUME_INTERACTION);
+}
+
+void DDDBrowserVolume::_validate_property(PropertyInfo &p_property) const {
+	const String n = p_property.name;
+	if (n == "volume_type" || n == "radius" || n == "extra_props") {
+		return;
+	}
+	bool show = false;
+	switch (volume_type) {
+		case VOLUME_AUTOSAVE:
+			show = (n == "single_use");
+			break;
+		case VOLUME_LOOK_AT:
+			show = (n == "event_name" || n == "single_use" || n == "cooldown_seconds" || n == "fov_degrees");
+			break;
+		case VOLUME_LOOKED_AT:
+			show = (n == "event_name" || n == "target_instance_id" || n == "single_use" || n == "cooldown_seconds" || n == "fov_degrees");
+			break;
+		case VOLUME_SINGLE_TRIGGER:
+		case VOLUME_EXIT_TRIGGER:
+			show = (n == "event_name");
+			break;
+		case VOLUME_MULTI_TRIGGER:
+			show = (n == "event_name" || n == "max_fires" || n == "auto_remove_on_fire");
+			break;
+		case VOLUME_COOLDOWN_TRIGGER:
+			show = (n == "event_name" || n == "cooldown_seconds" || n == "max_fires");
+			break;
+		case VOLUME_STAY_TRIGGER:
+			show = (n == "event_name" || n == "stay_interval");
+			break;
+		case VOLUME_TIMED_ENTRY_TRIGGER:
+			show = (n == "event_name" || n == "required_stay_time");
+			break;
+		case VOLUME_COUNTER_TRIGGER:
+			show = (n == "counter_word" || n == "required_count" || n == "auto_reset_after_fire" || n == "fire_once_when_reached");
+			break;
+		case VOLUME_SEQUENCE_TRIGGER:
+			show = (n == "sequence_group_id" || n == "sequence_index" || n == "reset_if_wrong" || n == "event_name");
+			break;
+		case VOLUME_TOGGLE_TRIGGER:
+			show = (n == "is_on" || n == "on_activate_event" || n == "on_deactivate_event");
+			break;
+		case VOLUME_TELEPORT:
+			show = (n == "target_position" || n == "keep_velocity");
+			break;
+		case VOLUME_INTERACTION:
+			show = (n == "event_name" || n == "action");
+			break;
+	}
+	if (!show) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+}
+
+void DDDBrowserVolume::set_volume_type(VolumeType p_type) {
+	volume_type = p_type;
+	notify_property_list_changed();
+}
+DDDBrowserVolume::VolumeType DDDBrowserVolume::get_volume_type() const {
+	return volume_type;
+}
+void DDDBrowserVolume::set_radius(float p_radius) {
+	radius = p_radius;
+}
+float DDDBrowserVolume::get_radius() const {
+	return radius;
+}
+void DDDBrowserVolume::set_event_name(const String &p_name) {
+	event_name = p_name;
+}
+String DDDBrowserVolume::get_event_name() const {
+	return event_name;
+}
+void DDDBrowserVolume::set_single_use(bool p_v) {
+	single_use = p_v;
+}
+bool DDDBrowserVolume::get_single_use() const {
+	return single_use;
+}
+void DDDBrowserVolume::set_cooldown_seconds(float p_v) {
+	cooldown_seconds = p_v;
+}
+float DDDBrowserVolume::get_cooldown_seconds() const {
+	return cooldown_seconds;
+}
+void DDDBrowserVolume::set_fov_degrees(float p_v) {
+	fov_degrees = p_v;
+}
+float DDDBrowserVolume::get_fov_degrees() const {
+	return fov_degrees;
+}
+void DDDBrowserVolume::set_target_instance_id(const String &p_id) {
+	target_instance_id = p_id;
+}
+String DDDBrowserVolume::get_target_instance_id() const {
+	return target_instance_id;
+}
+void DDDBrowserVolume::set_max_fires(int p_v) {
+	max_fires = p_v;
+}
+int DDDBrowserVolume::get_max_fires() const {
+	return max_fires;
+}
+void DDDBrowserVolume::set_auto_remove_on_fire(bool p_v) {
+	auto_remove_on_fire = p_v;
+}
+bool DDDBrowserVolume::get_auto_remove_on_fire() const {
+	return auto_remove_on_fire;
+}
+void DDDBrowserVolume::set_stay_interval(float p_v) {
+	stay_interval = p_v;
+}
+float DDDBrowserVolume::get_stay_interval() const {
+	return stay_interval;
+}
+void DDDBrowserVolume::set_required_stay_time(float p_v) {
+	required_stay_time = p_v;
+}
+float DDDBrowserVolume::get_required_stay_time() const {
+	return required_stay_time;
+}
+void DDDBrowserVolume::set_counter_word(const String &p_v) {
+	counter_word = p_v;
+}
+String DDDBrowserVolume::get_counter_word() const {
+	return counter_word;
+}
+void DDDBrowserVolume::set_required_count(int p_v) {
+	required_count = p_v;
+}
+int DDDBrowserVolume::get_required_count() const {
+	return required_count;
+}
+void DDDBrowserVolume::set_auto_reset_after_fire(bool p_v) {
+	auto_reset_after_fire = p_v;
+}
+bool DDDBrowserVolume::get_auto_reset_after_fire() const {
+	return auto_reset_after_fire;
+}
+void DDDBrowserVolume::set_fire_once_when_reached(bool p_v) {
+	fire_once_when_reached = p_v;
+}
+bool DDDBrowserVolume::get_fire_once_when_reached() const {
+	return fire_once_when_reached;
+}
+void DDDBrowserVolume::set_sequence_group_id(const String &p_v) {
+	sequence_group_id = p_v;
+}
+String DDDBrowserVolume::get_sequence_group_id() const {
+	return sequence_group_id;
+}
+void DDDBrowserVolume::set_sequence_index(int p_v) {
+	sequence_index = p_v;
+}
+int DDDBrowserVolume::get_sequence_index() const {
+	return sequence_index;
+}
+void DDDBrowserVolume::set_reset_if_wrong(bool p_v) {
+	reset_if_wrong = p_v;
+}
+bool DDDBrowserVolume::get_reset_if_wrong() const {
+	return reset_if_wrong;
+}
+void DDDBrowserVolume::set_is_on(bool p_v) {
+	is_on = p_v;
+}
+bool DDDBrowserVolume::get_is_on() const {
+	return is_on;
+}
+void DDDBrowserVolume::set_on_activate_event(const String &p_v) {
+	on_activate_event = p_v;
+}
+String DDDBrowserVolume::get_on_activate_event() const {
+	return on_activate_event;
+}
+void DDDBrowserVolume::set_on_deactivate_event(const String &p_v) {
+	on_deactivate_event = p_v;
+}
+String DDDBrowserVolume::get_on_deactivate_event() const {
+	return on_deactivate_event;
+}
+void DDDBrowserVolume::set_action(const String &p_v) {
+	action = p_v;
+}
+String DDDBrowserVolume::get_action() const {
+	return action;
+}
+void DDDBrowserVolume::set_target_position(const Vector3 &p_v) {
+	target_position = p_v;
+}
+Vector3 DDDBrowserVolume::get_target_position() const {
+	return target_position;
+}
+void DDDBrowserVolume::set_keep_velocity(bool p_v) {
+	keep_velocity = p_v;
+}
+bool DDDBrowserVolume::get_keep_velocity() const {
+	return keep_velocity;
+}
+void DDDBrowserVolume::set_extra_props(const Dictionary &p_props) {
+	extra_props = p_props;
+}
+Dictionary DDDBrowserVolume::get_extra_props() const {
+	return extra_props;
+}
+
+String DDDBrowserVolume::type_string() const {
+	return properties_key();
+}
+
+String DDDBrowserVolume::properties_key() const {
+	switch (volume_type) {
+		case VOLUME_AUTOSAVE:
+			return "autosaveVolume";
+		case VOLUME_LOOK_AT:
+			return "lookAtVolume";
+		case VOLUME_LOOKED_AT:
+			return "lookedAtVolume";
+		case VOLUME_MULTI_TRIGGER:
+			return "multiTriggerVolume";
+		case VOLUME_COOLDOWN_TRIGGER:
+			return "cooldownTriggerVolume";
+		case VOLUME_EXIT_TRIGGER:
+			return "exitTriggerVolume";
+		case VOLUME_STAY_TRIGGER:
+			return "stayTriggerVolume";
+		case VOLUME_TIMED_ENTRY_TRIGGER:
+			return "timedEntryTriggerVolume";
+		case VOLUME_COUNTER_TRIGGER:
+			return "counterTriggerVolume";
+		case VOLUME_SEQUENCE_TRIGGER:
+			return "sequenceTriggerVolume";
+		case VOLUME_TOGGLE_TRIGGER:
+			return "toggleTriggerVolume";
+		case VOLUME_TELEPORT:
+			return "teleportVolume";
+		case VOLUME_INTERACTION:
+			return "interactionVolume";
+		default:
+			return "singleTriggerVolume";
+	}
+}
+
+Dictionary DDDBrowserVolume::build_properties_dictionary() const {
+	Dictionary props = extra_props.duplicate();
+	switch (volume_type) {
+		case VOLUME_AUTOSAVE:
+			props["singleUse"] = single_use;
+			break;
+		case VOLUME_LOOK_AT:
+			props["eventName"] = event_name;
+			props["singleUse"] = single_use;
+			props["cooldownSeconds"] = cooldown_seconds;
+			props["fovDegrees"] = fov_degrees;
+			break;
+		case VOLUME_LOOKED_AT:
+			props["eventName"] = event_name;
+			props["targetInstanceId"] = target_instance_id;
+			props["singleUse"] = single_use;
+			props["cooldownSeconds"] = cooldown_seconds;
+			props["fovDegrees"] = fov_degrees;
+			break;
+		case VOLUME_SINGLE_TRIGGER:
+		case VOLUME_EXIT_TRIGGER:
+			props["eventName"] = event_name;
+			break;
+		case VOLUME_MULTI_TRIGGER:
+			props["eventName"] = event_name;
+			props["maxFires"] = max_fires;
+			props["autoRemoveOnFire"] = auto_remove_on_fire;
+			break;
+		case VOLUME_COOLDOWN_TRIGGER:
+			props["eventName"] = event_name;
+			props["cooldownSeconds"] = MAX(0.01, cooldown_seconds);
+			props["maxFires"] = max_fires;
+			break;
+		case VOLUME_STAY_TRIGGER:
+			props["eventName"] = event_name;
+			props["stayInterval"] = MAX(0.01, stay_interval);
+			break;
+		case VOLUME_TIMED_ENTRY_TRIGGER:
+			props["eventName"] = event_name;
+			props["requiredStayTime"] = MAX(0.01, required_stay_time);
+			break;
+		case VOLUME_COUNTER_TRIGGER:
+			props["counter_word"] = counter_word;
+			props["required_count"] = MAX(1, required_count);
+			props["auto_reset_after_fire"] = auto_reset_after_fire;
+			props["fire_once_when_reached"] = fire_once_when_reached;
+			break;
+		case VOLUME_SEQUENCE_TRIGGER:
+			props["sequence_group_id"] = sequence_group_id;
+			props["sequence_index"] = sequence_index;
+			props["reset_if_wrong"] = reset_if_wrong;
+			if (!event_name.is_empty()) {
+				props["eventName"] = event_name;
+			}
+			break;
+		case VOLUME_TOGGLE_TRIGGER:
+			props["is_on"] = is_on;
+			if (!on_activate_event.is_empty()) {
+				props["on_activate_event"] = on_activate_event;
+			}
+			if (!on_deactivate_event.is_empty()) {
+				props["on_deactivate_event"] = on_deactivate_event;
+			}
+			break;
+		case VOLUME_TELEPORT: {
+			Dictionary tp;
+			tp["x"] = target_position.x;
+			tp["y"] = target_position.y;
+			tp["z"] = target_position.z;
+			props["target_position"] = tp;
+			props["keep_velocity"] = keep_velocity;
+		} break;
+		case VOLUME_INTERACTION:
+			props["eventName"] = event_name;
+			props["action"] = action;
+			break;
+	}
+	return props;
+}

--- a/modules/dddbrowser/dddbrowser_volume.h
+++ b/modules/dddbrowser/dddbrowser_volume.h
@@ -1,0 +1,143 @@
+/**************************************************************************/
+/*  dddbrowser_volume.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/3d/node_3d.h"
+
+class DDDBrowserVolume : public Node3D {
+	GDCLASS(DDDBrowserVolume, Node3D);
+
+public:
+	enum VolumeType {
+		VOLUME_AUTOSAVE,
+		VOLUME_LOOK_AT,
+		VOLUME_LOOKED_AT,
+		VOLUME_SINGLE_TRIGGER,
+		VOLUME_MULTI_TRIGGER,
+		VOLUME_COOLDOWN_TRIGGER,
+		VOLUME_EXIT_TRIGGER,
+		VOLUME_STAY_TRIGGER,
+		VOLUME_TIMED_ENTRY_TRIGGER,
+		VOLUME_COUNTER_TRIGGER,
+		VOLUME_SEQUENCE_TRIGGER,
+		VOLUME_TOGGLE_TRIGGER,
+		VOLUME_TELEPORT,
+		VOLUME_INTERACTION,
+	};
+
+private:
+	VolumeType volume_type = VOLUME_SINGLE_TRIGGER;
+	float radius = 1.0f;
+	String event_name = "on_trigger";
+	bool single_use = false;
+	float cooldown_seconds = 1.0f;
+	float fov_degrees = 30.0f;
+	String target_instance_id;
+	int max_fires = 0;
+	bool auto_remove_on_fire = false;
+	float stay_interval = 1.0f;
+	float required_stay_time = 1.0f;
+	String counter_word = "count";
+	int required_count = 1;
+	bool auto_reset_after_fire = false;
+	bool fire_once_when_reached = false;
+	String sequence_group_id = "seq";
+	int sequence_index = 0;
+	bool reset_if_wrong = true;
+	bool is_on = false;
+	String on_activate_event;
+	String on_deactivate_event;
+	String action = "interact";
+	Vector3 target_position;
+	bool keep_velocity = false;
+	Dictionary extra_props;
+
+protected:
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
+
+public:
+	void set_volume_type(VolumeType p_type);
+	VolumeType get_volume_type() const;
+	void set_radius(float p_radius);
+	float get_radius() const;
+	void set_event_name(const String &p_name);
+	String get_event_name() const;
+	void set_single_use(bool p_v);
+	bool get_single_use() const;
+	void set_cooldown_seconds(float p_v);
+	float get_cooldown_seconds() const;
+	void set_fov_degrees(float p_v);
+	float get_fov_degrees() const;
+	void set_target_instance_id(const String &p_id);
+	String get_target_instance_id() const;
+	void set_max_fires(int p_v);
+	int get_max_fires() const;
+	void set_auto_remove_on_fire(bool p_v);
+	bool get_auto_remove_on_fire() const;
+	void set_stay_interval(float p_v);
+	float get_stay_interval() const;
+	void set_required_stay_time(float p_v);
+	float get_required_stay_time() const;
+	void set_counter_word(const String &p_v);
+	String get_counter_word() const;
+	void set_required_count(int p_v);
+	int get_required_count() const;
+	void set_auto_reset_after_fire(bool p_v);
+	bool get_auto_reset_after_fire() const;
+	void set_fire_once_when_reached(bool p_v);
+	bool get_fire_once_when_reached() const;
+	void set_sequence_group_id(const String &p_v);
+	String get_sequence_group_id() const;
+	void set_sequence_index(int p_v);
+	int get_sequence_index() const;
+	void set_reset_if_wrong(bool p_v);
+	bool get_reset_if_wrong() const;
+	void set_is_on(bool p_v);
+	bool get_is_on() const;
+	void set_on_activate_event(const String &p_v);
+	String get_on_activate_event() const;
+	void set_on_deactivate_event(const String &p_v);
+	String get_on_deactivate_event() const;
+	void set_action(const String &p_v);
+	String get_action() const;
+	void set_target_position(const Vector3 &p_v);
+	Vector3 get_target_position() const;
+	void set_keep_velocity(bool p_v);
+	bool get_keep_velocity() const;
+	void set_extra_props(const Dictionary &p_props);
+	Dictionary get_extra_props() const;
+
+	String type_string() const;
+	String properties_key() const;
+	Dictionary build_properties_dictionary() const;
+};
+
+VARIANT_ENUM_CAST(DDDBrowserVolume::VolumeType);

--- a/modules/dddbrowser/doc_classes/DDDBrowserAudio.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserAudio.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserAudio" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Spatial or ambient audio source for DDDBrowser levels.
+	</brief_description>
+	<description>
+		Exports an audio asset (wav/ogg) and an audio instance with loop, volume, and autoPlay.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="ambient" type="bool" setter="set_ambient" getter="get_ambient" default="false">
+		</member>
+		<member name="auto_play" type="bool" setter="set_auto_play" getter="get_auto_play" default="false">
+		</member>
+		<member name="format" type="int" setter="set_format" getter="get_format" enum="DDDBrowserAudio.Format" default="0">
+		</member>
+		<member name="loop" type="bool" setter="set_loop" getter="get_loop" default="false">
+		</member>
+		<member name="source_path" type="String" setter="set_source_path" getter="get_source_path" default="&quot;&quot;">
+		</member>
+		<member name="volume" type="float" setter="set_volume" getter="get_volume" default="1.0">
+		</member>
+	</members>
+	<constants>
+		<constant name="FORMAT_WAV" value="0" enum="Format">
+		</constant>
+		<constant name="FORMAT_OGG" value="1" enum="Format">
+		</constant>
+	</constants>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserExporter.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserExporter.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserExporter" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Exports a scene tree to a DDDBrowser page (OBJ/MTL meshes, scene JSON, discovery HTML).
+	</brief_description>
+	<description>
+		Walks a normal Blazium scene (and optional [DDDBrowserLevel] metadata) into DDDBrowser [code]scene.json[/code] plus assets.
+		[b]Dedicated nodes[/b] ([DDDBrowserSpawn], [DDDBrowserModel], portals, volumes, textbox/picturebox/audio/font/script) win over heuristics when both apply.
+		[b]Normal-scene heuristics[/b]: first [Camera3D] or a [Marker3D] named [code]Spawn[/code] → [code]spawn[/code]; [MeshInstance3D] / [StaticBody3D] → OBJ+MTL model (+ albedo textures and [CollisionShape3D] colliders); [Light3D]; [AudioStreamPlayer3D] (wav/ogg); [Label3D] → textbox; [Sprite3D] / [DDDBrowserPicturebox] → picturebox; [WorldEnvironment] sky → [code]skybox.uri[/code] when level skybox is unset.
+		[b]LuauScript[/b]: attached [code].luau[/code] / LuauScript resources on exported instances are copied into [code]scripts/[/code] and wired as [code]instances[].script[/code] (source passthrough). Prefer attaching a Blazium Luau [code]gdclass[/code] extending [Node3D]; DDDBrowser runs [code]_ready[/code] / [code]_process[/code] via its gdclass compatibility layer.
+		Skipped with warning: rigid/character physics semantics, [AnimationPlayer], CSG (unless already a baked mesh), unsupported collision shapes / streams.
+		Call [method get_last_warning] after export for skip/heuristic messages.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="build_scene_dictionary">
+			<return type="Dictionary" />
+			<param index="0" name="root" type="Node" />
+			<param index="1" name="export_dir" type="String" />
+			<description>
+				Walks [param root] and writes mesh/script/audio/texture assets under [param export_dir], returning the scene dictionary used for [code]scene.json[/code].
+			</description>
+		</method>
+		<method name="export_scene">
+			<return type="int" enum="Error" />
+			<param index="0" name="root" type="Node" />
+			<param index="1" name="export_dir" type="String" />
+			<param index="2" name="generate_html" type="bool" default="true" />
+			<description>
+				Builds the scene dictionary, writes [code]scene.json[/code], and optionally generates discovery HTML under [param export_dir]. Returns [constant OK] on success.
+			</description>
+		</method>
+		<method name="get_last_error" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the last hard export error message, or an empty string if none.
+			</description>
+		</method>
+		<method name="get_last_warning" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns joined skip/heuristic warnings from the last export or build, or an empty string if none.
+			</description>
+		</method>
+		<method name="get_validation_errors" qualifiers="const">
+			<return type="PackedStringArray" />
+			<param index="0" name="scene" type="Dictionary" />
+			<description>
+				Returns human-readable validation problems for [param scene], or an empty array when valid.
+			</description>
+		</method>
+		<method name="validate_scene_dictionary" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="scene" type="Dictionary" />
+			<description>
+				Returns [code]true[/code] if [param scene] passes schema-oriented validation checks used before writing.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserFont.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserFont.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserFont" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Font asset referenced by DDDBrowser textboxes.
+	</brief_description>
+	<description>
+		Asset-only node. Place under a [DDDBrowserTextbox] or reference via font asset id.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="asset_id" type="String" setter="set_asset_id" getter="get_asset_id" default="&quot;&quot;">
+		</member>
+		<member name="size" type="float" setter="set_size" getter="get_size" default="16.0">
+		</member>
+		<member name="source_path" type="String" setter="set_source_path" getter="get_source_path" default="&quot;&quot;">
+		</member>
+		<member name="style" type="int" setter="set_style" getter="get_style" enum="DDDBrowserFont.Style" default="0">
+		</member>
+	</members>
+	<constants>
+		<constant name="STYLE_NORMAL" value="0" enum="Style">
+		</constant>
+		<constant name="STYLE_BOLD" value="1" enum="Style">
+		</constant>
+		<constant name="STYLE_ITALIC" value="2" enum="Style">
+		</constant>
+	</constants>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserLevel.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserLevel.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserLevel" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Root node for authoring a DDDBrowser level in the editor.
+	</brief_description>
+	<description>
+		Holds scene metadata used by [DDDBrowserExporter]: name, rating, skybox (uri or six faces), world, gameType, movement bounds, autosave notification, and manifest URL.
+		[member gamemode_file] should be a [code].luau[/code] path; export copies it into [code]scripts/[/code] and emits [code]gamemode.file[/code] as the [b]filename[/b] (for example [code]gamemode_template.luau[/code]), which is what DDDBrowser resolves—not an asset id.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="author" type="String" setter="set_author" getter="get_author" default="&quot;&quot;">
+		</member>
+		<member name="autosave_color" type="Color" setter="set_autosave_color" getter="get_autosave_color" default="Color(1, 1, 1, 1)">
+		</member>
+		<member name="autosave_font" type="String" setter="set_autosave_font" getter="get_autosave_font" default="&quot;&quot;">
+		</member>
+		<member name="autosave_text" type="String" setter="set_autosave_text" getter="get_autosave_text" default="&quot;Game Saved&quot;">
+		</member>
+		<member name="autosave_x" type="float" setter="set_autosave_x" getter="get_autosave_x" default="0.0">
+		</member>
+		<member name="autosave_y" type="float" setter="set_autosave_y" getter="get_autosave_y" default="0.0">
+		</member>
+		<member name="base_url" type="String" setter="set_base_url" getter="get_base_url" default="&quot;&quot;">
+		</member>
+		<member name="bounds_max" type="Vector3" setter="set_bounds_max" getter="get_bounds_max" default="Vector3(100, 100, 100)">
+		</member>
+		<member name="bounds_min" type="Vector3" setter="set_bounds_min" getter="get_bounds_min" default="Vector3(-100, -100, -100)">
+		</member>
+		<member name="description" type="String" setter="set_description" getter="get_description" default="&quot;&quot;">
+		</member>
+		<member name="export_movement_bounds" type="bool" setter="set_export_movement_bounds" getter="get_export_movement_bounds" default="false">
+		</member>
+		<member name="game_type" type="int" setter="set_game_type" getter="get_game_type" enum="DDDBrowserLevel.GameType" default="0">
+		</member>
+		<member name="gamemode_file" type="String" setter="set_gamemode_file" getter="get_gamemode_file" default="&quot;&quot;">
+		</member>
+		<member name="manifest_url" type="String" setter="set_manifest_url" getter="get_manifest_url" default="&quot;&quot;">
+		</member>
+		<member name="rating" type="int" setter="set_rating" getter="get_rating" enum="DDDBrowserLevel.Rating" default="0">
+		</member>
+		<member name="scene_id" type="String" setter="set_scene_id" getter="get_scene_id" default="&quot;&quot;">
+		</member>
+		<member name="scene_name" type="String" setter="set_scene_name" getter="get_scene_name" default="&quot;Exported Scene&quot;">
+		</member>
+		<member name="schema_version" type="String" setter="set_schema_version" getter="get_schema_version" default="&quot;1.0&quot;">
+		</member>
+		<member name="skybox_nx" type="String" setter="set_skybox_nx" getter="get_skybox_nx" default="&quot;&quot;">
+		</member>
+		<member name="skybox_ny" type="String" setter="set_skybox_ny" getter="get_skybox_ny" default="&quot;&quot;">
+		</member>
+		<member name="skybox_nz" type="String" setter="set_skybox_nz" getter="get_skybox_nz" default="&quot;&quot;">
+		</member>
+		<member name="skybox_px" type="String" setter="set_skybox_px" getter="get_skybox_px" default="&quot;&quot;">
+		</member>
+		<member name="skybox_py" type="String" setter="set_skybox_py" getter="get_skybox_py" default="&quot;&quot;">
+		</member>
+		<member name="skybox_pz" type="String" setter="set_skybox_pz" getter="get_skybox_pz" default="&quot;&quot;">
+		</member>
+		<member name="skybox_rotation" type="Vector3" setter="set_skybox_rotation" getter="get_skybox_rotation" default="Vector3(0, 0, 0)">
+		</member>
+		<member name="skybox_uri" type="String" setter="set_skybox_uri" getter="get_skybox_uri" default="&quot;&quot;">
+		</member>
+		<member name="thumbnail_url" type="String" setter="set_thumbnail_url" getter="get_thumbnail_url" default="&quot;&quot;">
+		</member>
+		<member name="use_autosave_notification" type="bool" setter="set_use_autosave_notification" getter="get_use_autosave_notification" default="false">
+		</member>
+		<member name="version" type="String" setter="set_version" getter="get_version" default="&quot;1.0&quot;">
+		</member>
+		<member name="world_id" type="String" setter="set_world_id" getter="get_world_id" default="&quot;&quot;">
+		</member>
+		<member name="world_position" type="Vector3" setter="set_world_position" getter="get_world_position" default="Vector3(0, 0, 0)">
+		</member>
+	</members>
+	<constants>
+		<constant name="RATING_GENERAL" value="0" enum="Rating">
+		</constant>
+		<constant name="RATING_MODERATE" value="1" enum="Rating">
+		</constant>
+		<constant name="RATING_ADULT" value="2" enum="Rating">
+		</constant>
+		<constant name="GAME_TYPE_NONE" value="0" enum="GameType">
+		</constant>
+		<constant name="GAME_TYPE_FPS" value="1" enum="GameType">
+		</constant>
+	</constants>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserModel.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserModel.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserModel" inherits="MeshInstance3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Mesh model instance with optional collider and Luau script for DDDBrowser export.
+	</brief_description>
+	<description>
+		Extends [MeshInstance3D] with schema-aligned collider and instance script fields used by [DDDBrowserExporter].
+		[member script_path] must point at a DDDBrowser lifecycle [code].luau[/code] module (not a Blazium gdclass). Export sets [code]instances[].script.file[/code] to the script [b]asset id[/b].
+		[member script_data] is exported as [code]script.data[/code] and available in DDDBrowser as [code]self.data[/code] (including [code]boundingRadius[/code] for interact radius).
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="collider_box_size" type="Vector3" setter="set_collider_box_size" getter="get_collider_box_size" default="Vector3(1, 1, 1)">
+		</member>
+		<member name="collider_half_height" type="float" setter="set_collider_half_height" getter="get_collider_half_height" default="1.0">
+		</member>
+		<member name="collider_radius" type="float" setter="set_collider_radius" getter="get_collider_radius" default="0.5">
+		</member>
+		<member name="collider_type" type="int" setter="set_collider_type" getter="get_collider_type" enum="DDDBrowserModel.ColliderType" default="0">
+		</member>
+		<member name="pin_script_sha256" type="bool" setter="set_pin_script_sha256" getter="get_pin_script_sha256" default="true">
+		</member>
+		<member name="script_data" type="Dictionary" setter="set_script_data" getter="get_script_data" default="{}">
+		</member>
+		<member name="script_path" type="String" setter="set_script_path" getter="get_script_path" default="&quot;&quot;">
+		</member>
+	</members>
+	<constants>
+		<constant name="COLLIDER_NONE" value="0" enum="ColliderType">
+		</constant>
+		<constant name="COLLIDER_BOX" value="1" enum="ColliderType">
+		</constant>
+		<constant name="COLLIDER_SPHERE" value="2" enum="ColliderType">
+		</constant>
+		<constant name="COLLIDER_CAPSULE" value="3" enum="ColliderType">
+		</constant>
+		<constant name="COLLIDER_CYLINDER" value="4" enum="ColliderType">
+		</constant>
+	</constants>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserPicturebox.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserPicturebox.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserPicturebox" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		In-world picturebox (textured quad) for DDDBrowser levels.
+	</brief_description>
+	<description>
+		Exports a texture asset, picturebox asset, and picturebox instance from a local path or remote URI.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
+		</member>
+		<member name="texture_path" type="String" setter="set_texture_path" getter="get_texture_path" default="&quot;&quot;">
+		</member>
+		<member name="width" type="float" setter="set_width" getter="get_width" default="1.0">
+		</member>
+	</members>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserPortal.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserPortal.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserPortal" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Portal instance for DDDBrowser travel.
+	</brief_description>
+	<description>
+		Exports as a [code]portal[/code] instance with destination URL and trigger mode.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="destination_url" type="String" setter="set_destination_url" getter="get_destination_url" default="&quot;&quot;">
+		</member>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		</member>
+		<member name="trigger_mode" type="int" setter="set_trigger_mode" getter="get_trigger_mode" enum="DDDBrowserPortal.TriggerMode" default="1">
+		</member>
+	</members>
+	<constants>
+		<constant name="TRIGGER_AUTO" value="0" enum="TriggerMode">
+		</constant>
+		<constant name="TRIGGER_MANUAL" value="1" enum="TriggerMode">
+		</constant>
+		<constant name="TRIGGER_SCRIPT" value="2" enum="TriggerMode">
+		</constant>
+	</constants>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserPreviewServer.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserPreviewServer.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserPreviewServer" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Serves an exported DDDBrowser page via [HTTPServer] for local testing.
+	</brief_description>
+	<description>
+		Registers GET routes and uses [method HTTPResponse.set_file]. Enable Allow HTTP in DDDBrowser when loading [code]http://127.0.0.1[/code] URLs.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_index_url" qualifiers="const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="get_port" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_root_dir" qualifiers="const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="is_running" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="start">
+			<return type="int" enum="Error" />
+			<param index="0" name="root_dir" type="String" />
+			<param index="1" name="port" type="int" default="8081" />
+			<description>
+			</description>
+		</method>
+		<method name="stop">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserScript.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserScript.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserScript" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Luau script asset for DDDBrowser levels (not a Blazium [LuauScript] / gdclass).
+	</brief_description>
+	<description>
+		Asset-only node that exports a [code].luau[/code] file into [code]assets[][/code] with [code]mediaType[/code] [code]application/x-luau[/code].
+		Classic scripts [code]return[/code] a table with DDDBrowser lifecycle methods ([code]on_start[/code], [code]on_update[/code], etc.) and use [code skip-lint]Engine[/code] / [code skip-lint]Scene[/code] / [code skip-lint]Gamemode[/code] / [code]localStorage[/code].
+		For Blazium Luau [code]gdclass[/code] behaviors, attach a [LuauScript] to the instance node (e.g. [MeshInstance3D]) instead; the exporter passthroughs source and DDDBrowser runs [code]_ready[/code] / [code]_process[/code] via its compatibility layer. Use right-click [b]Check DDD Luau[/b] to compile-check with DDD API stubs.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="asset_id" type="String" setter="set_asset_id" getter="get_asset_id" default="&quot;&quot;">
+		</member>
+		<member name="pin_sha256" type="bool" setter="set_pin_sha256" getter="get_pin_sha256" default="true">
+		</member>
+		<member name="source_path" type="String" setter="set_source_path" getter="get_source_path" default="&quot;&quot;">
+		</member>
+	</members>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserSpawn.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserSpawn.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserSpawn" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Marks the player spawn position for DDDBrowser export.
+	</brief_description>
+	<description>
+		Exports as the scene [code]spawn[/code] vector.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserTextbox.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserTextbox.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserTextbox" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		In-world textbox asset and instance for DDDBrowser levels.
+	</brief_description>
+	<description>
+		Exports a textbox asset plus a textbox instance. Optionally references a font asset id or a child [DDDBrowserFont].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
+		</member>
+		<member name="font_asset_id" type="String" setter="set_font_asset_id" getter="get_font_asset_id" default="&quot;&quot;">
+		</member>
+		<member name="font_size" type="float" setter="set_font_size" getter="get_font_size" default="16.0">
+		</member>
+		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;Hello&quot;">
+		</member>
+		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
+		</member>
+	</members>
+</class>

--- a/modules/dddbrowser/doc_classes/DDDBrowserVolume.xml
+++ b/modules/dddbrowser/doc_classes/DDDBrowserVolume.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DDDBrowserVolume" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Trigger / interaction volume marker for DDDBrowser levels.
+	</brief_description>
+	<description>
+		Exports as one of the schema volume instance types. Inspector fields adapt to the selected volume type (eventName, cooldown, teleport target, interaction prompt, etc.). Extra properties merge for forward compatibility.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="action" type="String" setter="set_action" getter="get_action" default="&quot;interact&quot;">
+		</member>
+		<member name="auto_remove_on_fire" type="bool" setter="set_auto_remove_on_fire" getter="get_auto_remove_on_fire" default="false">
+		</member>
+		<member name="auto_reset_after_fire" type="bool" setter="set_auto_reset_after_fire" getter="get_auto_reset_after_fire" default="false">
+		</member>
+		<member name="cooldown_seconds" type="float" setter="set_cooldown_seconds" getter="get_cooldown_seconds" default="1.0">
+		</member>
+		<member name="counter_word" type="String" setter="set_counter_word" getter="get_counter_word" default="&quot;count&quot;">
+		</member>
+		<member name="event_name" type="String" setter="set_event_name" getter="get_event_name" default="&quot;on_trigger&quot;">
+		</member>
+		<member name="extra_props" type="Dictionary" setter="set_extra_props" getter="get_extra_props" default="{}">
+		</member>
+		<member name="fire_once_when_reached" type="bool" setter="set_fire_once_when_reached" getter="get_fire_once_when_reached" default="false">
+		</member>
+		<member name="fov_degrees" type="float" setter="set_fov_degrees" getter="get_fov_degrees" default="30.0">
+		</member>
+		<member name="is_on" type="bool" setter="set_is_on" getter="get_is_on" default="false">
+		</member>
+		<member name="keep_velocity" type="bool" setter="set_keep_velocity" getter="get_keep_velocity" default="false">
+		</member>
+		<member name="max_fires" type="int" setter="set_max_fires" getter="get_max_fires" default="0">
+		</member>
+		<member name="on_activate_event" type="String" setter="set_on_activate_event" getter="get_on_activate_event" default="&quot;&quot;">
+		</member>
+		<member name="on_deactivate_event" type="String" setter="set_on_deactivate_event" getter="get_on_deactivate_event" default="&quot;&quot;">
+		</member>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		</member>
+		<member name="required_count" type="int" setter="set_required_count" getter="get_required_count" default="1">
+		</member>
+		<member name="required_stay_time" type="float" setter="set_required_stay_time" getter="get_required_stay_time" default="1.0">
+		</member>
+		<member name="reset_if_wrong" type="bool" setter="set_reset_if_wrong" getter="get_reset_if_wrong" default="true">
+		</member>
+		<member name="sequence_group_id" type="String" setter="set_sequence_group_id" getter="get_sequence_group_id" default="&quot;seq&quot;">
+		</member>
+		<member name="sequence_index" type="int" setter="set_sequence_index" getter="get_sequence_index" default="0">
+		</member>
+		<member name="single_use" type="bool" setter="set_single_use" getter="get_single_use" default="false">
+		</member>
+		<member name="stay_interval" type="float" setter="set_stay_interval" getter="get_stay_interval" default="1.0">
+		</member>
+		<member name="target_instance_id" type="String" setter="set_target_instance_id" getter="get_target_instance_id" default="&quot;&quot;">
+		</member>
+		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, 0, 0)">
+		</member>
+		<member name="volume_type" type="int" setter="set_volume_type" getter="get_volume_type" enum="DDDBrowserVolume.VolumeType" default="3">
+		</member>
+	</members>
+	<constants>
+		<constant name="VOLUME_AUTOSAVE" value="0" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_LOOK_AT" value="1" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_LOOKED_AT" value="2" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_SINGLE_TRIGGER" value="3" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_MULTI_TRIGGER" value="4" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_COOLDOWN_TRIGGER" value="5" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_EXIT_TRIGGER" value="6" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_STAY_TRIGGER" value="7" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_TIMED_ENTRY_TRIGGER" value="8" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_COUNTER_TRIGGER" value="9" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_SEQUENCE_TRIGGER" value="10" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_TOGGLE_TRIGGER" value="11" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_TELEPORT" value="12" enum="VolumeType">
+		</constant>
+		<constant name="VOLUME_INTERACTION" value="13" enum="VolumeType">
+		</constant>
+	</constants>
+</class>

--- a/modules/dddbrowser/editor/dddbrowser_editor_plugin.cpp
+++ b/modules/dddbrowser/editor/dddbrowser_editor_plugin.cpp
@@ -1,0 +1,391 @@
+/**************************************************************************/
+/*  dddbrowser_editor_plugin.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "dddbrowser_editor_plugin.h"
+
+#include "../ddd_luau_check.h"
+#include "../dddbrowser_level.h"
+#include "../dddbrowser_portal.h"
+#include "../dddbrowser_script.h"
+#include "../dddbrowser_spawn.h"
+#include "../dddbrowser_volume.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
+#include "core/os/os.h"
+#include "editor/editor_data.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/gui/editor_file_dialog.h"
+#include "scene/gui/popup_menu.h"
+#include "scene/main/window.h"
+#include "scene/resources/packed_scene.h"
+#include "servers/display_server.h"
+
+void DDDBrowserFilesystemContextPlugin::set_callbacks(const Callable &p_export, const Callable &p_test, const Callable &p_create, const Callable &p_check_luau) {
+	export_cb = p_export;
+	test_cb = p_test;
+	create_cb = p_create;
+	check_luau_cb = p_check_luau;
+}
+
+void DDDBrowserFilesystemContextPlugin::get_options(const Vector<String> &p_paths) {
+	bool has_tscn = false;
+	bool has_luau = false;
+	for (int i = 0; i < p_paths.size(); i++) {
+		if (p_paths[i].ends_with(".tscn") || p_paths[i].ends_with(".scn")) {
+			has_tscn = true;
+		}
+		if (p_paths[i].ends_with(".luau")) {
+			has_luau = true;
+		}
+	}
+	if (has_tscn) {
+		add_context_menu_item(TTR("Export as DDDBrowser Page"), export_cb, Ref<Texture2D>());
+		add_context_menu_item(TTR("Test DDDBrowser Page (HTTPServer)"), test_cb, Ref<Texture2D>());
+	}
+	if (has_luau && check_luau_cb.is_valid()) {
+		add_context_menu_item(TTR("Check DDD Luau"), check_luau_cb, Ref<Texture2D>());
+	}
+	if (create_cb.is_valid()) {
+		add_context_menu_item(TTR("New DDDBrowser Level"), create_cb, Ref<Texture2D>());
+	}
+}
+
+void DDDBrowserSceneTreeContextPlugin::set_callbacks(const Callable &p_export, const Callable &p_test, const Callable &p_check_luau) {
+	export_cb = p_export;
+	test_cb = p_test;
+	check_luau_cb = p_check_luau;
+}
+
+void DDDBrowserSceneTreeContextPlugin::get_options(const Vector<String> &p_paths) {
+	add_context_menu_item(TTR("Export as DDDBrowser Page"), export_cb, Ref<Texture2D>());
+	add_context_menu_item(TTR("Test DDDBrowser Page (HTTPServer)"), test_cb, Ref<Texture2D>());
+	if (check_luau_cb.is_valid()) {
+		add_context_menu_item(TTR("Check DDD Luau"), check_luau_cb, Ref<Texture2D>());
+	}
+}
+
+void DDDBrowserEditorPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_export_paths", "paths"), &DDDBrowserEditorPlugin::_export_paths);
+	ClassDB::bind_method(D_METHOD("_test_paths", "paths"), &DDDBrowserEditorPlugin::_test_paths);
+	ClassDB::bind_method(D_METHOD("_create_level_paths", "paths"), &DDDBrowserEditorPlugin::_create_level_paths);
+	ClassDB::bind_method(D_METHOD("_check_luau_paths", "paths"), &DDDBrowserEditorPlugin::_check_luau_paths);
+	ClassDB::bind_method(D_METHOD("_export_to_path", "path"), &DDDBrowserEditorPlugin::_export_to_path);
+}
+
+String DDDBrowserEditorPlugin::get_plugin_name() const {
+	return "DDDBrowser";
+}
+
+String DDDBrowserEditorPlugin::_default_export_dir(const String &p_scene_path) const {
+	String base = ProjectSettings::get_singleton()->globalize_path("user://dddbrowser_preview");
+	String name = p_scene_path.get_file().get_basename();
+	if (name.is_empty()) {
+		name = "scene";
+	}
+	return base.path_join(name);
+}
+
+Node *DDDBrowserEditorPlugin::_load_scene_root(const String &p_path) {
+	if (p_path.is_empty()) {
+		return EditorNode::get_singleton()->get_edited_scene();
+	}
+	Ref<PackedScene> ps = ResourceLoader::load(p_path);
+	if (ps.is_null()) {
+		return nullptr;
+	}
+	return ps->instantiate();
+}
+
+void DDDBrowserEditorPlugin::_popup_export_dialog() {
+	Node *root = EditorNode::get_singleton()->get_edited_scene();
+	if (!root) {
+		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
+		return;
+	}
+	String filename = root->get_scene_file_path().get_file().get_basename();
+	if (filename.is_empty()) {
+		filename = root->get_name();
+	}
+	export_dialog->set_current_dir(ProjectSettings::get_singleton()->globalize_path("res://"));
+	export_dialog->set_current_file(filename);
+	export_dialog->popup_file_dialog();
+}
+
+void DDDBrowserEditorPlugin::_export_to_path(const String &p_path) {
+	Node *root = EditorNode::get_singleton()->get_edited_scene();
+	if (!root) {
+		return;
+	}
+	Error err = exporter->export_scene(root, p_path, true);
+	if (err != OK) {
+		EditorNode::get_singleton()->show_accept(vformat(TTR("DDDBrowser export failed: %s"), exporter->get_last_error()), TTR("OK"));
+		return;
+	}
+	EditorNode::get_singleton()->show_accept(vformat(TTR("Exported DDDBrowser page to:\n%s"), p_path), TTR("OK"));
+}
+
+void DDDBrowserEditorPlugin::_export_paths(const Variant &p_paths) {
+	Vector<String> paths = p_paths;
+	if (paths.is_empty()) {
+		_popup_export_dialog();
+		return;
+	}
+	String scene_path = paths[0];
+	Node *root = _load_scene_root(scene_path);
+	if (!root) {
+		root = EditorNode::get_singleton()->get_edited_scene();
+	}
+	if (!root) {
+		EditorNode::get_singleton()->show_accept(TTR("Could not load scene for DDDBrowser export."), TTR("OK"));
+		return;
+	}
+	String out_dir = _default_export_dir(scene_path.is_empty() ? root->get_scene_file_path() : scene_path);
+	Error err = exporter->export_scene(root, out_dir, true);
+	bool owned = root != EditorNode::get_singleton()->get_edited_scene();
+	if (owned) {
+		root->queue_free();
+	}
+	if (err != OK) {
+		EditorNode::get_singleton()->show_accept(vformat(TTR("DDDBrowser export failed: %s"), exporter->get_last_error()), TTR("OK"));
+		return;
+	}
+	EditorNode::get_singleton()->show_accept(vformat(TTR("Exported DDDBrowser page to:\n%s"), out_dir), TTR("OK"));
+}
+
+void DDDBrowserEditorPlugin::_test_scene_root(Node *p_root) {
+	ERR_FAIL_NULL(p_root);
+	String out_dir = _default_export_dir(p_root->get_scene_file_path());
+	Error err = exporter->export_scene(p_root, out_dir, true);
+	if (err != OK) {
+		EditorNode::get_singleton()->show_accept(vformat(TTR("DDDBrowser export failed: %s"), exporter->get_last_error()), TTR("OK"));
+		return;
+	}
+	err = preview_server->start(out_dir, 8081);
+	if (err != OK) {
+		EditorNode::get_singleton()->show_accept(TTR("Failed to start HTTPServer preview on port 8081."), TTR("OK"));
+		return;
+	}
+	String url = preview_server->get_index_url();
+	DisplayServer::get_singleton()->clipboard_set(url);
+	String msg = vformat(TTR("Preview server running.\nOpen in DDDBrowser (Allow HTTP):\n%s\n\nURL copied to clipboard."), url);
+	String exe = EDITOR_GET("dddbrowser/executable_path");
+	if (!exe.is_empty() && FileAccess::exists(exe)) {
+		List<String> args;
+		args.push_back(url);
+		OS::get_singleton()->create_process(exe, args);
+		msg += TTR("\nLaunched DDDBrowser executable.");
+	}
+	EditorNode::get_singleton()->show_accept(msg, TTR("OK"));
+}
+
+void DDDBrowserEditorPlugin::_test_paths(const Variant &p_paths) {
+	Vector<String> paths = p_paths;
+	Node *root = nullptr;
+	bool owned = false;
+	if (!paths.is_empty() && (paths[0].ends_with(".tscn") || paths[0].ends_with(".scn"))) {
+		root = _load_scene_root(paths[0]);
+		owned = root != nullptr;
+	}
+	if (!root) {
+		root = EditorNode::get_singleton()->get_edited_scene();
+	}
+	if (!root) {
+		EditorNode::get_singleton()->show_accept(TTR("Could not load scene for DDDBrowser test."), TTR("OK"));
+		return;
+	}
+	_test_scene_root(root);
+	if (owned) {
+		root->queue_free();
+	}
+}
+
+Error DDDBrowserEditorPlugin::_write_template_file(const String &p_res_path, const String &p_contents) const {
+	String abs = ProjectSettings::get_singleton()->globalize_path(p_res_path);
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(abs.get_base_dir());
+	Ref<FileAccess> f = FileAccess::open(abs, FileAccess::WRITE);
+	ERR_FAIL_COND_V(f.is_null(), ERR_CANT_CREATE);
+	f->store_string(p_contents);
+	return OK;
+}
+
+void DDDBrowserEditorPlugin::_check_luau_paths(const Variant &p_paths) {
+	Vector<String> paths = p_paths;
+	String script_path;
+	for (int i = 0; i < paths.size(); i++) {
+		if (paths[i].ends_with(".luau")) {
+			script_path = paths[i];
+			break;
+		}
+	}
+	if (script_path.is_empty()) {
+		List<Node *> selection = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
+		for (Node *n : selection) {
+			if (DDDBrowserScript *script_node = Object::cast_to<DDDBrowserScript>(n)) {
+				script_path = script_node->get_source_path();
+				break;
+			}
+		}
+	}
+	if (script_path.is_empty()) {
+		EditorNode::get_singleton()->show_accept(TTR("Select a .luau file or DDDBrowserScript node to check."), TTR("OK"));
+		return;
+	}
+	Dictionary result = DDDLuauCheck::check_file(script_path);
+	const bool ok = result.get("ok", false);
+	const String message = result.get("message", "");
+	EditorNode::get_singleton()->show_accept(ok ? message : vformat(TTR("DDD Luau check failed:\n%s"), message), TTR("OK"));
+}
+
+void DDDBrowserEditorPlugin::_create_level_paths(const Variant &p_paths) {
+	Vector<String> paths = p_paths;
+	String dir = "res://";
+	if (!paths.is_empty()) {
+		String p = paths[0];
+		String abs = ProjectSettings::get_singleton()->globalize_path(p);
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (da.is_valid() && da->dir_exists(abs)) {
+			dir = p;
+		} else {
+			dir = p.get_base_dir();
+		}
+	}
+	if (!dir.ends_with("/")) {
+		dir += "/";
+	}
+	String scripts_dir = dir.path_join("dddbrowser_scripts");
+	String entity_script_res = scripts_dir.path_join("entity_template.luau");
+	String gamemode_script_res = scripts_dir.path_join("gamemode_template.luau");
+	_write_template_file(entity_script_res, DDDLuauCheck::entity_template());
+	_write_template_file(gamemode_script_res, DDDLuauCheck::gamemode_template());
+
+	String save_path = dir.path_join("dddbrowser_level.tscn");
+
+	DDDBrowserLevel *level = memnew(DDDBrowserLevel);
+	level->set_name("DDDBrowserLevel");
+	level->set_scene_name("New DDDBrowser Level");
+	level->set_gamemode_file(gamemode_script_res);
+	DDDBrowserSpawn *spawn = memnew(DDDBrowserSpawn);
+	spawn->set_name("Spawn");
+	spawn->set_position(Vector3(0, 1.6, 4));
+	level->add_child(spawn);
+	spawn->set_owner(level);
+
+	DDDBrowserPortal *portal = memnew(DDDBrowserPortal);
+	portal->set_name("Portal");
+	portal->set_position(Vector3(3, 1, 0));
+	portal->set_destination_url("https://example.com/");
+	level->add_child(portal);
+	portal->set_owner(level);
+
+	DDDBrowserVolume *volume = memnew(DDDBrowserVolume);
+	volume->set_name("TriggerVolume");
+	volume->set_position(Vector3(-3, 1, 0));
+	volume->set_volume_type(DDDBrowserVolume::VOLUME_SINGLE_TRIGGER);
+	volume->set_event_name("on_enter");
+	level->add_child(volume);
+	volume->set_owner(level);
+
+	DDDBrowserScript *script_asset = memnew(DDDBrowserScript);
+	script_asset->set_name("EntityScript");
+	script_asset->set_asset_id("entity_template");
+	script_asset->set_source_path(entity_script_res);
+	level->add_child(script_asset);
+	script_asset->set_owner(level);
+
+	Ref<PackedScene> ps;
+	ps.instantiate();
+	ps->pack(level);
+	Error err = ResourceSaver::save(ps, save_path);
+	memdelete(level);
+	if (err != OK) {
+		EditorNode::get_singleton()->show_accept(TTR("Failed to create DDDBrowser level scene."), TTR("OK"));
+		return;
+	}
+	EditorNode::get_singleton()->load_scene(save_path);
+}
+
+DDDBrowserEditorPlugin::DDDBrowserEditorPlugin() {
+	exporter.instantiate();
+	preview_server.instantiate();
+
+	if (!EditorSettings::get_singleton()->has_setting("dddbrowser/executable_path")) {
+		EditorSettings::get_singleton()->set_setting("dddbrowser/executable_path", "");
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "dddbrowser/executable_path", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
+	}
+
+	export_dialog = memnew(EditorFileDialog);
+	export_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+	export_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+	export_dialog->set_title(TTR("Export DDDBrowser Page"));
+	export_dialog->connect("dir_selected", callable_mp(this, &DDDBrowserEditorPlugin::_export_to_path));
+	EditorNode::get_singleton()->get_gui_base()->add_child(export_dialog);
+
+	PopupMenu *menu = get_export_as_menu();
+	int idx = menu->get_item_count();
+	menu->add_item(TTR("DDDBrowser Page..."));
+	menu->set_item_metadata(idx, callable_mp(this, &DDDBrowserEditorPlugin::_popup_export_dialog));
+
+	fs_plugin.instantiate();
+	fs_plugin->set_callbacks(
+			callable_mp(this, &DDDBrowserEditorPlugin::_export_paths),
+			callable_mp(this, &DDDBrowserEditorPlugin::_test_paths),
+			Callable(),
+			callable_mp(this, &DDDBrowserEditorPlugin::_check_luau_paths));
+	add_context_menu_plugin(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM, fs_plugin);
+
+	fs_create_plugin.instantiate();
+	fs_create_plugin->set_callbacks(Callable(), Callable(), callable_mp(this, &DDDBrowserEditorPlugin::_create_level_paths));
+	add_context_menu_plugin(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, fs_create_plugin);
+
+	tree_plugin.instantiate();
+	tree_plugin->set_callbacks(
+			callable_mp(this, &DDDBrowserEditorPlugin::_export_paths),
+			callable_mp(this, &DDDBrowserEditorPlugin::_test_paths),
+			callable_mp(this, &DDDBrowserEditorPlugin::_check_luau_paths));
+	add_context_menu_plugin(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, tree_plugin);
+}
+
+DDDBrowserEditorPlugin::~DDDBrowserEditorPlugin() {
+	if (preview_server.is_valid()) {
+		preview_server->stop();
+	}
+	remove_context_menu_plugin(fs_plugin);
+	remove_context_menu_plugin(fs_create_plugin);
+	remove_context_menu_plugin(tree_plugin);
+}
+
+#endif

--- a/modules/dddbrowser/editor/dddbrowser_editor_plugin.h
+++ b/modules/dddbrowser/editor/dddbrowser_editor_plugin.h
@@ -1,0 +1,105 @@
+/**************************************************************************/
+/*  dddbrowser_editor_plugin.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "../dddbrowser_exporter.h"
+#include "../dddbrowser_preview_server.h"
+
+#include "editor/plugins/editor_context_menu_plugin.h"
+#include "editor/plugins/editor_plugin.h"
+
+class EditorFileDialog;
+
+class DDDBrowserFilesystemContextPlugin : public EditorContextMenuPlugin {
+	GDCLASS(DDDBrowserFilesystemContextPlugin, EditorContextMenuPlugin);
+
+	Callable export_cb;
+	Callable test_cb;
+	Callable create_cb;
+	Callable check_luau_cb;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	void set_callbacks(const Callable &p_export, const Callable &p_test, const Callable &p_create, const Callable &p_check_luau = Callable());
+	virtual void get_options(const Vector<String> &p_paths) override;
+};
+
+class DDDBrowserSceneTreeContextPlugin : public EditorContextMenuPlugin {
+	GDCLASS(DDDBrowserSceneTreeContextPlugin, EditorContextMenuPlugin);
+
+	Callable export_cb;
+	Callable test_cb;
+	Callable check_luau_cb;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	void set_callbacks(const Callable &p_export, const Callable &p_test, const Callable &p_check_luau = Callable());
+	virtual void get_options(const Vector<String> &p_paths) override;
+};
+
+class DDDBrowserEditorPlugin : public EditorPlugin {
+	GDCLASS(DDDBrowserEditorPlugin, EditorPlugin);
+
+	EditorFileDialog *export_dialog = nullptr;
+	Ref<DDDBrowserExporter> exporter;
+	Ref<DDDBrowserPreviewServer> preview_server;
+	Ref<DDDBrowserFilesystemContextPlugin> fs_plugin;
+	Ref<DDDBrowserFilesystemContextPlugin> fs_create_plugin;
+	Ref<DDDBrowserSceneTreeContextPlugin> tree_plugin;
+
+	void _popup_export_dialog();
+	void _export_to_path(const String &p_path);
+	void _export_paths(const Variant &p_paths);
+	void _test_paths(const Variant &p_paths);
+	void _create_level_paths(const Variant &p_paths);
+	void _check_luau_paths(const Variant &p_paths);
+	void _test_scene_root(Node *p_root);
+	Node *_load_scene_root(const String &p_path);
+	String _default_export_dir(const String &p_scene_path) const;
+	Error _write_template_file(const String &p_res_path, const String &p_contents) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_plugin_name() const override;
+	bool has_main_screen() const override { return false; }
+
+	DDDBrowserEditorPlugin();
+	~DDDBrowserEditorPlugin();
+};
+
+#endif

--- a/modules/dddbrowser/register_types.cpp
+++ b/modules/dddbrowser/register_types.cpp
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "dddbrowser_audio.h"
+#include "dddbrowser_exporter.h"
+#include "dddbrowser_font.h"
+#include "dddbrowser_level.h"
+#include "dddbrowser_model.h"
+#include "dddbrowser_picturebox.h"
+#include "dddbrowser_portal.h"
+#include "dddbrowser_preview_server.h"
+#include "dddbrowser_script.h"
+#include "dddbrowser_spawn.h"
+#include "dddbrowser_textbox.h"
+#include "dddbrowser_volume.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/dddbrowser_editor_plugin.h"
+#include "editor/plugins/editor_plugin.h"
+#endif
+
+void initialize_dddbrowser_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(DDDBrowserLevel);
+		GDREGISTER_CLASS(DDDBrowserSpawn);
+		GDREGISTER_CLASS(DDDBrowserPortal);
+		GDREGISTER_CLASS(DDDBrowserVolume);
+		GDREGISTER_CLASS(DDDBrowserModel);
+		GDREGISTER_CLASS(DDDBrowserTextbox);
+		GDREGISTER_CLASS(DDDBrowserPicturebox);
+		GDREGISTER_CLASS(DDDBrowserAudio);
+		GDREGISTER_CLASS(DDDBrowserFont);
+		GDREGISTER_CLASS(DDDBrowserScript);
+		GDREGISTER_CLASS(DDDBrowserExporter);
+		GDREGISTER_CLASS(DDDBrowserPreviewServer);
+	}
+
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		EditorPlugins::add_by_type<DDDBrowserEditorPlugin>();
+	}
+#endif
+}
+
+void uninitialize_dddbrowser_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+	}
+}

--- a/modules/dddbrowser/register_types.h
+++ b/modules/dddbrowser/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_dddbrowser_module(ModuleInitializationLevel p_level);
+void uninitialize_dddbrowser_module(ModuleInitializationLevel p_level);


### PR DESCRIPTION
## Summary
- Add `modules/dddbrowser` for exporting Blazium scenes to DDDBrowser pages (`scene.json`, OBJ/MTL meshes, textures, scripts).
- Dedicated level nodes (spawn, portal, volume, model, textbox, picturebox, audio, font, script) plus normal-scene heuristics (camera/marker spawn, lights, collision, audio, labels, sprites, skybox).
- Passthrough attached LuauScript sources onto instances; editor export, HTTPServer preview, New Level template, and Check DDD Luau.