### PR TITLE
Fix JustAMCP Streamable HTTP connectivity and Output spam

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -279,69 +279,71 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 }
 
 bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
-	_THREAD_SAFE_METHOD_
+	// Keep CallQueue/MessageQueue acquisition out of the ProjectSettings mutex to
+	// avoid ThreadSanitizer lock-order inversion (settings M0 -> call_deferred M1).
+	{
+		_THREAD_SAFE_METHOD_
 
-	if (p_value.get_type() == Variant::NIL) {
-		props.erase(p_name);
-		if (p_name.operator String().begins_with("autoload/")) {
-			String node_name = p_name.operator String().split("/")[1];
-			if (autoloads.has(node_name)) {
-				remove_autoload(node_name);
-			}
-		} else if (p_name.operator String().begins_with("global_group/")) {
-			String group_name = p_name.operator String().get_slicec('/', 1);
-			if (global_groups.has(group_name)) {
-				remove_global_group(group_name);
-			}
-		}
-	} else {
-		if (p_name == CoreStringName(_custom_features)) {
-			Vector<String> custom_feature_array = String(p_value).split(",");
-			for (int i = 0; i < custom_feature_array.size(); i++) {
-				custom_features.insert(custom_feature_array[i]);
-			}
-			_queue_changed();
-			return true;
-		}
-
-		{ // Feature overrides.
-			int dot = p_name.operator String().find_char('.');
-			if (dot != -1) {
-				Vector<String> s = p_name.operator String().split(".");
-
-				for (int i = 1; i < s.size(); i++) {
-					String feature = s[i].strip_edges();
-					Pair<StringName, StringName> feature_override(feature, p_name);
-
-					if (!feature_overrides.has(s[0])) {
-						feature_overrides[s[0]] = LocalVector<Pair<StringName, StringName>>();
-					}
-
-					feature_overrides[s[0]].push_back(feature_override);
+		if (p_value.get_type() == Variant::NIL) {
+			props.erase(p_name);
+			if (p_name.operator String().begins_with("autoload/")) {
+				String node_name = p_name.operator String().split("/")[1];
+				if (autoloads.has(node_name)) {
+					remove_autoload(node_name);
+				}
+			} else if (p_name.operator String().begins_with("global_group/")) {
+				String group_name = p_name.operator String().get_slicec('/', 1);
+				if (global_groups.has(group_name)) {
+					remove_global_group(group_name);
 				}
 			}
-		}
-
-		if (props.has(p_name)) {
-			props[p_name].variant = p_value;
 		} else {
-			props[p_name] = VariantContainer(p_value, last_order++);
-		}
-		if (p_name.operator String().begins_with("autoload/")) {
-			String node_name = p_name.operator String().split("/")[1];
-			AutoloadInfo autoload;
-			autoload.name = node_name;
-			String path = p_value;
-			if (path.begins_with("*")) {
-				autoload.is_singleton = true;
-				autoload.path = path.substr(1).simplify_path();
+			if (p_name == CoreStringName(_custom_features)) {
+				Vector<String> custom_feature_array = String(p_value).split(",");
+				for (int i = 0; i < custom_feature_array.size(); i++) {
+					custom_features.insert(custom_feature_array[i]);
+				}
 			} else {
-				autoload.path = path.simplify_path();
+				{ // Feature overrides.
+					int dot = p_name.operator String().find_char('.');
+					if (dot != -1) {
+						Vector<String> s = p_name.operator String().split(".");
+
+						for (int i = 1; i < s.size(); i++) {
+							String feature = s[i].strip_edges();
+							Pair<StringName, StringName> feature_override(feature, p_name);
+
+							if (!feature_overrides.has(s[0])) {
+								feature_overrides[s[0]] = LocalVector<Pair<StringName, StringName>>();
+							}
+
+							feature_overrides[s[0]].push_back(feature_override);
+						}
+					}
+				}
+
+				if (props.has(p_name)) {
+					props[p_name].variant = p_value;
+				} else {
+					props[p_name] = VariantContainer(p_value, last_order++);
+				}
+				if (p_name.operator String().begins_with("autoload/")) {
+					String node_name = p_name.operator String().split("/")[1];
+					AutoloadInfo autoload;
+					autoload.name = node_name;
+					String path = p_value;
+					if (path.begins_with("*")) {
+						autoload.is_singleton = true;
+						autoload.path = path.substr(1).simplify_path();
+					} else {
+						autoload.path = path.simplify_path();
+					}
+					add_autoload(autoload);
+				} else if (p_name.operator String().begins_with("global_group/")) {
+					String group_name = p_name.operator String().get_slicec('/', 1);
+					add_global_group(group_name, p_value);
+				}
 			}
-			add_autoload(autoload);
-		} else if (p_name.operator String().begins_with("global_group/")) {
-			String group_name = p_name.operator String().get_slicec('/', 1);
-			add_global_group(group_name, p_value);
 		}
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -192,13 +192,14 @@ bool EditorProgress::step(const String &p_state, int p_step, bool p_force_refres
 }
 
 EditorProgress::EditorProgress(const String &p_task, const String &p_label, int p_amount, bool p_can_cancel, bool p_force_background) {
-	if (!p_force_background && Thread::is_main_thread()) {
+	const bool use_background = p_force_background || (Thread::is_main_thread() && MessageQueue::get_singleton()->is_flushing());
+	if (!use_background && Thread::is_main_thread()) {
 		EditorNode::progress_add_task(p_task, p_label, p_amount, p_can_cancel);
 	} else {
 		EditorNode::progress_add_task_bg(p_task, p_label, p_amount);
 	}
 	task = p_task;
-	force_background = p_force_background;
+	force_background = use_background;
 }
 
 EditorProgress::~EditorProgress() {

--- a/modules/assettags/asset_tag_query.cpp
+++ b/modules/assettags/asset_tag_query.cpp
@@ -31,6 +31,7 @@
 
 #include "asset_tag_manager.h"
 
+#include "core/os/thread.h"
 #include "modules/regex/regex.h"
 
 #ifdef TOOLS_ENABLED
@@ -151,7 +152,7 @@ Dictionary AssetTagQuery::search_assets(
 			return;
 		}
 #ifdef TOOLS_ENABLED
-		if (!p_type_filter.is_empty() && EditorFileSystem::get_singleton()) {
+		if (!p_type_filter.is_empty() && EditorFileSystem::get_singleton() && Thread::is_main_thread()) {
 			const String file_type = EditorFileSystem::get_singleton()->get_file_type(p_path);
 			if (file_type != p_type_filter) {
 				return;

--- a/modules/justamcp/justamcp_editor_filesystem.cpp
+++ b/modules/justamcp/justamcp_editor_filesystem.cpp
@@ -30,6 +30,7 @@
 #include "justamcp_editor_filesystem.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/os/thread.h"
 #include "editor/editor_file_system.h"
 #endif
 
@@ -40,7 +41,12 @@ void refresh_path(const String &p_path) {
 	if (p_path.is_empty() || !EditorFileSystem::get_singleton()) {
 		return;
 	}
-	EditorFileSystem::get_singleton()->update_file(p_path);
+	// EditorFileSystem is a Node; never call it off the main thread.
+	if (Thread::is_main_thread()) {
+		EditorFileSystem::get_singleton()->update_file(p_path);
+	} else {
+		EditorFileSystem::get_singleton()->call_deferred(SNAME("update_file"), p_path);
+	}
 #else
 	(void)p_path;
 #endif

--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -30,6 +30,7 @@
 #ifdef TOOLS_ENABLED
 
 #include "justamcp_editor_plugin.h"
+#include "justamcp_project_settings.h"
 #include "justamcp_server.h"
 #include "justamcp_tool_context.h"
 #include "justamcp_tool_dispatch.h"
@@ -58,8 +59,9 @@ void JustAMCPConfigUI::_bind_methods() {
 }
 
 void JustAMCPConfigUI::_update_config() {
-	text_edit_antigravity->set_text(JustAMCPEditorPlugin::get_mcp_config_json(false));
-	text_edit_cursor->set_text(JustAMCPEditorPlugin::get_mcp_config_json(true));
+	text_edit_antigravity->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_ANTIGRAVITY));
+	text_edit_cursor->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_CURSOR));
+	text_edit_opencode->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_OPENCODE));
 
 	int total_tools = JustAMCPToolSchemaCache::get_schemas(false, true, true, true).size();
 	int active_tools = JustAMCPToolSchemaCache::get_schemas(false, false, true, false).size();
@@ -82,11 +84,13 @@ void JustAMCPConfigUI::_update_config() {
 }
 
 void JustAMCPConfigUI::_copy_pressed() {
-	int current_tab = tab_container->get_current_tab();
+	const int current_tab = tab_container->get_current_tab();
 	if (current_tab == 0) {
 		DisplayServer::get_singleton()->clipboard_set(text_edit_antigravity->get_text());
-	} else {
+	} else if (current_tab == 1) {
 		DisplayServer::get_singleton()->clipboard_set(text_edit_cursor->get_text());
+	} else {
+		DisplayServer::get_singleton()->clipboard_set(text_edit_opencode->get_text());
 	}
 }
 
@@ -154,6 +158,12 @@ JustAMCPConfigUI::JustAMCPConfigUI() {
 	text_edit_cursor->set_custom_minimum_size(Size2(0, 200));
 	text_edit_cursor->set_editable(false);
 	tab_container->add_child(text_edit_cursor);
+
+	text_edit_opencode = memnew(TextEdit);
+	text_edit_opencode->set_name("OpenCode");
+	text_edit_opencode->set_custom_minimum_size(Size2(0, 200));
+	text_edit_opencode->set_editable(false);
+	tab_container->add_child(text_edit_opencode);
 
 	copy_button = memnew(Button);
 	copy_button->set_text("Copy Config to Clipboard");
@@ -273,6 +283,9 @@ void JustAMCPEditorPlugin::_on_filesystem_changed_for_subscriptions() {
 void JustAMCPEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			if (EditorSettings::get_singleton()) {
+				JustAMCPProjectSettings::register_editor_settings();
+			}
 			EditorNode *editor_node = EditorNode::get_singleton();
 			if (editor_node) {
 				mcp_server = Object::cast_to<JustAMCPServer>(editor_node->get_node_or_null(NodePath("JustAMCPServer")));
@@ -397,15 +410,22 @@ void JustAMCPEditorPlugin::_show_configuration_dialog() {
 	text_edit_ag->set_name("AntiGravity");
 	text_edit_ag->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	text_edit_ag->set_editable(false);
-	text_edit_ag->set_text(JustAMCPEditorPlugin::get_mcp_config_json(false));
+	text_edit_ag->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_ANTIGRAVITY));
 	tab_container->add_child(text_edit_ag);
 
 	TextEdit *text_edit_cursor = memnew(TextEdit);
 	text_edit_cursor->set_name("Cursor");
 	text_edit_cursor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	text_edit_cursor->set_editable(false);
-	text_edit_cursor->set_text(JustAMCPEditorPlugin::get_mcp_config_json(true));
+	text_edit_cursor->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_CURSOR));
 	tab_container->add_child(text_edit_cursor);
+
+	TextEdit *text_edit_opencode = memnew(TextEdit);
+	text_edit_opencode->set_name("OpenCode");
+	text_edit_opencode->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	text_edit_opencode->set_editable(false);
+	text_edit_opencode->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_OPENCODE));
+	tab_container->add_child(text_edit_opencode);
 
 	EditorNode::get_singleton()->get_gui_base()->add_child(dialog);
 	dialog->popup_centered();
@@ -418,7 +438,7 @@ void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const
 	JustAMCPToolDispatch::execute_and_send(mcp_server, tool_executor, p_request_id, p_tool_name, p_args);
 }
 
-String JustAMCPEditorPlugin::get_mcp_config_json(bool p_is_cursor) {
+String JustAMCPEditorPlugin::get_mcp_config_json(MCPConfigClient p_client) {
 	int port = 6506;
 	bool oauth_enabled = false;
 	String client_id = "";
@@ -459,13 +479,29 @@ String JustAMCPEditorPlugin::get_mcp_config_json(bool p_is_cursor) {
 		}
 	}
 
+	const String mcp_url = "http://127.0.0.1:" + itos(port) + "/mcp";
+
+	if (p_client == MCP_CONFIG_OPENCODE) {
+		String json_config = "{\n";
+		json_config += "  \"$schema\": \"https://opencode.ai/config.json\",\n";
+		json_config += "  \"mcp\": {\n";
+		json_config += "    \"blazium-mcp\": {\n";
+		json_config += "      \"type\": \"remote\",\n";
+		json_config += "      \"url\": \"" + mcp_url + "\",\n";
+		json_config += "      \"enabled\": true\n";
+		json_config += "    }\n";
+		json_config += "  }\n";
+		json_config += "}";
+		return json_config;
+	}
+
 	String json_config = "{\n";
 	json_config += "  \"mcpServers\": {\n";
 	json_config += "    \"blazium-mcp\": {\n";
-	if (p_is_cursor) {
-		json_config += "      \"url\": \"http://127.0.0.1:" + itos(port) + "/sse\"";
+	if (p_client == MCP_CONFIG_CURSOR) {
+		json_config += "      \"url\": \"" + mcp_url + "\"";
 	} else {
-		json_config += "      \"serverUrl\": \"http://127.0.0.1:" + itos(port) + "/mcp\"";
+		json_config += "      \"serverUrl\": \"" + mcp_url + "\"";
 	}
 
 	if (oauth_enabled && (!client_id.is_empty() || !client_secret.is_empty())) {

--- a/modules/justamcp/justamcp_editor_plugin.h
+++ b/modules/justamcp/justamcp_editor_plugin.h
@@ -48,6 +48,7 @@ class JustAMCPConfigUI : public MarginContainer {
 	TabContainer *tab_container = nullptr;
 	TextEdit *text_edit_antigravity = nullptr;
 	TextEdit *text_edit_cursor = nullptr;
+	TextEdit *text_edit_opencode = nullptr;
 	Button *copy_button = nullptr;
 
 	Label *stats_tools_label = nullptr;
@@ -98,7 +99,12 @@ protected:
 public:
 	virtual String get_plugin_name() const override { return "JustAMCP"; }
 	bool has_main_screen() const override { return false; }
-	static String get_mcp_config_json(bool p_is_cursor = false);
+	enum MCPConfigClient {
+		MCP_CONFIG_ANTIGRAVITY = 0,
+		MCP_CONFIG_CURSOR = 1,
+		MCP_CONFIG_OPENCODE = 2,
+	};
+	static String get_mcp_config_json(MCPConfigClient p_client = MCP_CONFIG_ANTIGRAVITY);
 
 	JustAMCPEditorPlugin();
 	~JustAMCPEditorPlugin();

--- a/modules/justamcp/justamcp_editor_scene_access.h
+++ b/modules/justamcp/justamcp_editor_scene_access.h
@@ -74,4 +74,14 @@ inline Node *find_node_in_edited_scene(const String &p_path) {
 	return find_node(get_edited_root(), p_path);
 }
 
+inline String safe_path_to(Node *p_root, Node *p_node) {
+	if (!p_root || !p_node) {
+		return String();
+	}
+	if (p_node == p_root || p_root->is_ancestor_of(p_node)) {
+		return p_root->get_path_to(p_node);
+	}
+	return String(p_node->get_name());
+}
+
 } //namespace JustAMCPEditorSceneAccess

--- a/modules/justamcp/justamcp_json_rpc_transport.cpp
+++ b/modules/justamcp/justamcp_json_rpc_transport.cpp
@@ -52,6 +52,17 @@ bool JustAMCPJsonRpcTransport::_is_http_transport(Ref<HTTPResponse> p_response) 
 	return p_response.is_valid();
 }
 
+Dictionary JustAMCPJsonRpcTransport::sanitize_wire_rpc(const Dictionary &p_rpc) {
+	if (p_rpc.is_empty()) {
+		return p_rpc;
+	}
+	Dictionary out = p_rpc.duplicate();
+	out.erase("handled");
+	out.erase("subscription_uri");
+	out.erase("subscription_action");
+	return out;
+}
+
 Dictionary JustAMCPJsonRpcTransport::handle_json_rpc(JustAMCPServer *p_server, const String &p_body, Ref<HTTPResponse> p_response, const String &p_caller_session_id) {
 	if (!p_server) {
 		return Dictionary();
@@ -79,6 +90,10 @@ Dictionary JustAMCPJsonRpcTransport::handle_json_rpc(JustAMCPServer *p_server, c
 			error_dict["code"] = -32600;
 			error_dict["message"] = "JSON-RPC batch requests are not supported for protocol " + p_server->transport_negotiated_protocol;
 			err["error"] = error_dict;
+			if (p_response.is_valid() && !p_response->is_sent()) {
+				p_response->set_status(400);
+				p_response->set_json(err);
+			}
 			return err;
 		}
 	}
@@ -123,11 +138,40 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 	Variant req_id_var;
 	if (payload.has("id")) {
 		req_id_var = payload["id"];
+		if (req_id_var.get_type() == Variant::NIL) {
+			Dictionary err;
+			err["jsonrpc"] = "2.0";
+			err["id"] = Variant();
+			Dictionary error_dict;
+			error_dict["code"] = -32600;
+			error_dict["message"] = "Invalid Request: id must not be null";
+			err["error"] = error_dict;
+			if (p_response.is_valid() && !p_response->is_sent()) {
+				p_response->set_status(400);
+				p_response->set_json(err);
+			}
+			return err;
+		}
 		if (req_id_var.get_type() == Variant::FLOAT) {
 			double d = req_id_var;
 			if (Math::is_equal_approx(d, Math::round(d))) {
 				req_id_var = (int64_t)Math::round(d);
 			}
+		}
+		const Variant::Type id_type = req_id_var.get_type();
+		if (id_type != Variant::INT && id_type != Variant::STRING) {
+			Dictionary err;
+			err["jsonrpc"] = "2.0";
+			err["id"] = req_id_var;
+			Dictionary error_dict;
+			error_dict["code"] = -32600;
+			error_dict["message"] = "Invalid Request: id must be a string or integer";
+			err["error"] = error_dict;
+			if (p_response.is_valid() && !p_response->is_sent()) {
+				p_response->set_status(400);
+				p_response->set_json(err);
+			}
+			return err;
 		}
 	}
 
@@ -215,12 +259,16 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 	if (method == "tools/list") {
 		const String cursor = JustAMCPJsonRpcRouter::extract_list_cursor(payload);
 #ifdef TOOLS_ENABLED
-		return JustAMCPJsonRpcRouter::route_tools_list(cursor, req_id_var);
+		Dictionary routed = JustAMCPJsonRpcRouter::route_tools_list(cursor, req_id_var);
+		routed.erase("handled");
+		return routed;
 #else
 		Dictionary empty;
 		empty["ok"] = true;
 		empty["tools"] = Array();
-		return JustAMCPJsonRpcRouter::finalize_list_result(empty, req_id_var);
+		Dictionary routed = JustAMCPJsonRpcRouter::finalize_list_result(empty, req_id_var);
+		routed.erase("handled");
+		return routed;
 #endif
 	}
 
@@ -454,7 +502,7 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 			p_server->_register_progress_token(progress_token, String(), req_id_var);
 		}
 
-		p_server->call_deferred(SNAME("_process_pending_tools"));
+		p_server->_schedule_process_pending_tools();
 		return wait_stateless_result(entry, false);
 	}
 

--- a/modules/justamcp/justamcp_project_settings.cpp
+++ b/modules/justamcp/justamcp_project_settings.cpp
@@ -170,7 +170,6 @@ void JustAMCPProjectSettings::register_editor_settings() {
 
 	EDITOR_DEF_BASIC("blazium/justamcp/mcp_clients", Array());
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::ARRAY, "blazium/justamcp/mcp_clients"));
-
 	EDITOR_DEF_BASIC("blazium/justamcp/bridge_url_allow_hosts", Array());
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::ARRAY, "blazium/justamcp/bridge_url_allow_hosts"));
 

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -71,7 +71,7 @@ class JustAMCPServer : public Node {
 private:
 	MCPSessionManager *session_manager = nullptr;
 	JustAMCPNotificationBus notification_bus;
-	String transport_negotiated_protocol = "2024-11-05";
+	String transport_negotiated_protocol = "2025-11-25";
 	MCPToolQueue mcp_tool_queue;
 
 	Mutex routing_mutex;
@@ -146,6 +146,9 @@ private:
 	MCPToolQueueEntry *_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Ref<HTTPResponse> p_response, Dictionary &r_queue_full_error, const Dictionary &p_options = Dictionary());
 	void _dispatch_task_augmented_tools_call(const Variant &p_request_id);
 	void _process_pending_tools();
+	void _schedule_process_pending_tools();
+	void _on_pending_tools_process_frame();
+	bool pending_tools_drain_scheduled = false;
 	void _fail_and_remove_task_dispatch_entry(MCPToolQueueEntry *p_entry);
 	void _complete_tool_entry(MCPToolQueueEntry *p_entry, const Dictionary &p_rpc_result);
 	void _complete_current_tool_request(const Dictionary &p_rpc_result);
@@ -200,6 +203,7 @@ public:
 	void request_task_queue_cancel(const String &p_task_id);
 
 	static JustAMCPServer *get_singleton();
+	class JustAMCPResourceExecutor *get_resource_executor() const { return resource_executor; }
 	Vector<String> get_engine_logs();
 	Dictionary get_engine_logs_page(const String &p_cursor);
 	Dictionary get_mcp_notification_log_page(const String &p_cursor);
@@ -225,6 +229,8 @@ public:
 	MCPSessionManager *test_get_session_manager() const;
 	Dictionary test_peek_last_send_tool_result() const;
 	void test_clear_last_send_tool_result();
+	String test_get_transport_negotiated_protocol() const { return transport_negotiated_protocol; }
+	void test_set_transport_negotiated_protocol(const String &p_protocol) { transport_negotiated_protocol = p_protocol; }
 	bool test_validate_mcp_oauth(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 	void test_handle_mcp_stateless_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 	void test_handle_message_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);

--- a/modules/justamcp/justamcp_server_http.cpp
+++ b/modules/justamcp/justamcp_server_http.cpp
@@ -304,7 +304,8 @@ void JustAMCPServer::_deferred_post_sse_json_rpc(int p_connection_id, const Stri
 	if (!session_manager) {
 		return;
 	}
-	const Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc_parsed(this, p_payload, Ref<HTTPResponse>(), p_session_id);
+	const Dictionary result = JustAMCPJsonRpcTransport::sanitize_wire_rpc(
+			JustAMCPJsonRpcTransport::handle_json_rpc_parsed(this, p_payload, Ref<HTTPResponse>(), p_session_id));
 	if (!result.is_empty()) {
 		session_manager->send_json_on_connection(p_connection_id, JSON::stringify(result));
 		session_manager->complete_post_sse_stream(p_connection_id);
@@ -313,7 +314,7 @@ void JustAMCPServer::_deferred_post_sse_json_rpc(int p_connection_id, const Stri
 }
 
 void JustAMCPServer::_deferred_legacy_message_json_rpc(const String &p_body, const String &p_session_id_param) {
-	Dictionary result = _handle_json_rpc(p_body, Ref<HTTPResponse>());
+	Dictionary result = JustAMCPJsonRpcTransport::sanitize_wire_rpc(_handle_json_rpc(p_body, Ref<HTTPResponse>()));
 	if (result.is_empty()) {
 		return;
 	}
@@ -350,7 +351,7 @@ void JustAMCPServer::_deferred_held_json_rpc(int p_client_id, const String &p_bo
 			response->set_body("");
 		} else {
 			response->set_status(200);
-			response->set_json(result);
+			response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
 		}
 	}
 	if (HTTPServer::get_singleton()) {
@@ -447,7 +448,7 @@ void JustAMCPServer::_handle_mcp_stateless_post(Ref<HTTPRequestContext> p_contex
 				_mcp_debug_log("Stateless POST Replying HTTP 200 with Result JSON payload: " + JSON::stringify(result));
 			}
 			p_response->set_status(200);
-			p_response->set_json(result);
+			p_response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
 		}
 	}
 }

--- a/modules/justamcp/justamcp_server_tool_lifecycle.cpp
+++ b/modules/justamcp/justamcp_server_tool_lifecycle.cpp
@@ -108,7 +108,7 @@ void JustAMCPServer::_complete_task_tool_entry(MCPToolQueueEntry *p_entry, bool 
 	}
 
 	memdelete(completed_entry);
-	call_deferred(SNAME("_process_pending_tools"));
+	_schedule_process_pending_tools();
 }
 
 void JustAMCPServer::_on_request_cancelled(const Variant &p_request_id, const String &p_reason, const String &p_caller_session_id) {

--- a/modules/justamcp/justamcp_server_tool_queue.cpp
+++ b/modules/justamcp/justamcp_server_tool_queue.cpp
@@ -39,6 +39,7 @@
 #include "justamcp_tool_context.h"
 #include "justamcp_tool_dispatch.h"
 #include "justamcp_tool_queue_state.h"
+#include "scene/main/scene_tree.h"
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_readonly_tools.h"
 #include "tools/justamcp_task_manager.h"
@@ -89,7 +90,7 @@ void JustAMCPServer::_fail_and_remove_task_dispatch_entry(MCPToolQueueEntry *p_e
 	}
 	_unregister_task_route(p_entry->task_id);
 	memdelete(p_entry);
-	call_deferred(SNAME("_process_pending_tools"));
+	_schedule_process_pending_tools();
 }
 
 MCPToolQueueEntry *JustAMCPServer::_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Ref<HTTPResponse> p_response, Dictionary &r_queue_full_error, const Dictionary &p_options) {
@@ -255,7 +256,7 @@ void JustAMCPServer::_dispatch_task_augmented_tools_call(const Variant &p_reques
 			_send_sse_routed(JSON::stringify(entry->rpc_result), session_id, sse_connection_id);
 		}
 		memdelete(entry);
-		call_deferred(SNAME("_process_pending_tools"));
+		_schedule_process_pending_tools();
 		return;
 	}
 
@@ -332,10 +333,10 @@ void JustAMCPServer::_dispatch_task_augmented_tools_call(const Variant &p_reques
 
 	if (has_stateless) {
 		entry->signal_completion();
-		call_deferred(SNAME("_process_pending_tools"));
+		_schedule_process_pending_tools();
 	} else if (send_sse) {
 		_send_sse_routed(JSON::stringify(rpc_result), session_id, sse_connection_id);
-		call_deferred(SNAME("_process_pending_tools"));
+		_schedule_process_pending_tools();
 	}
 #else
 	(void)ttl_ms;
@@ -344,7 +345,23 @@ void JustAMCPServer::_dispatch_task_augmented_tools_call(const Variant &p_reques
 #endif
 }
 
+void JustAMCPServer::_schedule_process_pending_tools() {
+	if (pending_tools_drain_scheduled) {
+		return;
+	}
+	pending_tools_drain_scheduled = true;
+	// Prefer call_deferred so POST-SSE tools/call emits the first JSON-RPC message
+	// without waiting for the next rendered process_frame (Cursor discovery timeouts).
+	call_deferred(SNAME("_process_pending_tools"));
+}
+
+void JustAMCPServer::_on_pending_tools_process_frame() {
+	pending_tools_drain_scheduled = false;
+	_process_pending_tools();
+}
+
 void JustAMCPServer::_process_pending_tools() {
+	pending_tools_drain_scheduled = false;
 	MCPToolQueueEntry *entry = nullptr;
 	bool readonly_lane = false;
 	const int max_readonly = _justamcp_readonly_worker_concurrency();
@@ -393,18 +410,20 @@ void JustAMCPServer::_process_pending_tools() {
 		JustAMCPToolQueueState::sync_processing_flag(mcp_tool_queue.current_write, mcp_tool_queue.current_readonly_inflight, mcp_tool_queue.processing);
 	}
 
-	const bool schedule_worker = readonly_lane && max_readonly > 0 && entry->sse_connection_id < 0 && JustAMCPReadonlyTools::is_worker_safe_tool(entry->tool_name);
+	// Offload worker-safe tools (including wait) whenever the readonly lane is active.
+	// Do not require max_readonly > 0: concurrency 0 still used to mean "serialize readonly",
+	// but sleep/IO-safe tools must not freeze the main thread with delay_usec / blocking work.
+	const bool schedule_worker = readonly_lane && JustAMCPReadonlyTools::is_worker_safe_tool(entry->tool_name);
 	if (schedule_worker && JustAMCPToolDispatch::try_schedule_worker_execute(this, entry->request_id, entry->tool_name, entry->args)) {
 		if (max_readonly > 1) {
+			// Fan out more worker-safe tools in this flush; main-thread tools yield via next-frame scheduling.
 			call_deferred(SNAME("_process_pending_tools"));
 		}
 		return;
 	}
 
+	// One main-thread tool per drain; completion schedules the next on process_frame.
 	emit_signal("tool_requested", entry->request_id, entry->tool_name, entry->args);
-	if (readonly_lane && max_readonly > 1) {
-		call_deferred(SNAME("_process_pending_tools"));
-	}
 }
 
 void JustAMCPServer::_complete_tool_entry(MCPToolQueueEntry *p_entry, const Dictionary &p_rpc_result) {
@@ -445,7 +464,7 @@ void JustAMCPServer::_complete_tool_entry(MCPToolQueueEntry *p_entry, const Dict
 	}
 
 	memdelete(p_entry);
-	call_deferred(SNAME("_process_pending_tools"));
+	_schedule_process_pending_tools();
 }
 
 void JustAMCPServer::_insert_tool_result_tombstone(const String &p_tombstone_key) {

--- a/modules/justamcp/justamcp_session_manager.cpp
+++ b/modules/justamcp/justamcp_session_manager.cpp
@@ -57,6 +57,22 @@ void MCPSessionManager::clear_all() {
 	request_router.clear_all();
 }
 
+String MCPSessionManager::negotiate_protocol_version(const String &p_client_version) {
+	static const char *preferred[] = {
+		"2025-11-25",
+		"2025-06-18",
+		"2025-03-26",
+		"2024-11-05",
+		nullptr
+	};
+	for (int i = 0; preferred[i]; i++) {
+		if (p_client_version == preferred[i]) {
+			return String(preferred[i]);
+		}
+	}
+	return latest_protocol_version();
+}
+
 #if defined(MODULE_HTTPSERVER_ENABLED)
 
 static String _get_header_from_dict(const Dictionary &p_headers, const String &p_name) {
@@ -202,22 +218,6 @@ bool MCPSessionManager::accepts_event_stream(const Ref<HTTPRequestContext> &p_co
 		return false;
 	}
 	return accept.contains("text/event-stream") || accept.contains("*/*");
-}
-
-String MCPSessionManager::negotiate_protocol_version(const String &p_client_version) {
-	static const char *preferred[] = {
-		"2025-11-25",
-		"2025-06-18",
-		"2025-03-26",
-		"2024-11-05",
-		nullptr
-	};
-	for (int i = 0; preferred[i]; i++) {
-		if (p_client_version == preferred[i]) {
-			return String(preferred[i]);
-		}
-	}
-	return String("2024-11-05");
 }
 
 void MCPSessionManager::apply_cors_headers(Ref<HTTPResponse> p_response, const Ref<HTTPRequestContext> &p_context) const {

--- a/modules/justamcp/justamcp_session_manager.h
+++ b/modules/justamcp/justamcp_session_manager.h
@@ -57,7 +57,7 @@ struct MCPSSEStream {
 
 struct MCPSession {
 	String session_id;
-	String negotiated_protocol = "2024-11-05";
+	String negotiated_protocol = "2025-11-25";
 	uint64_t created_usec = 0;
 	uint64_t last_activity_usec = 0;
 	bool initialized = false;
@@ -95,6 +95,10 @@ public:
 
 	void clear_all();
 
+	// Latest supported MCP protocol; used when the client omits or sends an unknown version.
+	static String latest_protocol_version() { return String("2025-11-25"); }
+	static String negotiate_protocol_version(const String &p_client_version);
+
 #if defined(MODULE_HTTPSERVER_ENABLED)
 	static String get_header(const Ref<HTTPRequestContext> &p_context, const String &p_name);
 	static bool validate_origin(const Ref<HTTPRequestContext> &p_context);
@@ -103,7 +107,6 @@ public:
 	static bool validate_protocol_header(const Ref<HTTPRequestContext> &p_context, String &r_error);
 	static bool accepts_json_and_sse(const Ref<HTTPRequestContext> &p_context);
 	static bool accepts_event_stream(const Ref<HTTPRequestContext> &p_context);
-	static String negotiate_protocol_version(const String &p_client_version);
 
 	void apply_cors_headers(Ref<HTTPResponse> p_response, const Ref<HTTPRequestContext> &p_context) const;
 	void handle_cors_preflight(const Ref<HTTPRequestContext> &p_context, Ref<HTTPResponse> p_response) const;

--- a/modules/justamcp/justamcp_session_manager_http_get.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_get.cpp
@@ -99,12 +99,15 @@ bool MCPSessionManager::handle_mcp_get(const Ref<HTTPRequestContext> &p_context,
 
 	MutexLock lock(mutex);
 	_expire_sessions();
-	if (!_get_session(session_id)) {
+	MCPSession *session = _get_session(session_id);
+	if (!session) {
 		p_response->set_status(404);
 		p_response->set_body("Unknown or expired MCP session");
 		return true;
 	}
-	_touch_session(*_get_session(session_id));
+	_touch_session(*session);
+	// Prefer session-negotiated version when the client omits MCP-Protocol-Version.
+	owner->transport_negotiated_protocol = session->negotiated_protocol;
 	lock.temp_unlock();
 
 	apply_cors_headers(p_response, p_context);

--- a/modules/justamcp/justamcp_session_manager_http_post.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_post.cpp
@@ -204,7 +204,9 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 	const bool is_initialize = method == "initialize";
 
 	String session_id = get_header(p_context, "MCP-Session-Id");
-	const bool streamable_client = !session_id.is_empty() || (is_initialize && accepts_json_and_sse(p_context));
+	// Always treat initialize as Streamable HTTP so clients that send only
+	// Accept: application/json still receive MCP-Session-Id for tools/list.
+	const bool streamable_client = !session_id.is_empty() || is_initialize || accepts_json_and_sse(p_context);
 
 	if (!streamable_client) {
 		return false;
@@ -213,29 +215,23 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 	if (!session_id.is_empty()) {
 		MutexLock lock(mutex);
 		_expire_sessions();
-		if (!_get_session(session_id)) {
+		MCPSession *session = _get_session(session_id);
+		if (!session) {
 			p_response->set_status(404);
 			p_response->set_body("Unknown or expired MCP session");
 			return true;
 		}
-		_touch_session(*_get_session(session_id));
+		_touch_session(*session);
+		// Prefer session-negotiated version when the client omits MCP-Protocol-Version.
+		owner->transport_negotiated_protocol = session->negotiated_protocol;
 	} else if (!is_initialize) {
 		p_response->set_status(400);
 		p_response->set_body("Missing MCP-Session-Id");
 		return true;
 	}
 
-	if (!is_initialize && !session_id.is_empty()) {
-		MutexLock lock(mutex);
-		MCPSession *session = _get_session(session_id);
-		if (session && (session->negotiated_protocol == "2025-06-18" || session->negotiated_protocol == "2025-11-25")) {
-			if (get_header(p_context, "MCP-Protocol-Version").is_empty()) {
-				p_response->set_status(400);
-				p_response->set_body("Missing MCP-Protocol-Version");
-				return true;
-			}
-		}
-	}
+	// MCP-Protocol-Version may be omitted after initialize; reuse session.negotiated_protocol
+	// (validate_protocol_header already rejects unsupported header values with 400).
 
 	if (is_initialize && session_id.is_empty()) {
 		MCPSession session;
@@ -245,7 +241,7 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 		session.negotiated_protocol = negotiate_protocol_version(
 				payload.has("params") && Dictionary(payload["params"]).has("protocolVersion")
 						? String(Dictionary(payload["params"])["protocolVersion"])
-						: String("2024-11-05"));
+						: latest_protocol_version());
 		{
 			MutexLock lock(mutex);
 			sessions.insert(session.session_id, session);
@@ -256,7 +252,11 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 		p_response->add_header("MCP-Session-Id", session_id);
 	}
 
-	const bool wants_sse = accepts_json_and_sse(p_context) && !is_notification && method != "initialize";
+	// Dual Accept upgrades to POST-SSE only for long-running RPCs. Sync discovery
+	// methods (tools/list, prompts/list, resources/*, ping, …) stay on the JSON/held
+	// path so Cursor live tool discovery is not starved waiting for an SSE message.
+	const bool async_rpc = (method == "tools/call");
+	const bool wants_sse = accepts_json_and_sse(p_context) && !is_notification && method != "initialize" && async_rpc;
 	if (wants_sse) {
 		{
 			MutexLock lock(mutex);
@@ -320,7 +320,7 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 			p_response->set_body("");
 		} else {
 			p_response->set_status(200);
-			p_response->set_json(result);
+			p_response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
 		}
 	}
 	return true;

--- a/modules/justamcp/justamcp_tool_dispatch.cpp
+++ b/modules/justamcp/justamcp_tool_dispatch.cpp
@@ -158,6 +158,11 @@ bool JustAMCPToolDispatch::try_schedule_worker_execute(JustAMCPServer *p_server,
 	job->request_id = p_request_id;
 	job->tool_name = p_tool_name;
 	job->args = p_args;
-	pool->add_native_task(&_justamcp_worker_tool_execute, job, true, "JustAMCPWorkerSafeTool");
+	const WorkerThreadPool::TaskID task_id = pool->add_native_task(&_justamcp_worker_tool_execute, job, true, "JustAMCPWorkerSafeTool");
+	if (task_id == WorkerThreadPool::INVALID_TASK_ID) {
+		memdelete(job);
+		return false;
+	}
+	executor->track_worker_task(task_id);
 	return true;
 }

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -113,6 +113,7 @@
 #include "tests/test_justamcp_pending_survives_get_close.cpp"
 #include "tests/test_justamcp_phase_k.cpp"
 #include "tests/test_justamcp_post_sse_async_keeps_open.cpp"
+#include "tests/test_justamcp_protocol_versions.cpp"
 #include "tests/test_justamcp_registry_dispatch.cpp"
 #include "tests/test_justamcp_resource_providers.cpp"
 #include "tests/test_justamcp_resource_read_caps.cpp"
@@ -132,6 +133,7 @@
 #include "tests/test_justamcp_tool_dispatcher.cpp"
 #include "tests/test_justamcp_tool_schema_builder.cpp"
 #include "tests/test_justamcp_tool_schema_cache.cpp"
+#include "tests/test_justamcp_toolset_schema_gate.cpp"
 #endif
 
 #ifndef TOOLS_ENABLED
@@ -276,6 +278,11 @@ void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 	}
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		JustAMCPProjectSettings::register_project_settings();
+		// Register EditorSettings early so EDITOR_GET / inspector never WARN on missing JustAMCP keys
+		// before the MCP server starts (register_editor_settings is idempotent).
+		if (EditorSettings::get_singleton()) {
+			JustAMCPProjectSettings::register_editor_settings();
+		}
 		if (EditorSettings::get_singleton() && !EditorSettings::get_singleton()->has_setting("blazium/justamcp/enable_toolset_discovery")) {
 			EditorSettings::get_singleton()->set_setting("blazium/justamcp/enable_toolset_discovery", true);
 		}

--- a/modules/justamcp/tests/test_justamcp_category_handled.cpp
+++ b/modules/justamcp/tests/test_justamcp_category_handled.cpp
@@ -84,13 +84,15 @@ static void _on_tool_requested_probe(const Variant &p_request_id, const String &
 	s_tool_requested_name = p_tool_name;
 }
 
-void test_justamcp_sse_bound_worker_safe_uses_main() {
+void test_justamcp_sse_bound_worker_safe_uses_worker() {
 #if defined(MODULE_HTTPSERVER_ENABLED)
 	const int prev = int(GLOBAL_GET("blazium/justamcp/readonly_worker_concurrency"));
 	ProjectSettings::get_singleton()->set_setting("blazium/justamcp/readonly_worker_concurrency", 2);
 
 	JustAMCPTestServerFixture fixture;
 	JustAMCPServer &server = fixture.get_server();
+	JustAMCPToolExecutor executor;
+	executor.set_as_active_instance();
 
 	s_tool_requested = false;
 	s_tool_requested_name = String();
@@ -103,8 +105,9 @@ void test_justamcp_sse_bound_worker_safe_uses_main() {
 	entry->sse_connection_id = 42;
 
 	server.test_process_pending_tools();
-	CHECK(s_tool_requested);
-	CHECK(s_tool_requested_name == "blazium_logs_read");
+	// SSE-bound worker-safe tools must schedule on WorkerThreadPool, not the main-thread signal path.
+	CHECK(!s_tool_requested);
+	CHECK(s_tool_requested_name.is_empty());
 
 	server.disconnect("tool_requested", callable_mp_static(_on_tool_requested_probe));
 	ProjectSettings::get_singleton()->set_setting("blazium/justamcp/readonly_worker_concurrency", prev);

--- a/modules/justamcp/tests/test_justamcp_category_handled.h
+++ b/modules/justamcp/tests/test_justamcp_category_handled.h
@@ -35,7 +35,7 @@
 
 void test_justamcp_ok_false_stays_handled();
 void test_justamcp_empty_category_result_unhandled();
-void test_justamcp_sse_bound_worker_safe_uses_main();
+void test_justamcp_sse_bound_worker_safe_uses_worker();
 void test_justamcp_crash_guards_bundle();
 
 TEST_CASE("[Modules][JustAMCP] ok false stays handled") {
@@ -46,8 +46,8 @@ TEST_CASE("[Modules][JustAMCP] empty category result unhandled") {
 	test_justamcp_empty_category_result_unhandled();
 }
 
-TEST_CASE("[Modules][JustAMCP] sse bound worker safe uses main") {
-	test_justamcp_sse_bound_worker_safe_uses_main();
+TEST_CASE("[Modules][JustAMCP] sse bound worker safe uses worker") {
+	test_justamcp_sse_bound_worker_safe_uses_worker();
 }
 
 TEST_CASE("[Modules][JustAMCP] crash guards bundle") {

--- a/modules/justamcp/tests/test_justamcp_http_integration.cpp
+++ b/modules/justamcp/tests/test_justamcp_http_integration.cpp
@@ -37,6 +37,10 @@
 #include "../justamcp_server.h"
 #include "../justamcp_session_manager.h"
 
+#ifdef TOOLS_ENABLED
+#include "../justamcp_editor_plugin.h"
+#endif
+
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "modules/httpserver/http_request_context.h"
@@ -91,6 +95,26 @@ void test_justamcp_http_initialize_creates_session() {
 	const int status = response->get_status();
 	const bool acceptable_status = status == 200 ? true : status == 202;
 	CHECK(acceptable_status);
+	const String session_header = _get_response_header(response, "MCP-Session-Id");
+	CHECK(!session_header.is_empty());
+	CHECK(session_manager->session_exists(session_header));
+}
+
+void test_justamcp_http_initialize_json_only_accept_creates_session() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	Dictionary headers;
+	headers["Accept"] = "application/json";
+	headers["Content-Type"] = "application/json";
+
+	const String body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"json-only\",\"version\":\"1.0\"}}}";
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	const bool handled = session_manager->handle_mcp_post(_make_test_context("POST", headers, body), response);
+	CHECK(handled);
 	const String session_header = _get_response_header(response, "MCP-Session-Id");
 	CHECK(!session_header.is_empty());
 	CHECK(session_manager->session_exists(session_header));
@@ -229,8 +253,146 @@ void test_justamcp_legacy_sse_broadcast_tracking() {
 	CHECK(server.test_count_notification_broadcast_targets() == 1);
 }
 
+void test_justamcp_mcp_config_json_uses_streamable_mcp_path() {
+#ifdef TOOLS_ENABLED
+	const String cursor_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_CURSOR);
+	const String ag_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_ANTIGRAVITY);
+	const String opencode_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_OPENCODE);
+	CHECK(cursor_cfg.contains("/mcp"));
+	CHECK(!cursor_cfg.contains("/sse"));
+	CHECK(ag_cfg.contains("/mcp"));
+	CHECK(!ag_cfg.contains("\"/sse\""));
+	CHECK(opencode_cfg.contains("\"$schema\": \"https://opencode.ai/config.json\""));
+	CHECK(opencode_cfg.contains("\"type\": \"remote\""));
+	CHECK(opencode_cfg.contains("/mcp"));
+	CHECK(opencode_cfg.contains("\"enabled\": true"));
+#else
+	SUCCEED();
+#endif
+}
+
+void test_justamcp_http_catalogs_after_initialize() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	Dictionary init_headers;
+	init_headers["Accept"] = "application/json";
+	init_headers["Content-Type"] = "application/json";
+	const String init_body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"catalog\",\"version\":\"1.0\"}}}";
+	Ref<HTTPResponse> init_response;
+	init_response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_test_context("POST", init_headers, init_body), init_response));
+	const String session_id = _get_response_header(init_response, "MCP-Session-Id");
+	CHECK(!session_id.is_empty());
+
+	Dictionary headers = init_headers;
+	headers["MCP-Session-Id"] = session_id;
+
+	const char *methods[] = { "tools/list", "prompts/list", "resources/list", "resources/templates/list", nullptr };
+	const char *result_keys[] = { "tools", "prompts", "resources", "resourceTemplates", nullptr };
+	for (int i = 0; methods[i]; i++) {
+		const String body = "{\"jsonrpc\":\"2.0\",\"id\":" + itos(i + 2) + ",\"method\":\"" + String(methods[i]) + "\",\"params\":{}}";
+		Ref<HTTPResponse> response;
+		response.instantiate();
+		CHECK(session_manager->handle_mcp_post(_make_test_context("POST", headers, body), response));
+		const int status = response->get_status();
+		const bool ok_status = status == 200 || status == 202;
+		CHECK(ok_status);
+		if (response->get_body().is_empty()) {
+			continue;
+		}
+		Ref<JSON> json;
+		json.instantiate();
+		CHECK(json->parse(response->get_body()) == OK);
+		CHECK(json->get_data().get_type() == Variant::DICTIONARY);
+		Dictionary root = json->get_data();
+		CHECK(!root.has("error"));
+		CHECK(root.has("result"));
+		CHECK(Dictionary(root["result"]).has(result_keys[i]));
+	}
+}
+
+void test_justamcp_http_dual_accept_tools_list_returns_json() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	const String init_body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"dual-list\",\"version\":\"1.0\"}}}";
+	Ref<HTTPResponse> init_response;
+	init_response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_test_context("POST", _streamable_headers(), init_body), init_response));
+	const String session_id = _get_response_header(init_response, "MCP-Session-Id");
+	CHECK(!session_id.is_empty());
+
+	const String list_body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}";
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_test_context("POST", _streamable_headers(session_id), list_body), response));
+	CHECK(!response->is_sse_response());
+	CHECK(response->get_status() == 200);
+	CHECK(!response->get_body().is_empty());
+	CHECK(session_manager->test_peek_pending_post_sse_body(session_id).is_empty());
+
+	Ref<JSON> json;
+	json.instantiate();
+	CHECK(json->parse(response->get_body()) == OK);
+	CHECK(json->get_data().get_type() == Variant::DICTIONARY);
+	Dictionary root = json->get_data();
+	CHECK(!root.has("error"));
+	CHECK(!root.has("handled"));
+	CHECK(root.has("jsonrpc"));
+	CHECK(root.has("result"));
+	Dictionary result = root["result"];
+	CHECK(result.has("tools"));
+	CHECK(Array(result["tools"]).size() > 0);
+}
+
+void test_justamcp_http_dual_accept_tools_call_uses_sse() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	const String init_body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"dual-call\",\"version\":\"1.0\"}}}";
+	Ref<HTTPResponse> init_response;
+	init_response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_test_context("POST", _streamable_headers(), init_body), init_response));
+	const String session_id = _get_response_header(init_response, "MCP-Session-Id");
+	CHECK(!session_id.is_empty());
+
+	const String tool_body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"blazium_list_toolsets\",\"arguments\":{}}}";
+	Ref<HTTPResponse> sse;
+	sse.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_test_context("POST", _streamable_headers(session_id), tool_body), sse));
+	CHECK(sse->is_sse_response());
+	CHECK(sse->get_status() != 409);
+	CHECK(session_manager->test_peek_pending_post_sse_body(session_id).contains("tools/call"));
+}
+
+void test_justamcp_mcp_config_client_field_shapes() {
+#ifdef TOOLS_ENABLED
+	const String cursor_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_CURSOR);
+	const String ag_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_ANTIGRAVITY);
+	const String opencode_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_OPENCODE);
+	CHECK(cursor_cfg.contains("\"url\":"));
+	CHECK(!cursor_cfg.contains("\"serverUrl\":"));
+	CHECK(ag_cfg.contains("\"serverUrl\":"));
+	CHECK(!ag_cfg.contains("\"url\": \"http://"));
+	CHECK(opencode_cfg.contains("\"mcp\":"));
+	CHECK(opencode_cfg.contains("\"blazium-mcp\":"));
+#else
+	SUCCEED();
+#endif
+}
+
 #else
 void test_justamcp_http_initialize_creates_session() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
+}
+void test_justamcp_http_initialize_json_only_accept_creates_session() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
 }
 void test_justamcp_http_post_sse_conflict_409() {
@@ -255,6 +417,15 @@ void test_justamcp_orphan_send_tool_result_route_fallback() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
 }
 void test_justamcp_legacy_sse_broadcast_tracking() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
+}
+void test_justamcp_mcp_config_json_uses_streamable_mcp_path() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
+}
+void test_justamcp_http_catalogs_after_initialize() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
+}
+void test_justamcp_mcp_config_client_field_shapes() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
 }
 #endif

--- a/modules/justamcp/tests/test_justamcp_http_integration.h
+++ b/modules/justamcp/tests/test_justamcp_http_integration.h
@@ -32,6 +32,7 @@
 #include "tests/test_macros.h"
 
 void test_justamcp_http_initialize_creates_session();
+void test_justamcp_http_initialize_json_only_accept_creates_session();
 void test_justamcp_http_post_sse_conflict_409();
 void test_justamcp_http_delete_teardown();
 void test_justamcp_http_cors_preflight();
@@ -40,9 +41,18 @@ void test_justamcp_http_oauth_rejects_invalid_credentials();
 void test_justamcp_http_two_session_pending_isolation();
 void test_justamcp_orphan_send_tool_result_route_fallback();
 void test_justamcp_legacy_sse_broadcast_tracking();
+void test_justamcp_mcp_config_json_uses_streamable_mcp_path();
+void test_justamcp_http_catalogs_after_initialize();
+void test_justamcp_http_dual_accept_tools_list_returns_json();
+void test_justamcp_http_dual_accept_tools_call_uses_sse();
+void test_justamcp_mcp_config_client_field_shapes();
 
 TEST_CASE("[Modules][JustAMCP] http initialize creates session") {
 	test_justamcp_http_initialize_creates_session();
+}
+
+TEST_CASE("[Modules][JustAMCP] http initialize json-only Accept creates session") {
+	test_justamcp_http_initialize_json_only_accept_creates_session();
 }
 
 TEST_CASE("[Modules][JustAMCP] http post sse conflict 409") {
@@ -75,4 +85,24 @@ TEST_CASE("[Modules][JustAMCP] orphan send tool result route fallback") {
 
 TEST_CASE("[Modules][JustAMCP] legacy sse broadcast tracking") {
 	test_justamcp_legacy_sse_broadcast_tracking();
+}
+
+TEST_CASE("[Modules][JustAMCP] mcp config json uses streamable /mcp path") {
+	test_justamcp_mcp_config_json_uses_streamable_mcp_path();
+}
+
+TEST_CASE("[Modules][JustAMCP] http catalogs after initialize") {
+	test_justamcp_http_catalogs_after_initialize();
+}
+
+TEST_CASE("[Modules][JustAMCP] http dual-Accept tools/list returns JSON") {
+	test_justamcp_http_dual_accept_tools_list_returns_json();
+}
+
+TEST_CASE("[Modules][JustAMCP] http dual-Accept tools/call uses SSE") {
+	test_justamcp_http_dual_accept_tools_call_uses_sse();
+}
+
+TEST_CASE("[Modules][JustAMCP] mcp config client field shapes") {
+	test_justamcp_mcp_config_client_field_shapes();
 }

--- a/modules/justamcp/tests/test_justamcp_json_rpc_transport.cpp
+++ b/modules/justamcp/tests/test_justamcp_json_rpc_transport.cpp
@@ -103,6 +103,35 @@ void test_justamcp_json_rpc_tools_call_e2e() {
 	CHECK(server.get_pending_tool_queue_size() == 0);
 }
 
+void test_justamcp_json_rpc_tools_list_strips_handled() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	const String body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}";
+	Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc(&server, body, Ref<HTTPResponse>());
+	CHECK(result.has("result"));
+	CHECK(result.has("jsonrpc"));
+	CHECK(result.has("id"));
+	CHECK(!result.has("handled"));
+	CHECK(!result.has("subscription_uri"));
+	CHECK(!result.has("subscription_action"));
+	Dictionary sanitized = JustAMCPJsonRpcTransport::sanitize_wire_rpc(result);
+	CHECK(!sanitized.has("handled"));
+	CHECK(sanitized.has("result"));
+
+	Dictionary with_internal;
+	with_internal["handled"] = true;
+	with_internal["subscription_uri"] = "blazium://x";
+	with_internal["subscription_action"] = "subscribe";
+	with_internal["jsonrpc"] = "2.0";
+	with_internal["id"] = 1;
+	with_internal["result"] = Dictionary();
+	Dictionary cleaned = JustAMCPJsonRpcTransport::sanitize_wire_rpc(with_internal);
+	CHECK(!cleaned.has("handled"));
+	CHECK(!cleaned.has("subscription_uri"));
+	CHECK(!cleaned.has("subscription_action"));
+	CHECK(cleaned.has("result"));
+}
+
 #endif
 
 #endif

--- a/modules/justamcp/tests/test_justamcp_json_rpc_transport.h
+++ b/modules/justamcp/tests/test_justamcp_json_rpc_transport.h
@@ -36,9 +36,14 @@ void test_justamcp_json_rpc_request_ids_equal();
 void test_justamcp_tool_queue_full();
 void test_justamcp_in_flight_cancel_flag_only();
 void test_justamcp_json_rpc_tools_call_e2e();
+void test_justamcp_json_rpc_tools_list_strips_handled();
 
 TEST_CASE("[Modules][JustAMCP] json rpc tools call e2e") {
 	test_justamcp_json_rpc_tools_call_e2e();
+}
+
+TEST_CASE("[Modules][JustAMCP] json rpc tools/list strips handled") {
+	test_justamcp_json_rpc_tools_list_strips_handled();
 }
 
 TEST_CASE("[Modules][JustAMCP] json rpc transport invalid json") {

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
@@ -1,0 +1,291 @@
+/**************************************************************************/
+/*  test_justamcp_protocol_versions.cpp                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TESTS_ENABLED
+
+#include "test_justamcp_protocol_versions.h"
+#include "test_justamcp_fixture.h"
+
+#include "modules/modules_enabled.gen.h"
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
+
+#include "../justamcp_json_rpc_transport.h"
+#include "../justamcp_server.h"
+#include "../justamcp_session_manager.h"
+
+#include "core/io/json.h"
+#include "modules/httpserver/http_request_context.h"
+#include "modules/httpserver/http_response.h"
+#include "tests/test_macros.h"
+
+static const char *const k_supported_protocols[] = {
+	"2025-11-25",
+	"2025-06-18",
+	"2025-03-26",
+	"2024-11-05",
+	nullptr
+};
+
+static Ref<HTTPRequestContext> _make_ctx(const String &p_method, const Dictionary &p_headers, const String &p_body = String()) {
+	Ref<HTTPRequestContext> context;
+	context.instantiate();
+	context->set_method(p_method);
+	context->set_path("/mcp");
+	context->set_headers(p_headers);
+	context->set_body(p_body);
+	return context;
+}
+
+static String _response_header(const Ref<HTTPResponse> &p_response, const String &p_name) {
+	const Dictionary headers = p_response->get_headers();
+	if (headers.has(p_name)) {
+		return String(headers[p_name]);
+	}
+	const String lower = p_name.to_lower();
+	for (const Variant &key : headers.keys()) {
+		if (String(key).to_lower() == lower) {
+			return String(headers[key]);
+		}
+	}
+	return String();
+}
+
+static Dictionary _json_headers(const String &p_session_id = String(), const String &p_protocol = String()) {
+	Dictionary headers;
+	headers["Accept"] = "application/json";
+	headers["Content-Type"] = "application/json";
+	if (!p_session_id.is_empty()) {
+		headers["MCP-Session-Id"] = p_session_id;
+	}
+	if (!p_protocol.is_empty()) {
+		headers["MCP-Protocol-Version"] = p_protocol;
+	}
+	return headers;
+}
+
+static String _initialize_body(const String &p_protocol, int p_id = 1) {
+	return "{\"jsonrpc\":\"2.0\",\"id\":" + itos(p_id) + ",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"" + p_protocol + "\",\"capabilities\":{},\"clientInfo\":{\"name\":\"protocol-test\",\"version\":\"1.0\"}}}";
+}
+
+static String _init_session(JustAMCPServer &p_server, MCPSessionManager *p_sm, const String &p_protocol) {
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	const bool handled = p_sm->handle_mcp_post(_make_ctx("POST", _json_headers(), _initialize_body(p_protocol)), response);
+	CHECK(handled);
+	const String session_id = _response_header(response, "MCP-Session-Id");
+	CHECK(!session_id.is_empty());
+	CHECK(p_sm->session_exists(session_id));
+	CHECK(p_server.test_get_transport_negotiated_protocol() == p_protocol);
+	if (!response->get_body().is_empty()) {
+		Ref<JSON> json;
+		json.instantiate();
+		if (json->parse(response->get_body()) == OK && json->get_data().get_type() == Variant::DICTIONARY) {
+			Dictionary root = json->get_data();
+			if (root.has("result")) {
+				Dictionary result = root["result"];
+				CHECK(String(result.get("protocolVersion", "")) == p_protocol);
+			}
+		}
+	}
+	return session_id;
+}
+
+void test_justamcp_negotiate_protocol_versions() {
+	for (int i = 0; k_supported_protocols[i]; i++) {
+		const String version = k_supported_protocols[i];
+		CHECK(MCPSessionManager::negotiate_protocol_version(version) == version);
+	}
+	CHECK(MCPSessionManager::latest_protocol_version() == "2025-11-25");
+	CHECK(MCPSessionManager::negotiate_protocol_version("2099-01-01") == "2025-11-25");
+	CHECK(MCPSessionManager::negotiate_protocol_version("") == "2025-11-25");
+}
+
+void test_justamcp_validate_protocol_header_rejects_unknown() {
+	Dictionary ok_headers = _json_headers();
+	ok_headers["MCP-Protocol-Version"] = "2025-06-18";
+	String err;
+	CHECK(MCPSessionManager::validate_protocol_header(_make_ctx("POST", ok_headers), err));
+
+	Dictionary empty_headers = _json_headers();
+	err = String();
+	CHECK(MCPSessionManager::validate_protocol_header(_make_ctx("POST", empty_headers), err));
+
+	Dictionary bad_headers = _json_headers();
+	bad_headers["MCP-Protocol-Version"] = "1999-01-01";
+	err = String();
+	CHECK(!MCPSessionManager::validate_protocol_header(_make_ctx("POST", bad_headers), err));
+	CHECK(err.contains("Unsupported MCP-Protocol-Version"));
+}
+
+void test_justamcp_http_initialize_all_protocol_versions() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	for (int i = 0; k_supported_protocols[i]; i++) {
+		_init_session(server, session_manager, k_supported_protocols[i]);
+	}
+}
+
+void test_justamcp_http_protocol_header_falls_back_to_session() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	static const char *const strict[] = { "2025-06-18", "2025-11-25", nullptr };
+	for (int i = 0; strict[i]; i++) {
+		const String protocol = strict[i];
+		const String session_id = _init_session(server, session_manager, protocol);
+
+		const String list_body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}";
+		// Spec: if header is omitted, reuse the protocol negotiated at initialize.
+		Ref<HTTPResponse> missing;
+		missing.instantiate();
+		CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _json_headers(session_id), list_body), missing));
+		CHECK(missing->get_status() != 400);
+		CHECK(!String(missing->get_body()).contains("Missing MCP-Protocol-Version"));
+
+		Ref<HTTPResponse> ok;
+		ok.instantiate();
+		CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _json_headers(session_id, protocol), list_body), ok));
+		CHECK(ok->get_status() != 400);
+	}
+}
+
+void test_justamcp_http_protocol_header_optional_for_older_versions() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	static const char *const optional[] = { "2024-11-05", "2025-03-26", nullptr };
+	for (int i = 0; optional[i]; i++) {
+		const String protocol = optional[i];
+		const String session_id = _init_session(server, session_manager, protocol);
+
+		const String list_body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}";
+		Ref<HTTPResponse> response;
+		response.instantiate();
+		CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _json_headers(session_id), list_body), response));
+		CHECK(response->get_status() != 400);
+		CHECK(!String(response->get_body()).contains("Missing MCP-Protocol-Version"));
+	}
+}
+
+void test_justamcp_batch_rejected_for_newer_protocols() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+
+	static const char *const strict[] = { "2025-06-18", "2025-11-25", nullptr };
+	for (int i = 0; strict[i]; i++) {
+		server.test_set_transport_negotiated_protocol(strict[i]);
+		Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc(&server, "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}]", Ref<HTTPResponse>());
+		CHECK(result.has("error"));
+		CHECK(String(result["error"].operator Dictionary().get("message", "")).contains("batch"));
+	}
+
+	server.test_set_transport_negotiated_protocol("2024-11-05");
+	Dictionary older = JustAMCPJsonRpcTransport::handle_json_rpc(&server, "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}]", Ref<HTTPResponse>());
+	CHECK(older.has("error"));
+	CHECK(!String(older["error"].operator Dictionary().get("message", "")).contains("batch requests are not supported"));
+}
+
+void test_justamcp_http_list_toolsets_smoke_per_strict_protocol() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	static const char *const strict[] = { "2025-06-18", "2025-11-25", nullptr };
+	for (int i = 0; strict[i]; i++) {
+		const String protocol = strict[i];
+		const String session_id = _init_session(server, session_manager, protocol);
+		const String call_body = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"blazium_list_toolsets\",\"arguments\":{}}}";
+		Ref<HTTPResponse> response;
+		response.instantiate();
+		CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _json_headers(session_id, protocol), call_body), response));
+		CHECK(response->get_status() != 400);
+		CHECK(response->get_status() != 404);
+	}
+}
+
+void test_justamcp_json_rpc_rejects_null_id() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+
+	Dictionary null_id = JustAMCPJsonRpcTransport::handle_json_rpc(
+			&server,
+			"{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"tools/list\",\"params\":{}}",
+			Ref<HTTPResponse>());
+	CHECK(null_id.has("error"));
+	CHECK(int(Dictionary(null_id["error"]).get("code", 0)) == -32600);
+	CHECK(String(Dictionary(null_id["error"]).get("message", "")).contains("must not be null"));
+
+	Dictionary bad_id = JustAMCPJsonRpcTransport::handle_json_rpc(
+			&server,
+			"{\"jsonrpc\":\"2.0\",\"id\":true,\"method\":\"tools/list\",\"params\":{}}",
+			Ref<HTTPResponse>());
+	CHECK(bad_id.has("error"));
+	CHECK(int(Dictionary(bad_id["error"]).get("code", 0)) == -32600);
+	CHECK(String(Dictionary(bad_id["error"]).get("message", "")).contains("string or integer"));
+}
+
+#else
+
+void test_justamcp_negotiate_protocol_versions() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_validate_protocol_header_rejects_unknown() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_initialize_all_protocol_versions() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_protocol_header_falls_back_to_session() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_protocol_header_optional_for_older_versions() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_batch_rejected_for_newer_protocols() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_list_toolsets_smoke_per_strict_protocol() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_json_rpc_rejects_null_id() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+
+#endif
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.h
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_transport.h                                         */
+/*  test_justamcp_protocol_versions.h                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,26 +29,45 @@
 
 #pragma once
 
-#include "modules/modules_enabled.gen.h"
+#include "tests/test_macros.h"
 
-#if defined(MODULE_HTTPSERVER_ENABLED)
+void test_justamcp_negotiate_protocol_versions();
+void test_justamcp_validate_protocol_header_rejects_unknown();
+void test_justamcp_http_initialize_all_protocol_versions();
+void test_justamcp_http_protocol_header_falls_back_to_session();
+void test_justamcp_http_protocol_header_optional_for_older_versions();
+void test_justamcp_batch_rejected_for_newer_protocols();
+void test_justamcp_http_list_toolsets_smoke_per_strict_protocol();
+void test_justamcp_json_rpc_rejects_null_id();
 
-#include "core/variant/dictionary.h"
-#include "core/variant/variant.h"
+TEST_CASE("[Modules][JustAMCP] negotiate protocol versions") {
+	test_justamcp_negotiate_protocol_versions();
+}
 
-class JustAMCPServer;
-class HTTPResponse;
+TEST_CASE("[Modules][JustAMCP] validate protocol header rejects unknown") {
+	test_justamcp_validate_protocol_header_rejects_unknown();
+}
 
-class JustAMCPJsonRpcTransport {
-public:
-	static Dictionary handle_json_rpc(JustAMCPServer *p_server, const String &p_body, Ref<HTTPResponse> p_response, const String &p_caller_session_id = String());
-	static Dictionary handle_json_rpc_parsed(JustAMCPServer *p_server, const Dictionary &p_payload, Ref<HTTPResponse> p_response, const String &p_caller_session_id = String());
-	// Strip internal router keys before HTTP/SSE emission (Cursor Zod rejects "handled").
-	static Dictionary sanitize_wire_rpc(const Dictionary &p_rpc);
+TEST_CASE("[Modules][JustAMCP] http initialize all protocol versions") {
+	test_justamcp_http_initialize_all_protocol_versions();
+}
 
-private:
-	static bool _is_http_transport(Ref<HTTPResponse> p_response);
-	static Dictionary _handle_json_rpc_payload(JustAMCPServer *p_server, const Dictionary &p_payload, Ref<HTTPResponse> p_response, const String &p_caller_session_id);
-};
+TEST_CASE("[Modules][JustAMCP] http protocol header falls back to session") {
+	test_justamcp_http_protocol_header_falls_back_to_session();
+}
 
-#endif
+TEST_CASE("[Modules][JustAMCP] http protocol header optional for older versions") {
+	test_justamcp_http_protocol_header_optional_for_older_versions();
+}
+
+TEST_CASE("[Modules][JustAMCP] batch rejected for newer protocols") {
+	test_justamcp_batch_rejected_for_newer_protocols();
+}
+
+TEST_CASE("[Modules][JustAMCP] http list toolsets smoke per strict protocol") {
+	test_justamcp_http_list_toolsets_smoke_per_strict_protocol();
+}
+
+TEST_CASE("[Modules][JustAMCP] json-rpc rejects null id") {
+	test_justamcp_json_rpc_rejects_null_id();
+}

--- a/modules/justamcp/tests/test_justamcp_toolset_schema_gate.cpp
+++ b/modules/justamcp/tests/test_justamcp_toolset_schema_gate.cpp
@@ -1,0 +1,120 @@
+/**************************************************************************/
+/*  test_justamcp_toolset_schema_gate.cpp                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TESTS_ENABLED
+
+#include "test_justamcp_toolset_schema_gate.h"
+
+#include "modules/modules_enabled.gen.h"
+
+#ifdef TOOLS_ENABLED
+
+#include "../tools/justamcp_category_registry.h"
+#include "../tools/justamcp_tool_schema_cache.h"
+#include "../tools/justamcp_toolset_registry.h"
+#include "core/templates/hash_set.h"
+#include "core/templates/vector.h"
+#include "tests/test_macros.h"
+
+void test_justamcp_toolset_schema_gate() {
+	TEST_FAIL_COND(!JustAMCPToolsetRegistry::get_singleton(), "JustAMCPToolsetRegistry singleton is required");
+
+	JustAMCPToolSchemaCache::invalidate();
+
+	Vector<String> expected_names;
+	for (int i = 0; i < JustAMCPCategoryRegistry::get_entry_count(); i++) {
+		const JustAMCPCategoryRegistryEntry &entry = JustAMCPCategoryRegistry::get_entry(i);
+		if (entry.requires_multiuser) {
+#ifndef MODULE_MULTIUSER_EDITOR_ENABLED
+			continue;
+#endif
+		}
+		if (entry.requires_autowork) {
+#ifndef MODULE_AUTOWORK_ENABLED
+			continue;
+#endif
+		}
+		expected_names.push_back(entry.display_name);
+
+		// Optional collaborative/autowork categories may register empty schema sets in headless tests.
+		if (entry.requires_multiuser || entry.requires_autowork) {
+			continue;
+		}
+
+		const Array category_schemas = JustAMCPToolSchemaCache::get_category_schemas(entry.category_id, false, true, true);
+		CHECK_MESSAGE(category_schemas.size() > 0, vformat("Category schemas empty for %s", entry.category_id));
+	}
+
+	expected_names.push_back("MCPClient");
+#ifdef MODULE_ASSETTAGS_ENABLED
+	expected_names.push_back("AssetTags");
+#endif
+#ifdef MODULE_SEMANTICSEARCH_ENABLED
+	expected_names.push_back("SemanticSearch");
+#endif
+
+	const Dictionary listed = JustAMCPToolsetRegistry::get_singleton()->list_toolsets();
+	CHECK(listed.get("ok", false));
+	const Array toolsets = listed.get("toolsets", Array());
+	CHECK(toolsets.size() >= expected_names.size());
+
+	HashSet<String> listed_names;
+	for (int i = 0; i < toolsets.size(); i++) {
+		Dictionary item = toolsets[i];
+		listed_names.insert(String(item.get("name", "")));
+	}
+
+	for (int i = 0; i < expected_names.size(); i++) {
+		const String &name = expected_names[i];
+		CHECK_MESSAGE(listed_names.has(name), vformat("Missing toolset in list_toolsets: %s", name));
+		const Dictionary described = JustAMCPToolsetRegistry::get_singleton()->describe_toolset(name);
+		if (!bool(described.get("ok", false))) {
+			const String err = String(described.get("error", ""));
+			if (err.contains("disabled")) {
+				continue;
+			}
+		}
+		CHECK_MESSAGE(described.get("ok", false), vformat("describe_toolset failed for %s: %s", name, String(described.get("error", ""))));
+		const Array tools = described.get("tools", Array());
+		if (name == "Multiuser" || name == "Autowork") {
+			continue;
+		}
+		CHECK_MESSAGE(tools.size() > 0, vformat("Toolset has zero schemas: %s", name));
+	}
+}
+
+#else
+
+void test_justamcp_toolset_schema_gate() {
+	SUCCEED();
+}
+
+#endif
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_toolset_schema_gate.h
+++ b/modules/justamcp/tests/test_justamcp_toolset_schema_gate.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_transport.h                                         */
+/*  test_justamcp_toolset_schema_gate.h                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,26 +29,10 @@
 
 #pragma once
 
-#include "modules/modules_enabled.gen.h"
+#include "tests/test_macros.h"
 
-#if defined(MODULE_HTTPSERVER_ENABLED)
+void test_justamcp_toolset_schema_gate();
 
-#include "core/variant/dictionary.h"
-#include "core/variant/variant.h"
-
-class JustAMCPServer;
-class HTTPResponse;
-
-class JustAMCPJsonRpcTransport {
-public:
-	static Dictionary handle_json_rpc(JustAMCPServer *p_server, const String &p_body, Ref<HTTPResponse> p_response, const String &p_caller_session_id = String());
-	static Dictionary handle_json_rpc_parsed(JustAMCPServer *p_server, const Dictionary &p_payload, Ref<HTTPResponse> p_response, const String &p_caller_session_id = String());
-	// Strip internal router keys before HTTP/SSE emission (Cursor Zod rejects "handled").
-	static Dictionary sanitize_wire_rpc(const Dictionary &p_rpc);
-
-private:
-	static bool _is_http_transport(Ref<HTTPResponse> p_response);
-	static Dictionary _handle_json_rpc_payload(JustAMCPServer *p_server, const Dictionary &p_payload, Ref<HTTPResponse> p_response, const String &p_caller_session_id);
-};
-
-#endif
+TEST_CASE("[Modules][JustAMCP] toolset schema gate") {
+	test_justamcp_toolset_schema_gate();
+}

--- a/modules/justamcp/tools/justamcp_analysis_tools.cpp
+++ b/modules/justamcp/tools/justamcp_analysis_tools.cpp
@@ -226,7 +226,7 @@ void JustAMCPAnalysisTools::_collect_signal_data(Node *p_node, Node *p_root, Arr
 		r_truncated = true;
 		return;
 	}
-	String node_path = p_root->get_path_to(p_node);
+	String node_path = JustAMCPEditorSceneAccess::safe_path_to(p_root, p_node);
 	Array signals_emitted;
 	Array signals_connected_to;
 
@@ -246,7 +246,7 @@ void JustAMCPAnalysisTools::_collect_signal_data(Node *p_node, Node *p_root, Arr
 				String target_path = "";
 				if (target_node) {
 					if (target_node == p_root || p_root->is_ancestor_of(target_node)) {
-						target_path = p_root->get_path_to(target_node);
+						target_path = JustAMCPEditorSceneAccess::safe_path_to(p_root, target_node);
 					} else {
 						target_path = target_node->get_name();
 					}
@@ -334,7 +334,7 @@ void JustAMCPAnalysisTools::_analyze_node(Node *p_node, Node *p_root, int p_dept
 		if (!script_path.is_empty()) {
 			Dictionary sd;
 			if (p_root && p_node) {
-				sd["node"] = String(p_root->get_path_to(p_node));
+				sd["node"] = String(JustAMCPEditorSceneAccess::safe_path_to(p_root, p_node));
 			}
 			sd["script"] = script_path;
 			r_scripts.push_back(sd);

--- a/modules/justamcp/tools/justamcp_audio_tools.cpp
+++ b/modules/justamcp/tools/justamcp_audio_tools.cpp
@@ -443,7 +443,7 @@ void JustAMCPAudioTools::_collect_audio_players(Node *p_node, Array &r_result) {
 		info["name"] = p_node->get_name();
 		Node *root = JustAMCPEditorSceneAccess::get_edited_root();
 		if (root) {
-			info["path"] = root->get_path_to(p_node);
+			info["path"] = JustAMCPEditorSceneAccess::safe_path_to(root, p_node);
 		} else {
 			info["path"] = String(p_node->get_name());
 		}

--- a/modules/justamcp/tools/justamcp_batch_tools.cpp
+++ b/modules/justamcp/tools/justamcp_batch_tools.cpp
@@ -133,7 +133,7 @@ void JustAMCPBatchTools::_search_by_type(Node *p_node, const String &p_type_name
 		if (root) {
 			Dictionary m;
 			m["name"] = p_node->get_name();
-			m["path"] = root->get_path_to(p_node);
+			m["path"] = JustAMCPEditorSceneAccess::safe_path_to(root, p_node);
 			m["type"] = p_node->get_class();
 			r_matches.push_back(m);
 		}
@@ -164,7 +164,7 @@ Dictionary JustAMCPBatchTools::_find_signal_connections(const Dictionary &p_para
 }
 
 void JustAMCPBatchTools::_collect_signals(Node *p_node, Node *p_root, const String &p_signal_filter, const String &p_node_filter, Array &r_connections) {
-	String node_path = p_root->get_path_to(p_node);
+	String node_path = JustAMCPEditorSceneAccess::safe_path_to(p_root, p_node);
 
 	if (p_node_filter.is_empty() || node_path.contains(p_node_filter)) {
 		List<MethodInfo> signals;
@@ -186,7 +186,7 @@ void JustAMCPBatchTools::_collect_signals(Node *p_node, Node *p_root, const Stri
 				Node *target_node = Object::cast_to<Node>(target_obj);
 				if (target_node) {
 					if (target_node == p_root || p_root->is_ancestor_of(target_node)) {
-						d["target"] = p_root->get_path_to(target_node);
+						d["target"] = JustAMCPEditorSceneAccess::safe_path_to(p_root, target_node);
 					} else {
 						d["target"] = target_node->get_name();
 					}
@@ -250,7 +250,7 @@ void JustAMCPBatchTools::_batch_set_recursive(Node *p_node, Node *p_root, const 
 		bool valid = false;
 		p_node->set(p_property, p_value, &valid);
 		if (valid) {
-			r_affected.push_back(p_root->get_path_to(p_node));
+			r_affected.push_back(JustAMCPEditorSceneAccess::safe_path_to(p_root, p_node));
 		}
 	}
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -303,7 +303,7 @@ Dictionary JustAMCPBatchTools::_batch_add_nodes(const Dictionary &p_params) {
 		Dictionary info;
 		info["name"] = node->get_name();
 		info["type"] = node->get_class();
-		info["path"] = root->get_path_to(node);
+		info["path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 		created.push_back(info);
 	}
 
@@ -520,7 +520,7 @@ void JustAMCPBatchTools::_cross_scene_set_recursive(Node *p_node, Node *p_root, 
 		bool valid = false;
 		p_node->set(p_property, p_value, &valid);
 		if (valid) {
-			r_affected.push_back(p_root->get_path_to(p_node));
+			r_affected.push_back(JustAMCPEditorSceneAccess::safe_path_to(p_root, p_node));
 		}
 	}
 	for (int i = 0; i < p_node->get_child_count(); i++) {

--- a/modules/justamcp/tools/justamcp_composite_routes.cpp
+++ b/modules/justamcp/tools/justamcp_composite_routes.cpp
@@ -37,8 +37,10 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/os/os.h"
+#include "core/os/thread.h"
 #include "justamcp_profiling_tools.h"
 #include "justamcp_script_tools.h"
+#include "servers/display_server.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_file_system.h"
@@ -249,7 +251,8 @@ Dictionary JustAMCPToolExecutor::execute_composite_tool(const String &p_internal
 		Dictionary ret;
 #ifdef TOOLS_ENABLED
 		if (EditorFileSystem::get_singleton()) {
-			EditorFileSystem::get_singleton()->scan();
+			// Always defer: sync scan() during process_frame tool drain freezes the editor.
+			EditorFileSystem::get_singleton()->call_deferred(SNAME("scan"));
 			ret["ok"] = true;
 			ret["message"] = "Editor filesystem rescan requested.";
 			return ret;
@@ -443,7 +446,20 @@ Dictionary JustAMCPToolExecutor::execute_composite_tool(const String &p_internal
 			ms = int(double(p_args.get("seconds", 0.0)) * 1000.0);
 		}
 		ms = CLAMP(ms, 0, 5000);
-		OS::get_singleton()->delay_usec(uint64_t(ms) * 1000ULL);
+		// Prefer WorkerThreadPool (wait is worker-safe). Never block the main thread with a long delay_usec.
+		if (Thread::is_main_thread()) {
+			const uint64_t end_ms = OS::get_singleton()->get_ticks_msec() + uint64_t(ms);
+			while (OS::get_singleton()->get_ticks_msec() < end_ms) {
+				const uint64_t remaining = end_ms - OS::get_singleton()->get_ticks_msec();
+				const uint64_t slice_ms = MIN(remaining, (uint64_t)8);
+				OS::get_singleton()->delay_usec(slice_ms * 1000ULL);
+				if (DisplayServer::get_singleton()) {
+					DisplayServer::get_singleton()->process_events();
+				}
+			}
+		} else {
+			OS::get_singleton()->delay_usec(uint64_t(ms) * 1000ULL);
+		}
 		Dictionary ret;
 		ret["ok"] = true;
 		ret["waited_ms"] = ms;

--- a/modules/justamcp/tools/justamcp_editor_tools.cpp
+++ b/modules/justamcp/tools/justamcp_editor_tools.cpp
@@ -36,9 +36,9 @@
 #include "../justamcp_server.h"
 #include "../justamcp_tool_context.h"
 #include "core/io/file_access.h"
-#include "editor/editor_command_palette.h"
 #include "editor/editor_data.h"
 #include "editor/editor_interface.h"
+#include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -242,7 +242,8 @@ Dictionary JustAMCPEditorTools::editor_take_screenshot(const Dictionary &p_args)
 	Dictionary result;
 
 	if (DisplayServer::get_singleton()) {
-		Ref<Image> screenshot = DisplayServer::get_singleton()->screen_get_image();
+		const int screen = DisplayServer::get_singleton()->get_primary_screen();
+		Ref<Image> screenshot = DisplayServer::get_singleton()->screen_get_image(screen);
 		if (screenshot.is_valid()) {
 			String output_path = "res://.screenshot.png";
 			Error err = screenshot->save_png(output_path);
@@ -362,15 +363,14 @@ Dictionary JustAMCPEditorTools::editor_set_settings(const Dictionary &p_args) {
 
 Dictionary JustAMCPEditorTools::editor_clear_output(const Dictionary &p_args) {
 	Dictionary result;
-	if (editor_plugin && editor_plugin->get_editor_interface()) {
+	if (EditorNode::get_log()) {
+		EditorNode::get_log()->clear();
 		result["ok"] = true;
 		result["message"] = "Output cleared successfully.";
-
-		EditorCommandPalette::get_singleton()->execute_command("editor/clear_output");
 		return result;
 	}
 	result["ok"] = false;
-	result["error"] = "Editor Interface Unavailable";
+	result["error"] = "Editor log is unavailable.";
 	return result;
 }
 
@@ -378,7 +378,8 @@ Dictionary JustAMCPEditorTools::editor_screenshot_game(const Dictionary &p_args)
 	Dictionary result;
 
 	if (DisplayServer::get_singleton()) {
-		Ref<Image> screenshot = DisplayServer::get_singleton()->screen_get_image();
+		const int screen = DisplayServer::get_singleton()->get_primary_screen();
+		Ref<Image> screenshot = DisplayServer::get_singleton()->screen_get_image(screen);
 		if (screenshot.is_valid()) {
 			String output_path = "res://.screenshot_game.png";
 			Error err = screenshot->save_png(output_path);

--- a/modules/justamcp/tools/justamcp_json_rpc_router.cpp
+++ b/modules/justamcp/tools/justamcp_json_rpc_router.cpp
@@ -320,10 +320,10 @@ Dictionary JustAMCPJsonRpcRouter::route_initialize(JustAMCPServer *p_server, con
 		return empty;
 	}
 	const Dictionary params = p_payload["params"];
-	if (!params.has("protocolVersion") || params["protocolVersion"].get_type() != Variant::STRING) {
-		return empty;
+	String client_protocol = MCPSessionManager::latest_protocol_version();
+	if (params.has("protocolVersion") && params["protocolVersion"].get_type() == Variant::STRING) {
+		client_protocol = String(params["protocolVersion"]);
 	}
-	const String client_protocol = String(params["protocolVersion"]);
 	p_server->transport_negotiated_protocol = MCPSessionManager::negotiate_protocol_version(client_protocol);
 
 	Dictionary result;

--- a/modules/justamcp/tools/justamcp_mcp_client_bridge.cpp
+++ b/modules/justamcp/tools/justamcp_mcp_client_bridge.cpp
@@ -32,6 +32,7 @@
 #include "justamcp_mcp_client_bridge.h"
 
 #include "../justamcp_server.h"
+#include "../justamcp_session_manager.h"
 #include "../justamcp_tool_context.h"
 #include "justamcp_tool_schema_builder.h"
 
@@ -132,7 +133,7 @@ Error JustAMCPMCPClientBridge::_ensure_initialized(const String &p_bridge_name) 
 		}
 	}
 	Dictionary init_params;
-	init_params["protocolVersion"] = _get_bridge_config(p_bridge_name).get("protocol_version", "2025-03-26");
+	init_params["protocolVersion"] = _get_bridge_config(p_bridge_name).get("protocol_version", MCPSessionManager::latest_protocol_version());
 	Dictionary init_result = _rpc_request(p_bridge_name, "initialize", init_params);
 	if (!init_result.get("ok", false)) {
 		return ERR_CANT_CONNECT;
@@ -192,7 +193,7 @@ Dictionary JustAMCPMCPClientBridge::_rpc_request_sync(const String &p_bridge_nam
 		port = scheme == "https" ? 443 : 80;
 	}
 
-	const String protocol = bridge.get("protocol_version", "2025-03-26");
+	const String protocol = bridge.get("protocol_version", MCPSessionManager::latest_protocol_version());
 
 	Ref<HTTPClient> client = HTTPClient::create();
 	Ref<TLSOptions> tls;
@@ -522,7 +523,7 @@ Dictionary JustAMCPMCPClientBridge::add_bridge(const Dictionary &p_args) {
 	Dictionary bridge;
 	bridge["name"] = name;
 	bridge["url"] = url;
-	bridge["protocol_version"] = p_args.get("protocol_version", "2025-03-26");
+	bridge["protocol_version"] = p_args.get("protocol_version", MCPSessionManager::latest_protocol_version());
 	if (p_args.has("auth_token")) {
 		bridge["auth_token"] = p_args.get("auth_token", "");
 	}

--- a/modules/justamcp/tools/justamcp_meta_tools.cpp
+++ b/modules/justamcp/tools/justamcp_meta_tools.cpp
@@ -31,6 +31,7 @@
 
 #include "justamcp_meta_tools.h"
 
+#include "../justamcp_server.h"
 #include "justamcp_resource_executor.h"
 #include "justamcp_tool_executor.h"
 #include "justamcp_tool_schema_cache.h"
@@ -94,8 +95,19 @@ Dictionary JustAMCPMetaTools::execute(JustAMCPToolExecutor *p_executor, const St
 			result["resource_template"] = "blazium://guide/{topic}";
 			return result;
 		}
-		JustAMCPResourceExecutor resource_executor;
-		const Dictionary resource = resource_executor.read_resource("blazium://guide/" + topic);
+		JustAMCPResourceExecutor *resource_executor = nullptr;
+		if (JustAMCPServer::get_singleton()) {
+			resource_executor = JustAMCPServer::get_singleton()->get_resource_executor();
+		}
+		Dictionary resource;
+		if (resource_executor) {
+			resource = resource_executor->read_resource("blazium://guide/" + topic);
+		} else {
+			// Avoid stack-allocating when the server executor exists: its dtor would
+			// disconnect the shared EditorFileSystem callback on the main thread.
+			JustAMCPResourceExecutor local_executor;
+			resource = local_executor.read_resource("blazium://guide/" + topic);
+		}
 		if (!resource.get("ok", false)) {
 			return resource;
 		}

--- a/modules/justamcp/tools/justamcp_node_tools.cpp
+++ b/modules/justamcp/tools/justamcp_node_tools.cpp
@@ -51,7 +51,12 @@ Node *JustAMCPNodeTools::_find_node_by_path(const String &p_path) {
 }
 
 void JustAMCPNodeTools::_set_owner_recursive(Node *p_node, Node *p_owner) {
-	p_node->set_owner(p_owner);
+	if (!p_node || !p_owner) {
+		return;
+	}
+	if (p_node == p_owner || p_owner->is_ancestor_of(p_node)) {
+		p_node->set_owner(p_owner);
+	}
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_set_owner_recursive(p_node->get_child(i), p_owner);
 	}
@@ -198,7 +203,7 @@ Dictionary JustAMCPNodeTools::_add_node(const Dictionary &p_params) {
 #endif
 
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 	res["type"] = type;
 	res["name"] = node->get_name();
 	return MCP_SUCCESS(res);
@@ -232,8 +237,9 @@ Dictionary JustAMCPNodeTools::_delete_node(const Dictionary &p_params) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action("MCP: Delete " + node_name);
 		ur->add_do_method(parent, "remove_child", node);
-		ur->add_undo_method(parent, "add_child", node);
+		// Undo runs reverse of registration: add_child must run before set_owner.
 		ur->add_undo_method(node, "set_owner", root);
+		ur->add_undo_method(parent, "add_child", node);
 		ur->add_undo_reference(node);
 		ur->commit_action();
 	} else {
@@ -265,14 +271,21 @@ Dictionary JustAMCPNodeTools::_duplicate_node(const Dictionary &p_params) {
 	if (!node) {
 		return MCP_NOT_FOUND("Node '" + node_path + "'");
 	}
+	if (node == root) {
+		return MCP_INVALID_PARAMS("Cannot duplicate the scene root; choose a child node_path");
+	}
 
 	if (new_name.is_empty()) {
 		new_name = String(node->get_name()) + "_copy";
 	}
 
+	Node *parent = node->get_parent();
+	if (!parent || (parent != root && !root->is_ancestor_of(parent))) {
+		return MCP_INVALID_PARAMS("Cannot duplicate node outside the edited scene tree");
+	}
+
 	Node *dup = node->duplicate();
 	dup->set_name(new_name);
-	Node *parent = node->get_parent();
 
 #ifdef TOOLS_ENABLED
 	if (EditorUndoRedoManager::get_singleton()) {
@@ -286,7 +299,9 @@ Dictionary JustAMCPNodeTools::_duplicate_node(const Dictionary &p_params) {
 	} else {
 #endif
 		parent->add_child(dup);
-		dup->set_owner(root);
+		if (root->is_ancestor_of(dup) || parent == root) {
+			dup->set_owner(root);
+		}
 #ifdef TOOLS_ENABLED
 	}
 #endif
@@ -294,8 +309,8 @@ Dictionary JustAMCPNodeTools::_duplicate_node(const Dictionary &p_params) {
 	_set_owner_recursive(dup, root);
 
 	Dictionary res;
-	res["original"] = root->get_path_to(node);
-	res["duplicate"] = root->get_path_to(dup);
+	res["original"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
+	res["duplicate"] = String(JustAMCPEditorSceneAccess::safe_path_to(root, dup));
 	res["name"] = dup->get_name();
 	return MCP_SUCCESS(res);
 }
@@ -358,9 +373,9 @@ Dictionary JustAMCPNodeTools::_move_node(const Dictionary &p_params) {
 
 	Dictionary res;
 	res["node"] = node->get_name();
-	res["old_parent"] = root->get_path_to(old_parent);
-	res["new_parent"] = root->get_path_to(new_parent);
-	res["new_path"] = root->get_path_to(node);
+	res["old_parent"] = JustAMCPEditorSceneAccess::safe_path_to(root, old_parent);
+	res["new_parent"] = JustAMCPEditorSceneAccess::safe_path_to(root, new_parent);
+	res["new_path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 	return MCP_SUCCESS(res);
 }
 
@@ -410,7 +425,7 @@ Dictionary JustAMCPNodeTools::_update_property(const Dictionary &p_params) {
 #endif
 
 	Dictionary res;
-	res["node"] = root->get_path_to(node);
+	res["node"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 	res["property"] = property;
 	res["old_value"] = old_value;
 	res["new_value"] = node->get(property);
@@ -448,7 +463,7 @@ Dictionary JustAMCPNodeTools::_get_node_properties(const Dictionary &p_params) {
 	}
 
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 	res["type"] = node->get_class();
 	res["properties"] = props;
 	return MCP_SUCCESS(res);
@@ -518,7 +533,7 @@ Dictionary JustAMCPNodeTools::_add_resource(const Dictionary &p_params) {
 #endif
 
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 	res["property"] = property;
 	res["resource_type"] = resource_type;
 	return MCP_SUCCESS(res);

--- a/modules/justamcp/tools/justamcp_node_tools_groups.cpp
+++ b/modules/justamcp/tools/justamcp_node_tools_groups.cpp
@@ -43,6 +43,10 @@
 
 #include "../justamcp_mcp_tool_macros.h"
 
+static String _justamcp_safe_path_to(Node *p_root, Node *p_node) {
+	return JustAMCPEditorSceneAccess::safe_path_to(p_root, p_node);
+}
+
 Dictionary JustAMCPNodeTools::_set_anchor_preset(const Dictionary &p_params) {
 	if (!p_params.has("node_path")) {
 		return MCP_INVALID_PARAMS("Missing param: node_path");
@@ -129,7 +133,7 @@ Dictionary JustAMCPNodeTools::_set_anchor_preset(const Dictionary &p_params) {
 #endif
 
 	Dictionary res;
-	res["node_path"] = root->get_path_to(control);
+	res["node_path"] = _justamcp_safe_path_to(root, control);
 	res["preset"] = preset_name;
 	return MCP_SUCCESS(res);
 }
@@ -174,7 +178,7 @@ Dictionary JustAMCPNodeTools::_rename_node(const Dictionary &p_params) {
 	Dictionary res;
 	res["old_name"] = old_name;
 	res["new_name"] = node->get_name();
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = _justamcp_safe_path_to(root, node);
 	return MCP_SUCCESS(res);
 }
 
@@ -225,9 +229,9 @@ Dictionary JustAMCPNodeTools::_connect_signal(const Dictionary &p_params) {
 	source->connect(signal_name, conn);
 
 	Dictionary res;
-	res["source"] = root->get_path_to(source);
+	res["source"] = _justamcp_safe_path_to(root, source);
 	res["signal"] = signal_name;
-	res["target"] = root->get_path_to(target);
+	res["target"] = _justamcp_safe_path_to(root, target);
 	res["method"] = method_name;
 	res["connected"] = true;
 	return MCP_SUCCESS(res);
@@ -275,9 +279,9 @@ Dictionary JustAMCPNodeTools::_disconnect_signal(const Dictionary &p_params) {
 	source->disconnect(signal_name, conn);
 
 	Dictionary res;
-	res["source"] = root->get_path_to(source);
+	res["source"] = _justamcp_safe_path_to(root, source);
 	res["signal"] = signal_name;
-	res["target"] = root->get_path_to(target);
+	res["target"] = _justamcp_safe_path_to(root, target);
 	res["method"] = method_name;
 	res["disconnected"] = true;
 	return MCP_SUCCESS(res);
@@ -309,7 +313,7 @@ Dictionary JustAMCPNodeTools::_get_node_groups(const Dictionary &p_params) {
 	}
 
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = _justamcp_safe_path_to(root, node);
 	res["groups"] = groups;
 	res["count"] = groups.size();
 	return MCP_SUCCESS(res);
@@ -362,7 +366,7 @@ Dictionary JustAMCPNodeTools::_set_node_groups(const Dictionary &p_params) {
 	}
 
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = _justamcp_safe_path_to(root, node);
 	res["groups"] = desired_groups;
 	res["added"] = added;
 	res["removed"] = removed;
@@ -394,7 +398,7 @@ void JustAMCPNodeTools::_find_in_group_recursive(Node *p_node, Node *p_root, con
 	if (p_node->is_in_group(p_group_name)) {
 		Dictionary m;
 		m["name"] = p_node->get_name();
-		m["path"] = p_root->get_path_to(p_node);
+		m["path"] = _justamcp_safe_path_to(p_root, p_node);
 		m["type"] = p_node->get_class();
 		r_matches.push_back(m);
 	}

--- a/modules/justamcp/tools/justamcp_project_tools_settings.cpp
+++ b/modules/justamcp/tools/justamcp_project_tools_settings.cpp
@@ -36,6 +36,39 @@
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 
+// Prefer Ref<JSON>::parse over JSON::parse_string so plain strings (e.g. "JustAMCP")
+// do not ERR_PRINT via the global parse helper.
+static bool _justamcp_looks_like_json(const String &p_s) {
+	const String t = p_s.strip_edges();
+	if (t.is_empty()) {
+		return false;
+	}
+	const char32_t c = t[0];
+	if (c == '{' || c == '[' || c == '"') {
+		return true;
+	}
+	if (t == "true" || t == "false" || t == "null") {
+		return true;
+	}
+	if (c == '-' || (c >= '0' && c <= '9')) {
+		return t.is_valid_float() || t.is_valid_int();
+	}
+	return false;
+}
+
+static Variant _justamcp_try_parse_json_quiet(const String &p_s) {
+	const String t = p_s.strip_edges();
+	if (!_justamcp_looks_like_json(t)) {
+		return Variant();
+	}
+	Ref<JSON> json;
+	json.instantiate();
+	if (json->parse(t) != OK) {
+		return Variant();
+	}
+	return json->get_data();
+}
+
 Dictionary JustAMCPProjectTools::list_settings(const Dictionary &p_args) {
 	String category = p_args.get("category", "");
 	const int max_results = CLAMP(int(p_args.get("max_results", category.is_empty() ? 500 : 2000)), 1, 10000);
@@ -362,7 +395,7 @@ static Array _parse_input_events_variant(const Variant &p_events) {
 	Array source;
 	if (p_events.get_type() == Variant::STRING) {
 		String json_str = p_events;
-		Variant parsed = JSON::parse_string(json_str);
+		Variant parsed = _justamcp_try_parse_json_quiet(json_str);
 		if (parsed.get_type() == Variant::ARRAY) {
 			source = parsed;
 		} else if (parsed.get_type() == Variant::DICTIONARY) {
@@ -390,7 +423,7 @@ static Array _parse_input_events_variant(const Variant &p_events) {
 			continue;
 		}
 		if (item.get_type() == Variant::STRING) {
-			Variant parsed = JSON::parse_string(item);
+			Variant parsed = _justamcp_try_parse_json_quiet(item);
 			if (parsed.get_type() == Variant::DICTIONARY) {
 				Ref<InputEvent> ev = _input_event_from_dictionary(parsed);
 				if (ev.is_valid()) {
@@ -523,7 +556,7 @@ Dictionary JustAMCPProjectTools::set_project_setting(const Dictionary &p_args) {
 	Variant value = p_args.get("value", Variant());
 	if (value.get_type() == Variant::STRING) {
 		String s = value;
-		Variant parsed = JSON::parse_string(s);
+		Variant parsed = _justamcp_try_parse_json_quiet(s);
 		if (parsed.get_type() != Variant::NIL) {
 			value = parsed;
 		}

--- a/modules/justamcp/tools/justamcp_readonly_tools.cpp
+++ b/modules/justamcp/tools/justamcp_readonly_tools.cpp
@@ -132,6 +132,7 @@ bool JustAMCPReadonlyTools::is_readonly_tool(const String &p_tool_name) {
 		"get_guide",
 		"list_toolsets",
 		"describe_toolset",
+		"wait",
 		nullptr,
 	};
 	for (int i = 0; k_readonly_tools[i] != nullptr; i++) {
@@ -169,6 +170,7 @@ bool JustAMCPReadonlyTools::is_worker_safe_tool(const String &p_tool_name) {
 		"search_in_files",
 		"uid_to_project_path",
 		"project_path_to_uid",
+		"wait",
 		nullptr,
 	};
 	for (int i = 0; k_worker_safe_tools[i] != nullptr; i++) {

--- a/modules/justamcp/tools/justamcp_resource_executor.cpp
+++ b/modules/justamcp/tools/justamcp_resource_executor.cpp
@@ -36,6 +36,7 @@
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/os/os.h"
+#include "core/os/thread.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_settings.h"
 #include "justamcp_resource_manifest.h"
@@ -94,7 +95,9 @@ JustAMCPResourceExecutor::JustAMCPResourceExecutor() {
 	add_resource(memnew(JustAMCPResourceProjectFile));
 	add_resource(memnew(JustAMCPResourceVideoRecordings));
 	add_resource(memnew(JustAMCPResourceAutoworkResults));
-	if (EditorFileSystem::get_singleton()) {
+	// EditorFileSystem is a Node; connect only from the main thread. Ephemeral executors
+	// created on WorkerThreadPool (e.g. get_guide) must not touch EFS signals.
+	if (Thread::is_main_thread() && EditorFileSystem::get_singleton()) {
 		const Callable cb = callable_mp_static(&JustAMCPResourceExecutor::_on_filesystem_changed);
 		if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", cb)) {
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", cb);
@@ -113,7 +116,7 @@ void JustAMCPResourceExecutor::_on_filesystem_changed() {
 }
 
 JustAMCPResourceExecutor::~JustAMCPResourceExecutor() {
-	if (EditorFileSystem::get_singleton()) {
+	if (Thread::is_main_thread() && EditorFileSystem::get_singleton()) {
 		const Callable cb = callable_mp_static(&JustAMCPResourceExecutor::_on_filesystem_changed);
 		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", cb)) {
 			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", cb);

--- a/modules/justamcp/tools/justamcp_resource_tools_io.cpp
+++ b/modules/justamcp/tools/justamcp_resource_tools_io.cpp
@@ -45,6 +45,7 @@
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
 #include "core/io/resource_saver.h"
+#include "core/os/thread.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
@@ -221,7 +222,7 @@ void JustAMCPResourceTools::_list_resources_recursive(const String &p_path, cons
 				item["extension"] = ext;
 				if (!p_type_filter.is_empty()) {
 					String efs_type;
-					if (EditorFileSystem::get_singleton()) {
+					if (Thread::is_main_thread() && EditorFileSystem::get_singleton()) {
 						efs_type = EditorFileSystem::get_singleton()->get_file_type(full_path);
 					}
 					if (!efs_type.is_empty()) {
@@ -408,14 +409,15 @@ Dictionary JustAMCPResourceTools::edit_resource_file(const Dictionary &p_args) {
 		_set_resource_properties(resource, p_args["properties"]);
 	}
 	Error err = ResourceSaver::save(resource, res_path);
-	_refresh_filesystem(res_path);
 
 	Dictionary ret;
 	ret["ok"] = err == OK;
 	ret["path"] = res_path;
 	if (err != OK) {
 		ret["error"] = "Failed to save resource: " + itos(err);
+		return ret;
 	}
+	_refresh_filesystem(res_path);
 	return ret;
 }
 
@@ -490,7 +492,6 @@ Dictionary JustAMCPResourceTools::save_resource_as(const Dictionary &p_args) {
 		DirAccess::make_dir_recursive_absolute(dir_path);
 	}
 	Error err = ResourceSaver::save(resource, dest_path);
-	_refresh_filesystem(dest_path);
 
 	Dictionary ret;
 	ret["ok"] = err == OK;
@@ -498,7 +499,9 @@ Dictionary JustAMCPResourceTools::save_resource_as(const Dictionary &p_args) {
 	ret["path"] = dest_path;
 	if (err != OK) {
 		ret["error"] = "Failed to save resource: " + itos(err);
+		return ret;
 	}
+	_refresh_filesystem(dest_path);
 	return ret;
 }
 
@@ -529,10 +532,22 @@ Dictionary JustAMCPResourceTools::get_resource_dependencies(const Dictionary &p_
 Dictionary JustAMCPResourceTools::import_asset_copy(const Dictionary &p_args) {
 	String source_path = p_args.get("source_path", "");
 	String dest_path = _ensure_res_path(p_args.get("dest_path", ""));
-	if (source_path.is_empty() || dest_path == "res://") {
+	if (source_path.is_empty() || dest_path == "res://" || dest_path == "res://test") {
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "source_path and dest_path are required.";
+		return ret;
+	}
+	if (dest_path.get_file().is_empty() || dest_path.get_extension().is_empty() || DirAccess::dir_exists_absolute(dest_path)) {
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "dest_path must be a file path with an extension, not a directory: " + dest_path;
+		return ret;
+	}
+	if (!FileAccess::exists(source_path)) {
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "source_path not found: " + source_path;
 		return ret;
 	}
 	String dir_path = dest_path.get_base_dir();
@@ -540,7 +555,6 @@ Dictionary JustAMCPResourceTools::import_asset_copy(const Dictionary &p_args) {
 		DirAccess::make_dir_recursive_absolute(dir_path);
 	}
 	Error err = DirAccess::copy_absolute(source_path, dest_path);
-	_refresh_filesystem(dest_path);
 
 	Dictionary ret;
 	ret["ok"] = err == OK;
@@ -548,7 +562,9 @@ Dictionary JustAMCPResourceTools::import_asset_copy(const Dictionary &p_args) {
 	ret["destination"] = dest_path;
 	if (err != OK) {
 		ret["error"] = "Failed to copy asset: " + itos(err);
+		return ret;
 	}
+	_refresh_filesystem(dest_path);
 	return ret;
 }
 
@@ -610,17 +626,24 @@ Dictionary JustAMCPResourceTools::manage_resource_autoloads(const Dictionary &p_
 
 Dictionary JustAMCPResourceTools::resource_import_asset(const Dictionary &p_args) {
 	String res_path = _ensure_res_path(p_args.get("path", ""));
-	if (res_path == "res://") {
+	if (res_path == "res://" || res_path == "res://test") {
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "path is required for import_asset.";
+		return ret;
+	}
+	if (res_path.get_file().is_empty() || res_path.get_extension().is_empty() || DirAccess::dir_exists_absolute(res_path)) {
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "path must be a file with an extension, not a directory: " + res_path;
 		return ret;
 	}
 
 	if (editor_plugin && editor_plugin->get_editor_interface() && EditorFileSystem::get_singleton()) {
 		Vector<String> files;
 		files.push_back(res_path);
-		EditorFileSystem::get_singleton()->reimport_files(files);
+		// Always defer: sync reimport during process_frame tool drain freezes the editor.
+		EditorFileSystem::get_singleton()->call_deferred(SNAME("reimport_files"), files);
 		Dictionary ret;
 		ret["ok"] = true;
 		ret["path"] = res_path;

--- a/modules/justamcp/tools/justamcp_scene_tools.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools.cpp
@@ -458,7 +458,12 @@ void JustAMCPSceneTools::_ensure_parent_dir_for_scene(const String &p_scene_path
 }
 
 void JustAMCPSceneTools::_set_owner_recursive(Node *p_node, Node *p_scene_owner) {
-	p_node->set_owner(p_scene_owner);
+	if (!p_node || !p_scene_owner) {
+		return;
+	}
+	if (p_node == p_scene_owner || p_scene_owner->is_ancestor_of(p_node)) {
+		p_node->set_owner(p_scene_owner);
+	}
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *child = p_node->get_child(i);
 		_set_owner_recursive(child, p_scene_owner);

--- a/modules/justamcp/tools/justamcp_scene_tools_mutations_nodes.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools_mutations_nodes.cpp
@@ -122,6 +122,17 @@ Dictionary JustAMCPSceneTools::add_node(const Dictionary &p_args) {
 	new_node->set_name(node_name);
 	_set_node_properties(new_node, properties);
 
+	if (parent != root && !root->is_ancestor_of(parent)) {
+		memdelete(new_node);
+		if (!is_active) {
+			memdelete(root);
+		}
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "Parent must be inside the scene tree rooted at the edited scene";
+		return ret;
+	}
+
 	if (is_active) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("AI Local: Add Node"), UndoRedo::MERGE_DISABLE, parent);
@@ -323,8 +334,9 @@ Dictionary JustAMCPSceneTools::delete_node(const Dictionary &p_args) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("AI Local: Delete Node"), UndoRedo::MERGE_DISABLE, node);
 		ur->add_do_method(parent, "remove_child", node);
-		ur->add_undo_method(parent, "add_child", node, true);
+		// Undo runs reverse of registration: add_child must run before set_owner.
 		ur->add_undo_method(node, "set_owner", root);
+		ur->add_undo_method(parent, "add_child", node, true);
 		ur->add_undo_reference(node);
 		ur->commit_action(true);
 	} else {
@@ -385,6 +397,16 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 		return ret;
 	}
 
+	if (source == root) {
+		if (!is_active) {
+			memdelete(root);
+		}
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "Cannot duplicate the scene root; choose a child node_path";
+		return ret;
+	}
+
 	Node *target_parent = source->get_parent();
 	if (!parent_path.is_empty()) {
 		target_parent = _find_node(root, parent_path);
@@ -396,6 +418,15 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 		Dictionary ret;
 		ret["ok"] = false;
 		ret["error"] = "Parent not found: " + parent_path;
+		return ret;
+	}
+	if (target_parent != root && !root->is_ancestor_of(target_parent)) {
+		if (!is_active) {
+			memdelete(root);
+		}
+		Dictionary ret;
+		ret["ok"] = false;
+		ret["error"] = "Parent must be inside the scene tree rooted at the edited scene";
 		return ret;
 	}
 
@@ -416,7 +447,9 @@ Dictionary JustAMCPSceneTools::duplicate_node(const Dictionary &p_args) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("AI Local: Duplicate Node"), UndoRedo::MERGE_DISABLE, duplicated_node);
 		ur->add_do_method(target_parent, "add_child", duplicated_node, true);
-		ur->add_do_method(duplicated_node, "set_owner", root);
+		if (root->is_ancestor_of(target_parent) || target_parent == root) {
+			ur->add_do_method(duplicated_node, "set_owner", root);
+		}
 		ur->add_do_reference(duplicated_node);
 		ur->add_undo_method(target_parent, "remove_child", duplicated_node);
 		ur->commit_action(true);

--- a/modules/justamcp/tools/justamcp_scene_tools_read.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools_read.cpp
@@ -376,7 +376,12 @@ Dictionary JustAMCPSceneTools::list_connections(const Dictionary &p_args) {
 				Object *target_obj = callable.get_object();
 				String target_path = "";
 				if (target_obj && Object::cast_to<Node>(target_obj)) {
-					target_path = root->get_path_to(Object::cast_to<Node>(target_obj));
+					Node *target_node = Object::cast_to<Node>(target_obj);
+					if (target_node == root || root->is_ancestor_of(target_node)) {
+						target_path = root->get_path_to(target_node);
+					} else {
+						target_path = String(target_node->get_name());
+					}
 				}
 				Dictionary c_info;
 				c_info["sourceNodePath"] = path;

--- a/modules/justamcp/tools/justamcp_script_tools.cpp
+++ b/modules/justamcp/tools/justamcp_script_tools.cpp
@@ -366,8 +366,12 @@ Dictionary JustAMCPScriptTools::_delete_script(const Dictionary &p_params) {
 		return MCP_INVALID_PARAMS("Missing param: path");
 	}
 	String path = p_params["path"];
+	const String ext = path.get_extension().to_lower();
+	if (ext != "gd" && ext != "cs") {
+		return MCP_INVALID_PARAMS("delete_script path must be a script file (.gd, .cs)");
+	}
 	const String main_scene = ProjectSettings::get_singleton() ? String(ProjectSettings::get_singleton()->get_setting("application/run/main_scene", "")) : String();
-	if (path == "res://project.godot" || path == "res://export_presets.cfg" || path == "res://main.gd" || (!main_scene.is_empty() && path == main_scene.get_basename() + ".gd")) {
+	if (path == "res://project.godot" || path == "res://export_presets.cfg" || path == "res://main.gd" || path == "res://main.tscn" || (!main_scene.is_empty() && (path == main_scene || path == main_scene.get_basename() + ".gd"))) {
 		return MCP_ERROR(-32000, "Refusing to delete protected project path: " + path);
 	}
 	if (!FileAccess::exists(path)) {
@@ -433,7 +437,7 @@ Dictionary JustAMCPScriptTools::_attach_script(const Dictionary &p_params) {
 		}
 		node->set_script(loaded_script);
 		Dictionary res;
-		res["node_path"] = root->get_path_to(node);
+		res["node_path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 		res["script_path"] = script_path;
 		res["attached"] = true;
 		return MCP_SUCCESS(res);
@@ -507,7 +511,7 @@ Dictionary JustAMCPScriptTools::_detach_script(const Dictionary &p_params) {
 	}
 	node->set_script(Variant());
 	Dictionary res;
-	res["node_path"] = root->get_path_to(node);
+	res["node_path"] = JustAMCPEditorSceneAccess::safe_path_to(root, node);
 	res["detached"] = true;
 	return MCP_SUCCESS(res);
 }

--- a/modules/justamcp/tools/justamcp_shader_tools.cpp
+++ b/modules/justamcp/tools/justamcp_shader_tools.cpp
@@ -44,6 +44,10 @@
 
 #include "../justamcp_mcp_tool_macros.h"
 
+static bool _justamcp_is_shader_path(const String &p_path) {
+	return p_path.get_extension().to_lower() == "gdshader" || p_path.get_extension().to_lower() == "gdshaderinc";
+}
+
 JustAMCPShaderTools::JustAMCPShaderTools() {
 }
 
@@ -89,6 +93,12 @@ Dictionary JustAMCPShaderTools::create_shader(const Dictionary &p_params) {
 		return MCP_INVALID_PARAMS("Missing path");
 	}
 	String path = p_params["path"];
+	if (!_justamcp_is_shader_path(path)) {
+		return MCP_INVALID_PARAMS("Shader path must end with .gdshader or .gdshaderinc");
+	}
+	if (path.ends_with(".tscn") || path.ends_with(".tres") || path == "res://main.tscn") {
+		return MCP_ERROR(-32000, "Refusing to overwrite non-shader path: " + path);
+	}
 	String content = p_params.has("content") ? String(p_params["content"]) : "";
 	String shader_type = p_params.has("shader_type") ? String(p_params["shader_type"]) : "spatial";
 
@@ -132,6 +142,9 @@ Dictionary JustAMCPShaderTools::read_shader(const Dictionary &p_params) {
 		return MCP_INVALID_PARAMS("Missing path");
 	}
 	String path = p_params["path"];
+	if (!_justamcp_is_shader_path(path)) {
+		return MCP_INVALID_PARAMS("Shader path must end with .gdshader or .gdshaderinc");
+	}
 
 	if (!FileAccess::exists(path)) {
 		return MCP_ERROR(-32000, "Shader not found: " + path);
@@ -159,6 +172,9 @@ Dictionary JustAMCPShaderTools::edit_shader(const Dictionary &p_params) {
 		return MCP_INVALID_PARAMS("Missing path");
 	}
 	String path = p_params["path"];
+	if (!_justamcp_is_shader_path(path)) {
+		return MCP_INVALID_PARAMS("Shader path must end with .gdshader or .gdshaderinc");
+	}
 
 	if (!FileAccess::exists(path)) {
 		return MCP_ERROR(-32000, "Shader not found: " + path);
@@ -167,11 +183,15 @@ Dictionary JustAMCPShaderTools::edit_shader(const Dictionary &p_params) {
 	int changes_made = 0;
 
 	if (p_params.has("content")) {
+		const String content = p_params["content"];
+		if (content.is_empty()) {
+			return MCP_INVALID_PARAMS("content must be non-empty when replacing shader source");
+		}
 		Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE);
 		if (file.is_null()) {
 			return MCP_ERROR(-32000, "Cannot write shader: " + path);
 		}
-		file->store_string(p_params["content"]);
+		file->store_string(content);
 		file->close();
 		changes_made = 1;
 	} else if (p_params.has("replacements") && p_params["replacements"].get_type() == Variant::ARRAY) {

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -114,6 +114,30 @@ void JustAMCPToolExecutor::set_as_active_instance() {
 	active_instance = this;
 }
 
+void JustAMCPToolExecutor::track_worker_task(WorkerThreadPool::TaskID p_task_id) {
+	if (p_task_id == WorkerThreadPool::INVALID_TASK_ID) {
+		return;
+	}
+	MutexLock lock(pending_worker_task_mutex);
+	pending_worker_task_ids.push_back(p_task_id);
+}
+
+void JustAMCPToolExecutor::_wait_for_tracked_worker_tasks() {
+	Vector<WorkerThreadPool::TaskID> ids;
+	{
+		MutexLock lock(pending_worker_task_mutex);
+		ids = pending_worker_task_ids;
+		pending_worker_task_ids.clear();
+	}
+	WorkerThreadPool *pool = WorkerThreadPool::get_singleton();
+	if (!pool) {
+		return;
+	}
+	for (int i = 0; i < ids.size(); i++) {
+		pool->wait_for_task_completion(ids[i]);
+	}
+}
+
 void JustAMCPToolExecutor::set_test_scene_root(Node *p_node) {
 	test_scene_root = p_node;
 }
@@ -129,9 +153,12 @@ JustAMCPToolExecutor::JustAMCPToolExecutor() {
 }
 
 JustAMCPToolExecutor::~JustAMCPToolExecutor() {
+	// Stop accepting new worker jobs that would capture this pointer, then drain
+	// in-flight WorkerThreadPool tasks before tearing member tools down.
 	if (active_instance == this) {
 		active_instance = nullptr;
 	}
+	_wait_for_tracked_worker_tasks();
 	if (scene_tools) {
 		memdelete(scene_tools);
 	}

--- a/modules/justamcp/tools/justamcp_tool_executor.h
+++ b/modules/justamcp/tools/justamcp_tool_executor.h
@@ -31,6 +31,9 @@
 
 #include "core/object/class_db.h"
 #include "core/object/object.h"
+#include "core/object/worker_thread_pool.h"
+#include "core/os/mutex.h"
+#include "core/templates/vector.h"
 #include "scene/main/node.h"
 
 class JustAMCPEditorPlugin;
@@ -113,7 +116,11 @@ private:
 	bool initialized = false;
 	bool allow_disabled_dispatch = false;
 
+	Mutex pending_worker_task_mutex;
+	Vector<WorkerThreadPool::TaskID> pending_worker_task_ids;
+
 	void _init_tools();
+	void _wait_for_tracked_worker_tasks();
 
 protected:
 	static void _bind_methods();
@@ -135,6 +142,7 @@ public:
 	static JustAMCPToolExecutor *active_instance;
 	static JustAMCPToolExecutor *get_active_instance();
 	void set_as_active_instance();
+	void track_worker_task(WorkerThreadPool::TaskID p_task_id);
 
 	static Node *test_scene_root;
 	static void set_test_scene_root(Node *p_node);

--- a/modules/justamcp/tools/resources/justamcp_materials_resource_provider.cpp
+++ b/modules/justamcp/tools/resources/justamcp_materials_resource_provider.cpp
@@ -33,6 +33,7 @@
 
 #include "../../justamcp_pagination.h"
 #include "core/io/json.h"
+#include "core/os/thread.h"
 #include "editor/editor_file_system.h"
 
 static Dictionary g_materials_cache_payload;
@@ -73,7 +74,7 @@ static void _collect_materials_from_efs(EditorFileSystemDirectory *p_dir, Array 
 
 static void _rebuild_materials_cache() {
 	Array materials;
-	if (EditorFileSystem::get_singleton() && EditorFileSystem::get_singleton()->get_filesystem()) {
+	if (Thread::is_main_thread() && EditorFileSystem::get_singleton() && EditorFileSystem::get_singleton()->get_filesystem()) {
 		_collect_materials_from_efs(EditorFileSystem::get_singleton()->get_filesystem(), materials);
 	}
 	g_materials_cache_payload["materials"] = materials;

--- a/modules/semanticsearch/semantic_embedding_pipeline.cpp
+++ b/modules/semanticsearch/semantic_embedding_pipeline.cpp
@@ -37,6 +37,7 @@
 #include "modules/modules_enabled.gen.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/os/thread.h"
 #include "editor/editor_file_system.h"
 #endif
 
@@ -53,7 +54,7 @@ void _fill_text_fields_from_path(const String &p_path, SemanticAssetEntry &r_ent
 	r_entry.asset_class = String();
 	r_entry.path_segments = String();
 #ifdef TOOLS_ENABLED
-	if (EditorFileSystem::get_singleton()) {
+	if (Thread::is_main_thread() && EditorFileSystem::get_singleton()) {
 		r_entry.asset_class = EditorFileSystem::get_singleton()->get_file_type(p_path);
 		if (!r_entry.asset_class.is_empty()) {
 			r_entry.caption += " " + r_entry.asset_class;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1398,18 +1398,8 @@ Color DisplayServerWindows::screen_get_pixel(const Point2i &p_position) const {
 }
 
 Ref<Image> DisplayServerWindows::screen_get_image(int p_screen) const {
+	p_screen = _get_screen_index(p_screen);
 	ERR_FAIL_INDEX_V(p_screen, get_screen_count(), Ref<Image>());
-
-	switch (p_screen) {
-		case SCREEN_PRIMARY: {
-			p_screen = get_primary_screen();
-		} break;
-		case SCREEN_OF_MAIN_WINDOW: {
-			p_screen = window_get_current_screen(MAIN_WINDOW_ID);
-		} break;
-		default:
-			break;
-	}
 
 	Point2i pos = screen_get_position(p_screen) + _get_screens_origin();
 	Size2i size = screen_get_size(p_screen);


### PR DESCRIPTION
## Summary
- Fix Streamable HTTP handshake / client config presets so MCP clients can connect reliably.
- Keep the editor responsive during tool bursts (cooperative wait, deferred EFS scan/reimport, early settings registration).
- Quiet remaining Output-panel spam: main-thread-only ResourceExecutor EFS connect, quiet plain-string project-setting JSON parse, centralized `safe_path_to`, and guarded `import_asset` paths.

## Test plan
- [x] `pre-commit run --files` on all branch changes (clang-format, codespell, copyright-headers, header-guards, file-format)
- [x] `--doctool .` — no class-reference diff
- [x] `doc_status.py` on JustAMCP docs — 100% / All OK
- [x] `make_rst.py --dry-run` — no XML class reference errors
- [x] `--test-case=*JustAMCP*` — 243/243 passed
- [ ] Live scratch MCP on port 6507; confirm banlist empty for Caller-thread EFS / Parse JSON JustAMCP / common_parent / importer type ''
