### PR TITLE
Use 7z to create web template ZIP archives (#412)

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -52,6 +52,11 @@ jobs:
         run: |
           emcc -v
 
+      - name: Install p7zip for web template ZIP compression
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
+
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore
         with:

--- a/misc/scripts/make_icons.sh
+++ b/misc/scripts/make_icons.sh
@@ -12,7 +12,17 @@ done
 # 16px tga file for library
 convert icon16.png icon16.tga
 
-# zip for Linux
-zip blazium-icons.zip icon*.png
+# zip for Linux (7z ZIP for better DEFLATE; OS-native .zip format)
+SEVENZ=""
+if command -v 7z >/dev/null 2>&1; then
+  SEVENZ="7z"
+elif command -v 7za >/dev/null 2>&1; then
+  SEVENZ="7za"
+else
+  echo "Error: 7z/7za required to create blazium-icons.zip" >&2
+  exit 1
+fi
+rm -f blazium-icons.zip
+"$SEVENZ" a -tzip -bso0 -bd -mx=9 blazium-icons.zip icon*.png
 
 rm -f icon*.png

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -1,5 +1,7 @@
 import json
 import os
+import shutil
+import subprocess
 
 from SCons.Util import WhereIs
 
@@ -117,12 +119,30 @@ def create_template_zip(env, js, wasm, side):
         out_files.append(zip_dir.File(binary_name + ".youtube.playables.js"))
 
     zip_files = env.InstallAs(out_files, in_files)
-    env.Zip(
-        "#bin/blazium",
-        zip_files,
-        ZIPROOT=zip_dir,
-        ZIPSUFFIX="${PROGSUFFIX}${ZIPSUFFIX}",
-    )
+
+    # Prefer 7z-created ZIP (better DEFLATE) over SCons Zip / Info-ZIP; keep .zip format.
+    zip_root_path = zip_dir.get_abspath()
+
+    def zip_with_7z(target, source, env):
+        sevenz = shutil.which("7z") or shutil.which("7za")
+        if not sevenz:
+            raise RuntimeError(
+                "7z/7za is required to create web template ZIP archives. "
+                "Install p7zip-full (Linux) or sevenzip (Homebrew)."
+            )
+        archive = target[0].get_abspath()
+        if os.path.isfile(archive):
+            os.remove(archive)
+        subprocess.check_call(
+            [sevenz, "a", "-tzip", "-bso0", "-bd", "-mx=9", archive, "."],
+            cwd=zip_root_path,
+        )
+
+    # Same naming as former env.Zip(..., ZIPSUFFIX="${PROGSUFFIX}${ZIPSUFFIX}").
+    if "ZIPSUFFIX" not in env:
+        env["ZIPSUFFIX"] = ".zip"
+    zip_target = "#bin/blazium${PROGSUFFIX}${ZIPSUFFIX}"
+    env.Command(zip_target, zip_files, env.Action(zip_with_7z, "Compressing $TARGET with 7z..."))
 
 
 def get_template_zip_path(env):


### PR DESCRIPTION
## Summary
- Create web export/editor template ZIPs with `7z a -tzip -mx=9` instead of SCons `env.Zip` (standard ZIP format, stronger DEFLATE).
- Update `misc/scripts/make_icons.sh` to the same 7z ZIP flags.
- Install `p7zip-full` in `.github/workflows/web_builds.yml` so CI has `7z`/`7za`.

Fixes https://github.com/blazium-games/blazium/issues/412

Packaging companion PR: https://github.com/blazium-games/ci_cd/pull/49