### PR TITLE
Add ColdStorage editor VCS module for public service release

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -450,6 +450,51 @@
 		<member name="blazium/autowork/e2e_enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the Autowork framework will boot its WebSocket E2E server on startup, enabling orchestration from standard web runners (e.g. Playwright, Jest, Cypress).
 		</member>
+		<member name="blazium/coldstorage/auto_pull" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], runs [code]syncAll("#head")[/code] after a successful ColdStorage connect (or when [code]--coldstorage-auto-pull[/code] is passed).
+		</member>
+		<member name="blazium/coldstorage/autoload_on_startup" type="bool" setter="" getter="" default="false">
+			If [code]true[/code] and [member blazium/coldstorage/enabled] is also [code]true[/code], connects ColdStorage when the editor becomes ready.
+		</member>
+		<member name="blazium/coldstorage/ca_file" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional path to a CA certificate file used when [member blazium/coldstorage/use_tls] is [code]true[/code].
+		</member>
+		<member name="blazium/coldstorage/enabled" type="bool" setter="" getter="" default="false">
+			Master enable for the ColdStorage editor integration.
+		</member>
+		<member name="blazium/coldstorage/host" type="String" setter="" getter="" default="&quot;127.0.0.1&quot;">
+			ColdStorage server hostname or IP address.
+		</member>
+		<member name="blazium/coldstorage/override_editor_settings" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], Project Settings values override Editor Settings for ColdStorage connection options. Secrets (password, ticket, JWT) always stay in Editor Settings and are never written to [code]project.godot[/code].
+		</member>
+		<member name="blazium/coldstorage/port" type="int" setter="" getter="" default="1666">
+			ColdStorage server TCP port.
+		</member>
+		<member name="blazium/coldstorage/repo" type="String" setter="" getter="" default="&quot;default&quot;">
+			Repository name scoped on the ColdStorage server.
+		</member>
+		<member name="blazium/coldstorage/tls_insecure" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], skips TLS peer certificate verification (development only).
+		</member>
+		<member name="blazium/coldstorage/use_tls" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], connects to ColdStorage over TLS.
+		</member>
+		<member name="blazium/coldstorage/user" type="String" setter="" getter="" default="&quot;&quot;">
+			Username for ColdStorage login.
+		</member>
+		<member name="blazium/coldstorage/validate_on_startup" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], calls server [code]info()[/code] after connect and reports failure if validation fails.
+		</member>
+		<member name="blazium/coldstorage/workspace" type="String" setter="" getter="" default="&quot;default&quot;">
+			Workspace name used for the ColdStorage client session.
+		</member>
+		<member name="blazium/coldstorage/workspace_root" type="String" setter="" getter="" default="&quot;&quot;">
+			Local workspace root path. When empty, the project resource directory is used.
+		</member>
+		<member name="blazium/coldstorage/z_connection_controls" type="String" setter="" getter="" default="&quot;&quot;">
+			Sentinel property that injects ColdStorage connection controls into the settings inspector. Not meant to be edited directly.
+		</member>
 		<member name="blazium/justamcp/accepted_protocol_versions" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional comma-separated allowlist of MCP protocol versions this process will serve. Empty accepts every implemented version ([code]2026-07-28[/code] through [code]2024-11-05[/code]).
 		</member>

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -376,5 +376,23 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 			f->store_line("# Normalize EOL for all files that Git considers text files.");
 			f->store_line("* text=auto eol=lf");
 		}
+	} else if (p_vcs_metadata_type == VCSMetadata::COLDSTORAGE) {
+		Ref<FileAccess> f = FileAccess::open(p_dir.path_join(".csignore"), FileAccess::WRITE);
+		if (f.is_null()) {
+			ERR_FAIL_MSG("Couldn't create .csignore in project path.");
+		} else {
+			f->store_line("# Blazium / Godot 4+ specific ignores");
+			f->store_line(".godot/");
+			f->store_line("/android/");
+			f->store_line("*.translation");
+		}
+		f = FileAccess::open(p_dir.path_join(".cstorage"), FileAccess::WRITE);
+		if (f.is_null()) {
+			ERR_FAIL_MSG("Couldn't create .cstorage in project path.");
+		} else {
+			f->store_line("# ColdStorage workspace metadata (edit via Project > ColdStorage Configuration)");
+			f->store_line("workspace=default");
+			f->store_line("repo=default");
+		}
 	}
 }

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -97,6 +97,7 @@ protected:
 	static void _bind_methods();
 
 	DiffLine _convert_diff_line(const Dictionary &p_diff_line);
+	// Available to native in-tree providers that override the public API.
 	DiffHunk _convert_diff_hunk(const Dictionary &p_diff_hunk);
 	DiffFile _convert_diff_file(const Dictionary &p_diff_file);
 	Commit _convert_commit(const Dictionary &p_commit);
@@ -134,33 +135,35 @@ public:
 	enum class VCSMetadata {
 		NONE,
 		GIT,
+		COLDSTORAGE,
 	};
 	static void create_vcs_metadata_files(VCSMetadata p_vcs_metadata_type, String &p_dir);
 
-	// Proxies to the editor for use
-	bool initialize(const String &p_project_path);
-	void set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key_path, const String &p_ssh_private_key_path, const String &p_ssh_passphrase);
-	List<StatusFile> get_modified_files_data();
-	void stage_file(const String &p_file_path);
-	void unstage_file(const String &p_file_path);
-	void discard_file(const String &p_file_path);
-	void commit(const String &p_msg);
-	List<DiffFile> get_diff(const String &p_identifier, TreeArea p_area);
-	bool shut_down();
-	String get_vcs_name();
-	List<Commit> get_previous_commits(int p_max_commits);
-	List<String> get_branch_list();
-	List<String> get_remotes();
-	void create_branch(const String &p_branch_name);
-	void remove_branch(const String &p_branch_name);
-	void create_remote(const String &p_remote_name, const String &p_remote_url);
-	void remove_remote(const String &p_remote_name);
-	String get_current_branch_name();
-	bool checkout_branch(const String &p_branch_name);
-	void pull(const String &p_remote);
-	void push(const String &p_remote, bool p_force);
-	void fetch(const String &p_remote);
-	List<DiffHunk> get_line_diff(const String &p_file_path, const String &p_text);
+	// Proxies to the editor for use. Virtual so in-tree native providers (e.g. ColdStorage)
+	// can override; GDExtension/script providers continue via GDVIRTUAL in the base impl.
+	virtual bool initialize(const String &p_project_path);
+	virtual void set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key_path, const String &p_ssh_private_key_path, const String &p_ssh_passphrase);
+	virtual List<StatusFile> get_modified_files_data();
+	virtual void stage_file(const String &p_file_path);
+	virtual void unstage_file(const String &p_file_path);
+	virtual void discard_file(const String &p_file_path);
+	virtual void commit(const String &p_msg);
+	virtual List<DiffFile> get_diff(const String &p_identifier, TreeArea p_area);
+	virtual bool shut_down();
+	virtual String get_vcs_name();
+	virtual List<Commit> get_previous_commits(int p_max_commits);
+	virtual List<String> get_branch_list();
+	virtual List<String> get_remotes();
+	virtual void create_branch(const String &p_branch_name);
+	virtual void remove_branch(const String &p_branch_name);
+	virtual void create_remote(const String &p_remote_name, const String &p_remote_url);
+	virtual void remove_remote(const String &p_remote_name);
+	virtual String get_current_branch_name();
+	virtual bool checkout_branch(const String &p_branch_name);
+	virtual void pull(const String &p_remote);
+	virtual void push(const String &p_remote, bool p_force);
+	virtual void fetch(const String &p_remote);
+	virtual List<DiffHunk> get_line_diff(const String &p_file_path, const String &p_text);
 
 	// Helper functions to create and convert Dictionary into data structures
 	Dictionary create_diff_line(int p_new_line_no, int p_old_line_no, const String &p_content, const String &p_status);

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -969,6 +969,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	metadata_selection->set_custom_minimum_size(Size2(100, 20));
 	metadata_selection->add_item("None", (int)EditorVCSInterface::VCSMetadata::NONE);
 	metadata_selection->add_item("Git", (int)EditorVCSInterface::VCSMetadata::GIT);
+	metadata_selection->add_item("ColdStorage", (int)EditorVCSInterface::VCSMetadata::COLDSTORAGE);
 	metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
 	metadata_hb->add_child(metadata_selection);
 

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -1022,6 +1022,7 @@ ProjectDialog::ProjectDialog() {
 	vcs_metadata_selection->set_custom_minimum_size(Size2(100, 20));
 	vcs_metadata_selection->add_item(TTR("None"), (int)EditorVCSInterface::VCSMetadata::NONE);
 	vcs_metadata_selection->add_item(TTR("Git"), (int)EditorVCSInterface::VCSMetadata::GIT);
+	vcs_metadata_selection->add_item(TTR("ColdStorage"), (int)EditorVCSInterface::VCSMetadata::COLDSTORAGE);
 	vcs_metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
 	default_files_container->add_child(vcs_metadata_selection);
 	Control *spacer = memnew(Control);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -664,7 +664,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--create-project <path>", "Create a new project at the given path and exit.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--name <name>", "Project display name (used with --create-project).\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--renderer <type>", "Renderer: forward_plus, mobile, or gl_compatibility (used with --create-project).\n", CLI_OPTION_AVAILABILITY_EDITOR);
-	print_help_option("--vcs <none|git>", "Version control metadata to generate (used with --create-project).\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--vcs <none|git|coldstorage>", "Version control metadata to generate (used with --create-project).\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--force", "Allow creating a project in a non-empty directory (used with --create-project).\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--edit", "Open the newly created project in the editor (used with --create-project).\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--dump-gdextension-interface", "Generate a GDExtension header file \"gdextension_interface.h\" in the current folder. This file is the base file required to implement a GDExtension.\n", CLI_OPTION_AVAILABILITY_EDITOR);
@@ -1943,8 +1943,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 #ifdef TOOLS_ENABLED
 	if (create_project_cli) {
-		if (create_project_vcs != "none" && create_project_vcs != "git") {
-			OS::get_singleton()->print("Invalid --vcs value. Expected none or git.\n");
+		if (create_project_vcs != "none" && create_project_vcs != "git" && create_project_vcs != "coldstorage") {
+			OS::get_singleton()->print("Invalid --vcs value. Expected none, git, or coldstorage.\n");
 			goto error;
 		}
 
@@ -3911,6 +3911,8 @@ int Main::start() {
 		options.allow_nonempty = create_project_force;
 		if (create_project_vcs == "none") {
 			options.vcs = EditorVCSInterface::VCSMetadata::NONE;
+		} else if (create_project_vcs == "coldstorage") {
+			options.vcs = EditorVCSInterface::VCSMetadata::COLDSTORAGE;
 		} else {
 			options.vcs = EditorVCSInterface::VCSMetadata::GIT;
 		}

--- a/modules/coldstorage/SCsub
+++ b/modules/coldstorage/SCsub
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+import os
+import sys
+
+Import("env")
+Import("env_modules")
+
+# Shared resolver from config.py (same module directory).
+sys.path.insert(0, Dir(".").abspath)
+from config import resolve_coldstorage_sdk_path  # noqa: E402
+
+env_cs = env_modules.Clone()
+
+
+def enable_exceptions(target_env):
+    # ColdStorage SDK uses C++ exceptions.
+    if env.msvc:
+        target_env.Append(CXXFLAGS=["/EHsc"])
+        target_env["CPPDEFINES"] = [
+            d for d in target_env["CPPDEFINES"] if not (isinstance(d, tuple) and d[0] == "_HAS_EXCEPTIONS")
+        ]
+        target_env.Append(CPPDEFINES=[("_HAS_EXCEPTIONS", 1)])
+    else:
+        if "-fno-exceptions" in target_env["CXXFLAGS"]:
+            target_env["CXXFLAGS"].remove("-fno-exceptions")
+        target_env.Append(CXXFLAGS=["-fexceptions"])
+
+
+module_dir = Dir(".").abspath
+cs_path = env.get("coldstorage_sdk_resolved", "")
+if not cs_path:
+    cs_path = resolve_coldstorage_sdk_path(env, Dir("#").abspath, module_dir)
+if not cs_path or not os.path.isdir(os.path.join(cs_path, "src", "client", "sdk")):
+    print("modules/coldstorage: ColdStorage SDK not found; module should have been disabled by can_build().")
+    Return()
+
+cs_src = os.path.join(cs_path, "src")
+shim_dir = os.path.join(module_dir, "sdk_shims")
+
+env_cs.Prepend(
+    CPPPATH=[
+        shim_dir,  # mbedtls TLS/crypto/version + nlohmann/json.hpp (engine JSON shim)
+        cs_src,
+        "#thirdparty/zlib",
+        "#thirdparty/mbedtls/include",
+    ]
+)
+env_cs.Append(
+    CPPDEFINES=[
+        "CS_ENABLE_TLS=1",
+    ]
+)
+if env["platform"] == "windows":
+    # Do not redefine _WIN32_WINNT — platform/windows already sets it (clang-cl -Werror).
+    env_cs.Append(
+        CPPDEFINES=[
+            "WIN32_LEAN_AND_MEAN",
+            "NOMINMAX",
+        ]
+    )
+elif env["platform"] == "macos":
+    # std::filesystem needs macOS 10.15+; engine x86_64 default is 10.13.
+    env_cs.Append(CCFLAGS=["-mmacosx-version-min=10.15"])
+
+enable_exceptions(env_cs)
+
+# --- SDK sources (trimmed client + common; TLS/crypto via sdk_shims) ---
+sdk_sources = [
+    os.path.join(cs_src, "client", "sdk", "connection.cpp"),
+    os.path.join(cs_src, "client", "sdk", "client_sdk.cpp"),
+    os.path.join(cs_src, "client", "sdk", "sdk_admin.cpp"),
+    os.path.join(cs_src, "client", "sdk", "sdk_paths.cpp"),
+    os.path.join(cs_src, "client", "sdk", "sdk_print.cpp"),
+    os.path.join(cs_src, "client", "sdk", "sdk_transfer.cpp"),
+    os.path.join(cs_src, "client", "sdk", "workspace.cpp"),
+    os.path.join(cs_src, "client", "sdk", "workspace_filters.cpp"),
+    os.path.join(cs_src, "client", "sdk", "workspace_status.cpp"),
+    os.path.join(cs_src, "client", "sdk", "workspace_view.cpp"),
+    os.path.join(cs_src, "client", "sdk", "trust_store.cpp"),
+    os.path.join(cs_src, "client", "sdk", "tls_trust.cpp"),
+    os.path.join(cs_src, "common", "protocol", "framing.cpp"),
+    os.path.join(cs_src, "common", "protocol", "messages.cpp"),
+    os.path.join(cs_src, "common", "protocol", "session.cpp"),
+    os.path.join(cs_src, "common", "net", "plain_transport.cpp"),
+    os.path.join(cs_src, "common", "ignore", "ignore_matcher.cpp"),
+    os.path.join(cs_src, "common", "ignore", "csignore_parser.cpp"),
+    os.path.join(cs_src, "common", "ignore", "ignore_loader.cpp"),
+    os.path.join(cs_src, "common", "attributes", "attributes_map.cpp"),
+    os.path.join(cs_src, "common", "attributes", "eol_normalize.cpp"),
+    os.path.join(cs_src, "common", "util", "text_diff.cpp"),
+    os.path.join(cs_src, "common", "util", "sync_target.cpp"),
+]
+
+shim_sources = [
+    os.path.join(shim_dir, "common", "util", "crypto.cpp"),
+    os.path.join(shim_dir, "common", "net", "tls_context.cpp"),
+    os.path.join(shim_dir, "common", "net", "tls_transport.cpp"),
+    os.path.join(shim_dir, "common", "net", "tls_cert.cpp"),
+]
+
+sdk_obj = []
+env_sdk = env_cs.Clone()
+env_sdk.disable_warnings()
+enable_exceptions(env_sdk)
+
+# Object outputs under sdk_obj/ so names stay unique across client/common trees.
+sdk_obj_dir = Dir("sdk_obj")
+
+
+def _compile_external(target_env, out_list, paths):
+    for src in paths:
+        parent = os.path.basename(os.path.dirname(src))
+        base = os.path.splitext(os.path.basename(src))[0]
+        tgt = sdk_obj_dir.File(f"{parent}_{base}" + target_env["OBJSUFFIX"])
+        out_list.extend(target_env.Object(target=tgt, source=File(src)))
+
+
+_compile_external(env_sdk, sdk_obj, sdk_sources + shim_sources)
+env.modules_sources += sdk_obj
+
+# --- Module Godot/Blazium wrappers ---
+module_obj = []
+env_mod = env_cs.Clone()
+enable_exceptions(env_mod)
+env_mod.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+env.Depends(module_obj, sdk_obj)
+
+# Windows system libs (ws2_32, bcrypt, crypt32, …) come from platform/windows already.
+# Do not Append LIBS here — after LIBSUFFIX rewrite SCons would look for
+# ws2_32.windows.editor.x86_64.lib and fail the link.
+
+if env["tests"]:
+    env_mod.Append(CPPDEFINES=["TESTS_ENABLED"])

--- a/modules/coldstorage/cold_storage_async.cpp
+++ b/modules/coldstorage/cold_storage_async.cpp
@@ -1,0 +1,252 @@
+/**************************************************************************/
+/*  cold_storage_async.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_async.h"
+
+#include "cold_storage_vcs.h"
+
+// Include Godot headers before the SDK: winsock2.h defines CONNECT/IGNORE, which
+// break Godot enums if those headers are parsed afterward.
+#include "core/object/object.h"
+#include "core/object/worker_thread_pool.h"
+#include "core/os/mutex.h"
+
+#include "client/sdk/client_sdk.h"
+#include "client/sdk/tls_options.h"
+#ifdef CONNECT
+#undef CONNECT
+#endif
+#ifdef IGNORE
+#undef IGNORE
+#endif
+
+#include <exception>
+#include <memory>
+#include <utility>
+
+namespace {
+
+Mutex busy_mutex;
+bool busy = false;
+std::unique_ptr<coldstorage::ColdStorageClient> pending_client;
+
+struct Job {
+	ColdStorageConnectRequest req;
+	bool ok = false;
+	String error;
+	std::unique_ptr<coldstorage::ColdStorageClient> client;
+};
+
+void _cold_storage_async_complete(ObjectID p_caller_id, const StringName &p_method, bool p_ok, const String &p_error, int p_kind);
+
+String _connect_auth(coldstorage::ColdStorageClient &client, const ColdStorageConnectionConfig &cfg, const String &project_path) {
+	coldstorage::TlsOptions tls;
+	tls.enabled = cfg.use_tls;
+	tls.verifyPeer = !cfg.tls_insecure;
+	tls.caFile = String(cfg.ca_file).utf8().get_data();
+
+	const std::string host = String(cfg.host).utf8().get_data();
+	if (!client.connect(host, cfg.port, tls)) {
+		return "Failed to connect to " + cfg.host + ":" + itos(cfg.port);
+	}
+
+	client.setWorkspace(String(cfg.workspace).utf8().get_data());
+	client.setRepo(String(cfg.repo).utf8().get_data());
+
+	String root = cfg.workspace_root;
+	if (root.is_empty()) {
+		root = project_path;
+	}
+	client.setWorkspaceRoot(String(root).utf8().get_data());
+
+	if (!cfg.jwt.is_empty()) {
+		if (!client.authenticateWithJWT(String(cfg.jwt).utf8().get_data())) {
+			client.disconnect();
+			return "JWT authentication failed";
+		}
+	} else if (!cfg.ticket.is_empty()) {
+		client.setTicket(String(cfg.ticket).utf8().get_data());
+	} else if (!cfg.user.is_empty()) {
+		std::string ticket = client.login(String(cfg.user).utf8().get_data(), String(cfg.password).utf8().get_data());
+		if (ticket.empty()) {
+			String err = "Login failed";
+			if (!client.lastError().empty()) {
+				err += ": " + String(client.lastError().c_str());
+			}
+			client.disconnect();
+			return err;
+		}
+	}
+
+	client.ensureWorkspaceView();
+	return String();
+}
+
+void _worker(void *p_userdata) {
+	Job *job = static_cast<Job *>(p_userdata);
+	try {
+		auto client = std::make_unique<coldstorage::ColdStorageClient>();
+		const String auth_err = _connect_auth(*client, job->req.cfg, job->req.project_path);
+		if (!auth_err.is_empty()) {
+			job->ok = false;
+			job->error = auth_err;
+		} else if (job->req.validate) {
+			auto info = client->info();
+			if (info.name.empty() && info.version.empty()) {
+				job->ok = false;
+				job->error = "Server info() failed";
+				if (!client->lastError().empty()) {
+					job->error += ": " + String(client->lastError().c_str());
+				}
+				client->disconnect();
+			} else {
+				job->ok = true;
+			}
+		} else {
+			job->ok = true;
+		}
+
+		if (job->ok && job->req.auto_pull) {
+			auto r = client->syncAll("#head");
+			if (!r.success) {
+				job->ok = false;
+				job->error = String(r.error.c_str());
+				if (job->error.is_empty()) {
+					job->error = "syncAll failed";
+				}
+				client->disconnect();
+			}
+		}
+
+		if (job->ok) {
+			if (job->req.kind == ColdStorageConnectRequest::Kind::TEST_JOB) {
+				client->disconnect();
+				client.reset();
+			} else {
+				job->client = std::move(client);
+			}
+		}
+	} catch (const std::exception &e) {
+		job->ok = false;
+		job->error = String("ColdStorage exception: ") + e.what();
+		job->client.reset();
+	} catch (...) {
+		job->ok = false;
+		job->error = "ColdStorage unknown exception during connect";
+		job->client.reset();
+	}
+
+	{
+		MutexLock lock(busy_mutex);
+		pending_client = std::move(job->client);
+	}
+
+	const ObjectID caller_id = job->req.caller_id;
+	const bool ok = job->ok;
+	const String error = job->error;
+	const int kind = (int)job->req.kind;
+	const StringName method(job->req.complete_method);
+	memdelete(job);
+
+	// Keep busy=true until the main-thread trampoline (or caller) takes/discards.
+	// Completion must not be bound to the caller's lifetime: if the Object is
+	// freed between queue and flush, Object-bound deferred calls are dropped and
+	// busy would latch forever.
+	callable_mp_static(_cold_storage_async_complete).call_deferred(caller_id, method, ok, error, kind);
+}
+
+void _cold_storage_async_complete(ObjectID p_caller_id, const StringName &p_method, bool p_ok, const String &p_error, int p_kind) {
+	Object *caller = ObjectDB::get_instance(p_caller_id);
+	if (caller && p_method != StringName()) {
+		caller->call(p_method, p_ok, p_error, p_kind);
+	}
+
+	// Safety: clear latch if caller was freed or forgot to take/discard.
+	MutexLock lock(busy_mutex);
+	if (busy) {
+		busy = false;
+		if (pending_client) {
+			pending_client->disconnect();
+			pending_client.reset();
+		}
+	}
+}
+
+} //namespace
+
+bool cold_storage_connect_busy() {
+	MutexLock lock(busy_mutex);
+	return busy;
+}
+
+static std::unique_ptr<coldstorage::ColdStorageClient> _take_connected_client() {
+	MutexLock lock(busy_mutex);
+	busy = false;
+	return std::move(pending_client);
+}
+
+void cold_storage_discard_connected_client() {
+	std::unique_ptr<coldstorage::ColdStorageClient> client = _take_connected_client();
+	if (client) {
+		client->disconnect();
+	}
+}
+
+bool cold_storage_has_pending_client() {
+	MutexLock lock(busy_mutex);
+	return pending_client != nullptr;
+}
+
+bool cold_storage_adopt_connected_client_into(ColdStorageVCS *p_vcs, const ColdStorageConnectionConfig &p_cfg, const String &p_project_path) {
+	std::unique_ptr<coldstorage::ColdStorageClient> client = _take_connected_client();
+	if (!p_vcs || !client) {
+		return false;
+	}
+	return p_vcs->adopt_connected_client(std::move(client), p_cfg, p_project_path);
+}
+
+bool cold_storage_begin_connect_async(const ColdStorageConnectRequest &p_request) {
+	{
+		MutexLock lock(busy_mutex);
+		if (busy) {
+			return false;
+		}
+		busy = true;
+		pending_client.reset();
+	}
+
+	Job *job = memnew(Job);
+	job->req = p_request;
+	WorkerThreadPool::get_singleton()->add_native_task(&_worker, job, true, "ColdStorage Connect");
+	return true;
+}
+
+#endif

--- a/modules/coldstorage/cold_storage_async.h
+++ b/modules/coldstorage/cold_storage_async.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  cold_storage_async.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_settings.h"
+#include "core/object/object_id.h"
+#include "core/string/ustring.h"
+
+class ColdStorageVCS;
+
+struct ColdStorageConnectRequest {
+	enum class Kind {
+		CONNECT_JOB,
+		TEST_JOB,
+		STARTUP_JOB,
+	};
+
+	Kind kind = Kind::CONNECT_JOB;
+	ColdStorageConnectionConfig cfg;
+	String project_path;
+	bool validate = true;
+	bool auto_pull = false;
+	ObjectID caller_id;
+	String complete_method; // method(bool ok, String error, int kind) on caller
+};
+
+// Runs connect/login/(validate)/(syncAll) on a worker thread using a bare SDK client.
+// Completion is delivered via call_deferred to the caller Object.
+bool cold_storage_begin_connect_async(const ColdStorageConnectRequest &p_request);
+
+// True while a connect job is in flight (UI/startup busy guard).
+bool cold_storage_connect_busy();
+
+// Discard a pending connected client after async completion (main thread only).
+void cold_storage_discard_connected_client();
+
+// True if async completion left a connected client ready to adopt.
+bool cold_storage_has_pending_client();
+
+// Move a pending connected client into p_vcs (main thread only). Clears busy/pending.
+bool cold_storage_adopt_connected_client_into(ColdStorageVCS *p_vcs, const ColdStorageConnectionConfig &p_cfg, const String &p_project_path);
+
+#endif

--- a/modules/coldstorage/cold_storage_cli.cpp
+++ b/modules/coldstorage/cold_storage_cli.cpp
@@ -1,0 +1,144 @@
+/**************************************************************************/
+/*  cold_storage_cli.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_cli.h"
+
+#include "core/os/os.h"
+
+static bool _arg_starts(const String &p_arg, const String &p_prefix, String &r_value) {
+	if (!p_arg.begins_with(p_prefix)) {
+		return false;
+	}
+	r_value = p_arg.substr(p_prefix.length());
+	return true;
+}
+
+ColdStorageCliOverrides cold_storage_parse_cli() {
+	ColdStorageCliOverrides o;
+	const List<String> &args = OS::get_singleton()->get_cmdline_args();
+	for (const String &arg : args) {
+		if (arg == "--enable-coldstorage") {
+			o.enable = true;
+			o.has_enable = true;
+		} else if (arg == "--coldstorage-auto-pull") {
+			o.auto_pull = true;
+			o.has_auto_pull = true;
+		} else if (arg == "--coldstorage-no-validate") {
+			o.no_validate = true;
+		} else if (arg == "--coldstorage-tls") {
+			o.tls = true;
+			o.has_tls = true;
+		} else if (arg == "--coldstorage-tls-insecure") {
+			o.tls_insecure = true;
+			o.has_tls_insecure = true;
+		} else {
+			String val;
+			if (_arg_starts(arg, "--coldstorage-host=", val)) {
+				o.host = val;
+				o.has_host = true;
+			} else if (_arg_starts(arg, "--coldstorage-port=", val)) {
+				o.port = val.to_int();
+				o.has_port = true;
+			} else if (_arg_starts(arg, "--coldstorage-user=", val)) {
+				o.user = val;
+				o.has_user = true;
+			} else if (_arg_starts(arg, "--coldstorage-password=", val)) {
+				o.password = val;
+				o.has_password = true;
+			} else if (_arg_starts(arg, "--coldstorage-ticket=", val)) {
+				o.ticket = val;
+				o.has_ticket = true;
+			} else if (_arg_starts(arg, "--coldstorage-jwt=", val)) {
+				o.jwt = val;
+				o.has_jwt = true;
+			} else if (_arg_starts(arg, "--coldstorage-workspace=", val)) {
+				o.workspace = val;
+				o.has_workspace = true;
+			} else if (_arg_starts(arg, "--coldstorage-repo=", val)) {
+				o.repo = val;
+				o.has_repo = true;
+			}
+		}
+	}
+	return o;
+}
+
+void cold_storage_apply_cli_to_config(ColdStorageConnectionConfig &r_cfg, const ColdStorageCliOverrides &p_cli) {
+	if (p_cli.has_enable) {
+		r_cfg.enabled = p_cli.enable;
+		r_cfg.autoload_on_startup = p_cli.enable;
+	}
+	if (p_cli.has_auto_pull) {
+		r_cfg.auto_pull = p_cli.auto_pull;
+	}
+	if (p_cli.no_validate) {
+		r_cfg.validate_on_startup = false;
+	}
+	if (p_cli.has_host) {
+		r_cfg.host = p_cli.host;
+	}
+	if (p_cli.has_port) {
+		r_cfg.port = p_cli.port;
+	}
+	if (p_cli.has_user) {
+		r_cfg.user = p_cli.user;
+	}
+	if (p_cli.has_password) {
+		r_cfg.password = p_cli.password;
+	}
+	if (p_cli.has_ticket) {
+		r_cfg.ticket = p_cli.ticket;
+	}
+	if (p_cli.has_jwt) {
+		r_cfg.jwt = p_cli.jwt;
+	}
+	if (p_cli.has_workspace) {
+		r_cfg.workspace = p_cli.workspace;
+	}
+	if (p_cli.has_repo) {
+		r_cfg.repo = p_cli.repo;
+	}
+	if (p_cli.has_tls) {
+		r_cfg.use_tls = p_cli.tls;
+	}
+	if (p_cli.has_tls_insecure) {
+		r_cfg.tls_insecure = p_cli.tls_insecure;
+	}
+}
+
+bool cold_storage_should_autoconnect(const ColdStorageConnectionConfig &p_cfg, const ColdStorageCliOverrides &p_cli) {
+	if (p_cli.has_enable && p_cli.enable) {
+		return true;
+	}
+	return p_cfg.enabled && p_cfg.autoload_on_startup;
+}
+
+#endif

--- a/modules/coldstorage/cold_storage_cli.h
+++ b/modules/coldstorage/cold_storage_cli.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  cold_storage_cli.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_settings.h"
+
+struct ColdStorageCliOverrides {
+	bool enable = false;
+	bool has_enable = false;
+	bool auto_pull = false;
+	bool has_auto_pull = false;
+	bool no_validate = false;
+	bool has_host = false;
+	String host;
+	bool has_port = false;
+	int port = 1666;
+	bool has_user = false;
+	String user;
+	bool has_password = false;
+	String password;
+	bool has_ticket = false;
+	String ticket;
+	bool has_jwt = false;
+	String jwt;
+	bool has_workspace = false;
+	String workspace;
+	bool has_repo = false;
+	String repo;
+	bool tls = false;
+	bool has_tls = false;
+	bool tls_insecure = false;
+	bool has_tls_insecure = false;
+};
+
+ColdStorageCliOverrides cold_storage_parse_cli();
+void cold_storage_apply_cli_to_config(ColdStorageConnectionConfig &r_cfg, const ColdStorageCliOverrides &p_cli);
+bool cold_storage_should_autoconnect(const ColdStorageConnectionConfig &p_cfg, const ColdStorageCliOverrides &p_cli);
+
+#endif

--- a/modules/coldstorage/cold_storage_editor_plugin.cpp
+++ b/modules/coldstorage/cold_storage_editor_plugin.cpp
@@ -1,0 +1,300 @@
+/**************************************************************************/
+/*  cold_storage_editor_plugin.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_editor_plugin.h"
+
+#include "cold_storage_async.h"
+#include "cold_storage_settings.h"
+#include "cold_storage_settings_ui.h"
+#include "cold_storage_vcs.h"
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+#include "editor/editor_interface.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_vcs_interface.h"
+#include "editor/plugins/version_control_editor_plugin.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/label.h"
+
+ColdStorageEditorPlugin *ColdStorageEditorPlugin::singleton = nullptr;
+
+void ColdStorageEditorPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_show_configuration_dialog"), &ColdStorageEditorPlugin::_show_configuration_dialog);
+	ClassDB::bind_method(D_METHOD("_poll_runtime"), &ColdStorageEditorPlugin::_poll_runtime);
+	ClassDB::bind_method(D_METHOD("_on_async_complete", "ok", "error", "kind"), &ColdStorageEditorPlugin::_on_async_complete);
+}
+
+ColdStorageEditorPlugin::ColdStorageEditorPlugin() {
+	singleton = this;
+	cli_ = cold_storage_parse_cli();
+}
+
+ColdStorageEditorPlugin::~ColdStorageEditorPlugin() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+void ColdStorageEditorPlugin::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			cold_storage_register_editor_settings();
+			_setup_status_indicator();
+			add_tool_menu_item("ColdStorage Configuration", callable_mp(this, &ColdStorageEditorPlugin::_show_configuration_dialog));
+
+			inspector_plugin.instantiate();
+			add_inspector_plugin(inspector_plugin);
+
+			set_process(true);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			remove_tool_menu_item("ColdStorage Configuration");
+			if (inspector_plugin.is_valid()) {
+				remove_inspector_plugin(inspector_plugin);
+				inspector_plugin.unref();
+			}
+			_teardown_status_indicator();
+			set_process(false);
+		} break;
+		case NOTIFICATION_PROCESS: {
+			_poll_runtime();
+		} break;
+		default:
+			break;
+	}
+}
+
+void ColdStorageEditorPlugin::_setup_status_indicator() {
+	if (status_label) {
+		return;
+	}
+	status_label = memnew(Label);
+	status_label->set_text("CS: —");
+	status_label->set_tooltip_text("ColdStorage connection status");
+	add_control_to_container(CONTAINER_TOOLBAR, status_label);
+	_update_status_label("CS: Idle", Color(0.7, 0.7, 0.7));
+}
+
+void ColdStorageEditorPlugin::_teardown_status_indicator() {
+	if (!status_label) {
+		return;
+	}
+	remove_control_from_container(CONTAINER_TOOLBAR, status_label);
+	memdelete(status_label);
+	status_label = nullptr;
+}
+
+void ColdStorageEditorPlugin::_update_status_label(const String &p_text, const Color &p_color) {
+	if (!status_label) {
+		return;
+	}
+	status_label->set_text(p_text);
+	status_label->add_theme_color_override("font_color", p_color);
+}
+
+void ColdStorageEditorPlugin::_finish_startup() {
+	startup_done_ = true;
+	set_process(false);
+}
+
+void ColdStorageEditorPlugin::refresh_status_from_vcs() {
+	if (startup_busy_) {
+		_update_status_label("CS: Connecting…", Color(0.85, 0.75, 0.3));
+		return;
+	}
+	ColdStorageVCS *vcs = Object::cast_to<ColdStorageVCS>(EditorVCSInterface::get_singleton());
+	if (vcs && vcs->is_connected_to_server()) {
+		_update_status_label("CS: Connected", Color(0.3, 0.85, 0.4));
+	} else if (vcs && !vcs->get_last_error().is_empty()) {
+		_update_status_label("CS: Error", Color(0.95, 0.35, 0.3));
+	} else {
+		_update_status_label("CS: Disconnected", Color(0.75, 0.75, 0.75));
+	}
+}
+
+void ColdStorageEditorPlugin::_show_configuration_dialog() {
+	if (!config_dialog) {
+		config_dialog = memnew(AcceptDialog);
+		config_dialog->set_title("ColdStorage Configuration");
+		config_dialog->set_min_size(Size2(480, 520));
+		settings_ui = memnew(ColdStorageSettingsUI);
+		config_dialog->add_child(settings_ui);
+		EditorNode::get_singleton()->get_gui_base()->add_child(config_dialog);
+	}
+	config_dialog->popup_centered();
+}
+
+void ColdStorageEditorPlugin::_poll_runtime() {
+	_try_deferred_startup();
+}
+
+void ColdStorageEditorPlugin::_try_deferred_startup() {
+	if (startup_done_ || startup_busy_) {
+		return;
+	}
+	if (!EditorSettings::get_singleton()) {
+		return;
+	}
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node || !editor_node->is_editor_ready()) {
+		editor_ready_since_usec_ = 0;
+		return;
+	}
+	if (editor_ready_since_usec_ == 0) {
+		editor_ready_since_usec_ = OS::get_singleton()->get_ticks_usec();
+		return;
+	}
+
+	if (OS::get_singleton()->get_ticks_usec() - editor_ready_since_usec_ < 500'000) {
+		return;
+	}
+
+	ColdStorageConnectionConfig cfg = cold_storage_load_config();
+	cold_storage_apply_cli_to_config(cfg, cli_);
+
+	if (!cold_storage_should_autoconnect(cfg, cli_)) {
+		_finish_startup();
+		refresh_status_from_vcs();
+		return;
+	}
+
+	const bool validate = cfg.validate_on_startup && !cli_.no_validate;
+	const bool auto_pull = cfg.auto_pull || (cli_.has_auto_pull && cli_.auto_pull);
+
+	if (EditorVCSInterface::get_singleton()) {
+		ColdStorageVCS *existing = Object::cast_to<ColdStorageVCS>(EditorVCSInterface::get_singleton());
+		if (existing) {
+			existing->apply_connection_config(cfg);
+			if (existing->is_connected_to_server()) {
+				if (validate && !existing->validate_connection()) {
+					_update_status_label("CS: Validate failed", Color(0.95, 0.35, 0.3));
+					WARN_PRINT("ColdStorage validate failed: " + existing->get_last_error());
+				} else if (auto_pull) {
+					// Pull still blocks briefly; full reconnect path below is async.
+					existing->auto_pull_sync();
+				}
+				_finish_startup();
+				refresh_status_from_vcs();
+				return;
+			}
+			if (!_begin_vcs_connect_async(cfg, validate, auto_pull)) {
+				_finish_startup();
+				_update_status_label("CS: Busy", Color(0.95, 0.35, 0.3));
+			}
+			return;
+		}
+		// Another VCS is already active.
+		_finish_startup();
+		_update_status_label("CS: Other VCS active", Color(0.9, 0.75, 0.3));
+		return;
+	}
+
+	if (!_begin_vcs_connect_async(cfg, validate, auto_pull)) {
+		_finish_startup();
+		_update_status_label("CS: Busy", Color(0.95, 0.35, 0.3));
+	}
+}
+
+bool ColdStorageEditorPlugin::_begin_vcs_connect_async(const ColdStorageConnectionConfig &p_cfg, bool p_validate, bool p_auto_pull) {
+	ColdStorageConnectionConfig cfg = p_cfg;
+	cfg.enabled = true;
+	cold_storage_save_config(cfg);
+	pending_startup_cfg_ = cfg;
+
+	ColdStorageConnectRequest req;
+	req.kind = ColdStorageConnectRequest::Kind::STARTUP_JOB;
+	req.cfg = cfg;
+	req.project_path = OS::get_singleton()->get_resource_dir();
+	req.validate = p_validate;
+	req.auto_pull = p_auto_pull;
+	req.caller_id = get_instance_id();
+	req.complete_method = "_on_async_complete";
+
+	if (!cold_storage_begin_connect_async(req)) {
+		return false;
+	}
+	startup_busy_ = true;
+	_update_status_label("CS: Connecting…", Color(0.85, 0.75, 0.3));
+	return true;
+}
+
+void ColdStorageEditorPlugin::_on_async_complete(bool p_ok, const String &p_error, int p_kind) {
+	(void)p_kind;
+	startup_busy_ = false;
+	_finish_startup();
+
+	if (!p_ok) {
+		cold_storage_discard_connected_client();
+		_update_status_label("CS: Connect failed", Color(0.95, 0.35, 0.3));
+		WARN_PRINT("ColdStorage connect failed: " + p_error);
+		return;
+	}
+
+	if (!cold_storage_has_pending_client()) {
+		// Existing VCS path with validate/pull-only shouldn't happen with STARTUP keeping client.
+		refresh_status_from_vcs();
+		return;
+	}
+
+	if (EditorVCSInterface::get_singleton()) {
+		ColdStorageVCS *existing = Object::cast_to<ColdStorageVCS>(EditorVCSInterface::get_singleton());
+		if (existing) {
+			if (cold_storage_adopt_connected_client_into(existing, pending_startup_cfg_, OS::get_singleton()->get_resource_dir())) {
+				_update_status_label("CS: Connected", Color(0.3, 0.85, 0.4));
+			}
+			return;
+		}
+		// Drop client if another VCS took over.
+		cold_storage_discard_connected_client();
+		return;
+	}
+
+	ColdStorageVCS *vcs = memnew(ColdStorageVCS);
+	if (!cold_storage_adopt_connected_client_into(vcs, pending_startup_cfg_, OS::get_singleton()->get_resource_dir())) {
+		_update_status_label("CS: Connect failed", Color(0.95, 0.35, 0.3));
+		WARN_PRINT("ColdStorage connect failed: " + vcs->get_last_error());
+		memdelete(vcs);
+		return;
+	}
+
+	EditorVCSInterface::set_singleton(vcs);
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set("editor/version_control/plugin_name", "ColdStorageVCS");
+		ProjectSettings::get_singleton()->set("editor/version_control/autoload_on_startup", true);
+	}
+	if (VersionControlEditorPlugin::get_singleton()) {
+		VersionControlEditorPlugin::get_singleton()->register_editor();
+	}
+	_update_status_label("CS: Connected", Color(0.3, 0.85, 0.4));
+}
+
+#endif // TOOLS_ENABLED

--- a/modules/coldstorage/cold_storage_editor_plugin.h
+++ b/modules/coldstorage/cold_storage_editor_plugin.h
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  cold_storage_editor_plugin.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_cli.h"
+#include "cold_storage_settings.h"
+#include "editor/plugins/editor_plugin.h"
+
+class AcceptDialog;
+class Label;
+class ColdStorageSettingsInspectorPlugin;
+class ColdStorageSettingsUI;
+class ColdStorageVCS;
+
+class ColdStorageEditorPlugin : public EditorPlugin {
+	GDCLASS(ColdStorageEditorPlugin, EditorPlugin);
+
+	static ColdStorageEditorPlugin *singleton;
+
+	Label *status_label = nullptr;
+	AcceptDialog *config_dialog = nullptr;
+	ColdStorageSettingsUI *settings_ui = nullptr;
+	Ref<ColdStorageSettingsInspectorPlugin> inspector_plugin;
+
+	ColdStorageCliOverrides cli_;
+	bool startup_done_ = false;
+	bool startup_busy_ = false;
+	uint64_t editor_ready_since_usec_ = 0;
+	ColdStorageConnectionConfig pending_startup_cfg_;
+
+	void _setup_status_indicator();
+	void _teardown_status_indicator();
+	void _update_status_label(const String &p_text, const Color &p_color);
+	void _finish_startup();
+	void _show_configuration_dialog();
+	void _try_deferred_startup();
+	void _poll_runtime();
+	bool _begin_vcs_connect_async(const ColdStorageConnectionConfig &p_cfg, bool p_validate, bool p_auto_pull);
+	void _on_async_complete(bool p_ok, const String &p_error, int p_kind);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	static ColdStorageEditorPlugin *get_singleton() { return singleton; }
+
+	virtual String get_plugin_name() const override { return "ColdStorage"; }
+	bool has_main_screen() const override { return false; }
+
+	void refresh_status_from_vcs();
+
+	ColdStorageEditorPlugin();
+	~ColdStorageEditorPlugin() override;
+};
+
+#endif

--- a/modules/coldstorage/cold_storage_settings.cpp
+++ b/modules/coldstorage/cold_storage_settings.cpp
@@ -1,0 +1,195 @@
+/**************************************************************************/
+/*  cold_storage_settings.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_settings.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_settings.h"
+
+namespace {
+const char *NS = "blazium/coldstorage/";
+
+bool _is_secret_key(const String &p_key) {
+	return p_key.ends_with("/password") || p_key.ends_with("/ticket") || p_key.ends_with("/jwt");
+}
+
+void _clear_legacy_project_secrets() {
+	if (!ProjectSettings::get_singleton()) {
+		return;
+	}
+	bool cleared = false;
+	const String keys[] = {
+		String(NS) + "password",
+		String(NS) + "ticket",
+		String(NS) + "jwt",
+	};
+	for (const String &key : keys) {
+		if (ProjectSettings::get_singleton()->has_setting(key)) {
+			ProjectSettings::get_singleton()->clear(key);
+			cleared = true;
+		}
+	}
+	if (cleared) {
+		ProjectSettings::get_singleton()->save();
+	}
+}
+
+Variant _get_secret_setting(const String &p_key, const Variant &p_default) {
+	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting(p_key)) {
+		return EditorSettings::get_singleton()->get(p_key);
+	}
+	return p_default;
+}
+} //namespace
+
+void cold_storage_register_project_settings() {
+	GLOBAL_DEF_BASIC(String(NS) + "override_editor_settings", false);
+	GLOBAL_DEF_BASIC(String(NS) + "enabled", false);
+	GLOBAL_DEF_BASIC(String(NS) + "autoload_on_startup", false);
+	GLOBAL_DEF_BASIC(String(NS) + "validate_on_startup", true);
+	GLOBAL_DEF_BASIC(String(NS) + "auto_pull", false);
+	GLOBAL_DEF_BASIC(String(NS) + "host", "127.0.0.1");
+	GLOBAL_DEF_BASIC(String(NS) + "port", 1666);
+	GLOBAL_DEF_BASIC(String(NS) + "use_tls", false);
+	GLOBAL_DEF_BASIC(String(NS) + "tls_insecure", false);
+	GLOBAL_DEF_BASIC(String(NS) + "user", String());
+	// Secrets (password/ticket/jwt) are EditorSettings-only — never project.godot.
+	GLOBAL_DEF_BASIC(String(NS) + "workspace", "default");
+	GLOBAL_DEF_BASIC(String(NS) + "repo", "default");
+	GLOBAL_DEF_BASIC(String(NS) + "workspace_root", String());
+	GLOBAL_DEF_BASIC(String(NS) + "ca_file", String());
+	GLOBAL_DEF_BASIC(String(NS) + "z_connection_controls", String());
+	_clear_legacy_project_secrets();
+}
+
+void cold_storage_register_editor_settings() {
+	if (!EditorSettings::get_singleton()) {
+		return;
+	}
+	EDITOR_DEF_BASIC(String(NS) + "enabled", false);
+	EDITOR_DEF_BASIC(String(NS) + "autoload_on_startup", false);
+	EDITOR_DEF_BASIC(String(NS) + "validate_on_startup", true);
+	EDITOR_DEF_BASIC(String(NS) + "auto_pull", false);
+	EDITOR_DEF_BASIC(String(NS) + "host", "127.0.0.1");
+	EDITOR_DEF_BASIC(String(NS) + "port", 1666);
+	EDITOR_DEF_BASIC(String(NS) + "use_tls", false);
+	EDITOR_DEF_BASIC(String(NS) + "tls_insecure", false);
+	EDITOR_DEF_BASIC(String(NS) + "user", "");
+	EDITOR_DEF_BASIC(String(NS) + "password", "");
+	EDITOR_DEF_BASIC(String(NS) + "ticket", "");
+	EDITOR_DEF_BASIC(String(NS) + "jwt", "");
+	EDITOR_DEF_BASIC(String(NS) + "workspace", "default");
+	EDITOR_DEF_BASIC(String(NS) + "repo", "default");
+	EDITOR_DEF_BASIC(String(NS) + "workspace_root", "");
+	EDITOR_DEF_BASIC(String(NS) + "ca_file", "");
+	EDITOR_DEF_BASIC(String(NS) + "z_connection_controls", "");
+}
+
+Variant cold_storage_get_setting(const String &p_key, const Variant &p_default) {
+	if (_is_secret_key(p_key)) {
+		return _get_secret_setting(p_key, p_default);
+	}
+	const bool use_project = ProjectSettings::get_singleton() &&
+			(bool)ProjectSettings::get_singleton()->get_setting(String(NS) + "override_editor_settings", false);
+	if (use_project || !EditorSettings::get_singleton()) {
+		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_key)) {
+			return ProjectSettings::get_singleton()->get_setting(p_key);
+		}
+		return p_default;
+	}
+	if (EditorSettings::get_singleton()->has_setting(p_key)) {
+		return EditorSettings::get_singleton()->get(p_key);
+	}
+	return p_default;
+}
+
+ColdStorageConnectionConfig cold_storage_load_config() {
+	_clear_legacy_project_secrets();
+	ColdStorageConnectionConfig c;
+	c.enabled = cold_storage_get_setting(String(NS) + "enabled", false);
+	c.autoload_on_startup = cold_storage_get_setting(String(NS) + "autoload_on_startup", false);
+	c.validate_on_startup = cold_storage_get_setting(String(NS) + "validate_on_startup", true);
+	c.auto_pull = cold_storage_get_setting(String(NS) + "auto_pull", false);
+	c.host = cold_storage_get_setting(String(NS) + "host", "127.0.0.1");
+	c.port = cold_storage_get_setting(String(NS) + "port", 1666);
+	c.use_tls = cold_storage_get_setting(String(NS) + "use_tls", false);
+	c.tls_insecure = cold_storage_get_setting(String(NS) + "tls_insecure", false);
+	c.user = cold_storage_get_setting(String(NS) + "user", String());
+	c.password = cold_storage_get_setting(String(NS) + "password", String());
+	c.ticket = cold_storage_get_setting(String(NS) + "ticket", String());
+	c.jwt = cold_storage_get_setting(String(NS) + "jwt", String());
+	c.workspace = cold_storage_get_setting(String(NS) + "workspace", "default");
+	c.repo = cold_storage_get_setting(String(NS) + "repo", "default");
+	c.workspace_root = cold_storage_get_setting(String(NS) + "workspace_root", String());
+	c.ca_file = cold_storage_get_setting(String(NS) + "ca_file", String());
+	return c;
+}
+
+void cold_storage_save_config(const ColdStorageConnectionConfig &p_cfg) {
+	auto set_public = [&](const String &key, const Variant &val) {
+		if (ProjectSettings::get_singleton()) {
+			ProjectSettings::get_singleton()->set_setting(key, val);
+		}
+		if (EditorSettings::get_singleton()) {
+			EditorSettings::get_singleton()->set(key, val);
+		}
+	};
+	auto set_secret = [&](const String &key, const Variant &val) {
+		if (EditorSettings::get_singleton()) {
+			EditorSettings::get_singleton()->set(key, val);
+		}
+	};
+
+	set_public(String(NS) + "enabled", p_cfg.enabled);
+	set_public(String(NS) + "autoload_on_startup", p_cfg.autoload_on_startup);
+	set_public(String(NS) + "validate_on_startup", p_cfg.validate_on_startup);
+	set_public(String(NS) + "auto_pull", p_cfg.auto_pull);
+	set_public(String(NS) + "host", p_cfg.host);
+	set_public(String(NS) + "port", p_cfg.port);
+	set_public(String(NS) + "use_tls", p_cfg.use_tls);
+	set_public(String(NS) + "tls_insecure", p_cfg.tls_insecure);
+	set_public(String(NS) + "user", p_cfg.user);
+	set_secret(String(NS) + "password", p_cfg.password);
+	set_secret(String(NS) + "ticket", p_cfg.ticket);
+	set_secret(String(NS) + "jwt", p_cfg.jwt);
+	set_public(String(NS) + "workspace", p_cfg.workspace);
+	set_public(String(NS) + "repo", p_cfg.repo);
+	set_public(String(NS) + "workspace_root", p_cfg.workspace_root);
+	set_public(String(NS) + "ca_file", p_cfg.ca_file);
+
+	_clear_legacy_project_secrets();
+
+	if (EditorSettings::get_singleton()) {
+		EditorSettings::get_singleton()->save();
+	}
+}
+
+#endif

--- a/modules/coldstorage/cold_storage_settings.h
+++ b/modules/coldstorage/cold_storage_settings.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  cold_storage_settings.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/variant/variant.h"
+
+#ifdef TOOLS_ENABLED
+
+void cold_storage_register_project_settings();
+void cold_storage_register_editor_settings();
+
+struct ColdStorageConnectionConfig {
+	bool enabled = false;
+	bool autoload_on_startup = false;
+	bool validate_on_startup = true;
+	bool auto_pull = false;
+	String host = "127.0.0.1";
+	int port = 1666;
+	bool use_tls = false;
+	bool tls_insecure = false;
+	String user;
+	String password;
+	String ticket;
+	String jwt;
+	String workspace = "default";
+	String repo = "default";
+	String workspace_root;
+	String ca_file;
+};
+
+ColdStorageConnectionConfig cold_storage_load_config();
+void cold_storage_save_config(const ColdStorageConnectionConfig &p_cfg);
+
+Variant cold_storage_get_setting(const String &p_key, const Variant &p_default);
+
+#endif

--- a/modules/coldstorage/cold_storage_settings_ui.cpp
+++ b/modules/coldstorage/cold_storage_settings_ui.cpp
@@ -1,0 +1,345 @@
+/**************************************************************************/
+/*  cold_storage_settings_ui.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_settings_ui.h"
+
+#include "cold_storage_async.h"
+#include "cold_storage_editor_plugin.h"
+#include "cold_storage_settings.h"
+#include "cold_storage_vcs.h"
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+#include "editor/editor_vcs_interface.h"
+#include "editor/plugins/version_control_editor_plugin.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/spin_box.h"
+
+void ColdStorageSettingsUI::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_on_connect"), &ColdStorageSettingsUI::_on_connect);
+	ClassDB::bind_method(D_METHOD("_on_disconnect"), &ColdStorageSettingsUI::_on_disconnect);
+	ClassDB::bind_method(D_METHOD("_on_test"), &ColdStorageSettingsUI::_on_test);
+	ClassDB::bind_method(D_METHOD("_on_save"), &ColdStorageSettingsUI::_on_save);
+	ClassDB::bind_method(D_METHOD("_on_async_complete", "ok", "error", "kind"), &ColdStorageSettingsUI::_on_async_complete);
+}
+
+void ColdStorageSettingsUI::_notification(int p_what) {
+	if (p_what == NOTIFICATION_READY) {
+		_load_from_settings();
+		_refresh_status();
+	}
+}
+
+ColdStorageSettingsUI::ColdStorageSettingsUI() {
+	set_custom_minimum_size(Size2(0, 220));
+
+	VBoxContainer *vb = memnew(VBoxContainer);
+	add_child(vb);
+
+	status_label = memnew(Label);
+	status_label->set_text("ColdStorage: Disconnected");
+	vb->add_child(status_label);
+
+	host_edit = memnew(LineEdit);
+	host_edit->set_placeholder("Host");
+	vb->add_child(host_edit);
+
+	port_spin = memnew(SpinBox);
+	port_spin->set_min(1);
+	port_spin->set_max(65535);
+	port_spin->set_step(1);
+	port_spin->set_value(1666);
+	vb->add_child(port_spin);
+
+	user_edit = memnew(LineEdit);
+	user_edit->set_placeholder("User");
+	vb->add_child(user_edit);
+
+	password_edit = memnew(LineEdit);
+	password_edit->set_placeholder("Password (stored in Editor Settings only)");
+	password_edit->set_secret(true);
+	vb->add_child(password_edit);
+
+	workspace_edit = memnew(LineEdit);
+	workspace_edit->set_placeholder("Workspace");
+	vb->add_child(workspace_edit);
+
+	repo_edit = memnew(LineEdit);
+	repo_edit->set_placeholder("Repo");
+	vb->add_child(repo_edit);
+
+	jwt_edit = memnew(LineEdit);
+	jwt_edit->set_placeholder("JWT (optional, Editor Settings only)");
+	jwt_edit->set_secret(true);
+	vb->add_child(jwt_edit);
+
+	tls_cb = memnew(CheckBox);
+	tls_cb->set_text("Use TLS");
+	vb->add_child(tls_cb);
+
+	tls_insecure_cb = memnew(CheckBox);
+	tls_insecure_cb->set_text("TLS insecure (skip verify)");
+	vb->add_child(tls_insecure_cb);
+
+	auto_pull_cb = memnew(CheckBox);
+	auto_pull_cb->set_text("Auto-pull on connect");
+	vb->add_child(auto_pull_cb);
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	vb->add_child(hb);
+
+	connect_btn = memnew(Button);
+	connect_btn->set_text("Connect");
+	connect_btn->connect("pressed", callable_mp(this, &ColdStorageSettingsUI::_on_connect));
+	hb->add_child(connect_btn);
+
+	disconnect_btn = memnew(Button);
+	disconnect_btn->set_text("Disconnect");
+	disconnect_btn->connect("pressed", callable_mp(this, &ColdStorageSettingsUI::_on_disconnect));
+	hb->add_child(disconnect_btn);
+
+	test_btn = memnew(Button);
+	test_btn->set_text("Test");
+	test_btn->connect("pressed", callable_mp(this, &ColdStorageSettingsUI::_on_test));
+	hb->add_child(test_btn);
+
+	save_btn = memnew(Button);
+	save_btn->set_text("Save");
+	save_btn->connect("pressed", callable_mp(this, &ColdStorageSettingsUI::_on_save));
+	hb->add_child(save_btn);
+}
+
+void ColdStorageSettingsUI::_load_from_settings() {
+	ColdStorageConnectionConfig c = cold_storage_load_config();
+	host_edit->set_text(c.host);
+	port_spin->set_value(c.port);
+	user_edit->set_text(c.user);
+	password_edit->set_text(c.password);
+	workspace_edit->set_text(c.workspace);
+	repo_edit->set_text(c.repo);
+	jwt_edit->set_text(c.jwt);
+	tls_cb->set_pressed(c.use_tls);
+	tls_insecure_cb->set_pressed(c.tls_insecure);
+	auto_pull_cb->set_pressed(c.auto_pull);
+}
+
+void ColdStorageSettingsUI::_apply_to_config() {
+	ColdStorageConnectionConfig c = cold_storage_load_config();
+	c.enabled = true;
+	c.host = host_edit->get_text();
+	c.port = (int)port_spin->get_value();
+	c.user = user_edit->get_text();
+	c.password = password_edit->get_text();
+	c.workspace = workspace_edit->get_text();
+	c.repo = repo_edit->get_text();
+	c.jwt = jwt_edit->get_text();
+	c.use_tls = tls_cb->is_pressed();
+	c.tls_insecure = tls_insecure_cb->is_pressed();
+	c.auto_pull = auto_pull_cb->is_pressed();
+	cold_storage_save_config(c);
+	pending_cfg_ = c;
+}
+
+void ColdStorageSettingsUI::_set_busy(bool p_busy) {
+	ui_busy_ = p_busy;
+	if (connect_btn) {
+		connect_btn->set_disabled(p_busy);
+	}
+	if (test_btn) {
+		test_btn->set_disabled(p_busy);
+	}
+	if (save_btn) {
+		save_btn->set_disabled(p_busy);
+	}
+}
+
+void ColdStorageSettingsUI::_refresh_status() {
+	ColdStorageVCS *vcs = Object::cast_to<ColdStorageVCS>(EditorVCSInterface::get_singleton());
+	if (ui_busy_) {
+		status_label->set_text("ColdStorage: Working…");
+		status_label->add_theme_color_override("font_color", Color(0.85, 0.75, 0.3));
+	} else if (vcs && vcs->is_connected_to_server()) {
+		status_label->set_text("ColdStorage: Connected");
+		status_label->add_theme_color_override("font_color", Color(0.3, 0.85, 0.4));
+	} else if (vcs && !vcs->get_last_error().is_empty()) {
+		status_label->set_text("ColdStorage: Error — " + vcs->get_last_error());
+		status_label->add_theme_color_override("font_color", Color(0.95, 0.35, 0.3));
+	} else {
+		status_label->set_text("ColdStorage: Disconnected");
+		status_label->add_theme_color_override("font_color", Color(0.75, 0.75, 0.75));
+	}
+	if (ColdStorageEditorPlugin::get_singleton()) {
+		ColdStorageEditorPlugin::get_singleton()->refresh_status_from_vcs();
+	}
+}
+
+void ColdStorageSettingsUI::_on_save() {
+	_apply_to_config();
+	_refresh_status();
+}
+
+void ColdStorageSettingsUI::_on_connect() {
+	if (ui_busy_ || cold_storage_connect_busy()) {
+		return;
+	}
+	_apply_to_config();
+	pending_cfg_.autoload_on_startup = true;
+	cold_storage_save_config(pending_cfg_);
+
+	if (VersionControlEditorPlugin::get_singleton() && EditorVCSInterface::get_singleton()) {
+		VersionControlEditorPlugin::get_singleton()->shut_down();
+	} else if (EditorVCSInterface::get_singleton()) {
+		EditorVCSInterface::get_singleton()->shut_down();
+		memdelete(EditorVCSInterface::get_singleton());
+		EditorVCSInterface::set_singleton(nullptr);
+	}
+
+	ColdStorageConnectRequest req;
+	req.kind = ColdStorageConnectRequest::Kind::CONNECT_JOB;
+	req.cfg = pending_cfg_;
+	req.project_path = OS::get_singleton()->get_resource_dir();
+	req.validate = pending_cfg_.validate_on_startup;
+	req.auto_pull = pending_cfg_.auto_pull;
+	req.caller_id = get_instance_id();
+	req.complete_method = "_on_async_complete";
+
+	if (!cold_storage_begin_connect_async(req)) {
+		status_label->set_text("ColdStorage: Busy");
+		status_label->add_theme_color_override("font_color", Color(0.95, 0.35, 0.3));
+		return;
+	}
+	_set_busy(true);
+	_refresh_status();
+}
+
+void ColdStorageSettingsUI::_on_disconnect() {
+	if (ui_busy_) {
+		return;
+	}
+	if (VersionControlEditorPlugin::get_singleton()) {
+		VersionControlEditorPlugin::get_singleton()->shut_down();
+	} else if (EditorVCSInterface::get_singleton()) {
+		EditorVCSInterface::get_singleton()->shut_down();
+		memdelete(EditorVCSInterface::get_singleton());
+		EditorVCSInterface::set_singleton(nullptr);
+	}
+	_refresh_status();
+}
+
+void ColdStorageSettingsUI::_on_test() {
+	if (ui_busy_ || cold_storage_connect_busy()) {
+		return;
+	}
+	_apply_to_config();
+
+	ColdStorageConnectRequest req;
+	req.kind = ColdStorageConnectRequest::Kind::TEST_JOB;
+	req.cfg = pending_cfg_;
+	req.project_path = OS::get_singleton()->get_resource_dir();
+	req.validate = true;
+	req.auto_pull = false;
+	req.caller_id = get_instance_id();
+	req.complete_method = "_on_async_complete";
+
+	if (!cold_storage_begin_connect_async(req)) {
+		status_label->set_text("ColdStorage: Busy");
+		status_label->add_theme_color_override("font_color", Color(0.95, 0.35, 0.3));
+		return;
+	}
+	_set_busy(true);
+	_refresh_status();
+}
+
+void ColdStorageSettingsUI::_on_async_complete(bool p_ok, const String &p_error, int p_kind) {
+	_set_busy(false);
+	const auto kind = (ColdStorageConnectRequest::Kind)p_kind;
+
+	if (kind == ColdStorageConnectRequest::Kind::TEST_JOB) {
+		cold_storage_discard_connected_client();
+		if (p_ok) {
+			status_label->set_text("ColdStorage: Test OK");
+			status_label->add_theme_color_override("font_color", Color(0.3, 0.85, 0.4));
+		} else {
+			status_label->set_text("ColdStorage: Test failed — " + p_error);
+			status_label->add_theme_color_override("font_color", Color(0.95, 0.35, 0.3));
+		}
+		return;
+	}
+
+	if (!p_ok) {
+		cold_storage_discard_connected_client();
+		status_label->set_text("ColdStorage: Connect failed — " + p_error);
+		status_label->add_theme_color_override("font_color", Color(0.95, 0.35, 0.3));
+		_refresh_status();
+		return;
+	}
+
+	ColdStorageVCS *vcs = memnew(ColdStorageVCS);
+	if (!cold_storage_adopt_connected_client_into(vcs, pending_cfg_, OS::get_singleton()->get_resource_dir())) {
+		status_label->set_text("ColdStorage: Connect failed — " + vcs->get_last_error());
+		status_label->add_theme_color_override("font_color", Color(0.95, 0.35, 0.3));
+		memdelete(vcs);
+		_refresh_status();
+		return;
+	}
+
+	EditorVCSInterface::set_singleton(vcs);
+	ProjectSettings::get_singleton()->set("editor/version_control/plugin_name", "ColdStorageVCS");
+	ProjectSettings::get_singleton()->set("editor/version_control/autoload_on_startup", true);
+	if (VersionControlEditorPlugin::get_singleton()) {
+		VersionControlEditorPlugin::get_singleton()->register_editor();
+	}
+	_refresh_status();
+}
+
+bool ColdStorageSettingsInspectorPlugin::can_handle(Object *p_object) {
+	const String cname = p_object->get_class();
+	return cname == "ProjectSettings" || cname == "EditorSettings" || cname == "SectionedInspectorFilter";
+}
+
+bool ColdStorageSettingsInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
+	(void)p_object;
+	(void)p_type;
+	(void)p_hint;
+	(void)p_hint_text;
+	(void)p_usage;
+	(void)p_wide;
+	if (p_path == "blazium/coldstorage/z_connection_controls" || p_path == "z_connection_controls") {
+		add_custom_control(memnew(ColdStorageSettingsUI));
+		return true;
+	}
+	return false;
+}
+
+#endif

--- a/modules/coldstorage/cold_storage_settings_ui.h
+++ b/modules/coldstorage/cold_storage_settings_ui.h
@@ -1,0 +1,93 @@
+/**************************************************************************/
+/*  cold_storage_settings_ui.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_settings.h"
+#include "editor/editor_inspector.h"
+#include "scene/gui/margin_container.h"
+
+class Button;
+class CheckBox;
+class Label;
+class LineEdit;
+class SpinBox;
+class VBoxContainer;
+
+class ColdStorageSettingsUI : public MarginContainer {
+	GDCLASS(ColdStorageSettingsUI, MarginContainer);
+
+	Label *status_label = nullptr;
+	LineEdit *host_edit = nullptr;
+	SpinBox *port_spin = nullptr;
+	LineEdit *user_edit = nullptr;
+	LineEdit *password_edit = nullptr;
+	LineEdit *workspace_edit = nullptr;
+	LineEdit *repo_edit = nullptr;
+	LineEdit *jwt_edit = nullptr;
+	CheckBox *tls_cb = nullptr;
+	CheckBox *tls_insecure_cb = nullptr;
+	CheckBox *auto_pull_cb = nullptr;
+	Button *connect_btn = nullptr;
+	Button *disconnect_btn = nullptr;
+	Button *test_btn = nullptr;
+	Button *save_btn = nullptr;
+
+	ColdStorageConnectionConfig pending_cfg_;
+	bool ui_busy_ = false;
+
+	void _load_from_settings();
+	void _apply_to_config();
+	void _on_connect();
+	void _on_disconnect();
+	void _on_test();
+	void _on_save();
+	void _refresh_status();
+	void _set_busy(bool p_busy);
+	void _on_async_complete(bool p_ok, const String &p_error, int p_kind);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	ColdStorageSettingsUI();
+};
+
+class ColdStorageSettingsInspectorPlugin : public EditorInspectorPlugin {
+	GDCLASS(ColdStorageSettingsInspectorPlugin, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) override;
+};
+
+#endif

--- a/modules/coldstorage/cold_storage_vcs.cpp
+++ b/modules/coldstorage/cold_storage_vcs.cpp
@@ -1,0 +1,632 @@
+/**************************************************************************/
+/*  cold_storage_vcs.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_vcs.h"
+
+#include "core/io/file_access.h"
+#include "core/os/os.h"
+#include "core/templates/hash_set.h"
+
+#include "client/sdk/client_sdk.h"
+#include "client/sdk/tls_options.h"
+#include "common/util/text_diff.h"
+#ifdef CONNECT
+#undef CONNECT
+#endif
+#ifdef IGNORE
+#undef IGNORE
+#endif
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+void ColdStorageVCS::_bind_methods() {}
+
+ColdStorageVCS::ColdStorageVCS() = default;
+
+ColdStorageVCS::~ColdStorageVCS() {
+	shut_down();
+}
+
+void ColdStorageVCS::apply_connection_config(const ColdStorageConnectionConfig &p_cfg) {
+	config_ = p_cfg;
+	remote_name_ = config_.host + ":" + itos(config_.port);
+	if (!config_.workspace.is_empty()) {
+		current_branch_ = config_.workspace;
+	}
+}
+
+bool ColdStorageVCS::adopt_connected_client(std::unique_ptr<coldstorage::ColdStorageClient> p_client, const ColdStorageConnectionConfig &p_cfg, const String &p_project_path) {
+	if (!p_client || !p_client->isConnected()) {
+		last_error_ = "No connected ColdStorage client to adopt";
+		return false;
+	}
+	shut_down();
+	client_ = std::move(p_client);
+	apply_connection_config(p_cfg);
+	project_path_ = p_project_path;
+	last_error_.clear();
+	return true;
+}
+
+bool ColdStorageVCS::is_connected_to_server() const {
+	return client_ && client_->isConnected();
+}
+
+String ColdStorageVCS::_to_depot_path(const String &p_file_path) const {
+	String path = p_file_path.replace("\\", "/");
+	if (path.begins_with("res://")) {
+		path = path.substr(6);
+	}
+	while (path.begins_with("./")) {
+		path = path.substr(2);
+	}
+	if (path.begins_with("//")) {
+		return path;
+	}
+	return String("//depot/") + path;
+}
+
+String ColdStorageVCS::_to_local_rel(const String &p_depot_path) const {
+	String d = p_depot_path;
+	const String prefix = "//depot/";
+	if (d.begins_with(prefix)) {
+		d = d.substr(prefix.length());
+	}
+	return d;
+}
+
+bool ColdStorageVCS::_connect_and_auth() {
+	last_error_.clear();
+	try {
+		if (!client_) {
+			client_ = std::make_unique<coldstorage::ColdStorageClient>();
+		}
+		client_->disconnect();
+
+		coldstorage::TlsOptions tls;
+		tls.enabled = config_.use_tls;
+		tls.verifyPeer = !config_.tls_insecure;
+		tls.caFile = String(config_.ca_file).utf8().get_data();
+
+		const std::string host = String(config_.host).utf8().get_data();
+		if (!client_->connect(host, config_.port, tls)) {
+			last_error_ = "Failed to connect to " + config_.host + ":" + itos(config_.port);
+			return false;
+		}
+
+		client_->setWorkspace(String(config_.workspace).utf8().get_data());
+		client_->setRepo(String(config_.repo).utf8().get_data());
+
+		String root = config_.workspace_root;
+		if (root.is_empty()) {
+			root = project_path_;
+		}
+		client_->setWorkspaceRoot(String(root).utf8().get_data());
+
+		if (!config_.jwt.is_empty()) {
+			if (!client_->authenticateWithJWT(String(config_.jwt).utf8().get_data())) {
+				last_error_ = "JWT authentication failed";
+				client_->disconnect();
+				return false;
+			}
+		} else if (!config_.ticket.is_empty()) {
+			client_->setTicket(String(config_.ticket).utf8().get_data());
+		} else {
+			String user = config_.user.is_empty() ? username_ : config_.user;
+			String pass = config_.password.is_empty() ? password_ : config_.password;
+			if (!user.is_empty()) {
+				std::string ticket = client_->login(String(user).utf8().get_data(), String(pass).utf8().get_data());
+				if (ticket.empty()) {
+					last_error_ = "Login failed";
+					if (!client_->lastError().empty()) {
+						last_error_ += ": " + String(client_->lastError().c_str());
+					}
+					client_->disconnect();
+					return false;
+				}
+			}
+		}
+
+		client_->ensureWorkspaceView();
+		remote_name_ = config_.host + ":" + itos(config_.port);
+		return true;
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+		if (client_) {
+			client_->disconnect();
+		}
+		return false;
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception during connect";
+		popup_error(last_error_);
+		if (client_) {
+			client_->disconnect();
+		}
+		return false;
+	}
+}
+
+bool ColdStorageVCS::initialize(const String &p_project_path) {
+	project_path_ = p_project_path;
+	if (config_.host.is_empty()) {
+		config_ = cold_storage_load_config();
+	}
+	if (config_.workspace_root.is_empty()) {
+		config_.workspace_root = p_project_path;
+	}
+	return _connect_and_auth();
+}
+
+void ColdStorageVCS::set_credentials(const String &p_username, const String &p_password, const String &, const String &, const String &) {
+	username_ = p_username;
+	password_ = p_password;
+	if (!p_username.is_empty()) {
+		config_.user = p_username;
+	}
+	if (!p_password.is_empty()) {
+		config_.password = p_password;
+	}
+	if (client_ && client_->isConnected() && !config_.user.is_empty()) {
+		try {
+			client_->login(String(config_.user).utf8().get_data(), String(config_.password).utf8().get_data());
+		} catch (const std::exception &e) {
+			last_error_ = String("ColdStorage exception: ") + e.what();
+			popup_error(last_error_);
+		} catch (...) {
+			last_error_ = "ColdStorage unknown exception during login";
+			popup_error(last_error_);
+		}
+	}
+}
+
+List<EditorVCSInterface::StatusFile> ColdStorageVCS::get_modified_files_data() {
+	List<StatusFile> status_files;
+	TypedArray<Dictionary> out = _collect_modified_files();
+	for (int i = 0; i < out.size(); i++) {
+		status_files.push_back(_convert_status_file(out[i]));
+	}
+	return status_files;
+}
+
+TypedArray<Dictionary> ColdStorageVCS::_collect_modified_files() {
+	TypedArray<Dictionary> out;
+	if (!client_ || !client_->isConnected()) {
+		return out;
+	}
+
+	try {
+		HashSet<String> staged;
+		for (const auto &f : client_->opened()) {
+			ChangeType ct = CHANGE_TYPE_MODIFIED;
+			if (f.action == "add") {
+				ct = CHANGE_TYPE_NEW;
+			} else if (f.action == "delete") {
+				ct = CHANGE_TYPE_DELETED;
+			} else if (f.action == "integrate" || f.action == "branch") {
+				ct = CHANGE_TYPE_RENAMED;
+			}
+			const String local = _to_local_rel(String(f.depotPath.c_str()));
+			staged.insert(local);
+			out.push_back(create_status_file(local, ct, TREE_AREA_STAGED));
+		}
+
+		auto st = client_->status();
+		if (st.success) {
+			for (const auto &e : st.entries) {
+				if (e.state == "opened" || e.state == "unchanged" || e.state.empty()) {
+					continue;
+				}
+				const String local = _to_local_rel(String(e.depotPath.c_str()));
+				if (staged.has(local)) {
+					continue;
+				}
+				ChangeType ct = CHANGE_TYPE_MODIFIED;
+				if (e.state == "add") {
+					ct = CHANGE_TYPE_NEW;
+				} else if (e.state == "delete") {
+					ct = CHANGE_TYPE_DELETED;
+				}
+				out.push_back(create_status_file(local, ct, TREE_AREA_UNSTAGED));
+			}
+		}
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception while collecting status";
+		popup_error(last_error_);
+	}
+	return out;
+}
+
+void ColdStorageVCS::stage_file(const String &p_file_path) {
+	if (!client_) {
+		return;
+	}
+	try {
+		const String depot = _to_depot_path(p_file_path);
+		const std::string d = depot.utf8().get_data();
+		std::filesystem::path local = std::filesystem::path(String(project_path_).utf8().get_data()) / String(_to_local_rel(depot)).utf8().get_data();
+		std::error_code ec;
+		const bool exists = std::filesystem::exists(local, ec);
+		auto st = client_->fileInfo({ d });
+		bool tracked = false;
+		for (const auto &e : st.entries) {
+			if (e.depotPath == d && e.haveRev > 0) {
+				tracked = true;
+				break;
+			}
+		}
+		if (!exists && tracked) {
+			client_->delete_(d);
+		} else if (exists && !tracked) {
+			client_->add(d, local.generic_string());
+		} else if (exists) {
+			client_->edit(d);
+		}
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception while staging";
+		popup_error(last_error_);
+	}
+}
+
+void ColdStorageVCS::unstage_file(const String &p_file_path) {
+	if (!client_) {
+		return;
+	}
+	try {
+		client_->revert(_to_depot_path(p_file_path).utf8().get_data());
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception while unstaging";
+		popup_error(last_error_);
+	}
+}
+
+void ColdStorageVCS::discard_file(const String &p_file_path) {
+	unstage_file(p_file_path);
+}
+
+void ColdStorageVCS::commit(const String &p_msg) {
+	if (!client_) {
+		return;
+	}
+	try {
+		auto r = client_->submit(String(p_msg).utf8().get_data());
+		if (!r.success) {
+			last_error_ = String(r.error.c_str());
+			popup_error("ColdStorage submit failed: " + last_error_);
+		}
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception during submit";
+		popup_error(last_error_);
+	}
+}
+
+List<EditorVCSInterface::DiffFile> ColdStorageVCS::get_diff(const String &p_identifier, TreeArea p_area) {
+	(void)p_area;
+	List<DiffFile> diff_files;
+	TypedArray<Dictionary> files = _build_diff(p_identifier);
+	for (int i = 0; i < files.size(); i++) {
+		diff_files.push_back(_convert_diff_file(files[i]));
+	}
+	return diff_files;
+}
+
+TypedArray<Dictionary> ColdStorageVCS::_build_diff(const String &p_identifier) {
+	TypedArray<Dictionary> files;
+	if (!client_ || p_identifier.is_empty()) {
+		return files;
+	}
+
+	try {
+		const String depot = _to_depot_path(p_identifier);
+		std::string remote_content;
+		client_->printStreaming(depot.utf8().get_data(), [&](const uint8_t *data, size_t len) {
+			remote_content.append(reinterpret_cast<const char *>(data), len);
+			return true;
+		});
+
+		std::filesystem::path local_path = std::filesystem::path(String(project_path_).utf8().get_data()) / String(_to_local_rel(depot)).utf8().get_data();
+		std::ifstream in(local_path, std::ios::binary);
+		std::string local_content;
+		if (in) {
+			local_content.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+		}
+
+		Dictionary diff_file = create_diff_file(p_identifier, p_identifier);
+		TypedArray<Dictionary> hunks;
+		TypedArray<Dictionary> lines;
+
+		if (coldstorage::looksBinary(remote_content) || coldstorage::looksBinary(local_content)) {
+			Dictionary hunk = create_diff_hunk(1, 1, 1, 1);
+			lines.push_back(create_diff_line(-1, -1, "Binary file (diff not shown)", " "));
+			hunk = add_line_diffs_into_diff_hunk(hunk, lines);
+			hunks.push_back(hunk);
+			diff_file = add_diff_hunks_into_diff_file(diff_file, hunks);
+			files.push_back(diff_file);
+			return files;
+		}
+
+		const std::string rel = String(_to_local_rel(depot)).utf8().get_data();
+		const std::string unified = coldstorage::unifiedDiffText(remote_content, local_content,
+				"a/" + rel, "b/" + rel, rel);
+
+		int old_line = 0;
+		int new_line = 0;
+		const size_t max_lines = 2000;
+		size_t emitted = 0;
+		bool truncated = false;
+		std::istringstream ss(unified);
+		std::string line;
+		while (std::getline(ss, line)) {
+			if (line.rfind("---", 0) == 0 || line.rfind("+++", 0) == 0 || line.rfind("@@", 0) == 0) {
+				continue;
+			}
+			if (line.empty()) {
+				continue;
+			}
+			const char tag = line[0];
+			const String text = String(line.c_str() + 1);
+			if (emitted >= max_lines) {
+				truncated = true;
+				break;
+			}
+			if (tag == ' ') {
+				++old_line;
+				++new_line;
+				lines.push_back(create_diff_line(old_line, new_line, text, " "));
+			} else if (tag == '-') {
+				++old_line;
+				lines.push_back(create_diff_line(old_line, -1, text, "-"));
+			} else if (tag == '+') {
+				++new_line;
+				lines.push_back(create_diff_line(-1, new_line, text, "+"));
+			} else {
+				continue;
+			}
+			++emitted;
+		}
+		if (truncated) {
+			lines.push_back(create_diff_line(-1, -1, String("… truncated after ") + itos((int64_t)max_lines) + " lines", " "));
+		}
+
+		Dictionary hunk = create_diff_hunk(1, 1, MAX(old_line, 1), MAX(new_line, 1));
+		hunk = add_line_diffs_into_diff_hunk(hunk, lines);
+		hunks.push_back(hunk);
+		diff_file = add_diff_hunks_into_diff_file(diff_file, hunks);
+		files.push_back(diff_file);
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception while building diff";
+		popup_error(last_error_);
+	}
+	return files;
+}
+
+bool ColdStorageVCS::shut_down() {
+	try {
+		if (client_) {
+			client_->disconnect();
+			client_.reset();
+		}
+	} catch (...) {
+		client_.reset();
+	}
+	return true;
+}
+
+String ColdStorageVCS::get_vcs_name() {
+	return "ColdStorage";
+}
+
+List<EditorVCSInterface::Commit> ColdStorageVCS::get_previous_commits(int p_max_commits) {
+	List<Commit> commits;
+	if (!client_) {
+		return commits;
+	}
+	try {
+		int max_n = p_max_commits > 0 ? p_max_commits : 32;
+		auto entries = client_->log("//depot/...", max_n);
+		for (const auto &e : entries) {
+			commits.push_back(_convert_commit(create_commit(String(e.description.c_str()), String(e.user.c_str()),
+					itos(e.changeNum), e.timestamp, 0)));
+		}
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception while fetching log";
+		popup_error(last_error_);
+	}
+	return commits;
+}
+
+List<String> ColdStorageVCS::get_branch_list() {
+	List<String> out;
+	out.push_back(current_branch_);
+	return out;
+}
+
+List<String> ColdStorageVCS::get_remotes() {
+	List<String> out;
+	out.push_back(remote_name_);
+	return out;
+}
+
+void ColdStorageVCS::create_branch(const String &p_branch_name) {
+	if (!client_) {
+		return;
+	}
+	try {
+		const String src = "//depot/" + current_branch_ + "/...";
+		const String dst = "//depot/" + p_branch_name + "/...";
+		auto r = client_->branch(src.utf8().get_data(), dst.utf8().get_data());
+		if (r.success) {
+			current_branch_ = p_branch_name;
+		} else {
+			last_error_ = String(r.error.c_str());
+		}
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception while creating branch";
+		popup_error(last_error_);
+	}
+}
+
+void ColdStorageVCS::remove_branch(const String &p_branch_name) {
+	last_error_ = "ColdStorage does not support deleting branch '" + p_branch_name + "' from the editor client.";
+	popup_error(last_error_);
+}
+
+void ColdStorageVCS::create_remote(const String &p_remote_name, const String &p_remote_url) {
+	remote_name_ = p_remote_name;
+	if (p_remote_url.contains(":")) {
+		PackedStringArray parts = p_remote_url.split(":");
+		if (parts.size() >= 2) {
+			config_.host = parts[0];
+			config_.port = parts[1].to_int();
+		}
+	}
+}
+
+void ColdStorageVCS::remove_remote(const String &p_remote_name) {
+	if (p_remote_name == remote_name_) {
+		remote_name_ = config_.host + ":" + itos(config_.port);
+		return;
+	}
+	last_error_ = "ColdStorage remote '" + p_remote_name + "' was not found.";
+	popup_error(last_error_);
+}
+
+String ColdStorageVCS::get_current_branch_name() {
+	return current_branch_;
+}
+
+bool ColdStorageVCS::checkout_branch(const String &p_branch_name) {
+	current_branch_ = p_branch_name;
+	pull(remote_name_);
+	return true;
+}
+
+void ColdStorageVCS::pull(const String &) {
+	auto_pull_sync();
+}
+
+void ColdStorageVCS::push(const String &, bool) {
+	last_error_ = "ColdStorage publishes changes on Commit (submit). Push / force-push are not used.";
+	popup_error(last_error_);
+}
+
+void ColdStorageVCS::fetch(const String &p_remote) {
+	pull(p_remote);
+}
+
+List<EditorVCSInterface::DiffHunk> ColdStorageVCS::get_line_diff(const String &p_file_path, const String &) {
+	List<DiffHunk> hunks;
+	TypedArray<Dictionary> files = _build_diff(p_file_path);
+	if (files.is_empty()) {
+		return hunks;
+	}
+	DiffFile df = _convert_diff_file(files[0]);
+	for (const DiffHunk &h : df.diff_hunks) {
+		hunks.push_back(h);
+	}
+	return hunks;
+}
+
+bool ColdStorageVCS::validate_connection() {
+	if (!client_ || !client_->isConnected()) {
+		last_error_ = "Not connected";
+		return false;
+	}
+	try {
+		auto info = client_->info();
+		if (info.name.empty() && info.version.empty()) {
+			last_error_ = "Server info() failed";
+			if (!client_->lastError().empty()) {
+				last_error_ += ": " + String(client_->lastError().c_str());
+			}
+			return false;
+		}
+		return true;
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+		return false;
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception during validate";
+		popup_error(last_error_);
+		return false;
+	}
+}
+
+bool ColdStorageVCS::auto_pull_sync() {
+	if (!client_ || !client_->isConnected()) {
+		return false;
+	}
+	try {
+		auto r = client_->syncAll("#head");
+		if (!r.success) {
+			last_error_ = String(r.error.c_str());
+			return false;
+		}
+		return true;
+	} catch (const std::exception &e) {
+		last_error_ = String("ColdStorage exception: ") + e.what();
+		popup_error(last_error_);
+		return false;
+	} catch (...) {
+		last_error_ = "ColdStorage unknown exception during sync";
+		popup_error(last_error_);
+		return false;
+	}
+}
+
+#endif

--- a/modules/coldstorage/cold_storage_vcs.h
+++ b/modules/coldstorage/cold_storage_vcs.h
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*  cold_storage_vcs.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "cold_storage_settings.h"
+#include "editor/editor_vcs_interface.h"
+
+#include <memory>
+#include <string>
+
+namespace coldstorage {
+class ColdStorageClient;
+}
+
+class ColdStorageVCS : public EditorVCSInterface {
+	GDCLASS(ColdStorageVCS, EditorVCSInterface);
+
+	std::unique_ptr<coldstorage::ColdStorageClient> client_;
+	ColdStorageConnectionConfig config_;
+	String project_path_;
+	String last_error_;
+	String username_;
+	String password_;
+	String current_branch_ = "main";
+	String remote_name_ = "origin";
+
+	bool _connect_and_auth();
+	String _to_depot_path(const String &p_file_path) const;
+	String _to_local_rel(const String &p_depot_path) const;
+
+	TypedArray<Dictionary> _collect_modified_files();
+	TypedArray<Dictionary> _build_diff(const String &p_identifier);
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual bool initialize(const String &p_project_path) override;
+	virtual void set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key_path, const String &p_ssh_private_key_path, const String &p_ssh_passphrase) override;
+	virtual List<StatusFile> get_modified_files_data() override;
+	virtual void stage_file(const String &p_file_path) override;
+	virtual void unstage_file(const String &p_file_path) override;
+	virtual void discard_file(const String &p_file_path) override;
+	virtual void commit(const String &p_msg) override;
+	virtual List<DiffFile> get_diff(const String &p_identifier, TreeArea p_area) override;
+	virtual bool shut_down() override;
+	virtual String get_vcs_name() override;
+	virtual List<Commit> get_previous_commits(int p_max_commits) override;
+	virtual List<String> get_branch_list() override;
+	virtual List<String> get_remotes() override;
+	virtual void create_branch(const String &p_branch_name) override;
+	virtual void remove_branch(const String &p_branch_name) override;
+	virtual void create_remote(const String &p_remote_name, const String &p_remote_url) override;
+	virtual void remove_remote(const String &p_remote_name) override;
+	virtual String get_current_branch_name() override;
+	virtual bool checkout_branch(const String &p_branch_name) override;
+	virtual void pull(const String &p_remote) override;
+	virtual void push(const String &p_remote, bool p_force) override;
+	virtual void fetch(const String &p_remote) override;
+	virtual List<DiffHunk> get_line_diff(const String &p_file_path, const String &p_text) override;
+
+	void apply_connection_config(const ColdStorageConnectionConfig &p_cfg);
+	bool is_connected_to_server() const;
+	String get_last_error() const { return last_error_; }
+	bool validate_connection();
+	bool auto_pull_sync();
+
+	// Adopt a client already connected on a worker thread (main thread only).
+	bool adopt_connected_client(std::unique_ptr<coldstorage::ColdStorageClient> p_client, const ColdStorageConnectionConfig &p_cfg, const String &p_project_path);
+
+	ColdStorageVCS();
+	~ColdStorageVCS() override;
+};
+
+#endif

--- a/modules/coldstorage/config.py
+++ b/modules/coldstorage/config.py
@@ -1,0 +1,72 @@
+import os
+
+
+def get_opts(platform):
+    from SCons.Variables import PathVariable
+
+    return [
+        PathVariable(
+            "coldstorage_path",
+            "Path to ColdStorage repo root (contains src/client/sdk); overrides vendored modules/coldstorage/sdk",
+            "",
+            PathVariable.PathAccept,
+        ),
+    ]
+
+
+def resolve_coldstorage_sdk_path(env=None, engine_root=None, module_dir=None):
+    """Return absolute ColdStorage repo root if src/client/sdk exists, else ''."""
+    candidates = []
+    if env is not None:
+        configured = env.get("coldstorage_path", "")
+        if configured:
+            candidates.append(os.path.normpath(str(configured)))
+
+    # Vendored copy inside the Blazium module (primary for CI / releases).
+    if module_dir:
+        candidates.append(os.path.normpath(module_dir))
+        candidates.append(os.path.normpath(os.path.join(module_dir, "sdk")))
+
+    if engine_root:
+        engine_root = os.path.normpath(engine_root)
+        candidates.append(os.path.normpath(os.path.join(engine_root, "modules", "coldstorage", "sdk")))
+        candidates.append(os.path.normpath(os.path.join(engine_root, "..", "coldstorage")))
+        candidates.append(os.path.normpath(os.path.join(engine_root, "coldstorage-sdk")))
+
+    for path in candidates:
+        if path and os.path.isdir(os.path.join(path, "src", "client", "sdk")):
+            return path
+    return ""
+
+
+def can_build(env, platform):
+    if not env.editor_build:
+        return False
+
+    engine_root = env.Dir("#").abspath
+    module_dir = os.path.join(engine_root, "modules", "coldstorage")
+    sdk = resolve_coldstorage_sdk_path(env, engine_root, module_dir)
+    if not sdk:
+        return False
+
+    env.module_add_dependencies("coldstorage", ["mbedtls"], True)
+    env["coldstorage_sdk_resolved"] = sdk
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    # JSON comes from engine core/io/json via sdk_shims/nlohmann/json.hpp (no vendored nlohmann).
+    return [
+        "ColdStorageVCS",
+        "ColdStorageEditorPlugin",
+        "ColdStorageSettingsInspectorPlugin",
+        "ColdStorageSettingsUI",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/coldstorage/doc_classes/ColdStorageEditorPlugin.xml
+++ b/modules/coldstorage/doc_classes/ColdStorageEditorPlugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ColdStorageEditorPlugin" inherits="EditorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Editor plugin for ColdStorage configuration, status, and CLI autoconnect.
+	</brief_description>
+	<description>
+		Adds Project menu [b]ColdStorage Configuration[/b], toolbar connection status, and deferred startup for [code]--enable-coldstorage[/code] CLI flags.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/coldstorage/doc_classes/ColdStorageSettingsInspectorPlugin.xml
+++ b/modules/coldstorage/doc_classes/ColdStorageSettingsInspectorPlugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ColdStorageSettingsInspectorPlugin" inherits="EditorInspectorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Inspector plugin that injects ColdStorage connection controls.
+	</brief_description>
+	<description>
+		Replaces the [code]blazium/coldstorage/z_connection_controls[/code] sentinel property with [ColdStorageSettingsUI].
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/coldstorage/doc_classes/ColdStorageSettingsUI.xml
+++ b/modules/coldstorage/doc_classes/ColdStorageSettingsUI.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ColdStorageSettingsUI" inherits="MarginContainer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Connection controls for ColdStorage editor settings.
+	</brief_description>
+	<description>
+		Host/port/auth controls with Connect, Disconnect, Test, and Save actions. Embedded in Project/Editor settings via the [code]z_connection_controls[/code] sentinel.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="custom_minimum_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" overrides="Control" default="Vector2(0, 220)" />
+	</members>
+</class>

--- a/modules/coldstorage/doc_classes/ColdStorageVCS.xml
+++ b/modules/coldstorage/doc_classes/ColdStorageVCS.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ColdStorageVCS" inherits="EditorVCSInterface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Editor VCS provider backed by the ColdStorage client SDK.
+	</brief_description>
+	<description>
+		Implements [EditorVCSInterface] against a ColdStorage ([code]cstoraged[/code]) server. Stage maps to open-for-add/edit/delete, commit maps to submit, and pull/fetch map to sync.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/coldstorage/register_types.cpp
+++ b/modules/coldstorage/register_types.cpp
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#ifdef TOOLS_ENABLED
+#include "cold_storage_editor_plugin.h"
+#include "cold_storage_settings.h"
+#include "cold_storage_settings_ui.h"
+#include "cold_storage_vcs.h"
+#include "editor/editor_node.h"
+#include "editor/plugins/editor_plugin.h"
+#endif
+
+void initialize_coldstorage_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		cold_storage_register_project_settings();
+		GDREGISTER_CLASS(ColdStorageVCS);
+		GDREGISTER_CLASS(ColdStorageSettingsUI);
+		GDREGISTER_CLASS(ColdStorageSettingsInspectorPlugin);
+		GDREGISTER_CLASS(ColdStorageEditorPlugin);
+		EditorPlugins::add_by_type<ColdStorageEditorPlugin>();
+	}
+#else
+	(void)p_level;
+#endif
+}
+
+void uninitialize_coldstorage_module(ModuleInitializationLevel p_level) {
+	(void)p_level;
+}

--- a/modules/coldstorage/register_types.h
+++ b/modules/coldstorage/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_coldstorage_module(ModuleInitializationLevel p_level);
+void uninitialize_coldstorage_module(ModuleInitializationLevel p_level);

--- a/modules/coldstorage/sdk/src/client/sdk/client_sdk.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/client_sdk.cpp
@@ -1,0 +1,659 @@
+/**************************************************************************/
+/*  client_sdk.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/client_sdk.h"
+#include "client/sdk/sdk_internal.h"
+#include "client/sdk/workspace.h"
+#include "client/sdk/workspace_filters.h"
+#include "client/sdk/workspace_status.h"
+#include "common/protocol/messages.h"
+#include "common/util/net_trace.h"
+#include "common/util/sanitize.h"
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <mutex>
+#include <thread>
+
+namespace coldstorage {
+
+ColdStorageClient::ColdStorageClient() :
+		conn_(std::make_unique<ServerConnection>()) {}
+ColdStorageClient::~ColdStorageClient() = default;
+
+bool ColdStorageClient::connectTransport(const std::string &host, int port, const TlsOptions &tls) {
+	std::string safeHost = sanitize::trim(host);
+	if (!sanitize::isValidHost(safeHost)) {
+		std::cerr << "Error: invalid server host\n";
+		return false;
+	}
+	if (!sanitize::isValidPort(port)) {
+		std::cerr << "Error: invalid port number\n";
+		return false;
+	}
+	if (!conn_->connectTransport(safeHost, port, tls)) {
+		return false;
+	}
+	lastHost_ = safeHost;
+	lastPort_ = port;
+	lastTls_ = tls;
+	return true;
+}
+
+bool ColdStorageClient::negotiate() {
+	return conn_->negotiate();
+}
+
+std::string ColdStorageClient::peerFingerprint() const {
+	return conn_->peerFingerprint();
+}
+
+bool ColdStorageClient::connect(const std::string &host, int port, const TlsOptions &tls) {
+	CS_NET_TRACE("ColdStorageClient", "connect begin host=" << host << " port=" << port);
+	if (!connectTransport(host, port, tls)) {
+		CS_NET_TRACE("ColdStorageClient", "connect transport failed");
+		return false;
+	}
+	const bool ok = negotiate();
+	CS_NET_TRACE("ColdStorageClient", "connect " << (ok ? "ok" : "negotiate failed"));
+	return ok;
+}
+
+void ColdStorageClient::disconnect() {
+	conn_->disconnect();
+}
+bool ColdStorageClient::isConnected() const {
+	return conn_->isConnected();
+}
+void ColdStorageClient::setTicket(const std::string &ticket) {
+	ticket_ = ticket;
+}
+void ColdStorageClient::setWorkspace(const std::string &name) {
+	workspace_ = sanitize::trim(name);
+	invalidateWorkspaceView();
+}
+std::string ColdStorageClient::getWorkspace() const {
+	return workspace_;
+}
+void ColdStorageClient::setWorkspaceRoot(const std::string &root) {
+	workspaceRoot_ = root;
+	filters_.reset();
+	invalidateWorkspaceView();
+}
+
+void ColdStorageClient::initWorkspaceFilters(const IgnoreLoadOptions &opts) {
+	if (workspaceRoot_.empty()) {
+		return;
+	}
+	filters_ = std::make_unique<WorkspaceFilters>(workspaceRoot_, opts);
+}
+
+void ColdStorageClient::setMaxDownloadBytes(size_t bytes) {
+	maxDownloadBytes_ = bytes > 0 ? bytes : (32ULL * 1024 * 1024 * 1024);
+}
+
+void ColdStorageClient::setRepo(const std::string &repo) {
+	repo_ = sanitize::trim(repo);
+}
+std::string ColdStorageClient::getRepo() const {
+	return repo_;
+}
+
+StatusResult ColdStorageClient::status(const std::vector<std::string> &pathScope) {
+	if (!filters_) {
+		initWorkspaceFilters();
+	}
+	if (!filters_) {
+		StatusResult r;
+		r.error = "Workspace root not set";
+		return r;
+	}
+	filters_->reloadIfStale();
+	return computeWorkspaceStatus(*this, *filters_, pathScope);
+}
+
+FileInfoResult ColdStorageClient::fileInfo(const std::vector<std::string> &pathScope) {
+	if (!filters_) {
+		initWorkspaceFilters();
+	}
+	if (!filters_) {
+		FileInfoResult r;
+		r.error = "Workspace root not set";
+		return r;
+	}
+	filters_->reloadIfStale();
+	return computeWorkspaceFileInfo(*this, *filters_, pathScope);
+}
+
+ReconcileResult ColdStorageClient::reconcile(bool preview, ReconcileFlags flags,
+		const std::vector<std::string> &pathScope) {
+	if (!filters_) {
+		initWorkspaceFilters();
+	}
+	if (!filters_) {
+		ReconcileResult r;
+		r.error = "Workspace root not set";
+		return r;
+	}
+	filters_->reloadIfStale();
+	return reconcileWorkspace(*this, *filters_, preview, flags, pathScope);
+}
+
+const Workspace *ColdStorageClient::ensureWorkspaceView() {
+	if (cachedWorkspace_) {
+		return cachedWorkspace_.get();
+	}
+	if (workspaceViewLoaded_) {
+		return nullptr;
+	}
+	workspaceViewLoaded_ = true;
+	if (workspace_.empty() || workspaceRoot_.empty()) {
+		return nullptr;
+	}
+
+	auto page = exec("workspace_info", {});
+	if (!page.success || !page.data.value("success", false)) {
+		return nullptr;
+	}
+
+	nlohmann::json viewJson = page.data.value("view", nlohmann::json::array());
+	auto mappings = Workspace::parseView(viewJson);
+	cachedWorkspace_ = std::make_unique<Workspace>(workspace_, workspaceRoot_, mappings);
+	return cachedWorkspace_.get();
+}
+
+void ColdStorageClient::invalidateWorkspaceView() {
+	cachedWorkspace_.reset();
+	workspaceViewLoaded_ = false;
+}
+
+Message ColdStorageClient::makeCommand(const std::string &func, const nlohmann::json &args) {
+	Message msg;
+	msg.func = func;
+	msg.args = args;
+	if (!ticket_.empty()) {
+		msg.args["ticket"] = ticket_;
+	}
+	if (!user_.empty()) {
+		msg.args["user"] = user_;
+	}
+	if (!workspace_.empty()) {
+		msg.args["workspace"] = workspace_;
+	}
+	if (!repo_.empty()) {
+		msg.args["repo"] = repo_;
+	}
+	return msg;
+}
+
+ServerConnection::CommandResult ColdStorageClient::exec(const std::string &func, const nlohmann::json &args) {
+	return conn_->executeCommand(makeCommand(func, args));
+}
+
+std::string ColdStorageClient::login(const std::string &user, const std::string &password) {
+	CS_NET_TRACE("ColdStorageClient", "login begin user=" << user);
+
+	std::string safeUser = sanitize::trim(user);
+	std::string safePw = sanitize::trim(password);
+	auto result = exec("login", { { "user", safeUser }, { "password", safePw } });
+	if (result.success) {
+		ticket_ = result.data.value("ticket", "");
+		user_ = safeUser;
+		CS_NET_TRACE("ColdStorageClient", "login ok user=" << safeUser);
+		return ticket_;
+	}
+	CS_NET_TRACE("ColdStorageClient", "login failed user=" << safeUser << " error=" << result.error);
+	return "";
+}
+
+bool ColdStorageClient::authenticateWithJWT(const std::string &token) {
+	std::string safeToken = sanitize::trim(token);
+	if (!sanitize::isValidJWTFormat(safeToken)) {
+		std::cerr << "Error: invalid JWT token format\n";
+		return false;
+	}
+	auto result = exec("jwt_auth", { { "token", safeToken } });
+	if (result.success) {
+		user_ = result.data.value("user", "");
+		repo_ = result.data.value("org", "") + "/" + result.data.value("repo", "");
+		workspace_ = result.data.value("workspace", "");
+
+		ticket_ = "";
+		return true;
+	}
+	return false;
+}
+
+ServerInfo ColdStorageClient::info() {
+	auto result = exec("info");
+	ServerInfo si;
+	si.name = result.data.value("name", "");
+	si.version = result.data.value("version", "");
+	si.uptime = result.data.value("uptime", 0);
+	si.changeCount = result.data.value("change_count", 0);
+	return si;
+}
+
+bool ColdStorageClient::add(const std::string &depotPath, const std::string &localPath) {
+	auto result = exec("add", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+bool ColdStorageClient::edit(const std::string &depotPath) {
+	auto result = exec("edit", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+bool ColdStorageClient::delete_(const std::string &depotPath) {
+	auto result = exec("delete", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+bool ColdStorageClient::revert(const std::string &depotPath) {
+	auto result = exec("revert", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+std::vector<OpenedFile> ColdStorageClient::opened() {
+	lastError_.clear();
+	auto result = exec("opened");
+	std::vector<OpenedFile> files;
+	if (!result.success) {
+		lastError_ = result.error.empty() ? "opened failed" : result.error;
+		return files;
+	}
+	if (result.data.contains("files")) {
+		for (const auto &f : result.data["files"]) {
+			OpenedFile of;
+			of.depotPath = f.value("depot_path", "");
+			of.action = f.value("action", "");
+			of.baseRev = f.value("base_rev", 0);
+			of.fromPath = f.value("from_path", "");
+			of.fromRev = f.value("from_rev", 0);
+			files.push_back(std::move(of));
+		}
+	}
+	return files;
+}
+
+SubmitResult ColdStorageClient::submit(const std::string &description) {
+	lastError_.clear();
+	auto cmd = makeCommand("submit", { { "description", description } });
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return { false, 0, "Send failed" };
+	}
+
+	SubmitResult sr{ false, 0, "" };
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			sr.error = "Connection lost";
+			lastError_ = sr.error;
+			return sr;
+		}
+
+		if (instr->op == InstructionOp::SendFile) {
+			if (!respondSendFile(*instr)) {
+				sr.error = "Failed to send file content";
+				lastError_ = sr.error;
+				return sr;
+			}
+		} else if (instr->op == InstructionOp::Release) {
+			sr.success = instr->data.value("success", false);
+			sr.changeNum = instr->data.value("change_num", 0);
+			if (instr->data.contains("conflicts")) {
+				sr.conflictFiles = instr->data["conflicts"].get<std::vector<std::string>>();
+			}
+			if (!sr.success && lastError_.empty() && !sr.error.empty()) {
+				lastError_ = sr.error;
+			} else if (!sr.success && lastError_.empty()) {
+				lastError_ = "submit failed";
+			}
+			return sr;
+		} else if (instr->op == InstructionOp::Error) {
+			sr.error = instr->data.value("text", "");
+			lastError_ = sr.error;
+		}
+	}
+}
+
+SyncResult ColdStorageClient::sync(const std::string &targetSpec, const std::string &cursor,
+		const std::string &untilPath) {
+	lastError_.clear();
+	nlohmann::json args = { { "target", targetSpec } };
+	if (!cursor.empty()) {
+		args["cursor"] = cursor;
+		args["after_path"] = cursor;
+	}
+	if (!untilPath.empty()) {
+		args["until_path"] = untilPath;
+	}
+	auto cmd = makeCommand("sync", args);
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return { false, 0, 0, 0, 0, "Send failed" };
+	}
+
+	SyncResult sr{};
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			sr.error = "Connection lost";
+			lastError_ = sr.error;
+			return sr;
+		}
+
+		if (instr->op == InstructionOp::WriteFile || instr->op == InstructionOp::ChunkBegin) {
+			std::string err;
+			if (!sdk_internal::writeInstructionToLocalFile(*conn_, *instr, workspaceRoot_, &err,
+						maxDownloadBytes_, filters_.get())) {
+				sr.error = err;
+				lastError_ = err;
+				return sr;
+			}
+		} else if (instr->op == InstructionOp::DeleteFile) {
+			if (workspaceRoot_.empty()) {
+				sr.error = "Workspace root required for local file deletes";
+				lastError_ = sr.error;
+				return sr;
+			}
+			std::string depotPath = instr->data.value("path", "");
+			std::string localPath = sdk_internal::depotToLocalPath(depotPath, workspaceRoot_);
+			if (localPath.empty()) {
+				sr.error = "Invalid or escaped depot path on delete: " + depotPath;
+				lastError_ = sr.error;
+				return sr;
+			}
+			std::filesystem::remove(localPath);
+		} else if (instr->op == InstructionOp::Release) {
+			sr.success = instr->data.value("success", false);
+			sr.filesUpdated = instr->data.value("updated", 0);
+			sr.filesDeleted = instr->data.value("deleted", 0);
+			sr.filesUnchanged = instr->data.value("unchanged", 0);
+			sr.filesDenied = instr->data.value("denied", 0);
+			sr.more = instr->data.value("more", false);
+			sr.nextCursor = instr->data.value("next_cursor", "");
+			sr.stoppedAtLimit = instr->data.value("stopped_at_limit", false);
+			if (!sr.success && lastError_.empty()) {
+				if (!sr.error.empty()) {
+					lastError_ = sr.error;
+				} else {
+					lastError_ = "sync failed";
+				}
+			}
+			return sr;
+		} else if (instr->op == InstructionOp::Error) {
+			sr.error = instr->data.value("text", "");
+			lastError_ = sr.error;
+		} else if (instr->op == InstructionOp::Info) {
+		}
+	}
+}
+
+SyncResult ColdStorageClient::syncAll(const std::string &targetSpec) {
+	SyncResult total{};
+	total.success = true;
+	std::string cursor;
+	constexpr int kMaxPages = 100000;
+	for (int page = 0; page < kMaxPages; ++page) {
+		auto sr = sync(targetSpec, cursor);
+		if (!sr.success) {
+			total.success = false;
+			total.error = sr.error;
+			return total;
+		}
+		total.filesUpdated += sr.filesUpdated;
+		total.filesDeleted += sr.filesDeleted;
+		total.filesUnchanged += sr.filesUnchanged;
+		total.filesDenied += sr.filesDenied;
+		if (!sr.more) {
+			total.more = false;
+			total.nextCursor.clear();
+			total.stoppedAtLimit = false;
+			return total;
+		}
+		cursor = sr.nextCursor;
+		if (cursor.empty()) {
+			total.success = false;
+			total.error = "sync more=true but next_cursor empty";
+			total.more = true;
+			total.stoppedAtLimit = sr.stoppedAtLimit;
+			return total;
+		}
+	}
+	total.success = false;
+	total.error = "syncAll exceeded max pages";
+	total.more = true;
+	return total;
+}
+
+SyncResult ColdStorageClient::syncAllParallel(int workers, const std::string &targetSpec) {
+	if (workers < 1) {
+		workers = 1;
+	}
+	if (workers > 8) {
+		workers = 8;
+	}
+	if (workers == 1 || !conn_ || lastHost_.empty() || ticket_.empty()) {
+		return syncAll(targetSpec);
+	}
+
+	static const char *kSplits[] = {
+		"//0", "//4", "//8", "//A", "//E", "//a", "//e", "//~"
+	};
+	std::vector<std::string> bounds;
+	bounds.push_back("");
+	for (int i = 0; i < workers - 1 && i < 7; ++i) {
+		bounds.push_back(kSplits[i]);
+	}
+
+	bounds.push_back("//~~~");
+
+	SyncResult total{};
+	total.success = true;
+	std::mutex totalMu;
+	std::atomic<bool> failed{ false };
+	std::string failError;
+
+	auto drainRange = [&](const std::string &after, const std::string &until) {
+		ColdStorageClient worker;
+		if (!worker.connect(lastHost_, lastPort_, lastTls_)) {
+			std::lock_guard<std::mutex> lock(totalMu);
+			failed = true;
+			failError = "parallel sync connect failed";
+			return;
+		}
+		worker.setTicket(ticket_);
+		worker.user_ = user_;
+		worker.setWorkspace(workspace_);
+		worker.setWorkspaceRoot(workspaceRoot_);
+		worker.setRepo(repo_);
+		worker.setMaxDownloadBytes(maxDownloadBytes_);
+
+		std::string cursor = after;
+		constexpr int kMaxPages = 100000;
+		for (int page = 0; page < kMaxPages && !failed.load(); ++page) {
+			auto sr = worker.sync(targetSpec, cursor, until);
+			if (!sr.success) {
+				std::lock_guard<std::mutex> lock(totalMu);
+				failed = true;
+				failError = sr.error.empty() ? "parallel sync page failed" : sr.error;
+				return;
+			}
+			{
+				std::lock_guard<std::mutex> lock(totalMu);
+				total.filesUpdated += sr.filesUpdated;
+				total.filesDeleted += sr.filesDeleted;
+				total.filesUnchanged += sr.filesUnchanged;
+				total.filesDenied += sr.filesDenied;
+			}
+			if (!sr.more) {
+				break;
+			}
+			cursor = sr.nextCursor;
+			if (cursor.empty()) {
+				break;
+			}
+			if (!until.empty() && cursor >= until) {
+				break;
+			}
+		}
+	};
+
+	std::vector<std::thread> threads;
+	threads.reserve(static_cast<size_t>(workers));
+	for (size_t i = 0; i + 1 < bounds.size(); ++i) {
+		threads.emplace_back(drainRange, bounds[i], bounds[i + 1]);
+	}
+	for (auto &t : threads) {
+		t.join();
+	}
+
+	if (failed.load()) {
+		total.success = false;
+		total.error = failError;
+		return total;
+	}
+
+	const std::string kOrphanPrefix = std::string("orphan") + '\x1f';
+	std::string orphanCursor = kOrphanPrefix;
+	constexpr int kMaxPages = 100000;
+	for (int page = 0; page < kMaxPages; ++page) {
+		auto sr = sync(targetSpec, orphanCursor);
+		if (!sr.success) {
+			total.success = false;
+			total.error = sr.error;
+			return total;
+		}
+		total.filesUpdated += sr.filesUpdated;
+		total.filesDeleted += sr.filesDeleted;
+		total.filesUnchanged += sr.filesUnchanged;
+		total.filesDenied += sr.filesDenied;
+		if (!sr.more) {
+			break;
+		}
+		orphanCursor = sr.nextCursor;
+		if (orphanCursor.empty()) {
+			break;
+		}
+	}
+	return total;
+}
+
+std::vector<LogEntry> ColdStorageClient::log(const std::string &depotPath, int maxEntries) {
+	auto result = exec("log", { { "depot_path", depotPath }, { "max_entries", maxEntries } });
+	std::vector<LogEntry> entries;
+	if (result.data.contains("entries")) {
+		for (const auto &e : result.data["entries"]) {
+			entries.push_back({ e.value("depot_path", ""), e.value("rev_num", 0), e.value("change_num", 0),
+					e.value("action", ""), e.value("user", ""), e.value("description", ""), e.value("timestamp", 0) });
+		}
+	}
+	return entries;
+}
+
+BranchResult ColdStorageClient::branch(const std::string &src, const std::string &dst) {
+	lastError_.clear();
+	auto result = exec("branch", { { "source", src }, { "destination", dst } });
+	BranchResult br;
+	br.success = result.success;
+	br.error = result.error;
+	if (result.success) {
+		br.changeNum = result.data.value("change_num", static_cast<int64_t>(0));
+		br.files = result.data.value("files", 0);
+		br.denied = result.data.value("denied", 0);
+	} else {
+		lastError_ = result.error.empty() ? "branch failed" : result.error;
+	}
+	return br;
+}
+
+IntegrateResult ColdStorageClient::integrate(const std::string &src, const std::string &dst) {
+	lastError_.clear();
+	auto result = exec("integrate", { { "source", src }, { "destination", dst } });
+	IntegrateResult ir;
+	ir.success = result.success;
+	ir.filesScheduled = result.data.value("files_scheduled", 0);
+	if (result.data.contains("resolve_needed")) {
+		ir.resolveNeeded = result.data["resolve_needed"].get<std::vector<std::string>>();
+	}
+	ir.error = result.error;
+	if (!ir.success) {
+		lastError_ = result.error.empty() ? "integrate failed" : result.error;
+	}
+	return ir;
+}
+
+ResolveResult ColdStorageClient::resolve(const std::string &depotPath, const std::string &resolution) {
+	lastError_.clear();
+	auto cmd = makeCommand("resolve", { { "depot_path", depotPath }, { "resolution", resolution } });
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return { false, "Send failed" };
+	}
+
+	ResolveResult rr;
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			rr.error = "Connection lost";
+			lastError_ = rr.error;
+			return rr;
+		}
+
+		if (instr->op == InstructionOp::WriteFile || instr->op == InstructionOp::ChunkBegin) {
+			std::string err;
+			if (!sdk_internal::writeInstructionToLocalFile(*conn_, *instr, workspaceRoot_, &err,
+						maxDownloadBytes_, filters_.get())) {
+				rr.error = err.empty() ? "Failed to write resolved file" : err;
+				lastError_ = rr.error;
+				return rr;
+			}
+		} else if (instr->op == InstructionOp::Release) {
+			rr.success = instr->data.value("success", false);
+			rr.hadConflicts = instr->data.value("had_conflicts", false);
+			if (!rr.success && rr.error.empty()) {
+				rr.error = instr->data.value("error", "Resolve failed");
+			}
+			if (!rr.success) {
+				lastError_ = rr.error;
+			}
+			return rr;
+		} else if (instr->op == InstructionOp::Error) {
+			rr.error = instr->data.value("text", "");
+			lastError_ = rr.error;
+		} else if (instr->op == InstructionOp::Info) {
+		}
+	}
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/client_sdk.h
+++ b/modules/coldstorage/sdk/src/client/sdk/client_sdk.h
@@ -1,0 +1,314 @@
+/**************************************************************************/
+/*  client_sdk.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "client/sdk/connection.h"
+#include "client/sdk/tls_options.h"
+#include "common/ignore/ignore_loader.h"
+#include <functional>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+class Workspace;
+
+struct ServerInfo {
+	std::string name;
+	std::string version;
+	int64_t uptime;
+	int64_t changeCount;
+};
+struct SubmitResult {
+	bool success;
+	int64_t changeNum;
+	std::string error;
+	std::vector<std::string> conflictFiles;
+};
+struct SyncResult {
+	bool success = false;
+	int filesUpdated = 0;
+	int filesDeleted = 0;
+	int filesUnchanged = 0;
+	int filesDenied = 0;
+	std::string error;
+	bool more = false;
+	std::string nextCursor;
+	bool stoppedAtLimit = false;
+};
+struct LogEntry {
+	std::string depotPath;
+	int64_t revNum;
+	int64_t changeNum;
+	std::string action;
+	std::string user;
+	std::string description;
+	int64_t timestamp;
+};
+struct OpenedFile {
+	std::string depotPath;
+	std::string action;
+	int64_t baseRev = 0;
+	std::string fromPath;
+	int64_t fromRev = 0;
+};
+struct BranchResult {
+	bool success = false;
+	int64_t changeNum = 0;
+	int files = 0;
+	int denied = 0;
+	std::string error;
+};
+struct IntegrateResult {
+	bool success;
+	int filesScheduled;
+	std::vector<std::string> resolveNeeded;
+	std::string error;
+};
+struct ResolveResult {
+	bool success = false;
+	std::string error;
+	bool hadConflicts = false;
+};
+struct VerifyResult {
+	bool success = false;
+	int verified = 0;
+	int errors = 0;
+	bool more = false;
+	std::string cursor;
+	std::string nextCursor;
+	std::string error;
+};
+struct GcResult {
+	bool success = false;
+	int orphansRemoved = 0;
+	int blobsRemoved = 0;
+	int64_t contentRefsPurged = 0;
+	std::string error;
+	bool more = false;
+	std::string nextCursor;
+};
+
+class WorkspaceFilters;
+
+struct StatusEntry {
+	std::string depotPath;
+	std::string localPath;
+	std::string state;
+};
+
+struct StatusResult {
+	bool success = false;
+	std::vector<StatusEntry> entries;
+	std::string error;
+};
+
+struct WorkspaceFileInfo {
+	std::string depotPath;
+	std::string localPath;
+	std::string state;
+	int64_t headRev = 0;
+	std::string headDigest;
+	int64_t headSize = 0;
+	std::string headFtype;
+	int64_t haveRev = 0;
+	std::string haveDigest;
+	int64_t haveSize = 0;
+	std::string openedAction;
+	int64_t openedBaseRev = 0;
+	std::string localDigest;
+	int64_t localSize = 0;
+};
+
+struct FileInfoResult {
+	bool success = false;
+	std::vector<WorkspaceFileInfo> entries;
+	std::string error;
+};
+
+struct ReconcileFlags {
+	bool allowAdd = true;
+	bool allowEdit = true;
+	bool allowDelete = true;
+	bool detectMoves = false;
+	bool keepWorkspace = false;
+};
+
+struct ReconcileResult {
+	bool success = false;
+	int added = 0;
+	int edited = 0;
+	int deleted = 0;
+	int moved = 0;
+	int skipped = 0;
+	std::string error;
+};
+
+struct AdminResult {
+	bool success = false;
+	std::string error;
+	nlohmann::json data = nlohmann::json::object();
+};
+
+class ColdStorageClient {
+public:
+	ColdStorageClient();
+	~ColdStorageClient();
+
+	bool connectTransport(const std::string &host, int port, const TlsOptions &tls = {});
+	bool negotiate();
+	std::string peerFingerprint() const;
+	bool connect(const std::string &host, int port, const TlsOptions &tls = {});
+	void disconnect();
+	bool isConnected() const;
+
+	std::string login(const std::string &user, const std::string &password);
+	bool authenticateWithJWT(const std::string &token);
+	void setTicket(const std::string &ticket);
+
+	ServerInfo info();
+	bool add(const std::string &depotPath, const std::string &localPath);
+	bool edit(const std::string &depotPath);
+	bool delete_(const std::string &depotPath);
+	bool revert(const std::string &depotPath);
+	std::vector<OpenedFile> opened();
+	SubmitResult submit(const std::string &description);
+
+	SyncResult sync(const std::string &targetSpec = "#head", const std::string &cursor = "",
+			const std::string &untilPath = "");
+
+	SyncResult syncAll(const std::string &targetSpec = "#head");
+
+	SyncResult syncAllParallel(int workers = 4, const std::string &targetSpec = "#head");
+	std::vector<LogEntry> log(const std::string &depotPath, int maxEntries = 100);
+
+	std::string print(const std::string &pathSpec);
+
+	using PrintChunkFn = std::function<bool(const uint8_t *data, size_t len)>;
+	bool printStreaming(const std::string &pathSpec, PrintChunkFn callback);
+
+	bool printToFile(const std::string &pathSpec, const std::string &filePath);
+	BranchResult branch(const std::string &src, const std::string &dst);
+	IntegrateResult integrate(const std::string &src, const std::string &dst);
+	ResolveResult resolve(const std::string &depotPath, const std::string &resolution);
+	bool obliterate(const std::string &depotPath);
+	VerifyResult verify(int64_t limit = 500, const std::string &cursor = "");
+
+	GcResult gc(int64_t maxAgeSeconds = 0, bool purgeZeroRefs = true,
+			const std::string &cursor = "");
+
+	GcResult gcAll(int64_t maxAgeSeconds = 0, bool purgeZeroRefs = true);
+
+	StatusResult status(const std::vector<std::string> &pathScope = {});
+	FileInfoResult fileInfo(const std::vector<std::string> &pathScope = {});
+	ReconcileResult reconcile(bool preview, ReconcileFlags flags,
+			const std::vector<std::string> &pathScope = {});
+	bool printAtRev(const std::string &depotPath, int64_t revNum, PrintChunkFn callback);
+	const Workspace *ensureWorkspaceView();
+	void invalidateWorkspaceView();
+
+	bool lock(const std::string &depotPath);
+	bool unlock(const std::string &depotPath);
+	bool labelCreate(const std::string &name, int64_t changeNum = 0, const std::string &description = "");
+	bool labelDelete(const std::string &name);
+	std::vector<nlohmann::json> labelList();
+	bool shelve(const std::string &name, const std::string &description = "");
+	bool unshelve(const std::string &name, bool keep = false);
+
+	bool userCreate(const std::string &name, const std::string &password);
+	bool userDelete(const std::string &name);
+	bool protectAdd(int64_t seq, const std::string &level, const std::string &subject,
+			const std::string &path, bool isExclusion = false);
+	AdminResult protectList();
+	AdminResult backup(const std::string &path, const std::string &mode = "");
+
+	AdminResult orgCreate(const std::string &name, const std::string &displayName = "",
+			const std::string &description = "");
+	AdminResult orgDelete(const std::string &name);
+	AdminResult orgList();
+	AdminResult orgInfo(const std::string &name);
+	AdminResult orgMemberAdd(const std::string &org, const std::string &user,
+			const std::string &role);
+	AdminResult orgMemberRemove(const std::string &org, const std::string &user);
+	AdminResult orgMemberList(const std::string &org);
+
+	AdminResult repoCreate(const std::string &org, const std::string &name,
+			const std::string &displayName = "",
+			const std::string &description = "");
+	AdminResult repoDelete(const std::string &org, const std::string &name);
+	AdminResult repoList(const std::string &org);
+	AdminResult repoInfo(const std::string &org, const std::string &name);
+	AdminResult repoMemberAdd(const std::string &org, const std::string &name,
+			const std::string &user, const std::string &role);
+	AdminResult repoMemberRemove(const std::string &org, const std::string &name,
+			const std::string &user);
+	AdminResult repoMemberList(const std::string &org, const std::string &name);
+
+	const std::string &lastError() const { return lastError_; }
+
+	void setWorkspace(const std::string &name);
+	std::string getWorkspace() const;
+	void setWorkspaceRoot(const std::string &root);
+	std::string workspaceRoot() const { return workspaceRoot_; }
+	void setMaxDownloadBytes(size_t bytes);
+	size_t maxDownloadBytes() const { return maxDownloadBytes_; }
+	void initWorkspaceFilters(const IgnoreLoadOptions &opts = {});
+	WorkspaceFilters *workspaceFilters() { return filters_.get(); }
+	const WorkspaceFilters *workspaceFilters() const { return filters_.get(); }
+
+	void setRepo(const std::string &repo);
+	std::string getRepo() const;
+
+	ServerConnection::CommandResult exec(const std::string &func, const nlohmann::json &args = {});
+
+private:
+	std::unique_ptr<ServerConnection> conn_;
+	std::string ticket_;
+	std::string user_;
+	std::string workspace_;
+	std::string workspaceRoot_;
+	size_t maxDownloadBytes_ = 32ULL * 1024 * 1024 * 1024;
+	std::string repo_;
+	std::string lastError_;
+	std::string lastHost_;
+	int lastPort_ = 0;
+	TlsOptions lastTls_;
+	std::unique_ptr<WorkspaceFilters> filters_;
+	mutable std::unique_ptr<Workspace> cachedWorkspace_;
+	mutable bool workspaceViewLoaded_ = false;
+
+	Message makeCommand(const std::string &func, const nlohmann::json &args = {});
+
+	bool respondSendFile(const Instruction &instr);
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/connection.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/connection.cpp
@@ -1,0 +1,281 @@
+/**************************************************************************/
+/*  connection.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/connection.h"
+#include "common/net/plain_transport.h"
+#include "common/net/tls_context.h"
+#include "common/net/tls_transport.h"
+#include "common/util/net_trace.h"
+#include <iostream>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace coldstorage {
+
+namespace {
+
+constexpr size_t kMaxStoredInstructions = 10000;
+
+}
+
+std::once_flag ServerConnection::wsaInitFlag_;
+
+void ServerConnection::initWsa() {
+#ifdef _WIN32
+	std::call_once(wsaInitFlag_, []() {
+		WSADATA wsaData;
+		WSAStartup(MAKEWORD(2, 2), &wsaData);
+	});
+#endif
+}
+
+ServerConnection::ServerConnection() :
+		connected_(false) {
+	initWsa();
+}
+
+ServerConnection::~ServerConnection() {
+	disconnect();
+}
+
+bool ServerConnection::connectTransport(const std::string &host, int port, const TlsOptions &tls) {
+	CS_NET_TRACE("ServerConnection", "connectTransport begin host=" << host << " port=" << port << " tls=" << (tls.enabled ? "on" : "off"));
+
+	struct addrinfo hints{}, *result;
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+
+	std::string portStr = std::to_string(port);
+	CS_NET_TRACE("ServerConnection", "getaddrinfo begin");
+	if (getaddrinfo(host.c_str(), portStr.c_str(), &hints, &result) != 0) {
+		CS_NET_TRACE("ServerConnection", "getaddrinfo failed");
+		return false;
+	}
+	CS_NET_TRACE("ServerConnection", "getaddrinfo ok");
+
+	socket_t sock = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+	if (sock == kInvalidSocket) {
+		CS_NET_TRACE("ServerConnection", "socket() failed");
+		freeaddrinfo(result);
+		return false;
+	}
+	CS_NET_TRACE("ServerConnection", "socket() ok fd=" << static_cast<long long>(sock));
+
+	CS_NET_TRACE("ServerConnection", "TCP connect begin");
+	if (::connect(sock, result->ai_addr, static_cast<int>(result->ai_addrlen)) != 0) {
+		CS_NET_TRACE("ServerConnection", "TCP connect failed");
+#ifdef _WIN32
+		closesocket(sock);
+#else
+		::close(sock);
+#endif
+		freeaddrinfo(result);
+		return false;
+	}
+	CS_NET_TRACE("ServerConnection", "TCP connect ok");
+
+	freeaddrinfo(result);
+
+	if (tls.enabled) {
+		CS_NET_TRACE("ServerConnection", "TLS configureClient begin");
+		TLSContext ctx;
+		if (!ctx.configureClient(tls.caFile, tls.verifyPeer, tls.certFile, tls.keyFile)) {
+			CS_NET_TRACE("ServerConnection", "TLS configureClient failed");
+#ifdef _WIN32
+			closesocket(sock);
+#else
+			::close(sock);
+#endif
+			return false;
+		}
+		CS_NET_TRACE("ServerConnection", "TlsTransport::connect begin");
+		transport_ = TlsTransport::connect(sock, host, ctx);
+		if (!transport_) {
+			CS_NET_TRACE("ServerConnection", "TlsTransport::connect failed");
+#ifdef _WIN32
+			closesocket(sock);
+#else
+			::close(sock);
+#endif
+			return false;
+		}
+		CS_NET_TRACE("ServerConnection", "TlsTransport::connect ok");
+	} else {
+		CS_NET_TRACE("ServerConnection", "plain transport");
+		transport_ = makePlainTransport(sock);
+	}
+
+	connected_ = true;
+	CS_NET_TRACE("ServerConnection", "connectTransport ok");
+	return true;
+}
+
+bool ServerConnection::connect(const std::string &host, int port, const TlsOptions &tls) {
+	CS_NET_TRACE("ServerConnection", "connect begin");
+	if (!connectTransport(host, port, tls)) {
+		return false;
+	}
+	CS_NET_TRACE("ServerConnection", "negotiate begin");
+	const bool ok = negotiate();
+	CS_NET_TRACE("ServerConnection", "negotiate " << (ok ? "ok" : "failed"));
+	if (!ok) {
+		disconnect();
+	}
+	return ok;
+}
+
+std::string ServerConnection::peerFingerprint() const {
+	if (!transport_) {
+		return {};
+	}
+	return transport_->peerFingerprint();
+}
+
+void ServerConnection::disconnect() {
+	if (transport_) {
+		transport_->close();
+		transport_.reset();
+	}
+	connected_ = false;
+}
+
+bool ServerConnection::isConnected() const {
+	return connected_ && transport_ != nullptr;
+}
+
+bool ServerConnection::negotiate() {
+	if (!transport_) {
+		CS_NET_TRACE("ServerConnection", "negotiate failed: no transport");
+		return false;
+	}
+	transport_->setRecvTimeout(30);
+	CS_NET_TRACE("ServerConnection", "negotiate send protocol request");
+
+	ProtocolInfo info;
+	info.capabilities = { "upload_resume", "download_resume" };
+	auto msg = makeProtocolRequest(info);
+	if (!sendMessage(msg)) {
+		CS_NET_TRACE("ServerConnection", "negotiate sendMessage failed");
+		return false;
+	}
+	CS_NET_TRACE("ServerConnection", "negotiate waiting for ack");
+
+	std::vector<uint8_t> frameData;
+	if (!readFrame(*transport_, frameData)) {
+		CS_NET_TRACE("ServerConnection", "negotiate readFrame failed");
+		return false;
+	}
+	auto ack = Message::deserialize(frameData);
+	if (!ack || ack->func != "protocol") {
+		CS_NET_TRACE("ServerConnection", "negotiate ack invalid");
+		return false;
+	}
+
+	if (ack->args.value("type", "") == "error" ||
+			ack->args.contains("error")) {
+		CS_NET_TRACE("ServerConnection", "negotiate rejected by server");
+		return false;
+	}
+	const int peerVer = ack->args.value("version", -1);
+	if (peerVer != coldstorage::version::PROTOCOL_VERSION) {
+		CS_NET_TRACE("ServerConnection", "negotiate version mismatch peer=" << peerVer);
+		return false;
+	}
+	CS_NET_TRACE("ServerConnection", "negotiate ack ok");
+	return true;
+}
+
+bool ServerConnection::sendMessage(const Message &msg) {
+	CS_NET_TRACE("ServerConnection", "sendMessage func=" << msg.func << " bytes=pending");
+	auto data = msg.serialize();
+	CS_NET_TRACE("ServerConnection", "sendMessage func=" << msg.func << " bytes=" << data.size());
+	return writeFrame(*transport_, data);
+}
+
+std::optional<Message> ServerConnection::readMessage() {
+	std::vector<uint8_t> frameData;
+	if (!readFrame(*transport_, frameData)) {
+		return std::nullopt;
+	}
+	return Message::deserialize(frameData);
+}
+
+bool ServerConnection::sendInstruction(const Instruction &instr) {
+	auto data = instr.serialize();
+	return writeFrame(*transport_, data);
+}
+
+std::optional<Instruction> ServerConnection::readInstruction() {
+	std::vector<uint8_t> frameData;
+	if (!readFrame(*transport_, frameData)) {
+		return std::nullopt;
+	}
+	return Instruction::deserialize(frameData);
+}
+
+ServerConnection::CommandResult ServerConnection::executeCommand(const Message &cmd) {
+	CommandResult result;
+	if (!sendMessage(cmd)) {
+		result.error = "Failed to send command";
+		return result;
+	}
+
+	while (true) {
+		auto instr = readInstruction();
+		if (!instr) {
+			result.error = "Connection lost";
+			return result;
+		}
+
+		if (result.instructions.size() < kMaxStoredInstructions) {
+			result.instructions.push_back(*instr);
+		} else {
+			result.instructionsTruncated = true;
+		}
+
+		if (instr->op == InstructionOp::Release) {
+			result.data = instr->data;
+			result.success = instr->data.value("success", false);
+			return result;
+		} else if (instr->op == InstructionOp::Error) {
+			result.error = instr->data.value("text", "Unknown error");
+		}
+	}
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/connection.h
+++ b/modules/coldstorage/sdk/src/client/sdk/connection.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  connection.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "client/sdk/tls_options.h"
+#include "common/net/stream_transport.h"
+#include "common/protocol/framing.h"
+#include "common/protocol/messages.h"
+#include "common/protocol/session.h"
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+class ServerConnection {
+public:
+	ServerConnection();
+	~ServerConnection();
+
+	bool connectTransport(const std::string &host, int port, const TlsOptions &tls = {});
+	bool connect(const std::string &host, int port, const TlsOptions &tls = {});
+	void disconnect();
+	bool isConnected() const;
+	std::string peerFingerprint() const;
+	bool negotiate();
+	bool sendMessage(const Message &msg);
+	std::optional<Message> readMessage();
+	bool sendInstruction(const Instruction &instr);
+	std::optional<Instruction> readInstruction();
+
+	struct CommandResult {
+		bool success = false;
+		std::string error;
+		nlohmann::json data;
+		std::vector<Instruction> instructions;
+		bool instructionsTruncated = false;
+	};
+	CommandResult executeCommand(const Message &cmd);
+
+private:
+	TransportPtr transport_;
+	bool connected_;
+	static std::once_flag wsaInitFlag_;
+	static void initWsa();
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/sdk_admin.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/sdk_admin.cpp
@@ -1,0 +1,370 @@
+/**************************************************************************/
+/*  sdk_admin.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/client_sdk.h"
+
+namespace coldstorage {
+
+bool ColdStorageClient::obliterate(const std::string &depotPath) {
+	auto result = exec("obliterate", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+VerifyResult ColdStorageClient::verify(int64_t limit, const std::string &cursor) {
+	if (limit <= 0) {
+		limit = 500;
+	}
+	nlohmann::json args = { { "limit", limit } };
+	if (!cursor.empty()) {
+		args["cursor"] = cursor;
+	}
+	auto result = exec("verify", args);
+	VerifyResult out;
+	out.success = result.success;
+	out.error = result.error;
+	if (result.success) {
+		out.verified = result.data.value("verified", 0);
+		out.errors = result.data.value("errors", 0);
+		out.more = result.data.value("more", false);
+		out.cursor = result.data.value("cursor", "");
+		out.nextCursor = result.data.value("next_cursor", "");
+	}
+	return out;
+}
+
+GcResult ColdStorageClient::gc(int64_t maxAgeSeconds, bool purgeZeroRefs,
+		const std::string &cursor) {
+	nlohmann::json args = {
+		{ "max_age_seconds", maxAgeSeconds },
+		{ "purge_zero_refs", purgeZeroRefs }
+	};
+	if (!cursor.empty()) {
+		args["cursor"] = cursor;
+	}
+	auto result = exec("gc", args);
+	GcResult out;
+	out.success = result.success;
+	out.error = result.error;
+	if (result.success) {
+		out.orphansRemoved = result.data.value("orphans_removed", 0);
+		out.blobsRemoved = result.data.value("blobs_removed", 0);
+		out.contentRefsPurged = result.data.value("content_refs_purged", static_cast<int64_t>(0));
+		out.more = result.data.value("more", false);
+		out.nextCursor = result.data.value("next_cursor", "");
+	}
+	return out;
+}
+
+GcResult ColdStorageClient::gcAll(int64_t maxAgeSeconds, bool purgeZeroRefs) {
+	GcResult total{};
+	total.success = true;
+	std::string cursor;
+	constexpr int kMaxPages = 100000;
+	for (int page = 0; page < kMaxPages; ++page) {
+		auto gr = gc(maxAgeSeconds, purgeZeroRefs, cursor);
+		if (!gr.success) {
+			total.success = false;
+			total.error = gr.error;
+			return total;
+		}
+		total.orphansRemoved += gr.orphansRemoved;
+		total.blobsRemoved += gr.blobsRemoved;
+		total.contentRefsPurged += gr.contentRefsPurged;
+		if (!gr.more) {
+			total.more = false;
+			total.nextCursor.clear();
+			return total;
+		}
+		cursor = gr.nextCursor;
+		if (cursor.empty()) {
+			total.success = false;
+			total.error = "gc more=true but next_cursor empty";
+			total.more = true;
+			return total;
+		}
+	}
+	total.success = false;
+	total.error = "gcAll exceeded max pages";
+	total.more = true;
+	return total;
+}
+
+bool ColdStorageClient::lock(const std::string &depotPath) {
+	auto result = exec("lock", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+bool ColdStorageClient::unlock(const std::string &depotPath) {
+	auto result = exec("unlock", { { "depot_path", depotPath } });
+	return result.success;
+}
+
+bool ColdStorageClient::labelCreate(const std::string &name, int64_t changeNum, const std::string &description) {
+	nlohmann::json args = { { "action", "create" }, { "name", name }, { "description", description } };
+	if (changeNum > 0) {
+		args["change_num"] = changeNum;
+	}
+	auto result = exec("label", args);
+	return result.success;
+}
+
+bool ColdStorageClient::labelDelete(const std::string &name) {
+	auto result = exec("label", { { "action", "delete" }, { "name", name } });
+	return result.success;
+}
+
+std::vector<nlohmann::json> ColdStorageClient::labelList() {
+	auto result = exec("label", { { "action", "list" } });
+	if (result.data.contains("labels")) {
+		return result.data["labels"].get<std::vector<nlohmann::json>>();
+	}
+	return {};
+}
+
+bool ColdStorageClient::userCreate(const std::string &name, const std::string &password) {
+	lastError_.clear();
+	auto result = exec("user", { { "action", "create" }, { "name", name }, { "password", password } });
+	if (!result.success) {
+		lastError_ = result.error.empty() ? "user create failed" : result.error;
+	}
+	return result.success;
+}
+
+bool ColdStorageClient::userDelete(const std::string &name) {
+	lastError_.clear();
+	auto result = exec("user", { { "action", "delete" }, { "name", name } });
+	if (!result.success) {
+		lastError_ = result.error.empty() ? "user delete failed" : result.error;
+	}
+	return result.success;
+}
+
+bool ColdStorageClient::protectAdd(int64_t seq, const std::string &level, const std::string &subject,
+		const std::string &path, bool isExclusion) {
+	lastError_.clear();
+	nlohmann::json args = {
+		{ "action", "add" },
+		{ "seq", seq },
+		{ "level", level },
+		{ "subject", subject },
+		{ "path", path },
+		{ "is_exclusion", isExclusion },
+	};
+	auto result = exec("protect", args);
+	if (!result.success) {
+		lastError_ = result.error.empty() ? "protect add failed" : result.error;
+	}
+	return result.success;
+}
+
+AdminResult ColdStorageClient::protectList() {
+	lastError_.clear();
+	auto result = exec("protect", { { "action", "list" } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "protect list failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::backup(const std::string &path, const std::string &mode) {
+	lastError_.clear();
+	nlohmann::json args = { { "path", path } };
+	if (!mode.empty()) {
+		args["mode"] = mode;
+	}
+	auto result = exec("backup", args);
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "backup failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgCreate(const std::string &name, const std::string &displayName,
+		const std::string &description) {
+	lastError_.clear();
+	nlohmann::json args = { { "action", "create" }, { "name", name } };
+	if (!displayName.empty()) {
+		args["display_name"] = displayName;
+	}
+	if (!description.empty()) {
+		args["description"] = description;
+	}
+	auto result = exec("org", args);
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org create failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgDelete(const std::string &name) {
+	lastError_.clear();
+	auto result = exec("org", { { "action", "delete" }, { "name", name } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org delete failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgList() {
+	lastError_.clear();
+	auto result = exec("org", { { "action", "list" } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org list failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgInfo(const std::string &name) {
+	lastError_.clear();
+	auto result = exec("org", { { "action", "info" }, { "name", name } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org info failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgMemberAdd(const std::string &org, const std::string &user,
+		const std::string &role) {
+	lastError_.clear();
+	auto result = exec("org", { { "action", "member" }, { "member_action", "add" }, { "org", org }, { "user", user }, { "role", role } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org member add failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgMemberRemove(const std::string &org, const std::string &user) {
+	lastError_.clear();
+	auto result = exec("org", { { "action", "member" }, { "member_action", "remove" }, { "org", org }, { "user", user } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org member remove failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::orgMemberList(const std::string &org) {
+	lastError_.clear();
+	auto result = exec("org", { { "action", "member" }, { "member_action", "list" }, { "org", org } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "org member list failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoCreate(const std::string &org, const std::string &name,
+		const std::string &displayName,
+		const std::string &description) {
+	lastError_.clear();
+	nlohmann::json args = { { "action", "create" }, { "org", org }, { "name", name } };
+	if (!displayName.empty()) {
+		args["display_name"] = displayName;
+	}
+	if (!description.empty()) {
+		args["description"] = description;
+	}
+	auto result = exec("repo", args);
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo create failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoDelete(const std::string &org, const std::string &name) {
+	lastError_.clear();
+	auto result = exec("repo", { { "action", "delete" }, { "org", org }, { "name", name } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo delete failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoList(const std::string &org) {
+	lastError_.clear();
+	auto result = exec("repo", { { "action", "list" }, { "org", org } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo list failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoInfo(const std::string &org, const std::string &name) {
+	lastError_.clear();
+	auto result = exec("repo", { { "action", "info" }, { "org", org }, { "name", name } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo info failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoMemberAdd(const std::string &org, const std::string &name,
+		const std::string &user, const std::string &role) {
+	lastError_.clear();
+	auto result = exec("repo", { { "action", "member" }, { "member_action", "add" }, { "org", org }, { "name", name }, { "user", user }, { "role", role } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo member add failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoMemberRemove(const std::string &org, const std::string &name,
+		const std::string &user) {
+	lastError_.clear();
+	auto result = exec("repo", { { "action", "member" }, { "member_action", "remove" }, { "org", org }, { "name", name }, { "user", user } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo member remove failed" : result.error;
+	}
+	return out;
+}
+
+AdminResult ColdStorageClient::repoMemberList(const std::string &org, const std::string &name) {
+	lastError_.clear();
+	auto result = exec("repo", { { "action", "member" }, { "member_action", "list" }, { "org", org }, { "name", name } });
+	AdminResult out{ result.success, result.error, result.data };
+	if (!out.success) {
+		lastError_ = result.error.empty() ? "repo member list failed" : result.error;
+	}
+	return out;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/sdk_internal.h
+++ b/modules/coldstorage/sdk/src/client/sdk/sdk_internal.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  sdk_internal.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "client/sdk/connection.h"
+#include "common/protocol/messages.h"
+#include <string>
+
+namespace coldstorage {
+class WorkspaceFilters;
+namespace sdk_internal {
+
+std::string depotToLocalPath(const std::string &depotPath, const std::string &workspaceRoot);
+
+bool writeInstructionToLocalFile(ServerConnection &conn, const Instruction &instr,
+		const std::string &workspaceRoot,
+		std::string *errorOut = nullptr,
+		size_t maxDownloadBytes = 32ULL * 1024 * 1024 * 1024,
+		WorkspaceFilters *filters = nullptr);
+
+inline constexpr size_t kForceChunkUploadThreshold = 1 * 1024 * 1024;
+inline bool shouldForceChunkedUpload(size_t fileSize) {
+	return fileSize > kForceChunkUploadThreshold;
+}
+
+} //namespace sdk_internal
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/sdk_paths.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/sdk_paths.cpp
@@ -1,0 +1,408 @@
+/**************************************************************************/
+/*  sdk_paths.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/sdk_internal.h"
+#include "client/sdk/workspace_filters.h"
+#include "common/util/sanitize.h"
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+namespace coldstorage {
+namespace sdk_internal {
+namespace {
+
+bool pathUnderRoot(const std::filesystem::path &candidate,
+		const std::filesystem::path &root) {
+	std::error_code ec;
+	auto normalCand = std::filesystem::weakly_canonical(candidate, ec);
+	if (ec) {
+		normalCand = candidate.lexically_normal();
+	}
+	auto normalRoot = std::filesystem::weakly_canonical(root, ec);
+	if (ec) {
+		normalRoot = root.lexically_normal();
+	}
+	auto rel = normalCand.lexically_relative(normalRoot);
+	auto s = rel.generic_string();
+	if (s.empty() || s == ".") {
+		return false;
+	}
+	if (s == ".." || s.rfind("../", 0) == 0) {
+		return false;
+	}
+	if (s.find("/../") != std::string::npos) {
+		return false;
+	}
+	return true;
+}
+
+bool isValidDownloadId(const std::string &id) {
+	return sanitize::isHexDigest64(id);
+}
+
+bool saveDownloadState(const std::filesystem::path &statePath, int64_t offset,
+		int64_t totalSize, const std::string &downloadId) {
+	nlohmann::json j = {
+		{ "offset", offset },
+		{ "total_size", totalSize },
+		{ "download_id", downloadId },
+	};
+	std::ofstream out(statePath, std::ios::trunc);
+	if (!out.is_open()) {
+		return false;
+	}
+	out << j.dump();
+	return static_cast<bool>(out);
+}
+
+bool loadDownloadState(const std::filesystem::path &statePath, const std::string &downloadId,
+		int64_t &offsetOut, int64_t &totalSizeOut) {
+	std::ifstream in(statePath);
+	if (!in.is_open()) {
+		return false;
+	}
+	try {
+		nlohmann::json j;
+		in >> j;
+		if (j.value("download_id", "") != downloadId) {
+			return false;
+		}
+		offsetOut = j.value("offset", static_cast<int64_t>(0));
+		totalSizeOut = j.value("total_size", static_cast<int64_t>(-1));
+		if (offsetOut < 0) {
+			offsetOut = 0;
+		}
+		return true;
+	} catch (...) {
+		return false;
+	}
+}
+
+} //namespace
+
+std::string depotToLocalPath(const std::string &depotPath, const std::string &workspaceRoot) {
+	if (!sanitize::isValidDepotPath(depotPath)) {
+		return {};
+	}
+	std::string relPath = depotPath;
+	if (relPath.find("//") == 0) {
+		auto thirdSlash = relPath.find('/', 2);
+		if (thirdSlash != std::string::npos) {
+			relPath = relPath.substr(thirdSlash + 1);
+		} else {
+			return {};
+		}
+	}
+	if (relPath.empty() || relPath.find("..") != std::string::npos) {
+		return {};
+	}
+	if (workspaceRoot.empty()) {
+		return relPath;
+	}
+
+	std::filesystem::path root(workspaceRoot);
+	std::filesystem::path local = root / relPath;
+	if (!pathUnderRoot(local, root)) {
+		return {};
+	}
+	return local.generic_string();
+}
+
+bool writeInstructionToLocalFile(ServerConnection &conn, const Instruction &instr,
+		const std::string &workspaceRoot,
+		std::string *errorOut, size_t maxDownloadBytes,
+		WorkspaceFilters *filters) {
+	if (workspaceRoot.empty()) {
+		if (errorOut) {
+			*errorOut = "Workspace root required for local file writes";
+		}
+		return false;
+	}
+	if (maxDownloadBytes == 0) {
+		maxDownloadBytes = 32ULL * 1024 * 1024 * 1024;
+	}
+	std::string depotPath = instr.data.value("path", "");
+	std::string localPath = depotToLocalPath(depotPath, workspaceRoot);
+	if (localPath.empty()) {
+		if (errorOut) {
+			*errorOut = "Invalid or escaped depot path: " + depotPath;
+		}
+		return false;
+	}
+	std::filesystem::path p(localPath);
+	std::filesystem::create_directories(p.parent_path());
+
+	if (instr.op == InstructionOp::WriteFile) {
+		std::vector<uint8_t> payload = instr.payload;
+		if (filters) {
+			payload = filters->normalizeForSyncWrite(depotPath, payload);
+		}
+		std::ofstream out(localPath, std::ios::binary | std::ios::trunc);
+		if (!out.is_open()) {
+			if (errorOut) {
+				*errorOut = "Failed to open local file: " + localPath;
+			}
+			return false;
+		}
+		out.write(reinterpret_cast<const char *>(payload.data()),
+				static_cast<std::streamsize>(payload.size()));
+		return true;
+	}
+
+	if (instr.op == InstructionOp::DeleteFile) {
+		std::error_code ec;
+		std::filesystem::remove(localPath, ec);
+		return true;
+	}
+
+	if (instr.op != InstructionOp::ChunkBegin) {
+		if (errorOut) {
+			*errorOut = "Unexpected instruction for file write";
+		}
+		return false;
+	}
+
+	const bool resumeSupported = instr.data.value("resume_supported", false);
+	const std::string downloadId = instr.data.value("download_id", "");
+	const int64_t totalSize = instr.data.value("total_size", static_cast<int64_t>(-1));
+	int64_t segmentBytes = instr.data.value("segment_bytes", static_cast<int64_t>(0));
+	if (segmentBytes <= 0) {
+		segmentBytes = 256LL * 1024 * 1024;
+	}
+
+	std::filesystem::path partialPath = p;
+	std::filesystem::path statePath;
+	int64_t resumeFrom = 0;
+
+	if (resumeSupported && !downloadId.empty()) {
+		if (!isValidDownloadId(downloadId)) {
+			if (errorOut) {
+				*errorOut = "Invalid download_id (expected 64 hex chars)";
+			}
+			return false;
+		}
+		auto dlDir = std::filesystem::path(workspaceRoot) / ".coldstorage" / "downloads" / downloadId;
+		if (!pathUnderRoot(dlDir, std::filesystem::path(workspaceRoot))) {
+			if (errorOut) {
+				*errorOut = "download_id path escapes workspace";
+			}
+			return false;
+		}
+		std::filesystem::create_directories(dlDir);
+		partialPath = dlDir / "partial";
+		statePath = dlDir / "STATE.json";
+		if (!pathUnderRoot(partialPath, std::filesystem::path(workspaceRoot)) ||
+				!pathUnderRoot(statePath, std::filesystem::path(workspaceRoot))) {
+			if (errorOut) {
+				*errorOut = "download session path escapes workspace";
+			}
+			return false;
+		}
+		std::error_code ec;
+		int64_t partialSize = 0;
+		if (std::filesystem::exists(partialPath, ec) && !ec) {
+			partialSize = static_cast<int64_t>(std::filesystem::file_size(partialPath, ec));
+			if (ec) {
+				partialSize = 0;
+			}
+		}
+		int64_t stateOffset = 0;
+		int64_t stateTotal = -1;
+		if (std::filesystem::exists(statePath, ec) && !ec &&
+				loadDownloadState(statePath, downloadId, stateOffset, stateTotal)) {
+			if (stateTotal >= 0 && totalSize >= 0 && stateTotal != totalSize) {
+				resumeFrom = partialSize;
+			} else {
+				resumeFrom = std::min(stateOffset, partialSize);
+			}
+		} else {
+			resumeFrom = partialSize;
+		}
+		if (totalSize >= 0 && resumeFrom > totalSize) {
+			resumeFrom = 0;
+		}
+
+		if (totalSize >= 0) {
+			auto downloadsRoot =
+					std::filesystem::path(workspaceRoot) / ".coldstorage" / "downloads";
+			uint64_t used = 0;
+			std::error_code walkEc;
+			if (std::filesystem::exists(downloadsRoot, walkEc) && !walkEc) {
+				for (auto it = std::filesystem::recursive_directory_iterator(downloadsRoot, walkEc);
+						!walkEc && it != std::filesystem::recursive_directory_iterator();
+						it.increment(walkEc)) {
+					if (!it->is_regular_file(walkEc)) {
+						continue;
+					}
+					used += static_cast<uint64_t>(it->file_size(walkEc));
+				}
+			}
+			int64_t need = totalSize - resumeFrom;
+			if (need < 0) {
+				need = 0;
+			}
+
+			if (used + static_cast<uint64_t>(need) > maxDownloadBytes) {
+				if (errorOut) {
+					*errorOut = "download disk quota exceeded (limits.max_download_bytes)";
+				}
+				return false;
+			}
+		}
+
+		Instruction reply;
+		reply.op = InstructionOp::ResumeDownload;
+		reply.data = { { "download_id", downloadId }, { "resume_from", resumeFrom } };
+		if (!conn.sendInstruction(reply)) {
+			if (errorOut) {
+				*errorOut = "Failed to send resume_download";
+			}
+			return false;
+		}
+	} else if (resumeSupported) {
+		Instruction reply;
+		reply.op = InstructionOp::ResumeDownload;
+		reply.data = { { "download_id", downloadId }, { "resume_from", 0 } };
+		if (!conn.sendInstruction(reply)) {
+			if (errorOut) {
+				*errorOut = "Failed to send resume_download";
+			}
+			return false;
+		}
+	}
+
+	std::ios::openmode mode = std::ios::binary;
+	if (resumeFrom > 0) {
+		mode |= std::ios::app;
+	} else {
+		mode |= std::ios::trunc;
+	}
+	std::ofstream out(partialPath, mode);
+	if (!out.is_open()) {
+		if (errorOut) {
+			*errorOut = "Failed to open local file for chunked write: " +
+					partialPath.generic_string();
+		}
+		return false;
+	}
+
+	int64_t written = resumeFrom;
+	int64_t lastStateAt = resumeFrom;
+	while (true) {
+		auto chunkInstr = conn.readInstruction();
+		if (!chunkInstr) {
+			out.close();
+			if (resumeSupported && !statePath.empty()) {
+				saveDownloadState(statePath, written, totalSize, downloadId);
+			}
+			if (errorOut) {
+				*errorOut = "Connection lost during chunked transfer";
+			}
+			return false;
+		}
+		if (chunkInstr->op == InstructionOp::ChunkEnd) {
+			break;
+		}
+		if (chunkInstr->op == InstructionOp::Error) {
+			out.close();
+			if (errorOut) {
+				*errorOut = chunkInstr->data.value("text", "Server error during download");
+			}
+			return false;
+		}
+		if (chunkInstr->op != InstructionOp::ChunkData) {
+			out.close();
+			if (errorOut) {
+				*errorOut = "Unexpected instruction during chunked transfer";
+			}
+			return false;
+		}
+		int64_t chunkOffset = chunkInstr->data.value("offset", static_cast<int64_t>(-1));
+		if (chunkOffset >= 0 && chunkOffset != written) {
+			out.close();
+			if (errorOut) {
+				*errorOut = "ChunkData offset mismatch: expected " + std::to_string(written) +
+						" got " + std::to_string(chunkOffset);
+			}
+			return false;
+		}
+		out.write(reinterpret_cast<const char *>(chunkInstr->payload.data()),
+				static_cast<std::streamsize>(chunkInstr->payload.size()));
+		if (!out) {
+			if (errorOut) {
+				*errorOut = "Write failed during chunked transfer";
+			}
+			return false;
+		}
+		written += static_cast<int64_t>(chunkInstr->payload.size());
+
+		if (resumeSupported && !statePath.empty() &&
+				written - lastStateAt >= segmentBytes) {
+			saveDownloadState(statePath, written, totalSize, downloadId);
+			lastStateAt = written;
+		}
+	}
+	out.close();
+	if (resumeSupported && !statePath.empty() && written != lastStateAt) {
+		saveDownloadState(statePath, written, totalSize, downloadId);
+	}
+
+	if (resumeSupported && !downloadId.empty() && partialPath != p) {
+		if (!isValidDownloadId(downloadId) ||
+				!pathUnderRoot(partialPath, std::filesystem::path(workspaceRoot))) {
+			if (errorOut) {
+				*errorOut = "Refusing to promote unsafe download partial";
+			}
+			return false;
+		}
+		std::error_code ec;
+		std::filesystem::create_directories(p.parent_path(), ec);
+		std::filesystem::rename(partialPath, p, ec);
+		if (ec) {
+			std::filesystem::copy_file(partialPath, p,
+					std::filesystem::copy_options::overwrite_existing, ec);
+			if (ec) {
+				if (errorOut) {
+					*errorOut = "Failed to promote download partial: " + ec.message();
+				}
+				return false;
+			}
+			std::filesystem::remove(partialPath, ec);
+		}
+		if (!statePath.empty()) {
+			std::filesystem::remove(statePath, ec);
+			std::filesystem::remove(statePath.parent_path(), ec);
+		}
+	}
+	return true;
+}
+
+} //namespace sdk_internal
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/sdk_print.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/sdk_print.cpp
@@ -1,0 +1,259 @@
+/**************************************************************************/
+/*  sdk_print.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/client_sdk.h"
+#include "common/protocol/messages.h"
+#include "common/util/sanitize.h"
+#include <filesystem>
+#include <fstream>
+
+namespace coldstorage {
+namespace {
+
+bool parsePrintSpec(const std::string &pathSpec, std::string &depotPath, int64_t &revNum,
+		std::string &error) {
+	depotPath = sanitize::trim(pathSpec);
+	revNum = 0;
+	if (depotPath.empty()) {
+		error = "Empty print path";
+		return false;
+	}
+	auto hash = depotPath.rfind('#');
+	if (hash == std::string::npos) {
+		return true;
+	}
+	std::string revPart = depotPath.substr(hash + 1);
+	depotPath = depotPath.substr(0, hash);
+	if (depotPath.empty()) {
+		error = "Invalid print path";
+		return false;
+	}
+	if (revPart.empty() || revPart == "head") {
+		revNum = 0;
+		return true;
+	}
+	try {
+		size_t idx = 0;
+		long long v = std::stoll(revPart, &idx, 10);
+		if (idx != revPart.size() || v <= 0) {
+			error = "Invalid revision in print path: #" + revPart;
+			return false;
+		}
+		revNum = static_cast<int64_t>(v);
+	} catch (...) {
+		error = "Invalid revision in print path: #" + revPart;
+		return false;
+	}
+	return true;
+}
+
+} //namespace
+
+std::string ColdStorageClient::print(const std::string &pathSpec) {
+	static constexpr size_t kPrintAssembleCap = 32ULL * 1024 * 1024;
+	lastError_.clear();
+	std::string assembled;
+	bool ok = printStreaming(pathSpec, [&](const uint8_t *data, size_t len) {
+		if (assembled.size() + len > kPrintAssembleCap) {
+			lastError_ = "print() exceeded 32MiB assemble cap; use printToFile or printStreaming";
+			return false;
+		}
+		assembled.append(reinterpret_cast<const char *>(data), len);
+		return true;
+	});
+	if (!ok) {
+		if (lastError_.empty()) {
+			lastError_ = "print failed";
+		}
+		return "";
+	}
+	return assembled;
+}
+
+bool ColdStorageClient::printStreaming(const std::string &pathSpec, PrintChunkFn callback) {
+	if (!callback) {
+		return false;
+	}
+	lastError_.clear();
+	std::string depotPath;
+	int64_t revNum = 0;
+	std::string parseErr;
+	if (!parsePrintSpec(pathSpec, depotPath, revNum, parseErr)) {
+		lastError_ = parseErr;
+		return false;
+	}
+	nlohmann::json args = { { "depot_path", depotPath } };
+	if (revNum > 0) {
+		args["rev_num"] = revNum;
+	}
+	auto cmd = makeCommand("print", args);
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return false;
+	}
+
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			lastError_ = "Connection lost";
+			return false;
+		}
+
+		if (instr->op == InstructionOp::WriteFile) {
+			if (!instr->payload.empty()) {
+				if (!callback(instr->payload.data(), instr->payload.size())) {
+					return false;
+				}
+			}
+		} else if (instr->op == InstructionOp::ChunkBegin) {
+			const bool resumeSupported = instr->data.value("resume_supported", false);
+			if (resumeSupported) {
+				Instruction reply;
+				reply.op = InstructionOp::ResumeDownload;
+				reply.data = {
+					{ "download_id", instr->data.value("download_id", "") },
+					{ "resume_from", 0 },
+				};
+				if (!conn_->sendInstruction(reply)) {
+					return false;
+				}
+			}
+			while (true) {
+				auto chunk = conn_->readInstruction();
+				if (!chunk) {
+					return false;
+				}
+				if (chunk->op == InstructionOp::ChunkEnd) {
+					break;
+				}
+				if (chunk->op != InstructionOp::ChunkData) {
+					return false;
+				}
+				if (!chunk->payload.empty()) {
+					if (!callback(chunk->payload.data(), chunk->payload.size())) {
+						return false;
+					}
+				}
+			}
+		} else if (instr->op == InstructionOp::Release) {
+			bool ok = instr->data.value("success", false);
+			if (!ok && lastError_.empty()) {
+				lastError_ = "print failed";
+			}
+			return ok;
+		} else if (instr->op == InstructionOp::Error) {
+			lastError_ = instr->data.value("text", "print failed");
+			return false;
+		}
+	}
+}
+
+bool ColdStorageClient::printToFile(const std::string &pathSpec, const std::string &filePath) {
+	std::filesystem::path p(filePath);
+	if (p.has_parent_path()) {
+		std::filesystem::create_directories(p.parent_path());
+	}
+	std::ofstream out(filePath, std::ios::binary | std::ios::trunc);
+	if (!out.is_open()) {
+		return false;
+	}
+	return printStreaming(pathSpec, [&](const uint8_t *data, size_t len) {
+		out.write(reinterpret_cast<const char *>(data), static_cast<std::streamsize>(len));
+		return static_cast<bool>(out);
+	});
+}
+
+bool ColdStorageClient::printAtRev(const std::string &depotPath, int64_t revNum, PrintChunkFn callback) {
+	if (!callback || revNum <= 0) {
+		return false;
+	}
+	lastError_.clear();
+	auto cmd = makeCommand("print", { { "depot_path", depotPath }, { "rev_num", revNum } });
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return false;
+	}
+
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			lastError_ = "Connection lost";
+			return false;
+		}
+
+		if (instr->op == InstructionOp::WriteFile) {
+			if (!instr->payload.empty()) {
+				if (!callback(instr->payload.data(), instr->payload.size())) {
+					return false;
+				}
+			}
+		} else if (instr->op == InstructionOp::ChunkBegin) {
+			const bool resumeSupported = instr->data.value("resume_supported", false);
+			if (resumeSupported) {
+				Instruction reply;
+				reply.op = InstructionOp::ResumeDownload;
+				reply.data = {
+					{ "download_id", instr->data.value("download_id", "") },
+					{ "resume_from", 0 },
+				};
+				if (!conn_->sendInstruction(reply)) {
+					return false;
+				}
+			}
+			while (true) {
+				auto chunk = conn_->readInstruction();
+				if (!chunk) {
+					return false;
+				}
+				if (chunk->op == InstructionOp::ChunkEnd) {
+					break;
+				}
+				if (chunk->op != InstructionOp::ChunkData) {
+					return false;
+				}
+				if (!chunk->payload.empty()) {
+					if (!callback(chunk->payload.data(), chunk->payload.size())) {
+						return false;
+					}
+				}
+			}
+		} else if (instr->op == InstructionOp::Release) {
+			bool ok = instr->data.value("success", false);
+			if (!ok && lastError_.empty()) {
+				lastError_ = "print failed";
+			}
+			return ok;
+		} else if (instr->op == InstructionOp::Error) {
+			lastError_ = instr->data.value("text", "print failed");
+			return false;
+		}
+	}
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/sdk_transfer.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/sdk_transfer.cpp
@@ -1,0 +1,188 @@
+/**************************************************************************/
+/*  sdk_transfer.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/client_sdk.h"
+#include "client/sdk/sdk_internal.h"
+#include "client/sdk/workspace_filters.h"
+#include "common/protocol/messages.h"
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+
+namespace coldstorage {
+
+bool ColdStorageClient::respondSendFile(const Instruction &instr) {
+	std::string depotPath = instr.data.value("path", "");
+	bool chunkedRequested = instr.data.value("chunked", false);
+	int64_t resumeOffset = instr.data.value("resume_offset", static_cast<int64_t>(0));
+	std::string uploadId = instr.data.value("upload_id", "");
+	int64_t segmentBytes = instr.data.value("segment_bytes", static_cast<int64_t>(0));
+	std::string localPath = sdk_internal::depotToLocalPath(depotPath, workspaceRoot_);
+
+	static constexpr size_t kClientChunkSize = 1 * 1024 * 1024;
+
+	std::ifstream file(localPath, std::ios::binary);
+	if (!file.is_open()) {
+		Instruction resp;
+		resp.op = InstructionOp::SendFile;
+		resp.data = { { "path", depotPath } };
+		return conn_->sendInstruction(resp);
+	}
+
+	file.seekg(0, std::ios::end);
+	auto fileSize = static_cast<size_t>(file.tellg());
+	file.seekg(0, std::ios::beg);
+
+	if (resumeOffset < 0 || static_cast<size_t>(resumeOffset) > fileSize) {
+		return false;
+	}
+
+	const bool useChunked = chunkedRequested ||
+			sdk_internal::shouldForceChunkedUpload(fileSize) ||
+			resumeOffset > 0 ||
+			(segmentBytes > 0 && fileSize > static_cast<size_t>(segmentBytes));
+	if (useChunked) {
+		if (resumeOffset > 0) {
+			file.seekg(static_cast<std::streamoff>(resumeOffset), std::ios::beg);
+		}
+		Instruction beginInstr;
+		beginInstr.op = InstructionOp::ChunkBegin;
+		beginInstr.data = { { "path", depotPath },
+			{ "total_size", static_cast<int64_t>(fileSize) },
+			{ "chunk_size", kClientChunkSize },
+			{ "resume_from", resumeOffset } };
+		if (!uploadId.empty()) {
+			beginInstr.data["upload_id"] = uploadId;
+		}
+		if (!conn_->sendInstruction(beginInstr)) {
+			return false;
+		}
+
+		size_t offset = static_cast<size_t>(resumeOffset);
+		int chunkNum = 0;
+		while (offset < fileSize) {
+			size_t remaining = fileSize - offset;
+			size_t thisChunk = std::min(remaining, kClientChunkSize);
+			Instruction chunkInstr;
+			chunkInstr.op = InstructionOp::ChunkData;
+			chunkInstr.data = { { "chunk_num", chunkNum }, { "offset", static_cast<int64_t>(offset) } };
+			chunkInstr.payload.resize(thisChunk);
+			file.read(reinterpret_cast<char *>(chunkInstr.payload.data()),
+					static_cast<std::streamsize>(thisChunk));
+			auto got = static_cast<size_t>(file.gcount());
+			if (got == 0) {
+				break;
+			}
+			chunkInstr.payload.resize(got);
+			if (!conn_->sendInstruction(chunkInstr)) {
+				return false;
+			}
+			offset += got;
+			chunkNum++;
+		}
+		Instruction endInstr;
+		endInstr.op = InstructionOp::ChunkEnd;
+		endInstr.data = { { "path", depotPath },
+			{ "total_size", static_cast<int64_t>(offset) },
+			{ "chunks", chunkNum } };
+		return conn_->sendInstruction(endInstr);
+	}
+
+	Instruction resp;
+	resp.op = InstructionOp::SendFile;
+	resp.data = { { "path", depotPath } };
+	resp.payload.assign(std::istreambuf_iterator<char>(file),
+			std::istreambuf_iterator<char>());
+	if (filters_) {
+		resp.payload = filters_->normalizeForSubmit(depotPath, resp.payload);
+	}
+	return conn_->sendInstruction(resp);
+}
+
+bool ColdStorageClient::shelve(const std::string &name, const std::string &description) {
+	lastError_.clear();
+	auto cmd = makeCommand("shelve", { { "name", name }, { "description", description } });
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return false;
+	}
+
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			lastError_ = "Connection lost";
+			return false;
+		}
+
+		if (instr->op == InstructionOp::SendFile) {
+			if (!respondSendFile(*instr)) {
+				lastError_ = "Failed to upload shelf content";
+				return false;
+			}
+		} else if (instr->op == InstructionOp::Release) {
+			return instr->data.value("success", false);
+		} else if (instr->op == InstructionOp::Error) {
+			lastError_ = instr->data.value("text", "shelve failed");
+			return false;
+		}
+	}
+}
+
+bool ColdStorageClient::unshelve(const std::string &name, bool keep) {
+	lastError_.clear();
+	auto cmd = makeCommand("unshelve", { { "name", name }, { "keep", keep } });
+	if (!conn_->sendMessage(cmd)) {
+		lastError_ = "Send failed";
+		return false;
+	}
+
+	while (true) {
+		auto instr = conn_->readInstruction();
+		if (!instr) {
+			lastError_ = "Connection lost";
+			return false;
+		}
+
+		if (instr->op == InstructionOp::WriteFile || instr->op == InstructionOp::ChunkBegin) {
+			std::string err;
+			if (!sdk_internal::writeInstructionToLocalFile(*conn_, *instr, workspaceRoot_, &err,
+						maxDownloadBytes_, filters_.get())) {
+				lastError_ = err.empty() ? "Failed to write unshelve file" : err;
+				return false;
+			}
+		} else if (instr->op == InstructionOp::Release) {
+			return instr->data.value("success", false);
+		} else if (instr->op == InstructionOp::Error) {
+			lastError_ = instr->data.value("text", "unshelve failed");
+			return false;
+		}
+	}
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/tls_options.h
+++ b/modules/coldstorage/sdk/src/client/sdk/tls_options.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  tls_options.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace coldstorage {
+
+struct TlsOptions {
+	bool enabled = false;
+	std::string caFile;
+	std::string certFile;
+	std::string keyFile;
+	bool verifyPeer = true;
+	bool pinFingerprint = false;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/tls_trust.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/tls_trust.cpp
@@ -1,0 +1,130 @@
+/**************************************************************************/
+/*  tls_trust.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/tls_trust.h"
+#include "common/net/tls_cert.h"
+
+#include <iostream>
+
+#ifdef _WIN32
+#include <io.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#include <unistd.h>
+#endif
+
+namespace coldstorage {
+
+namespace {
+
+bool fingerprintsMatch(const std::string &a, const std::string &b) {
+	return normalizeFingerprint(a) == normalizeFingerprint(b);
+}
+
+} //namespace
+
+TrustDecision verifyServerTrust(const std::string &host, int port,
+		const std::string &fingerprint,
+		const TrustOptions &opts,
+		TrustStore &store,
+		std::string *messageOut) {
+	if (!opts.pinningEnabled || fingerprint.empty()) {
+		return TrustDecision::Trusted;
+	}
+
+	if (!opts.expectedFingerprint.empty()) {
+		if (!fingerprintsMatch(fingerprint, opts.expectedFingerprint)) {
+			if (messageOut) {
+				*messageOut = "Server fingerprint does not match --accept-fingerprint value";
+			}
+			return TrustDecision::Mismatch;
+		}
+		store.save(host, port, fingerprint);
+		return TrustDecision::AcceptedNew;
+	}
+
+	auto existing = store.lookup(host, port);
+	if (existing) {
+		if (!fingerprintsMatch(fingerprint, existing->fingerprint)) {
+			if (messageOut) {
+				*messageOut = "Server fingerprint changed! Possible MITM.\n"
+							  "  Expected: " +
+						existing->fingerprint + "\n"
+												"  Got:      " +
+						fingerprint + "\n"
+									  "Remove with: cstorage trust remove " +
+						TrustStore::makeKey(host, port);
+			}
+			return TrustDecision::Mismatch;
+		}
+		store.save(host, port, fingerprint);
+		return TrustDecision::Trusted;
+	}
+
+	if (opts.acceptNew) {
+		store.save(host, port, fingerprint);
+		return TrustDecision::AcceptedNew;
+	}
+
+	bool canPrompt = opts.interactive && isatty(fileno(stdin)) != 0;
+	if (!canPrompt) {
+		if (messageOut) {
+			*messageOut = "Unknown server fingerprint. Use --accept-new or --accept-fingerprint for non-interactive use.";
+		}
+		return TrustDecision::Rejected;
+	}
+
+	std::string key = TrustStore::makeKey(host, port);
+	std::cerr << "WARNING: Unknown server " << key << "\n";
+	std::cerr << "TLS fingerprint: " << fingerprint << "\n";
+	std::cerr << "Trust this server? [y]es / [n]o / [a]ccept and remember: ";
+	std::cerr.flush();
+
+	std::string line;
+	if (!std::getline(std::cin, line)) {
+		return TrustDecision::Rejected;
+	}
+	if (line.empty()) {
+		return TrustDecision::Rejected;
+	}
+
+	char c = static_cast<char>(std::tolower(static_cast<unsigned char>(line[0])));
+	if (c == 'y') {
+		store.save(host, port, fingerprint);
+		return TrustDecision::AcceptedNew;
+	}
+	if (c == 'a') {
+		store.save(host, port, fingerprint);
+		return TrustDecision::AcceptedNew;
+	}
+	return TrustDecision::Rejected;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/tls_trust.h
+++ b/modules/coldstorage/sdk/src/client/sdk/tls_trust.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  tls_trust.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "client/sdk/trust_store.h"
+#include <string>
+
+namespace coldstorage {
+
+enum class TrustDecision {
+	Trusted,
+	AcceptedNew,
+	Rejected,
+	Mismatch
+};
+
+struct TrustOptions {
+	bool pinningEnabled = true;
+	bool acceptNew = false;
+	std::string expectedFingerprint;
+	bool interactive = true;
+};
+
+TrustDecision verifyServerTrust(const std::string &host, int port,
+		const std::string &fingerprint,
+		const TrustOptions &opts,
+		TrustStore &store,
+		std::string *messageOut = nullptr);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/trust_store.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/trust_store.cpp
@@ -1,0 +1,208 @@
+/**************************************************************************/
+/*  trust_store.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/trust_store.h"
+#include "common/util/sanitize.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+namespace coldstorage {
+
+namespace {
+
+std::string nowIso8601() {
+	auto now = std::chrono::system_clock::now();
+	auto t = std::chrono::system_clock::to_time_t(now);
+	std::tm tm{};
+#ifdef _WIN32
+	gmtime_s(&tm, &t);
+#else
+	gmtime_r(&t, &tm);
+#endif
+	std::ostringstream oss;
+	oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+	return oss.str();
+}
+
+std::string defaultTrustPath() {
+	fs::path home;
+	if (auto envHome = sanitize::safeGetenv("HOME"); !envHome.empty()) {
+		home = envHome;
+	} else if (auto envProfile = sanitize::safeGetenv("USERPROFILE"); !envProfile.empty()) {
+		home = envProfile;
+	} else {
+		home = fs::temp_directory_path();
+	}
+	fs::path dir = home / ".cstorage";
+	fs::create_directories(dir);
+	return (dir / "known_hosts.json").string();
+}
+
+std::string lowerHost(const std::string &host) {
+	std::string h = sanitize::trim(host);
+	std::transform(h.begin(), h.end(), h.begin(),
+			[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+	return h;
+}
+
+} //namespace
+
+TrustStore::TrustStore() :
+		path_(defaultTrustPath()) {}
+
+TrustStore::TrustStore(std::string path) :
+		path_(std::move(path)) {}
+
+std::string TrustStore::makeKey(const std::string &host, int port) {
+	return lowerHost(host) + ":" + std::to_string(port);
+}
+
+void TrustStore::load() const {
+	if (loaded_) {
+		return;
+	}
+	loaded_ = true;
+	cache_.clear();
+	cacheRaw_.clear();
+
+	std::ifstream in(path_);
+	if (!in.is_open()) {
+		return;
+	}
+
+	try {
+		nlohmann::json j;
+		in >> j;
+		if (!j.is_object()) {
+			return;
+		}
+		for (auto it = j.begin(); it != j.end(); ++it) {
+			if (!it.value().is_object()) {
+				continue;
+			}
+			TrustEntry entry;
+			entry.fingerprint = it.value().value("fingerprint", "");
+			entry.firstSeen = it.value().value("first_seen", "");
+			entry.lastSeen = it.value().value("last_seen", "");
+			cache_.emplace_back(it.key(), entry);
+		}
+	} catch (...) {
+	}
+}
+
+bool TrustStore::persist() const {
+	nlohmann::json j = nlohmann::json::object();
+	for (const auto &[key, entry] : cache_) {
+		j[key] = {
+			{ "fingerprint", entry.fingerprint },
+			{ "first_seen", entry.firstSeen },
+			{ "last_seen", entry.lastSeen }
+		};
+	}
+
+	const std::string tmp = path_ + ".tmp";
+	{
+		std::ofstream out(tmp, std::ios::trunc);
+		if (!out.is_open()) {
+			return false;
+		}
+		out << j.dump(2);
+		if (!out.good()) {
+			return false;
+		}
+	}
+#ifndef _WIN32
+	fs::permissions(tmp, fs::perms::owner_read | fs::perms::owner_write);
+#endif
+	std::error_code ec;
+	fs::rename(tmp, path_, ec);
+	if (ec) {
+		fs::remove(tmp, ec);
+		return false;
+	}
+	return true;
+}
+
+std::optional<TrustEntry> TrustStore::lookup(const std::string &host, int port) const {
+	load();
+	std::string key = makeKey(host, port);
+	for (const auto &[k, entry] : cache_) {
+		if (k == key) {
+			return entry;
+		}
+	}
+	return std::nullopt;
+}
+
+bool TrustStore::save(const std::string &host, int port, const std::string &fingerprint) {
+	load();
+	std::string key = makeKey(host, port);
+	std::string now = nowIso8601();
+	for (auto &[k, entry] : cache_) {
+		if (k == key) {
+			entry.fingerprint = fingerprint;
+			entry.lastSeen = now;
+			return persist();
+		}
+	}
+	TrustEntry entry;
+	entry.fingerprint = fingerprint;
+	entry.firstSeen = now;
+	entry.lastSeen = now;
+	cache_.emplace_back(key, entry);
+	return persist();
+}
+
+bool TrustStore::remove(const std::string &host, int port) {
+	load();
+	std::string key = makeKey(host, port);
+	auto it = std::remove_if(cache_.begin(), cache_.end(),
+			[&](const auto &p) { return p.first == key; });
+	if (it == cache_.end()) {
+		return false;
+	}
+	cache_.erase(it, cache_.end());
+	return persist();
+}
+
+std::vector<std::pair<std::string, TrustEntry>> TrustStore::list() const {
+	load();
+	return cache_;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/trust_store.h
+++ b/modules/coldstorage/sdk/src/client/sdk/trust_store.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  trust_store.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct TrustEntry {
+	std::string fingerprint;
+	std::string firstSeen;
+	std::string lastSeen;
+};
+
+class TrustStore {
+public:
+	TrustStore();
+	explicit TrustStore(std::string path);
+
+	static std::string makeKey(const std::string &host, int port);
+	std::optional<TrustEntry> lookup(const std::string &host, int port) const;
+	bool save(const std::string &host, int port, const std::string &fingerprint);
+	bool remove(const std::string &host, int port);
+	std::vector<std::pair<std::string, TrustEntry>> list() const;
+
+	const std::string &path() const { return path_; }
+
+private:
+	std::string path_;
+	mutable bool loaded_ = false;
+
+	void load() const;
+	bool persist() const;
+
+	mutable std::string cacheRaw_;
+	mutable std::vector<std::pair<std::string, TrustEntry>> cache_;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace.cpp
@@ -1,0 +1,117 @@
+/**************************************************************************/
+/*  workspace.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/workspace.h"
+#include <algorithm>
+
+namespace coldstorage {
+
+Workspace::Workspace(const std::string &name, const std::string &root, const std::vector<ViewMapping> &view) :
+		name_(name), root_(root), view_(view) {}
+
+const std::string &Workspace::name() const {
+	return name_;
+}
+const std::string &Workspace::root() const {
+	return root_;
+}
+const std::vector<ViewMapping> &Workspace::view() const {
+	return view_;
+}
+
+std::string Workspace::depotToLocal(const std::string &depotPath) const {
+	for (const auto &m : view_) {
+		if (m.isExclusion) {
+			continue;
+		}
+		std::string depotPrefix = m.depotPattern;
+		if (depotPrefix.size() >= 3 && depotPrefix.substr(depotPrefix.size() - 3) == "...") {
+			depotPrefix = depotPrefix.substr(0, depotPrefix.size() - 3);
+		}
+		if (depotPath.substr(0, depotPrefix.size()) == depotPrefix) {
+			std::string localPrefix = m.localPattern;
+			if (localPrefix.size() >= 3 && localPrefix.substr(localPrefix.size() - 3) == "...") {
+				localPrefix = localPrefix.substr(0, localPrefix.size() - 3);
+			}
+			return localPrefix + depotPath.substr(depotPrefix.size());
+		}
+	}
+	return depotPath;
+}
+
+std::string Workspace::localToDepot(const std::string &localPath) const {
+	for (const auto &m : view_) {
+		if (m.isExclusion) {
+			continue;
+		}
+		std::string localPrefix = m.localPattern;
+		if (localPrefix.size() >= 3 && localPrefix.substr(localPrefix.size() - 3) == "...") {
+			localPrefix = localPrefix.substr(0, localPrefix.size() - 3);
+		}
+		if (localPath.substr(0, localPrefix.size()) == localPrefix) {
+			std::string depotPrefix = m.depotPattern;
+			if (depotPrefix.size() >= 3 && depotPrefix.substr(depotPrefix.size() - 3) == "...") {
+				depotPrefix = depotPrefix.substr(0, depotPrefix.size() - 3);
+			}
+			return depotPrefix + localPath.substr(localPrefix.size());
+		}
+	}
+	return localPath;
+}
+
+bool Workspace::isPathInView(const std::string &depotPath) const {
+	bool inView = false;
+	for (const auto &m : view_) {
+		std::string prefix = m.depotPattern;
+		if (prefix.size() >= 3 && prefix.substr(prefix.size() - 3) == "...") {
+			prefix = prefix.substr(0, prefix.size() - 3);
+		}
+		if (depotPath.substr(0, prefix.size()) == prefix) {
+			inView = !m.isExclusion;
+		}
+	}
+	return inView;
+}
+
+std::vector<ViewMapping> Workspace::parseView(const nlohmann::json &viewJson) {
+	std::vector<ViewMapping> result;
+	if (!viewJson.is_array()) {
+		return result;
+	}
+	for (const auto &entry : viewJson) {
+		ViewMapping m;
+		m.depotPattern = entry.value("depot", "");
+		m.localPattern = entry.value("local", "");
+		m.isExclusion = entry.value("exclusion", false);
+		result.push_back(m);
+	}
+	return result;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace.h
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  workspace.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct ViewMapping {
+	std::string depotPattern;
+	std::string localPattern;
+	bool isExclusion = false;
+};
+
+class Workspace {
+public:
+	Workspace(const std::string &name, const std::string &root, const std::vector<ViewMapping> &view);
+	std::string depotToLocal(const std::string &depotPath) const;
+	std::string localToDepot(const std::string &localPath) const;
+	bool isPathInView(const std::string &depotPath) const;
+	const std::string &name() const;
+	const std::string &root() const;
+	const std::vector<ViewMapping> &view() const;
+	static std::vector<ViewMapping> parseView(const nlohmann::json &viewJson);
+
+private:
+	std::string name_;
+	std::string root_;
+	std::vector<ViewMapping> view_;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace_filters.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace_filters.cpp
@@ -1,0 +1,203 @@
+/**************************************************************************/
+/*  workspace_filters.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/workspace_filters.h"
+#include "common/attributes/eol_normalize.h"
+#include "common/util/sanitize.h"
+#include <algorithm>
+
+namespace fs = std::filesystem;
+namespace coldstorage {
+namespace {
+
+bool underColdstorageMeta(const fs::path &rel) {
+	std::string s = rel.generic_string();
+	return s == ".coldstorage" || s.rfind(".coldstorage/", 0) == 0;
+}
+
+} //namespace
+
+WorkspaceFilters::WorkspaceFilters(std::string workspaceRoot, IgnoreLoadOptions ignoreOpts) :
+		workspaceRoot_(std::move(workspaceRoot)), ignoreOpts_(std::move(ignoreOpts)) {}
+
+void WorkspaceFilters::ensureLoaded() const {
+	if (loaded_) {
+		IgnoreLoader loader(workspaceRoot_);
+		auto files = loader.listIgnoreFiles(ignoreOpts_);
+		if (files == trackedIgnoreFiles_) {
+			return;
+		}
+	}
+	IgnoreLoader loader(workspaceRoot_);
+	matcher_ = loader.buildMatcher(ignoreOpts_);
+	loadGitAttributesTree(workspaceRoot_, attributes_);
+	trackedIgnoreFiles_ = loader.listIgnoreFiles(ignoreOpts_);
+	loaded_ = true;
+}
+
+void WorkspaceFilters::reloadIfStale() {
+	loaded_ = false;
+	ensureLoaded();
+}
+
+std::string WorkspaceFilters::depotFromLocalRel(const std::string &rel) const {
+	if (!sanitize::isValidDepotPath("//depot/" + rel)) {
+		return {};
+	}
+	return "//depot/" + rel;
+}
+
+std::string WorkspaceFilters::localRelFromArg(const fs::path &root, const std::string &arg) {
+	if (arg.find("//") == 0) {
+		if (arg.rfind("//depot/", 0) != 0) {
+			return {};
+		}
+		return arg.substr(8);
+	}
+	fs::path p(arg);
+	if (p.is_absolute()) {
+		std::error_code ec;
+		p = fs::relative(p, root, ec);
+		if (ec) {
+			return {};
+		}
+	}
+	return p.lexically_normal().generic_string();
+}
+
+std::optional<std::string> WorkspaceFilters::localToDepot(const std::string &arg) const {
+	ensureLoaded();
+	if (arg.find("//") == 0) {
+		if (sanitize::isValidDepotPath(arg)) {
+			return arg;
+		}
+		return std::nullopt;
+	}
+	const std::string rel = localRelFromArg(fs::path(workspaceRoot_), arg);
+	if (rel.empty() || rel.find("..") != std::string::npos) {
+		return std::nullopt;
+	}
+	return depotFromLocalRel(rel);
+}
+
+std::vector<AddCandidate> WorkspaceFilters::collectAddPaths(const std::string &arg) const {
+	ensureLoaded();
+	std::vector<AddCandidate> out;
+	fs::path root(workspaceRoot_);
+	std::string rel = localRelFromArg(root, arg);
+	if (rel.empty()) {
+		return out;
+	}
+
+	fs::path target = root / rel;
+	std::error_code ec;
+	if (!fs::exists(target, ec)) {
+		return out;
+	}
+
+	auto emitFile = [&](const fs::path &file, const std::string &fileRel) {
+		if (underColdstorageMeta(fs::path(fileRel))) {
+			return;
+		}
+		const bool isDir = fs::is_directory(file, ec);
+		if (matcher_.isIgnored(fileRel, isDir)) {
+			return;
+		}
+		if (isDir) {
+			return;
+		}
+		AddCandidate c;
+		c.localPath = file.lexically_normal().string();
+		c.depotPath = depotFromLocalRel(fileRel);
+		if (!c.depotPath.empty()) {
+			out.push_back(std::move(c));
+		}
+	};
+
+	if (fs::is_directory(target, ec)) {
+		for (auto it = fs::recursive_directory_iterator(
+					 target, fs::directory_options::skip_permission_denied, ec);
+				!ec && it != fs::recursive_directory_iterator(); it.increment(ec)) {
+			if (!it->is_regular_file(ec)) {
+				continue;
+			}
+			std::error_code ec2;
+			auto fileRel = fs::relative(it->path(), root, ec2).generic_string();
+			if (ec2) {
+				continue;
+			}
+			emitFile(it->path(), fileRel);
+		}
+	} else {
+		emitFile(target, rel);
+	}
+	return out;
+}
+
+IgnoreMatchInfo WorkspaceFilters::matchIgnore(const std::string &localRelPath, bool isDir) const {
+	ensureLoaded();
+	return matcher_.match(localRelPath, isDir);
+}
+
+ResolvedGitAttributes WorkspaceFilters::attrsForDepotPath(const std::string &depotPath) const {
+	ensureLoaded();
+	std::string rel = depotPath;
+	if (rel.rfind("//depot/", 0) == 0) {
+		rel = rel.substr(8);
+	}
+	return attributes_.resolve(rel);
+}
+
+std::vector<uint8_t> WorkspaceFilters::normalizeForSubmit(const std::string &depotPath,
+		const std::vector<uint8_t> &data) const {
+	auto attrs = attrsForDepotPath(depotPath);
+	if (attrs.isBinary || !attrs.normalizeEol) {
+		return data;
+	}
+	if (!isProbablyText(data)) {
+		return data;
+	}
+	EolStyle style = attrs.eol == EolStyle::Unspecified ? EolStyle::Lf : attrs.eol;
+	return normalizeEol(data, style);
+}
+
+std::vector<uint8_t> WorkspaceFilters::normalizeForSyncWrite(const std::string &depotPath,
+		const std::vector<uint8_t> &data) const {
+	auto attrs = attrsForDepotPath(depotPath);
+	if (attrs.isBinary || !attrs.normalizeEol) {
+		return data;
+	}
+	if (!isProbablyText(data)) {
+		return data;
+	}
+	EolStyle style = attrs.eol == EolStyle::Unspecified ? EolStyle::Native : attrs.eol;
+	return normalizeEol(data, style);
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace_filters.h
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace_filters.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  workspace_filters.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/attributes/attributes_map.h"
+#include "common/attributes/gitattributes.h"
+#include "common/ignore/ignore_loader.h"
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct AddCandidate {
+	std::string depotPath;
+	std::string localPath;
+};
+
+class WorkspaceFilters {
+public:
+	WorkspaceFilters(std::string workspaceRoot, IgnoreLoadOptions ignoreOpts = {});
+
+	void reloadIfStale();
+	std::optional<std::string> localToDepot(const std::string &arg) const;
+	std::vector<AddCandidate> collectAddPaths(const std::string &arg) const;
+	IgnoreMatchInfo matchIgnore(const std::string &localRelPath, bool isDir) const;
+	ResolvedGitAttributes attrsForDepotPath(const std::string &depotPath) const;
+	std::vector<uint8_t> normalizeForSubmit(const std::string &depotPath,
+			const std::vector<uint8_t> &data) const;
+	std::vector<uint8_t> normalizeForSyncWrite(const std::string &depotPath,
+			const std::vector<uint8_t> &data) const;
+
+	const std::string &workspaceRoot() const { return workspaceRoot_; }
+
+private:
+	std::string workspaceRoot_;
+	IgnoreLoadOptions ignoreOpts_;
+	mutable IgnoreMatcher matcher_;
+	mutable GitAttributesMap attributes_;
+	mutable std::vector<std::string> trackedIgnoreFiles_;
+	mutable bool loaded_ = false;
+
+	void ensureLoaded() const;
+	std::string depotFromLocalRel(const std::string &rel) const;
+	static std::string localRelFromArg(const std::filesystem::path &root, const std::string &arg);
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace_status.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace_status.cpp
@@ -1,0 +1,398 @@
+/**************************************************************************/
+/*  workspace_status.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/workspace_status.h"
+#include "client/sdk/workspace_filters.h"
+#include "client/sdk/workspace_view.h"
+#include "common/util/crypto.h"
+#include <filesystem>
+#include <iostream>
+#include <set>
+#include <unordered_map>
+
+namespace fs = std::filesystem;
+namespace coldstorage {
+namespace {
+
+bool inScope(const std::string &depotPath, const std::vector<std::string> &scope) {
+	if (scope.empty()) {
+		return true;
+	}
+	for (const auto &s : scope) {
+		auto depot = s.find("//") == 0 ? s : std::string("//depot/") + s;
+		if (depotPath == depot || depotPath.rfind(depot + "/", 0) == 0) {
+			return true;
+		}
+		fs::path p(s);
+		if (p.is_relative()) {
+			std::string prefix = "//depot/" + p.generic_string();
+			if (depotPath == prefix || depotPath.rfind(prefix + "/", 0) == 0) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+bool inScopeLocal(ColdStorageClient &client, WorkspaceFilters &filters,
+		const std::string &localAbs, const std::vector<std::string> &scope) {
+	if (scope.empty()) {
+		return true;
+	}
+	for (const auto &s : scope) {
+		if (s.find("//") == 0) {
+			auto local = depotToLocalPathMapped(client, s, filters.workspaceRoot());
+			if (!local.empty()) {
+				std::error_code ec;
+				if (fs::equivalent(localAbs, local, ec)) {
+					return true;
+				}
+				const std::string prefix = local + "/";
+				if (localAbs.rfind(prefix, 0) == 0) {
+					return true;
+				}
+			}
+			continue;
+		}
+		fs::path root(filters.workspaceRoot());
+		fs::path target = fs::path(s).is_absolute() ? fs::path(s) : root / s;
+		std::error_code ec;
+		target = fs::weakly_canonical(target, ec);
+		if (ec) {
+			target = (root / s).lexically_normal();
+		}
+		const std::string targetStr = target.generic_string();
+		if (localAbs == targetStr) {
+			return true;
+		}
+		if (localAbs.rfind(targetStr + "/", 0) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+std::string computeState(const WorkspaceFileInfo &info, bool isOpened) {
+	if (isOpened) {
+		return "opened";
+	}
+	const int64_t haveRev = info.haveRev;
+	const int64_t headRev = info.headRev;
+	const std::string &haveDigest = info.haveDigest;
+	std::error_code ec;
+	const bool localExists = !info.localPath.empty() && fs::exists(info.localPath, ec);
+
+	if (haveRev > 0 && !localExists) {
+		return "delete";
+	}
+	if (localExists && haveRev > 0 && !haveDigest.empty()) {
+		if (info.localDigest != haveDigest) {
+			return "edit";
+		}
+		return (headRev > haveRev) ? "sync" : "unchanged";
+	}
+	if (localExists && haveRev == 0) {
+		return "sync";
+	}
+	if (!localExists && haveRev == 0) {
+		return "";
+	}
+	return headRev > haveRev ? "sync" : "unchanged";
+}
+
+void fillLocalDigest(WorkspaceFileInfo &info) {
+	std::error_code ec;
+	if (info.localPath.empty() || !fs::exists(info.localPath, ec)) {
+		return;
+	}
+	info.localDigest = sha256File(info.localPath, &info.localSize);
+}
+
+} //namespace
+
+FileInfoResult computeWorkspaceFileInfo(ColdStorageClient &client, WorkspaceFilters &filters,
+		const std::vector<std::string> &pathScope) {
+	FileInfoResult result;
+	std::unordered_map<std::string, OpenedFile> opened;
+	for (const auto &f : client.opened()) {
+		opened[f.depotPath] = f;
+	}
+
+	std::set<std::string> depotKnown;
+	std::string cursor;
+	do {
+		auto page = client.exec("status", { { "cursor", cursor } });
+		if (!page.success) {
+			result.error = page.error.empty() ? client.lastError() : page.error;
+			return result;
+		}
+		if (!page.data.contains("entries")) {
+			break;
+		}
+		for (const auto &e : page.data["entries"]) {
+			const std::string depotPath = e.value("depot_path", "");
+			if (!inScope(depotPath, pathScope)) {
+				continue;
+			}
+			depotKnown.insert(depotPath);
+
+			WorkspaceFileInfo info;
+			info.depotPath = depotPath;
+			info.localPath =
+					depotToLocalPathMapped(client, depotPath, filters.workspaceRoot());
+			info.headRev = e.value("head_rev", static_cast<int64_t>(0));
+			info.headDigest = e.value("head_digest", "");
+			info.headSize = e.value("head_size", static_cast<int64_t>(0));
+			info.headFtype = e.value("head_ftype", "");
+			info.haveRev = e.value("have_rev", static_cast<int64_t>(0));
+			info.haveDigest = e.value("have_digest", "");
+			info.haveSize = e.value("have_size", static_cast<int64_t>(0));
+			info.openedAction = e.value("opened_action", "");
+			info.openedBaseRev = e.value("opened_base_rev", static_cast<int64_t>(0));
+
+			const bool isOpened = opened.count(depotPath) > 0;
+			fillLocalDigest(info);
+			info.state = computeState(info, isOpened);
+			if (info.state.empty()) {
+				continue;
+			}
+			result.entries.push_back(std::move(info));
+		}
+		if (!page.data.value("more", false)) {
+			break;
+		}
+		cursor = page.data.value("next_cursor", "");
+	} while (!cursor.empty());
+
+	fs::path root(filters.workspaceRoot());
+	std::error_code ec;
+	if (fs::exists(root, ec)) {
+		for (auto it = fs::recursive_directory_iterator(
+					 root, fs::directory_options::skip_permission_denied, ec);
+				!ec && it != fs::recursive_directory_iterator(); it.increment(ec)) {
+			if (!it->is_regular_file(ec)) {
+				continue;
+			}
+			const std::string localAbs = it->path().lexically_normal().string();
+			std::error_code ec2;
+			auto rel = fs::relative(it->path(), root, ec2).generic_string();
+			if (ec2 || rel.empty()) {
+				continue;
+			}
+			if (rel.rfind(".coldstorage", 0) == 0) {
+				continue;
+			}
+			if (filters.matchIgnore(rel, false).ignored) {
+				continue;
+			}
+			if (!inScopeLocal(client, filters, localAbs, pathScope)) {
+				continue;
+			}
+
+			auto depotOpt = localToDepotPathMapped(client, localAbs, filters.workspaceRoot());
+			if (!depotOpt) {
+				continue;
+			}
+			if (depotKnown.count(*depotOpt)) {
+				continue;
+			}
+
+			WorkspaceFileInfo info;
+			info.depotPath = *depotOpt;
+			info.localPath = localAbs;
+			fillLocalDigest(info);
+			info.state = "add";
+			result.entries.push_back(std::move(info));
+		}
+	}
+
+	result.success = true;
+	return result;
+}
+
+StatusResult computeWorkspaceStatus(ColdStorageClient &client, WorkspaceFilters &filters,
+		const std::vector<std::string> &pathScope) {
+	StatusResult result;
+	auto fileInfo = computeWorkspaceFileInfo(client, filters, pathScope);
+	if (!fileInfo.success) {
+		result.error = fileInfo.error;
+		return result;
+	}
+	result.entries.reserve(fileInfo.entries.size());
+	for (const auto &fi : fileInfo.entries) {
+		StatusEntry se;
+		se.depotPath = fi.depotPath;
+		se.localPath = fi.localPath;
+		se.state = fi.state;
+		result.entries.push_back(std::move(se));
+	}
+	result.success = true;
+	return result;
+}
+
+ReconcileResult reconcileWorkspace(ColdStorageClient &client, WorkspaceFilters &filters,
+		bool preview, ReconcileFlags flags,
+		const std::vector<std::string> &pathScope) {
+	ReconcileResult rr;
+	auto fileInfo = computeWorkspaceFileInfo(client, filters, pathScope);
+	if (!fileInfo.success) {
+		rr.error = fileInfo.error;
+		return rr;
+	}
+
+	std::unordered_map<std::string, OpenedFile> opened;
+	for (const auto &f : client.opened()) {
+		opened[f.depotPath] = f;
+	}
+
+	struct PendingAction {
+		enum Kind { Add,
+			Edit,
+			Delete,
+			Move } kind;
+		WorkspaceFileInfo info;
+		std::string moveFromDepot;
+	};
+	std::vector<PendingAction> pending;
+
+	for (const auto &e : fileInfo.entries) {
+		if (e.state == "opened" || e.state == "unchanged" || e.state == "sync") {
+			++rr.skipped;
+			continue;
+		}
+		if (opened.count(e.depotPath)) {
+			++rr.skipped;
+			continue;
+		}
+		if (e.state == "add" && flags.allowAdd) {
+			pending.push_back({ PendingAction::Add, e, {} });
+		} else if (e.state == "edit" && flags.allowEdit) {
+			pending.push_back({ PendingAction::Edit, e, {} });
+		} else if (e.state == "delete" && flags.allowDelete) {
+			if (flags.keepWorkspace) {
+				++rr.skipped;
+				if (preview) {
+					std::cout << "skip delete (keep workspace) " << e.depotPath << "\n";
+				}
+				continue;
+			}
+			pending.push_back({ PendingAction::Delete, e, {} });
+		} else {
+			++rr.skipped;
+		}
+	}
+
+	if (flags.detectMoves && flags.allowAdd && flags.allowDelete) {
+		std::vector<size_t> addIdx;
+		std::vector<size_t> delIdx;
+		for (size_t i = 0; i < pending.size(); ++i) {
+			if (pending[i].kind == PendingAction::Add && !pending[i].info.localDigest.empty()) {
+				addIdx.push_back(i);
+			} else if (pending[i].kind == PendingAction::Delete &&
+					!pending[i].info.haveDigest.empty()) {
+				delIdx.push_back(i);
+			}
+		}
+		std::vector<bool> usedAdd(addIdx.size(), false);
+		std::vector<bool> usedDel(delIdx.size(), false);
+		for (size_t di = 0; di < delIdx.size(); ++di) {
+			const auto &delInfo = pending[delIdx[di]].info;
+			for (size_t ai = 0; ai < addIdx.size(); ++ai) {
+				if (usedAdd[ai] || usedDel[di]) {
+					continue;
+				}
+				const auto &addInfo = pending[addIdx[ai]].info;
+				if (delInfo.haveDigest == addInfo.localDigest) {
+					usedAdd[ai] = true;
+					usedDel[di] = true;
+					pending[delIdx[di]].kind = PendingAction::Move;
+					pending[delIdx[di]].moveFromDepot = delInfo.depotPath;
+					pending[delIdx[di]].info = addInfo;
+					break;
+				}
+			}
+		}
+		for (size_t ai = 0; ai < addIdx.size(); ++ai) {
+			if (usedAdd[ai]) {
+				pending[addIdx[ai]].kind = PendingAction::Move;
+			}
+		}
+	}
+
+	for (const auto &p : pending) {
+		if (p.kind == PendingAction::Move && p.moveFromDepot.empty()) {
+			continue;
+		}
+		if (p.kind == PendingAction::Move) {
+			if (preview) {
+				std::cout << "move " << p.moveFromDepot << " -> " << p.info.depotPath << "\n";
+				++rr.moved;
+				continue;
+			}
+			if (!client.delete_(p.moveFromDepot)) {
+				rr.error = client.lastError();
+				return rr;
+			}
+			if (!client.add(p.info.depotPath, p.info.localPath)) {
+				rr.error = client.lastError();
+				return rr;
+			}
+			++rr.moved;
+		} else if (p.kind == PendingAction::Add) {
+			if (preview) {
+				std::cout << "add " << p.info.depotPath << "\n";
+			} else if (!client.add(p.info.depotPath, p.info.localPath)) {
+				rr.error = client.lastError();
+				return rr;
+			}
+			++rr.added;
+		} else if (p.kind == PendingAction::Edit) {
+			if (preview) {
+				std::cout << "edit " << p.info.depotPath << "\n";
+			} else if (!client.edit(p.info.depotPath)) {
+				rr.error = client.lastError();
+				return rr;
+			}
+			++rr.edited;
+		} else if (p.kind == PendingAction::Delete) {
+			if (preview) {
+				std::cout << "delete " << p.info.depotPath << "\n";
+			} else if (!client.delete_(p.info.depotPath)) {
+				rr.error = client.lastError();
+				return rr;
+			}
+			++rr.deleted;
+		}
+	}
+
+	rr.success = rr.error.empty();
+	return rr;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace_status.h
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace_status.h
@@ -1,0 +1,47 @@
+/**************************************************************************/
+/*  workspace_status.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "client/sdk/client_sdk.h"
+#include <vector>
+
+namespace coldstorage {
+
+class WorkspaceFilters;
+
+FileInfoResult computeWorkspaceFileInfo(ColdStorageClient &client, WorkspaceFilters &filters,
+		const std::vector<std::string> &pathScope = {});
+StatusResult computeWorkspaceStatus(ColdStorageClient &client, WorkspaceFilters &filters,
+		const std::vector<std::string> &pathScope = {});
+ReconcileResult reconcileWorkspace(ColdStorageClient &client, WorkspaceFilters &filters,
+		bool preview, ReconcileFlags flags,
+		const std::vector<std::string> &pathScope = {});
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace_view.cpp
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace_view.cpp
@@ -1,0 +1,114 @@
+/**************************************************************************/
+/*  workspace_view.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "client/sdk/workspace_view.h"
+#include "client/sdk/client_sdk.h"
+#include "client/sdk/sdk_internal.h"
+#include <filesystem>
+
+namespace fs = std::filesystem;
+namespace coldstorage {
+namespace {
+
+std::string normalizeMappedLocal(const std::string &root, const std::string &mapped) {
+	if (mapped.empty()) {
+		return {};
+	}
+	fs::path p(mapped);
+	if (p.is_absolute()) {
+		return p.lexically_normal().generic_string();
+	}
+	if (mapped.rfind("./", 0) == 0) {
+		return (fs::path(root) / mapped.substr(2)).lexically_normal().generic_string();
+	}
+	return (fs::path(root) / mapped).lexically_normal().generic_string();
+}
+
+std::string localPathForMapping(const Workspace &ws, const std::string &absPath) {
+	std::error_code ec;
+	fs::path rel = fs::relative(absPath, ws.root(), ec);
+	if (ec) {
+		return absPath;
+	}
+	const std::string relStr = rel.generic_string();
+	if (relStr.empty() || relStr == ".") {
+		return absPath;
+	}
+	return "./" + relStr;
+}
+
+} //namespace
+
+const Workspace *ensureWorkspaceView(ColdStorageClient &client) {
+	return client.ensureWorkspaceView();
+}
+
+void invalidateWorkspaceView(ColdStorageClient &client) {
+	client.invalidateWorkspaceView();
+}
+
+std::string depotToLocalPathMapped(ColdStorageClient &client, const std::string &depotPath,
+		const std::string &workspaceRoot) {
+	if (const Workspace *ws = ensureWorkspaceView(client)) {
+		std::string mapped = ws->depotToLocal(depotPath);
+		if (mapped != depotPath && !mapped.empty()) {
+			return normalizeMappedLocal(ws->root(), mapped);
+		}
+	}
+	return sdk_internal::depotToLocalPath(depotPath, workspaceRoot);
+}
+
+std::optional<std::string> localToDepotPathMapped(ColdStorageClient &client,
+		const std::string &localAbsPath,
+		const std::string &workspaceRoot) {
+	if (const Workspace *ws = ensureWorkspaceView(client)) {
+		std::string asLocal = localPathForMapping(*ws, localAbsPath);
+		std::string depot = ws->localToDepot(asLocal);
+		if (depot != asLocal && !depot.empty() && depot.find("//") == 0) {
+			return depot;
+		}
+		depot = ws->localToDepot(localAbsPath);
+		if (depot != localAbsPath && !depot.empty() && depot.find("//") == 0) {
+			return depot;
+		}
+	}
+	fs::path root(workspaceRoot);
+	std::error_code ec;
+	fs::path rel = fs::relative(localAbsPath, root, ec);
+	if (ec || rel.empty()) {
+		return std::nullopt;
+	}
+	const std::string relStr = rel.generic_string();
+	if (relStr.find("..") != std::string::npos) {
+		return std::nullopt;
+	}
+	return std::string("//depot/") + relStr;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/client/sdk/workspace_view.h
+++ b/modules/coldstorage/sdk/src/client/sdk/workspace_view.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  workspace_view.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "client/sdk/workspace.h"
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace coldstorage {
+
+class ColdStorageClient;
+
+const Workspace *ensureWorkspaceView(ColdStorageClient &client);
+void invalidateWorkspaceView(ColdStorageClient &client);
+
+std::string depotToLocalPathMapped(ColdStorageClient &client, const std::string &depotPath,
+		const std::string &workspaceRoot);
+std::optional<std::string> localToDepotPathMapped(ColdStorageClient &client,
+		const std::string &localAbsPath,
+		const std::string &workspaceRoot);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/attributes/attributes_map.cpp
+++ b/modules/coldstorage/sdk/src/common/attributes/attributes_map.cpp
@@ -1,0 +1,234 @@
+/**************************************************************************/
+/*  attributes_map.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/attributes/attributes_map.h"
+#include "common/attributes/eol_normalize.h"
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+namespace coldstorage {
+namespace {
+
+std::string normalizeSlashes(std::string s) {
+	for (char &c : s) {
+		if (c == '\\') {
+			c = '/';
+		}
+	}
+	while (!s.empty() && s.front() == '/') {
+		s.erase(s.begin());
+	}
+	return s;
+}
+
+std::string trim(const std::string &s) {
+	size_t a = 0;
+	while (a < s.size() && std::isspace(static_cast<unsigned char>(s[a]))) {
+		++a;
+	}
+	size_t b = s.size();
+	while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) {
+		--b;
+	}
+	return s.substr(a, b - a);
+}
+
+bool fnmatchSimple(const char *pat, const char *str) {
+	while (*pat && *str) {
+		if (*pat == '*') {
+			++pat;
+			while (*pat == '*') {
+				++pat;
+			}
+			if (!*pat) {
+				return true;
+			}
+			while (*str) {
+				if (fnmatchSimple(pat, str)) {
+					return true;
+				}
+				++str;
+			}
+			return false;
+		}
+		if (*pat != *str) {
+			return false;
+		}
+		++pat;
+		++str;
+	}
+	while (*pat == '*') {
+		++pat;
+	}
+	return !*pat && !*str;
+}
+
+} //namespace
+
+void GitAttributesMap::clear() {
+	layers_.clear();
+}
+
+bool GitAttributesMap::matchPattern(const std::string &pattern, const std::string &path) {
+	std::string pat = pattern;
+	if (!pat.empty() && pat.back() == '/') {
+		pat.pop_back();
+	}
+	if (pat.find('/') == std::string::npos) {
+		size_t slash = path.rfind('/');
+		std::string base = slash == std::string::npos ? path : path.substr(slash + 1);
+		return fnmatchSimple(pat.c_str(), base.c_str()) || fnmatchSimple(pat.c_str(), path.c_str());
+	}
+	return fnmatchSimple(pat.c_str(), path.c_str());
+}
+
+std::vector<GitAttributesEntry> GitAttributesMap::parseContent(const std::string &content) {
+	std::vector<GitAttributesEntry> entries;
+	std::istringstream in(content);
+	std::string line;
+	while (std::getline(in, line)) {
+		line = trim(line);
+		if (line.empty() || line[0] == '#') {
+			continue;
+		}
+		std::istringstream ls(line);
+		GitAttributesEntry e;
+		if (!(ls >> e.pattern)) {
+			continue;
+		}
+		std::string tok;
+		while (ls >> tok) {
+			if (tok == "text") {
+				e.text = true;
+			} else if (tok == "-text") {
+				e.textUnset = true;
+			} else if (tok == "binary") {
+				e.binary = true;
+			} else if (tok == "text=auto") {
+				e.textAuto = true;
+			} else if (tok == "eol=lf") {
+				e.eol = EolStyle::Lf;
+			} else if (tok == "eol=crlf") {
+				e.eol = EolStyle::Crlf;
+			} else if (tok == "eol=native") {
+				e.eol = EolStyle::Native;
+			}
+		}
+		entries.push_back(std::move(e));
+	}
+	return entries;
+}
+
+void GitAttributesMap::addLayer(const std::string &baseDir, std::vector<GitAttributesEntry> entries) {
+	layers_.push_back({ normalizeSlashes(baseDir), std::move(entries) });
+}
+
+void GitAttributesMap::loadFile(const std::string &path, const std::string &baseDir) {
+	std::ifstream in(path, std::ios::binary);
+	if (!in.is_open()) {
+		return;
+	}
+	std::ostringstream oss;
+	oss << in.rdbuf();
+	addLayer(baseDir, parseContent(oss.str()));
+}
+
+ResolvedGitAttributes GitAttributesMap::resolve(const std::string &relPath) const {
+	ResolvedGitAttributes out;
+	const std::string path = normalizeSlashes(relPath);
+	const GitAttributesEntry *last = nullptr;
+
+	for (const auto &layer : layers_) {
+		std::string candidate = path;
+		if (!layer.baseDir.empty()) {
+			if (path.size() <= layer.baseDir.size() || path.compare(0, layer.baseDir.size(), layer.baseDir) != 0) {
+				continue;
+			}
+			if (path[layer.baseDir.size()] != '/') {
+				continue;
+			}
+			candidate = path.substr(layer.baseDir.size() + 1);
+		}
+		for (const auto &e : layer.entries) {
+			if (matchPattern(e.pattern, candidate)) {
+				last = &e;
+			}
+		}
+	}
+
+	if (!last) {
+		return out;
+	}
+	if (last->binary || last->textUnset) {
+		out.isBinary = true;
+		return out;
+	}
+	if (last->text || last->textAuto) {
+		out.normalizeEol = true;
+	}
+	if (last->eol != EolStyle::Unspecified) {
+		out.eol = last->eol;
+	} else if (out.normalizeEol) {
+		out.eol = EolStyle::Native;
+	}
+	return out;
+}
+
+void loadGitAttributesTree(const std::string &workspaceRoot, GitAttributesMap &map) {
+	map.clear();
+	fs::path root(workspaceRoot);
+	std::error_code ec;
+	if (!fs::exists(root, ec)) {
+		return;
+	}
+	std::vector<fs::path> files;
+	for (auto it = fs::recursive_directory_iterator(root, fs::directory_options::skip_permission_denied, ec);
+			!ec && it != fs::recursive_directory_iterator(); it.increment(ec)) {
+		if (!it->is_regular_file(ec)) {
+			continue;
+		}
+		if (it->path().filename() != ".gitattributes") {
+			continue;
+		}
+		files.push_back(it->path());
+	}
+	std::sort(files.begin(), files.end());
+	for (const auto &f : files) {
+		std::error_code ec2;
+		auto rel = fs::relative(f.parent_path(), root, ec2);
+		std::string base = ec2 ? "" : rel.generic_string();
+		map.loadFile(f.string(), base);
+	}
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/attributes/attributes_map.h
+++ b/modules/coldstorage/sdk/src/common/attributes/attributes_map.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  attributes_map.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/attributes/gitattributes.h"
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+class GitAttributesMap {
+public:
+	void clear();
+	void addLayer(const std::string &baseDir, std::vector<GitAttributesEntry> entries);
+	void loadFile(const std::string &path, const std::string &baseDir);
+	ResolvedGitAttributes resolve(const std::string &relPath) const;
+	static std::vector<GitAttributesEntry> parseContent(const std::string &content);
+
+private:
+	struct Layer {
+		std::string baseDir;
+		std::vector<GitAttributesEntry> entries;
+	};
+	std::vector<Layer> layers_;
+	static bool matchPattern(const std::string &pattern, const std::string &path);
+};
+
+void loadGitAttributesTree(const std::string &workspaceRoot, GitAttributesMap &map);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/attributes/eol_normalize.cpp
+++ b/modules/coldstorage/sdk/src/common/attributes/eol_normalize.cpp
@@ -1,0 +1,105 @@
+/**************************************************************************/
+/*  eol_normalize.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/attributes/eol_normalize.h"
+
+#include <algorithm>
+#include <cstddef>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace coldstorage {
+
+bool isProbablyText(const std::vector<uint8_t> &data) {
+	if (data.empty()) {
+		return true;
+	}
+	size_t check = std::min(data.size(), size_t(8192));
+	for (size_t i = 0; i < check; ++i) {
+		if (data[i] == 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static EolStyle nativeEol() {
+#ifdef _WIN32
+	return EolStyle::Crlf;
+#else
+	return EolStyle::Lf;
+#endif
+}
+
+std::vector<uint8_t> normalizeEol(const std::vector<uint8_t> &data, EolStyle target) {
+	if (target == EolStyle::Unspecified) {
+		target = EolStyle::Native;
+	}
+	if (target == EolStyle::Native) {
+		target = nativeEol();
+	}
+
+	std::vector<uint8_t> out;
+	out.reserve(data.size());
+	for (size_t i = 0; i < data.size(); ++i) {
+		if (data[i] == '\r' && i + 1 < data.size() && data[i + 1] == '\n') {
+			if (target == EolStyle::Lf) {
+				out.push_back('\n');
+			} else {
+				out.push_back('\r');
+				out.push_back('\n');
+			}
+			++i;
+		} else if (data[i] == '\n') {
+			if (target == EolStyle::Crlf) {
+				out.push_back('\r');
+				out.push_back('\n');
+			} else {
+				out.push_back('\n');
+			}
+		} else if (data[i] == '\r') {
+			if (target == EolStyle::Lf) {
+				out.push_back('\n');
+			} else {
+				out.push_back('\r');
+				out.push_back('\n');
+			}
+		} else {
+			out.push_back(data[i]);
+		}
+	}
+	return out;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/attributes/eol_normalize.h
+++ b/modules/coldstorage/sdk/src/common/attributes/eol_normalize.h
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  eol_normalize.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/attributes/gitattributes.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+std::vector<uint8_t> normalizeEol(const std::vector<uint8_t> &data, EolStyle target);
+bool isProbablyText(const std::vector<uint8_t> &data);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/attributes/gitattributes.h
+++ b/modules/coldstorage/sdk/src/common/attributes/gitattributes.h
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*  gitattributes.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace coldstorage {
+
+enum class EolStyle { Unspecified,
+	Lf,
+	Crlf,
+	Native };
+
+struct GitAttributesEntry {
+	std::string pattern;
+	bool text = false;
+	bool textUnset = false;
+	bool binary = false;
+	bool textAuto = false;
+	EolStyle eol = EolStyle::Unspecified;
+};
+
+struct ResolvedGitAttributes {
+	bool normalizeEol = false;
+	EolStyle eol = EolStyle::Native;
+	bool isBinary = false;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/csignore_parser.cpp
+++ b/modules/coldstorage/sdk/src/common/ignore/csignore_parser.cpp
@@ -1,0 +1,147 @@
+/**************************************************************************/
+/*  csignore_parser.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/ignore/csignore_parser.h"
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+namespace coldstorage {
+
+IgnoreSyntax syntaxFromFilename(const std::string &filename) {
+	fs::path p(filename);
+	const std::string name = p.filename().string();
+	if (name == ".p4ignore" || name == "p4ignore.txt") {
+		return IgnoreSyntax::P4;
+	}
+	return IgnoreSyntax::Git;
+}
+
+static std::string trim(const std::string &s) {
+	size_t a = 0;
+	while (a < s.size() && std::isspace(static_cast<unsigned char>(s[a]))) {
+		++a;
+	}
+	size_t b = s.size();
+	while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) {
+		--b;
+	}
+	return s.substr(a, b - a);
+}
+
+static std::string toLower(std::string s) {
+	for (char &c : s) {
+		c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+	}
+	return s;
+}
+
+static bool iequals(const std::string &a, const std::string &b) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < a.size(); ++i) {
+		if (std::tolower(static_cast<unsigned char>(a[i])) !=
+				std::tolower(static_cast<unsigned char>(b[i]))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+std::vector<IgnoreRule> parseIgnoreFileContent(IgnoreSyntax syntax, const std::string &content,
+		const std::string &sourceFile) {
+	std::vector<IgnoreRule> rules;
+	std::istringstream in(content);
+	std::string line;
+	int lineNo = 0;
+	while (std::getline(in, line)) {
+		++lineNo;
+		if (auto rule = IgnoreMatcher::parseRuleLine(syntax, line, sourceFile, lineNo)) {
+			rules.push_back(*rule);
+		}
+	}
+	return rules;
+}
+
+CsignoreParseResult parseCsignoreContent(const std::string &content, const std::string &sourceFile,
+		const std::string &sourceDir) {
+	CsignoreParseResult result;
+	IgnoreSyntax current = IgnoreSyntax::Git;
+	std::istringstream in(content);
+	std::string line;
+	int lineNo = 0;
+	while (std::getline(in, line)) {
+		++lineNo;
+		std::string t = trim(line);
+		if (t.empty() || t[0] == '#') {
+			continue;
+		}
+		if (t[0] == '@') {
+			std::string lower = toLower(t);
+			if (lower.rfind("@syntax", 0) == 0) {
+				std::string rest = trim(t.substr(7));
+				if (iequals(rest, "p4")) {
+					current = IgnoreSyntax::P4;
+				} else {
+					current = IgnoreSyntax::Git;
+				}
+				continue;
+			}
+			if (lower.rfind("@include", 0) == 0) {
+				std::string rest = trim(t.substr(8));
+				IgnoreSyntax incSyntax = IgnoreSyntax::Git;
+				auto sp = rest.find(" syntax=");
+				std::string pathPart = rest;
+				if (sp != std::string::npos) {
+					pathPart = trim(rest.substr(0, sp));
+					std::string syn = toLower(trim(rest.substr(sp + 8)));
+					if (syn == "p4") {
+						incSyntax = IgnoreSyntax::P4;
+					} else if (syn == "auto") {
+						incSyntax = syntaxFromFilename(pathPart);
+					}
+				}
+				fs::path incPath = fs::path(sourceDir) / pathPart;
+				result.includes.emplace_back(incPath.lexically_normal().string(), incSyntax);
+				continue;
+			}
+			continue;
+		}
+		if (auto rule = IgnoreMatcher::parseRuleLine(current, line, sourceFile, lineNo)) {
+			result.rules.push_back(*rule);
+		}
+	}
+	return result;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/csignore_parser.h
+++ b/modules/coldstorage/sdk/src/common/ignore/csignore_parser.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  csignore_parser.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/ignore/ignore_matcher.h"
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+IgnoreSyntax syntaxFromFilename(const std::string &filename);
+
+struct CsignoreParseResult {
+	std::vector<IgnoreRule> rules;
+	std::vector<std::pair<std::string, IgnoreSyntax>> includes;
+};
+
+CsignoreParseResult parseCsignoreContent(const std::string &content, const std::string &sourceFile,
+		const std::string &sourceDir);
+
+std::vector<IgnoreRule> parseIgnoreFileContent(IgnoreSyntax syntax, const std::string &content,
+		const std::string &sourceFile);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/ignore_loader.cpp
+++ b/modules/coldstorage/sdk/src/common/ignore/ignore_loader.cpp
@@ -1,0 +1,236 @@
+/**************************************************************************/
+/*  ignore_loader.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/ignore/ignore_loader.h"
+#include "common/ignore/csignore_parser.h"
+#include "common/util/sanitize.h"
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+
+namespace fs = std::filesystem;
+namespace coldstorage {
+namespace {
+
+std::string readFile(const fs::path &path) {
+	std::ifstream in(path, std::ios::binary);
+	if (!in.is_open()) {
+		return {};
+	}
+	std::ostringstream oss;
+	oss << in.rdbuf();
+	return oss.str();
+}
+
+std::string relFromRoot(const fs::path &root, const fs::path &file) {
+	std::error_code ec;
+	auto rel = fs::relative(file.parent_path(), root, ec);
+	if (ec) {
+		return {};
+	}
+	const std::string s = rel.generic_string();
+	return s == "." ? std::string{} : s;
+}
+
+void collectNamedFiles(const fs::path &root, const char *name, std::vector<fs::path> &out) {
+	std::error_code ec;
+	if (!fs::exists(root, ec)) {
+		return;
+	}
+	for (auto it = fs::recursive_directory_iterator(root, fs::directory_options::skip_permission_denied, ec);
+			!ec && it != fs::recursive_directory_iterator(); it.increment(ec)) {
+		if (!it->is_regular_file(ec)) {
+			continue;
+		}
+		if (it->path().filename() == name) {
+			out.push_back(it->path());
+		}
+	}
+}
+
+void loadFileIntoMatcher(IgnoreMatcher &matcher, const fs::path &file, const fs::path &root,
+		IgnoreSyntax syntax) {
+	const std::string content = readFile(file);
+	if (content.empty() && !fs::exists(file)) {
+		return;
+	}
+	const std::string baseDir = relFromRoot(root, file);
+	if (file.filename() == ".csignore") {
+		auto parsed = parseCsignoreContent(content, file.string(), file.parent_path().string());
+		if (!parsed.rules.empty()) {
+			matcher.addRules(baseDir, parsed.rules);
+		}
+		for (const auto &[incPath, incSyntax] : parsed.includes) {
+			fs::path p(incPath);
+			if (!fs::exists(p)) {
+				continue;
+			}
+			auto rules = parseIgnoreFileContent(incSyntax, readFile(p), p.string());
+			matcher.addRules(relFromRoot(root, p), rules);
+		}
+	} else {
+		auto rules = parseIgnoreFileContent(syntax, content, file.string());
+		matcher.addRules(baseDir, rules);
+	}
+}
+
+} //namespace
+
+IgnoreLoader::IgnoreLoader(std::string workspaceRoot) :
+		workspaceRoot_(std::move(workspaceRoot)) {}
+
+std::vector<std::string> splitP4IgnoreEnv(const std::string &value) {
+	std::vector<std::string> parts;
+	std::string cur;
+	for (char c : value) {
+#ifdef _WIN32
+		if (c == ';') {
+#else
+		if (c == ':' || c == ';') {
+#endif
+			if (!cur.empty()) {
+				parts.push_back(cur);
+			}
+			cur.clear();
+		} else {
+			cur += c;
+		}
+	}
+	if (!cur.empty()) {
+		parts.push_back(cur);
+	}
+	return parts;
+}
+
+std::vector<std::string> IgnoreLoader::listIgnoreFiles(const IgnoreLoadOptions &opts) const {
+	std::set<std::string> files;
+	fs::path root(workspaceRoot_);
+	std::vector<fs::path> found;
+	if (opts.csignore) {
+		collectNamedFiles(root, ".csignore", found);
+	}
+	if (opts.gitignore) {
+		collectNamedFiles(root, ".gitignore", found);
+	}
+	if (opts.p4ignore) {
+		collectNamedFiles(root, ".p4ignore", found);
+		collectNamedFiles(root, "p4ignore.txt", found);
+	}
+	for (const auto &p : found) {
+		files.insert(p.lexically_normal().string());
+	}
+
+	std::string env = sanitize::safeGetenv("P4IGNORE");
+	if (env.empty()) {
+		env = sanitize::safeGetenv("CSTORAGE_P4IGNORE");
+	}
+	for (const auto &part : splitP4IgnoreEnv(env)) {
+		fs::path p(part);
+		if (!p.is_absolute()) {
+			p = root / p;
+		}
+		if (fs::exists(p)) {
+			files.insert(p.lexically_normal().string());
+		}
+	}
+	for (const auto &extra : opts.extraFiles) {
+		fs::path p(extra);
+		if (!p.is_absolute()) {
+			p = root / p;
+		}
+		if (fs::exists(p)) {
+			files.insert(p.lexically_normal().string());
+		}
+	}
+	return std::vector<std::string>(files.begin(), files.end());
+}
+
+IgnoreMatcher IgnoreLoader::buildMatcher(const IgnoreLoadOptions &opts) const {
+	IgnoreMatcher matcher;
+	fs::path root(workspaceRoot_);
+	std::vector<fs::path> csignores, gitignores, p4ignores;
+
+	if (opts.csignore) {
+		collectNamedFiles(root, ".csignore", csignores);
+	}
+	if (opts.gitignore) {
+		collectNamedFiles(root, ".gitignore", gitignores);
+	}
+	if (opts.p4ignore) {
+		collectNamedFiles(root, ".p4ignore", p4ignores);
+		collectNamedFiles(root, "p4ignore.txt", p4ignores);
+	}
+
+	auto sortByDepth = [&root](std::vector<fs::path> &v) {
+		std::sort(v.begin(), v.end(), [&root](const fs::path &a, const fs::path &b) {
+			return relFromRoot(root, a) < relFromRoot(root, b);
+		});
+	};
+	sortByDepth(csignores);
+	sortByDepth(gitignores);
+	sortByDepth(p4ignores);
+
+	for (const auto &f : csignores) {
+		loadFileIntoMatcher(matcher, f, root, IgnoreSyntax::Git);
+	}
+	for (const auto &f : gitignores) {
+		loadFileIntoMatcher(matcher, f, root, IgnoreSyntax::Git);
+	}
+	for (const auto &f : p4ignores) {
+		loadFileIntoMatcher(matcher, f, root, IgnoreSyntax::P4);
+	}
+
+	std::string env = sanitize::safeGetenv("P4IGNORE");
+	if (env.empty()) {
+		env = sanitize::safeGetenv("CSTORAGE_P4IGNORE");
+	}
+	for (const auto &part : splitP4IgnoreEnv(env)) {
+		fs::path p(part);
+		if (!p.is_absolute()) {
+			p = root / p;
+		}
+		if (fs::exists(p)) {
+			loadFileIntoMatcher(matcher, p, root, syntaxFromFilename(p.string()));
+		}
+	}
+	for (const auto &extra : opts.extraFiles) {
+		fs::path p(extra);
+		if (!p.is_absolute()) {
+			p = root / p;
+		}
+		if (fs::exists(p)) {
+			loadFileIntoMatcher(matcher, p, root, syntaxFromFilename(p.string()));
+		}
+	}
+	return matcher;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/ignore_loader.h
+++ b/modules/coldstorage/sdk/src/common/ignore/ignore_loader.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  ignore_loader.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/ignore/ignore_matcher.h"
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct IgnoreLoadOptions {
+	bool csignore = true;
+	bool gitignore = true;
+	bool p4ignore = true;
+	std::vector<std::string> extraFiles;
+};
+
+class IgnoreLoader {
+public:
+	explicit IgnoreLoader(std::string workspaceRoot);
+
+	IgnoreMatcher buildMatcher(const IgnoreLoadOptions &opts) const;
+	std::vector<std::string> listIgnoreFiles(const IgnoreLoadOptions &opts) const;
+
+private:
+	std::string workspaceRoot_;
+};
+
+std::vector<std::string> splitP4IgnoreEnv(const std::string &value);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/ignore_matcher.cpp
+++ b/modules/coldstorage/sdk/src/common/ignore/ignore_matcher.cpp
@@ -1,0 +1,272 @@
+/**************************************************************************/
+/*  ignore_matcher.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/ignore/ignore_matcher.h"
+#include <algorithm>
+#include <cctype>
+
+namespace coldstorage {
+namespace {
+
+std::string normalizeSlashes(std::string s) {
+	for (char &c : s) {
+		if (c == '\\') {
+			c = '/';
+		}
+	}
+	while (!s.empty() && s.front() == '/') {
+		s.erase(s.begin());
+	}
+	while (!s.empty() && s.back() == '/') {
+		s.pop_back();
+	}
+	return s;
+}
+
+bool iequals(const std::string &a, const std::string &b) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < a.size(); ++i) {
+		if (std::tolower(static_cast<unsigned char>(a[i])) !=
+				std::tolower(static_cast<unsigned char>(b[i]))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool matchSegment(const char *pat, const char *patEnd, const char *str, const char *strEnd) {
+	while (pat < patEnd && str < strEnd) {
+		if (*pat == '*') {
+			++pat;
+			if (pat < patEnd && *pat == '*') {
+				++pat;
+				while (pat < patEnd && *pat == '*') {
+					++pat;
+				}
+				if (pat >= patEnd) {
+					return true;
+				}
+				while (str < strEnd) {
+					if (matchSegment(pat, patEnd, str, strEnd)) {
+						return true;
+					}
+					++str;
+				}
+				return false;
+			}
+			while (str <= strEnd) {
+				if (matchSegment(pat, patEnd, str, strEnd)) {
+					return true;
+				}
+				++str;
+			}
+			return false;
+		}
+		if (*pat != *str) {
+			return false;
+		}
+		++pat;
+		++str;
+	}
+	while (pat < patEnd && *pat == '*') {
+		++pat;
+	}
+	return pat >= patEnd && str >= strEnd;
+}
+
+bool pathMatchPattern(const std::string &path, const std::string &pattern, bool anchored) {
+	if (pattern.empty()) {
+		return false;
+	}
+	const char *p = pattern.c_str();
+	const char *pe = p + pattern.size();
+	const char *s = path.c_str();
+	const char *se = s + path.size();
+
+	if (pattern.find('/') == std::string::npos) {
+		if (matchSegment(p, pe, s, se)) {
+			return true;
+		}
+		if (anchored) {
+			return false;
+		}
+		size_t last = path.rfind('/');
+		std::string base = (last == std::string::npos) ? path : path.substr(last + 1);
+		return matchSegment(p, pe, base.c_str(), base.c_str() + base.size());
+	}
+
+	return matchSegment(p, pe, s, se);
+}
+
+std::string pathRelativeToBase(const std::string &relPath, const std::string &baseDir) {
+	std::string base = normalizeSlashes(baseDir);
+	std::string path = normalizeSlashes(relPath);
+	if (base.empty()) {
+		return path;
+	}
+	if (path.size() <= base.size()) {
+		return path;
+	}
+	if (path.compare(0, base.size(), base) != 0) {
+		return {};
+	}
+	if (path[base.size()] != '/') {
+		return {};
+	}
+	return path.substr(base.size() + 1);
+}
+
+} //namespace
+
+void IgnoreMatcher::clear() {
+	layers_.clear();
+}
+
+void IgnoreMatcher::addLayer(IgnoreLayer layer) {
+	layer.baseDir = normalizeSlashes(std::move(layer.baseDir));
+	layers_.push_back(std::move(layer));
+}
+
+void IgnoreMatcher::addRules(const std::string &baseDir, const std::vector<IgnoreRule> &rules) {
+	IgnoreLayer layer;
+	layer.baseDir = normalizeSlashes(baseDir);
+	layer.rules = rules;
+	addLayer(std::move(layer));
+}
+
+std::optional<IgnoreRule> IgnoreMatcher::parseRuleLine(IgnoreSyntax syntax, const std::string &line,
+		const std::string &sourceFile, int lineNo) {
+	std::string trimmed = line;
+	while (!trimmed.empty() && (trimmed.back() == ' ' || trimmed.back() == '\t' || trimmed.back() == '\r')) {
+		trimmed.pop_back();
+	}
+	size_t start = 0;
+	while (start < trimmed.size() && (trimmed[start] == ' ' || trimmed[start] == '\t')) {
+		++start;
+	}
+	if (start >= trimmed.size()) {
+		return std::nullopt;
+	}
+	if (trimmed[start] == '#') {
+		return std::nullopt;
+	}
+
+	IgnoreRule rule;
+	rule.syntax = syntax;
+	rule.sourceFile = sourceFile;
+	rule.sourceLine = lineNo;
+
+	size_t i = start;
+	if (trimmed[i] == '\\' && i + 1 < trimmed.size() && trimmed[i + 1] == '#') {
+		i += 2;
+	} else if (trimmed[i] == '!') {
+		rule.negated = true;
+		++i;
+		while (i < trimmed.size() && (trimmed[i] == ' ' || trimmed[i] == '\t')) {
+			++i;
+		}
+	}
+
+	std::string pat = trimmed.substr(i);
+	pat = normalizeSlashes(pat);
+	if (pat.empty()) {
+		return std::nullopt;
+	}
+
+	if (pat.back() == '/') {
+		rule.dirOnly = true;
+		pat.pop_back();
+	}
+	while (!pat.empty() && pat.front() == '/') {
+		rule.anchored = true;
+		pat.erase(pat.begin());
+	}
+	rule.pattern = pat;
+	return rule;
+}
+
+bool IgnoreMatcher::matchPattern(const IgnoreRule &rule, const std::string &relPath, bool isDir) {
+	if (rule.dirOnly && !isDir) {
+		return false;
+	}
+	const std::string path = normalizeSlashes(relPath);
+	if (rule.anchored) {
+		if (rule.pattern.find('/') == std::string::npos) {
+			if (path.find('/') != std::string::npos) {
+				return false;
+			}
+		} else if (path.size() < rule.pattern.size() ||
+				path.compare(0, rule.pattern.size(), rule.pattern) != 0 ||
+				(path.size() > rule.pattern.size() && path[rule.pattern.size()] != '/')) {
+			return false;
+		}
+	}
+	return pathMatchPattern(path, rule.pattern, rule.anchored);
+}
+
+IgnoreMatchInfo IgnoreMatcher::match(const std::string &relPath, bool isDir) const {
+	IgnoreMatchInfo info;
+	const std::string normPath = normalizeSlashes(relPath);
+	bool ignored = false;
+
+	for (const auto &layer : layers_) {
+		const std::string relToBase = pathRelativeToBase(normPath, layer.baseDir);
+		if (relToBase.empty() && !layer.baseDir.empty()) {
+			continue;
+		}
+		const std::string &candidate = layer.baseDir.empty() ? normPath : relToBase;
+
+		for (const auto &rule : layer.rules) {
+			if (!matchPattern(rule, candidate, isDir)) {
+				continue;
+			}
+			ignored = !rule.negated;
+			if (ignored) {
+				info.ignored = true;
+				info.matchedPattern = rule.pattern;
+				info.sourceFile = rule.sourceFile;
+				info.sourceLine = rule.sourceLine;
+				info.syntax = rule.syntax;
+			} else {
+				info = {};
+			}
+		}
+	}
+
+	info.ignored = ignored;
+	return info;
+}
+
+bool IgnoreMatcher::isIgnored(const std::string &relPath, bool isDir) const {
+	return match(relPath, isDir).ignored;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/ignore_matcher.h
+++ b/modules/coldstorage/sdk/src/common/ignore/ignore_matcher.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  ignore_matcher.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/ignore/ignore_rule.h"
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct IgnoreLayer {
+	std::string baseDir;
+	std::vector<IgnoreRule> rules;
+};
+
+class IgnoreMatcher {
+public:
+	void clear();
+	void addLayer(IgnoreLayer layer);
+	void addRules(const std::string &baseDir, const std::vector<IgnoreRule> &rules);
+
+	bool isIgnored(const std::string &relPath, bool isDir) const;
+	IgnoreMatchInfo match(const std::string &relPath, bool isDir) const;
+
+	static std::optional<IgnoreRule> parseRuleLine(IgnoreSyntax syntax, const std::string &line,
+			const std::string &sourceFile, int lineNo);
+	static bool matchPattern(const IgnoreRule &rule, const std::string &relPath, bool isDir);
+
+private:
+	std::vector<IgnoreLayer> layers_;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/ignore_rule.h
+++ b/modules/coldstorage/sdk/src/common/ignore/ignore_rule.h
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  ignore_rule.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/ignore/ignore_syntax.h"
+#include <string>
+
+namespace coldstorage {
+
+struct IgnoreRule {
+	std::string pattern;
+	bool negated = false;
+	bool dirOnly = false;
+	bool anchored = false;
+	IgnoreSyntax syntax = IgnoreSyntax::Git;
+	std::string sourceFile;
+	int sourceLine = 0;
+};
+
+struct IgnoreMatchInfo {
+	bool ignored = false;
+	std::string matchedPattern;
+	std::string sourceFile;
+	int sourceLine = 0;
+	IgnoreSyntax syntax = IgnoreSyntax::Git;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/ignore/ignore_syntax.h
+++ b/modules/coldstorage/sdk/src/common/ignore/ignore_syntax.h
@@ -1,0 +1,37 @@
+/**************************************************************************/
+/*  ignore_syntax.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+namespace coldstorage {
+
+enum class IgnoreSyntax { Git,
+	P4 };
+
+}

--- a/modules/coldstorage/sdk/src/common/net/plain_transport.cpp
+++ b/modules/coldstorage/sdk/src/common/net/plain_transport.cpp
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*  plain_transport.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/net/plain_transport.h"
+
+#include <climits>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace coldstorage {
+
+PlainSocketTransport::PlainSocketTransport(socket_t sock) :
+		sock_(sock) {}
+
+PlainSocketTransport::~PlainSocketTransport() {
+	close();
+}
+
+bool PlainSocketTransport::readAll(uint8_t *data, size_t len) {
+	size_t totalRecv = 0;
+	while (totalRecv < len) {
+#ifdef _WIN32
+		int toRecv = static_cast<int>(
+				(len - totalRecv) > INT_MAX ? INT_MAX : (len - totalRecv));
+		int received = ::recv(sock_, reinterpret_cast<char *>(data + totalRecv),
+				toRecv, 0);
+		if (received <= 0) {
+			return false;
+		}
+#else
+		ssize_t received = ::recv(sock_, data + totalRecv, len - totalRecv, 0);
+		if (received <= 0) {
+			return false;
+		}
+#endif
+		totalRecv += static_cast<size_t>(received);
+	}
+	return true;
+}
+
+bool PlainSocketTransport::writeAll(const uint8_t *data, size_t len) {
+	size_t totalSent = 0;
+	while (totalSent < len) {
+#ifdef _WIN32
+		int toSend = static_cast<int>(
+				(len - totalSent) > INT_MAX ? INT_MAX : (len - totalSent));
+		int sent = ::send(sock_, reinterpret_cast<const char *>(data + totalSent),
+				toSend, 0);
+		if (sent == SOCKET_ERROR) {
+			return false;
+		}
+#else
+		ssize_t sent = ::send(sock_, data + totalSent, len - totalSent, MSG_NOSIGNAL);
+		if (sent <= 0) {
+			return false;
+		}
+#endif
+		totalSent += static_cast<size_t>(sent);
+	}
+	return true;
+}
+
+void PlainSocketTransport::close() {
+	if (sock_ != kInvalidSocket) {
+#ifdef _WIN32
+		closesocket(sock_);
+#else
+		::close(sock_);
+#endif
+		sock_ = kInvalidSocket;
+	}
+}
+
+bool PlainSocketTransport::setRecvTimeout(int seconds) {
+	if (sock_ == kInvalidSocket) {
+		return false;
+	}
+#ifdef _WIN32
+	DWORD timeout = static_cast<DWORD>(seconds) * 1000;
+	return setsockopt(sock_, SOL_SOCKET, SO_RCVTIMEO,
+				   reinterpret_cast<const char *>(&timeout), sizeof(timeout)) == 0;
+#else
+	struct timeval tv;
+	tv.tv_sec = seconds;
+	tv.tv_usec = 0;
+	return setsockopt(sock_, SOL_SOCKET, SO_RCVTIMEO,
+				   reinterpret_cast<const char *>(&tv), sizeof(tv)) == 0;
+#endif
+}
+
+socket_t PlainSocketTransport::release() {
+	socket_t s = sock_;
+	sock_ = kInvalidSocket;
+	return s;
+}
+
+TransportPtr makePlainTransport(socket_t sock) {
+	return std::make_unique<PlainSocketTransport>(sock);
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/net/plain_transport.h
+++ b/modules/coldstorage/sdk/src/common/net/plain_transport.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  plain_transport.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/net/stream_transport.h"
+
+namespace coldstorage {
+
+class PlainSocketTransport : public StreamTransport {
+public:
+	explicit PlainSocketTransport(socket_t sock);
+	~PlainSocketTransport() override;
+
+	PlainSocketTransport(const PlainSocketTransport &) = delete;
+	PlainSocketTransport &operator=(const PlainSocketTransport &) = delete;
+
+	bool readAll(uint8_t *data, size_t len) override;
+	bool writeAll(const uint8_t *data, size_t len) override;
+	void close() override;
+	bool setRecvTimeout(int seconds) override;
+	socket_t rawSocket() const override { return sock_; }
+
+	socket_t release();
+
+private:
+	socket_t sock_;
+};
+
+TransportPtr makePlainTransport(socket_t sock);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/net/socket_types.h
+++ b/modules/coldstorage/sdk/src/common/net/socket_types.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  socket_types.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <winsock2.h>
+using socket_t = SOCKET;
+constexpr socket_t kInvalidSocket = INVALID_SOCKET;
+using addr_len_t = int;
+#else
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using socket_t = int;
+constexpr socket_t kInvalidSocket = -1;
+using addr_len_t = socklen_t;
+#endif
+
+namespace coldstorage {}

--- a/modules/coldstorage/sdk/src/common/net/stream_transport.h
+++ b/modules/coldstorage/sdk/src/common/net/stream_transport.h
@@ -1,0 +1,59 @@
+/**************************************************************************/
+/*  stream_transport.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/net/socket_types.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace coldstorage {
+
+class StreamTransport {
+public:
+	virtual ~StreamTransport() = default;
+
+	virtual bool readAll(uint8_t *data, size_t len) = 0;
+	virtual bool writeAll(const uint8_t *data, size_t len) = 0;
+	virtual void close() = 0;
+	virtual bool setRecvTimeout(int seconds) = 0;
+	virtual socket_t rawSocket() const { return kInvalidSocket; }
+	virtual std::string peerFingerprint() const { return {}; }
+	virtual std::optional<std::string> peerCertIdentity(const std::string &field) const {
+		(void)field;
+		return std::nullopt;
+	}
+};
+
+using TransportPtr = std::unique_ptr<StreamTransport>;
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/net/tls_cert.h
+++ b/modules/coldstorage/sdk/src/common/net/tls_cert.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  tls_cert.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <ctime>
+#include <optional>
+#include <string>
+
+struct ssl_st;
+typedef struct ssl_st SSL;
+struct x509_st;
+typedef struct x509_st X509;
+
+namespace coldstorage {
+
+std::string fingerprintFromX509(X509 *cert);
+std::string getPeerFingerprint(SSL *ssl);
+std::string getCertFingerprint(const std::string &certPath);
+std::string normalizeFingerprint(const std::string &fp);
+
+bool generateSelfSignedCert(const std::string &certPath, const std::string &keyPath,
+		const std::string &commonName, int validDays);
+
+bool generateCaCert(const std::string &caCertPath, const std::string &caKeyPath, int validDays);
+bool generateSignedCert(const std::string &caCertPath, const std::string &caKeyPath,
+		const std::string &subjectCn, const std::string &certPath,
+		const std::string &keyPath, int validDays, bool isClientCert);
+
+std::string getPeerCertIdentity(SSL *ssl, const std::string &field);
+
+std::optional<std::time_t> getCertExpiry(const std::string &certPath);
+int daysUntilExpiry(const std::string &certPath);
+bool isCertExpired(const std::string &certPath);
+
+std::string formatCertExpiryDate(const std::string &certPath);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/net/tls_context.h
+++ b/modules/coldstorage/sdk/src/common/net/tls_context.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  tls_context.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <string>
+
+struct ssl_ctx_st;
+typedef struct ssl_ctx_st SSL_CTX;
+
+namespace coldstorage {
+
+class TLSContext {
+public:
+	enum class Mode { Server,
+		Client };
+
+	TLSContext();
+	~TLSContext();
+
+	TLSContext(const TLSContext &) = delete;
+	TLSContext &operator=(const TLSContext &) = delete;
+
+	static void initLibraries();
+
+	bool configureServer(const std::string &certFile, const std::string &keyFile,
+			const std::string &caFile = "");
+	bool configureClient(const std::string &caFile, bool verifyPeer,
+			const std::string &certFile = "",
+			const std::string &keyFile = "");
+
+	SSL_CTX *native() const { return ctx_; }
+	Mode mode() const { return mode_; }
+
+private:
+	void freeContext();
+
+	SSL_CTX *ctx_ = nullptr;
+	Mode mode_ = Mode::Server;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/net/tls_transport.h
+++ b/modules/coldstorage/sdk/src/common/net/tls_transport.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  tls_transport.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/net/stream_transport.h"
+#include "common/net/tls_context.h"
+#include <optional>
+#include <string>
+
+struct ssl_st;
+typedef struct ssl_st SSL;
+
+namespace coldstorage {
+
+class TlsTransport : public StreamTransport {
+public:
+	static TransportPtr accept(socket_t sock, const TLSContext &ctx);
+	static TransportPtr connect(socket_t sock, const std::string &host, const TLSContext &ctx);
+
+	~TlsTransport() override;
+
+	TlsTransport(const TlsTransport &) = delete;
+	TlsTransport &operator=(const TlsTransport &) = delete;
+
+	bool readAll(uint8_t *data, size_t len) override;
+	bool writeAll(const uint8_t *data, size_t len) override;
+	void close() override;
+	bool setRecvTimeout(int seconds) override;
+	socket_t rawSocket() const override { return sock_; }
+	std::string peerFingerprint() const override;
+	std::optional<std::string> peerCertIdentity(const std::string &field) const override;
+
+private:
+	TlsTransport(socket_t sock, SSL *ssl);
+
+	socket_t sock_;
+	SSL *ssl_;
+	int recvTimeoutMs_;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/protocol/framing.cpp
+++ b/modules/coldstorage/sdk/src/common/protocol/framing.cpp
@@ -1,0 +1,115 @@
+/**************************************************************************/
+/*  framing.cpp                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/protocol/framing.h"
+#include "common/net/plain_transport.h"
+#include "common/util/net_trace.h"
+
+#include <climits>
+#include <cstring>
+#include <iostream>
+
+namespace coldstorage {
+
+bool writeFrame(StreamTransport &transport, const std::vector<uint8_t> &payload,
+		size_t maxFrameSize) {
+	CS_NET_TRACE("Framing", "writeFrame begin bytes=" << payload.size());
+	if (payload.size() > maxFrameSize) {
+		std::cerr << "[framing] writeFrame rejected: payload size "
+				  << payload.size() << " exceeds maxFrameSize " << maxFrameSize
+				  << ". Use chunked transfer for large payloads." << std::endl;
+		return false;
+	}
+	if (payload.size() > UINT32_MAX) {
+		std::cerr << "[framing] writeFrame rejected: payload size "
+				  << payload.size() << " exceeds UINT32_MAX (4GB frame limit). "
+				  << "Use chunked transfer for large payloads." << std::endl;
+		return false;
+	}
+
+	uint32_t len = static_cast<uint32_t>(payload.size());
+	uint8_t header[4];
+	header[0] = static_cast<uint8_t>((len >> 24) & 0xFF);
+	header[1] = static_cast<uint8_t>((len >> 16) & 0xFF);
+	header[2] = static_cast<uint8_t>((len >> 8) & 0xFF);
+	header[3] = static_cast<uint8_t>((len) & 0xFF);
+
+	if (!transport.writeAll(header, 4)) {
+		CS_NET_TRACE("Framing", "writeFrame header failed");
+		return false;
+	}
+	if (!payload.empty() && !transport.writeAll(payload.data(), payload.size())) {
+		CS_NET_TRACE("Framing", "writeFrame payload failed");
+		return false;
+	}
+	CS_NET_TRACE("Framing", "writeFrame ok bytes=" << payload.size());
+	return true;
+}
+
+bool readFrame(StreamTransport &transport, std::vector<uint8_t> &payload,
+		size_t maxFrameSize) {
+	CS_NET_TRACE("Framing", "readFrame begin max=" << maxFrameSize);
+	uint8_t header[4];
+	if (!transport.readAll(header, 4)) {
+		CS_NET_TRACE("Framing", "readFrame header failed");
+		return false;
+	}
+
+	uint32_t len = (static_cast<uint32_t>(header[0]) << 24) |
+			(static_cast<uint32_t>(header[1]) << 16) |
+			(static_cast<uint32_t>(header[2]) << 8) |
+			(static_cast<uint32_t>(header[3]));
+
+	if (static_cast<size_t>(len) > maxFrameSize) {
+		std::cerr << "[framing] readFrame rejected: frame length "
+				  << len << " bytes exceeds maxFrameSize "
+				  << maxFrameSize << " bytes" << std::endl;
+		return false;
+	}
+
+	payload.resize(len);
+	if (len > 0 && !transport.readAll(payload.data(), len)) {
+		CS_NET_TRACE("Framing", "readFrame payload failed len=" << len);
+		return false;
+	}
+	CS_NET_TRACE("Framing", "readFrame ok bytes=" << len);
+	return true;
+}
+
+bool writeFrame(socket_t sock, const std::vector<uint8_t> &payload, size_t maxFrameSize) {
+	PlainSocketTransport transport(sock);
+	return writeFrame(static_cast<StreamTransport &>(transport), payload, maxFrameSize);
+}
+
+bool readFrame(socket_t sock, std::vector<uint8_t> &payload, size_t maxFrameSize) {
+	PlainSocketTransport transport(sock);
+	return readFrame(static_cast<StreamTransport &>(transport), payload, maxFrameSize);
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/protocol/framing.h
+++ b/modules/coldstorage/sdk/src/common/protocol/framing.h
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  framing.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/net/stream_transport.h"
+#include <cstdint>
+#include <vector>
+
+namespace coldstorage {
+
+bool writeFrame(StreamTransport &transport, const std::vector<uint8_t> &payload,
+		size_t maxFrameSize = 64 * 1024 * 1024);
+bool readFrame(StreamTransport &transport, std::vector<uint8_t> &payload,
+		size_t maxFrameSize = 64 * 1024 * 1024);
+
+bool writeFrame(socket_t sock, const std::vector<uint8_t> &payload,
+		size_t maxFrameSize = 64 * 1024 * 1024);
+bool readFrame(socket_t sock, std::vector<uint8_t> &payload,
+		size_t maxFrameSize = 64 * 1024 * 1024);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/protocol/messages.cpp
+++ b/modules/coldstorage/sdk/src/common/protocol/messages.cpp
@@ -1,0 +1,174 @@
+/**************************************************************************/
+/*  messages.cpp                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/protocol/messages.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+
+namespace coldstorage {
+
+const char *instructionOpToString(InstructionOp op) {
+	switch (op) {
+		case InstructionOp::WriteFile:
+			return "write_file";
+		case InstructionOp::DeleteFile:
+			return "delete_file";
+		case InstructionOp::SendFile:
+			return "send_file";
+		case InstructionOp::Info:
+			return "info";
+		case InstructionOp::Error:
+			return "error";
+		case InstructionOp::Release:
+			return "release";
+		case InstructionOp::ChunkBegin:
+			return "chunk_begin";
+		case InstructionOp::ChunkData:
+			return "chunk_data";
+		case InstructionOp::ChunkEnd:
+			return "chunk_end";
+		case InstructionOp::ResumeDownload:
+			return "resume_download";
+	}
+	return "unknown";
+}
+
+InstructionOp instructionOpFromString(const std::string &str) {
+	if (str == "write_file") {
+		return InstructionOp::WriteFile;
+	}
+	if (str == "delete_file") {
+		return InstructionOp::DeleteFile;
+	}
+	if (str == "send_file") {
+		return InstructionOp::SendFile;
+	}
+	if (str == "info") {
+		return InstructionOp::Info;
+	}
+	if (str == "error") {
+		return InstructionOp::Error;
+	}
+	if (str == "release") {
+		return InstructionOp::Release;
+	}
+	if (str == "chunk_begin") {
+		return InstructionOp::ChunkBegin;
+	}
+	if (str == "chunk_data") {
+		return InstructionOp::ChunkData;
+	}
+	if (str == "chunk_end") {
+		return InstructionOp::ChunkEnd;
+	}
+	if (str == "resume_download") {
+		return InstructionOp::ResumeDownload;
+	}
+	throw std::invalid_argument("Unknown InstructionOp: " + str);
+}
+
+std::vector<uint8_t> Message::serialize() const {
+	nlohmann::json j;
+	j["func"] = func;
+	j["args"] = args;
+
+	std::string s = j.dump();
+	return std::vector<uint8_t>(s.begin(), s.end());
+}
+
+std::optional<Message> Message::deserialize(const std::vector<uint8_t> &data) {
+	try {
+		std::string s(data.begin(), data.end());
+		nlohmann::json j = nlohmann::json::parse(s);
+
+		Message msg;
+		msg.func = j.at("func").get<std::string>();
+		msg.args = j.value("args", nlohmann::json::object());
+		return msg;
+	} catch (const nlohmann::json::exception &) {
+		return std::nullopt;
+	}
+}
+
+std::vector<uint8_t> Instruction::serialize() const {
+	nlohmann::json j;
+	j["op"] = instructionOpToString(op);
+	j["data"] = data;
+	j["payload_size"] = payload.size();
+
+	std::string header = j.dump();
+
+	std::vector<uint8_t> result;
+	result.reserve(header.size() + 1 + payload.size());
+
+	result.insert(result.end(), header.begin(), header.end());
+
+	result.push_back(0x00);
+
+	if (!payload.empty()) {
+		result.insert(result.end(), payload.begin(), payload.end());
+	}
+
+	return result;
+}
+
+std::optional<Instruction> Instruction::deserialize(const std::vector<uint8_t> &data) {
+	try {
+		auto sep = std::find(data.begin(), data.end(), uint8_t{ 0 });
+		if (sep == data.end()) {
+			return std::nullopt;
+		}
+
+		std::string headerStr(data.begin(), sep);
+		nlohmann::json j = nlohmann::json::parse(headerStr);
+
+		Instruction instr;
+		instr.op = instructionOpFromString(j.at("op").get<std::string>());
+		instr.data = j.value("data", nlohmann::json::object());
+
+		size_t payloadSize = j.value("payload_size", static_cast<size_t>(0));
+		auto payloadBegin = sep + 1;
+		const size_t available = static_cast<size_t>(data.end() - payloadBegin);
+
+		if (payloadSize != available) {
+			return std::nullopt;
+		}
+		if (payloadSize > 0) {
+			instr.payload.assign(payloadBegin, payloadBegin + payloadSize);
+		}
+
+		return instr;
+	} catch (const std::exception &) {
+		return std::nullopt;
+	}
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/protocol/messages.h
+++ b/modules/coldstorage/sdk/src/common/protocol/messages.h
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*  messages.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct Message {
+	std::string func;
+	nlohmann::json args;
+
+	std::vector<uint8_t> serialize() const;
+	static std::optional<Message> deserialize(const std::vector<uint8_t> &data);
+};
+
+enum class InstructionOp {
+	WriteFile,
+	DeleteFile,
+	SendFile,
+	Info,
+	Error,
+	Release,
+
+	ChunkBegin,
+	ChunkData,
+	ChunkEnd,
+
+	ResumeDownload
+};
+
+struct Instruction {
+	InstructionOp op;
+	nlohmann::json data;
+	std::vector<uint8_t> payload;
+
+	std::vector<uint8_t> serialize() const;
+	static std::optional<Instruction> deserialize(const std::vector<uint8_t> &data);
+};
+
+const char *instructionOpToString(InstructionOp op);
+InstructionOp instructionOpFromString(const std::string &str);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/protocol/session.cpp
+++ b/modules/coldstorage/sdk/src/common/protocol/session.cpp
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  session.cpp                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/protocol/session.h"
+
+namespace coldstorage {
+
+Message makeProtocolRequest(const ProtocolInfo &info) {
+	Message msg;
+	msg.func = "protocol";
+	msg.args["version"] = info.version;
+	msg.args["bufsize"] = info.bufsize;
+	msg.args["capabilities"] = info.capabilities;
+	msg.args["client_version"] = info.clientVersion;
+	msg.args["type"] = "request";
+	return msg;
+}
+
+Message makeProtocolAck(const ProtocolInfo &info) {
+	Message msg;
+	msg.func = "protocol";
+	msg.args["version"] = info.version;
+	msg.args["bufsize"] = info.bufsize;
+	msg.args["capabilities"] = info.capabilities;
+	msg.args["server_version"] = coldstorage::version::FULL;
+	msg.args["min_client_version"] = coldstorage::version::MIN_CLIENT;
+	msg.args["type"] = "ack";
+	return msg;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/protocol/session.h
+++ b/modules/coldstorage/sdk/src/common/protocol/session.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  session.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "common/protocol/messages.h"
+#include "common/version/version.h"
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+struct ProtocolInfo {
+	int version = coldstorage::version::PROTOCOL_VERSION;
+	std::string clientVersion = coldstorage::version::FULL;
+	int bufsize = 64 * 1024 * 1024;
+	std::vector<std::string> capabilities;
+};
+
+Message makeProtocolRequest(const ProtocolInfo &info);
+
+Message makeProtocolAck(const ProtocolInfo &info);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/crypto.h
+++ b/modules/coldstorage/sdk/src/common/util/crypto.h
@@ -1,0 +1,79 @@
+/**************************************************************************/
+/*  crypto.h                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+std::string sha256(const std::string &data);
+std::string sha256(const uint8_t *data, size_t len);
+
+std::string sha256File(const std::string &path, int64_t *sizeOut = nullptr);
+
+std::string sha256FileRange(const std::string &path, int64_t offset, int64_t length);
+
+class Sha256Hasher {
+public:
+	Sha256Hasher();
+	~Sha256Hasher();
+	Sha256Hasher(const Sha256Hasher &) = delete;
+	Sha256Hasher &operator=(const Sha256Hasher &) = delete;
+	void update(const uint8_t *data, size_t len);
+	void update(const char *data, size_t len);
+	std::string finalHex();
+
+private:
+	struct State;
+	State *state_ = nullptr;
+};
+
+class Sha256OStream : public std::ostream {
+public:
+	Sha256OStream();
+	~Sha256OStream() override;
+	std::string digest();
+
+private:
+	class Buf;
+	Buf *buf_ = nullptr;
+};
+
+std::string hmac_sha256(const std::string &key, const std::string &data);
+
+std::string hash_password(const std::string &password);
+bool verify_password(const std::string &password, const std::string &hash);
+
+std::string random_token(size_t bytes = 32);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/net_trace.h
+++ b/modules/coldstorage/sdk/src/common/util/net_trace.h
@@ -1,0 +1,178 @@
+/**************************************************************************/
+/*  net_trace.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <unistd.h>
+#include <fstream>
+#endif
+
+namespace coldstorage {
+
+inline bool csNetTraceEnabled() {
+	static const bool enabled = []() {
+		const char *value = std::getenv("COLDSTORAGE_TEST_TRACE");
+		if (value == nullptr) {
+			return false;
+		}
+		return value[0] != '0' && value[0] != '\0';
+	}();
+	return enabled;
+}
+
+inline std::string csNetTraceThreadId() {
+	std::ostringstream oss;
+	oss << std::this_thread::get_id();
+	return oss.str();
+}
+
+inline long long csNetTraceElapsedMs() {
+	using clock = std::chrono::steady_clock;
+	static const clock::time_point start = clock::now();
+	return std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - start).count();
+}
+
+inline int csNetTraceProcessThreadCount() {
+#ifdef _WIN32
+	return -1;
+#else
+	std::ifstream status("/proc/self/status");
+	if (!status.is_open()) {
+		return -1;
+	}
+	std::string line;
+	while (std::getline(status, line)) {
+		if (line.rfind("Threads:", 0) == 0) {
+			return std::stoi(line.substr(8));
+		}
+	}
+	return -1;
+#endif
+}
+
+inline void csNetTraceLine(const char *component, const std::string &message) {
+	if (!csNetTraceEnabled()) {
+		return;
+	}
+	const int threads = csNetTraceProcessThreadCount();
+	std::cerr << "[TRACE +" << csNetTraceElapsedMs() << "ms"
+			  << " component=" << component
+			  << " tid=" << csNetTraceThreadId();
+	if (threads >= 0) {
+		std::cerr << " threads=" << threads;
+	}
+	std::cerr << "] " << message << std::endl;
+}
+
+inline void csNetTraceThreadSnapshot(const char *component) {
+	if (!csNetTraceEnabled()) {
+		return;
+	}
+#ifndef _WIN32
+	std::ostringstream oss;
+	oss << "thread snapshot";
+	const int self = static_cast<int>(::getpid());
+	int listed = 0;
+	for (int tid = 1; tid < 100000; ++tid) {
+		std::ifstream comm("/proc/self/task/" + std::to_string(tid) + "/comm");
+		std::ifstream wchan("/proc/self/task/" + std::to_string(tid) + "/wchan");
+		if (!comm.is_open()) {
+			continue;
+		}
+		std::string name;
+		std::getline(comm, name);
+		std::string wait;
+		if (wchan.is_open()) {
+			std::getline(wchan, wait);
+		}
+		oss << " {tid=" << tid << " comm=" << name << " wchan=" << wait << "}";
+		++listed;
+		if (listed >= 8) {
+			break;
+		}
+	}
+	oss << " pid=" << self;
+	csNetTraceLine(component, oss.str());
+#else
+	csNetTraceLine(component, "thread snapshot unavailable on Windows");
+#endif
+}
+
+class CsNetTraceWatchdog {
+public:
+	explicit CsNetTraceWatchdog(const char *component) :
+			component_(component), stop_(false) {
+		if (!csNetTraceEnabled()) {
+			return;
+		}
+		worker_ = std::thread([this]() {
+			while (!stop_.load(std::memory_order_acquire)) {
+				csNetTraceThreadSnapshot(component_);
+				std::this_thread::sleep_for(std::chrono::seconds(1));
+			}
+		});
+	}
+
+	~CsNetTraceWatchdog() {
+		stop_.store(true, std::memory_order_release);
+		if (worker_.joinable()) {
+			worker_.join();
+		}
+	}
+
+	CsNetTraceWatchdog(const CsNetTraceWatchdog &) = delete;
+	CsNetTraceWatchdog &operator=(const CsNetTraceWatchdog &) = delete;
+
+private:
+	const char *component_;
+	std::atomic<bool> stop_;
+	std::thread worker_;
+};
+
+#define CS_NET_TRACE(component, expr)                                      \
+	do {                                                                   \
+		if (::coldstorage::csNetTraceEnabled()) {                          \
+			std::ostringstream _cs_trace_oss;                              \
+			_cs_trace_oss << expr;                                         \
+			::coldstorage::csNetTraceLine(component, _cs_trace_oss.str()); \
+		}                                                                  \
+	} while (0)
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/sanitize.h
+++ b/modules/coldstorage/sdk/src/common/util/sanitize.h
@@ -1,0 +1,516 @@
+/**************************************************************************/
+/*  sanitize.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+#include <string>
+
+namespace coldstorage {
+namespace sanitize {
+
+inline std::string trim(const std::string &s) {
+	auto start = s.find_first_not_of(" \t\n\r\f\v");
+	if (start == std::string::npos) {
+		return "";
+	}
+	auto end = s.find_last_not_of(" \t\n\r\f\v");
+	return s.substr(start, end - start + 1);
+}
+
+inline std::string trimLeft(const std::string &s) {
+	auto start = s.find_first_not_of(" \t\n\r\f\v");
+	return (start == std::string::npos) ? "" : s.substr(start);
+}
+
+inline std::string trimRight(const std::string &s) {
+	auto end = s.find_last_not_of(" \t\n\r\f\v");
+	return (end == std::string::npos) ? "" : s.substr(0, end + 1);
+}
+
+inline std::string stripControlChars(const std::string &s) {
+	std::string result;
+	result.reserve(s.size());
+	for (char c : s) {
+		if (c == '\t' || c == '\n' || c == '\r') {
+			result += c;
+			continue;
+		}
+		if (static_cast<unsigned char>(c) >= 0x20 && c != 0x7F) {
+			result += c;
+		}
+	}
+	return result;
+}
+
+inline std::string stripNonPrintable(const std::string &s) {
+	std::string result;
+	result.reserve(s.size());
+	for (unsigned char c : s) {
+		if (c >= 0x20 && c < 0x7F) {
+			result += static_cast<char>(c);
+		}
+	}
+	return result;
+}
+
+inline bool checkMaxLength(const std::string &s, size_t maxLen) {
+	return s.size() <= maxLen;
+}
+
+inline std::string truncate(const std::string &s, size_t maxLen) {
+	return s.size() <= maxLen ? s : s.substr(0, maxLen);
+}
+
+inline bool isValidName(const std::string &s, size_t minLen = 1, size_t maxLen = 128) {
+	if (s.size() < minLen || s.size() > maxLen) {
+		return false;
+	}
+	if (s.empty()) {
+		return false;
+	}
+
+	if (!std::isalnum(static_cast<unsigned char>(s[0]))) {
+		return false;
+	}
+
+	if (!std::isalnum(static_cast<unsigned char>(s.back()))) {
+		return false;
+	}
+
+	for (char c : s) {
+		if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_' && c != '.') {
+			return false;
+		}
+	}
+
+	for (size_t i = 1; i < s.size(); i++) {
+		if (!std::isalnum(static_cast<unsigned char>(s[i])) &&
+				!std::isalnum(static_cast<unsigned char>(s[i - 1]))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+inline std::string sanitizeName(const std::string &s, size_t maxLen = 128) {
+	std::string result;
+	result.reserve(std::min(s.size(), maxLen));
+	for (char c : s) {
+		if (result.size() >= maxLen) {
+			break;
+		}
+		if (std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_' || c == '.') {
+			result += c;
+		}
+	}
+
+	while (!result.empty() && !std::isalnum(static_cast<unsigned char>(result.front()))) {
+		result.erase(result.begin());
+	}
+	while (!result.empty() && !std::isalnum(static_cast<unsigned char>(result.back()))) {
+		result.pop_back();
+	}
+	return result;
+}
+
+inline bool hasDotDotSegment(const std::string &path) {
+	if (path.size() < 3) {
+		return false;
+	}
+	size_t i = 2;
+	while (i < path.size()) {
+		size_t j = path.find('/', i);
+		if (j == std::string::npos) {
+			j = path.size();
+		}
+		std::string seg = trim(path.substr(i, j - i));
+		if (seg == ".." || seg == ".") {
+			return true;
+		}
+		i = j + 1;
+	}
+	return false;
+}
+
+inline bool hasEmptySegment(const std::string &path) {
+	if (path.size() < 3) {
+		return false;
+	}
+	size_t i = 2;
+	while (i < path.size()) {
+		size_t j = path.find('/', i);
+		if (j == std::string::npos) {
+			j = path.size();
+		}
+
+		if (j == i) {
+			return true;
+		}
+		std::string seg = trim(path.substr(i, j - i));
+		if (seg.empty()) {
+			return true;
+		}
+		i = j + 1;
+	}
+	return false;
+}
+
+inline bool isReservedDepotPath(const std::string &path) {
+	if (path == "//.shelf" || path == "//.cs.shelf") {
+		return true;
+	}
+	if (path.rfind("//.shelf/", 0) == 0) {
+		return true;
+	}
+	if (path.rfind("//.cs.shelf/", 0) == 0) {
+		return true;
+	}
+	return false;
+}
+
+inline bool isHexDigest64(const std::string &s) {
+	if (s.size() != 64) {
+		return false;
+	}
+	for (unsigned char c : s) {
+		if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+					(c >= 'A' && c <= 'F'))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+inline bool isShelfContentPath(const std::string &path) {
+	static constexpr const char kPrefix[] = "//.cs.shelf/";
+	constexpr size_t kPrefixLen = sizeof(kPrefix) - 1;
+	if (path.size() <= kPrefixLen || path.compare(0, kPrefixLen, kPrefix) != 0) {
+		return false;
+	}
+	if (path.find('\0') != std::string::npos) {
+		return false;
+	}
+	if (path.find('\\') != std::string::npos) {
+		return false;
+	}
+	if (path.find("//", 2) != std::string::npos) {
+		return false;
+	}
+	if (hasDotDotSegment(path) || hasEmptySegment(path)) {
+		return false;
+	}
+
+	std::string rest = path.substr(kPrefixLen);
+	auto slash = rest.find('/');
+	if (slash == std::string::npos || slash == 0) {
+		return false;
+	}
+	std::string name = rest.substr(0, slash);
+	std::string hex = rest.substr(slash + 1);
+	if (hex.find('/') != std::string::npos) {
+		return false;
+	}
+	if (!isValidName(name) || !isHexDigest64(hex)) {
+		return false;
+	}
+	return true;
+}
+
+inline std::string collapseDepotSlashes(const std::string &path) {
+	if (path.size() < 2) {
+		return path;
+	}
+	std::string out;
+	out.reserve(path.size());
+	out.push_back(path[0]);
+	out.push_back(path[1]);
+	for (size_t i = 2; i < path.size(); ++i) {
+		if (path[i] == '/' && !out.empty() && out.back() == '/') {
+			continue;
+		}
+		out.push_back(path[i]);
+	}
+	return out;
+}
+
+inline bool isWindowsReservedSegment(const std::string &seg) {
+	if (seg.empty()) {
+		return false;
+	}
+
+	std::string base = seg;
+	while (!base.empty() && (base.back() == ' ' || base.back() == '.')) {
+		base.pop_back();
+	}
+	auto dot = base.find('.');
+	if (dot != std::string::npos) {
+		base = base.substr(0, dot);
+	}
+	for (char &c : base) {
+		if (c >= 'a' && c <= 'z') {
+			c = static_cast<char>(c - 'a' + 'A');
+		}
+	}
+	static const char *kNames[] = {
+		"CON",
+		"PRN",
+		"AUX",
+		"NUL",
+		"COM1",
+		"COM2",
+		"COM3",
+		"COM4",
+		"COM5",
+		"COM6",
+		"COM7",
+		"COM8",
+		"COM9",
+		"LPT1",
+		"LPT2",
+		"LPT3",
+		"LPT4",
+		"LPT5",
+		"LPT6",
+		"LPT7",
+		"LPT8",
+		"LPT9",
+	};
+	for (const char *n : kNames) {
+		if (base == n) {
+			return true;
+		}
+	}
+	return false;
+}
+
+inline bool hasWindowsReservedDepotSegment(const std::string &path) {
+	if (path.size() < 3) {
+		return false;
+	}
+	size_t i = 2;
+	while (i < path.size()) {
+		size_t j = path.find('/', i);
+		if (j == std::string::npos) {
+			j = path.size();
+		}
+		if (j > i && isWindowsReservedSegment(path.substr(i, j - i))) {
+			return true;
+		}
+		i = j + 1;
+	}
+	return false;
+}
+
+inline bool isSafeProtectPath(const std::string &path) {
+	if (path.size() < 3 || path.compare(0, 2, "//") != 0) {
+		return false;
+	}
+	if (path.find("//", 2) != std::string::npos) {
+		return false;
+	}
+
+	if (path == "//*" || path == "//..." || path == "//?") {
+		return false;
+	}
+	if (path.size() >= 3 && path.compare(path.size() - 3, 3, "...") == 0) {
+		std::string prefix = path.substr(0, path.size() - 3);
+		if (prefix.size() <= 2) {
+			return false;
+		}
+		if (prefix.back() != '/') {
+			return false;
+		}
+		return true;
+	}
+
+	if (path.find('/', 2) == std::string::npos) {
+		return false;
+	}
+	return true;
+}
+
+inline bool isValidDepotPath(const std::string &path) {
+	if (path.size() < 3 || path.size() > 4096) {
+		return false;
+	}
+	if (path.substr(0, 2) != "//") {
+		return false;
+	}
+
+	if (path.find('\0') != std::string::npos) {
+		return false;
+	}
+
+	if (path.find('\\') != std::string::npos) {
+		return false;
+	}
+	if (path.find(':') != std::string::npos) {
+		return false;
+	}
+
+	if (path.find("//", 2) != std::string::npos) {
+		return false;
+	}
+
+	if (path.find("/../") != std::string::npos) {
+		return false;
+	}
+	if (path.find("/./") != std::string::npos) {
+		return false;
+	}
+	if (hasDotDotSegment(path)) {
+		return false;
+	}
+	if (hasEmptySegment(path)) {
+		return false;
+	}
+	if (hasWindowsReservedDepotSegment(path)) {
+		return false;
+	}
+
+	if (path.size() <= 2 || path[2] == '/') {
+		return false;
+	}
+
+	for (size_t i = 2; i < path.size(); i++) {
+		unsigned char c = static_cast<unsigned char>(path[i]);
+		if (c < 0x20 || c == 0x7F) {
+			return false;
+		}
+	}
+	if (isReservedDepotPath(path)) {
+		return false;
+	}
+	return true;
+}
+
+inline bool isAllowedContentDepotPath(const std::string &path) {
+	return isValidDepotPath(path) || isShelfContentPath(path);
+}
+
+inline bool isValidRole(const std::string &role) {
+	return role == "owner" || role == "admin" || role == "write" ||
+			role == "read" || role == "none";
+}
+
+inline bool isValidPort(int port) {
+	return port >= 1 && port <= 65535;
+}
+
+inline int clampPort(int port) {
+	if (port < 1) {
+		return 1666;
+	}
+	if (port > 65535) {
+		return 1666;
+	}
+	return port;
+}
+
+inline int clampInt(int val, int minVal, int maxVal) {
+	if (val < minVal) {
+		return minVal;
+	}
+	if (val > maxVal) {
+		return maxVal;
+	}
+	return val;
+}
+
+inline size_t clampSize(size_t val, size_t minVal, size_t maxVal) {
+	if (val < minVal) {
+		return minVal;
+	}
+	if (val > maxVal) {
+		return maxVal;
+	}
+	return val;
+}
+
+inline bool isValidHost(const std::string &host) {
+	if (host.empty() || host.size() > 253) {
+		return false;
+	}
+
+	for (unsigned char c : host) {
+		if (c < 0x20 || c == 0x7F) {
+			return false;
+		}
+		if (c == ';' || c == '|' || c == '&' || c == '$' || c == '`') {
+			return false;
+		}
+		if (c == '\'' || c == '"' || c == '(' || c == ')') {
+			return false;
+		}
+	}
+	return true;
+}
+
+inline bool isValidJWTFormat(const std::string &token) {
+	if (token.empty() || token.size() > 16384) {
+		return false;
+	}
+
+	int dots = 0;
+	for (char c : token) {
+		if (c == '.') {
+			dots++;
+		}
+
+		if (!std::isalnum(static_cast<unsigned char>(c)) &&
+				c != '-' && c != '_' && c != '.' && c != '=') {
+			return false;
+		}
+	}
+	return dots == 2;
+}
+
+inline std::string sanitizeText(const std::string &s, size_t maxLen = 65536) {
+	std::string result = stripControlChars(s);
+	return truncate(result, maxLen);
+}
+
+inline bool isValidPassword(const std::string &pw) {
+	return pw.size() >= 1 && pw.size() <= 1024;
+}
+
+inline std::string safeGetenv(const char *name, size_t maxLen = 4096) {
+	const char *val = std::getenv(name);
+	if (!val) {
+		return "";
+	}
+	std::string s(val);
+	return truncate(trim(s), maxLen);
+}
+
+} //namespace sanitize
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/sync_target.cpp
+++ b/modules/coldstorage/sdk/src/common/util/sync_target.cpp
@@ -1,0 +1,201 @@
+/**************************************************************************/
+/*  sync_target.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/util/sync_target.h"
+#include "common/util/sanitize.h"
+#include <cctype>
+
+namespace coldstorage {
+namespace {
+
+bool parsePositiveInt(const std::string &s, int64_t &out) {
+	if (s.empty()) {
+		return false;
+	}
+	try {
+		size_t idx = 0;
+		long long v = std::stoll(s, &idx, 10);
+		if (idx != s.size() || v <= 0) {
+			return false;
+		}
+		out = static_cast<int64_t>(v);
+		return true;
+	} catch (...) {
+		return false;
+	}
+}
+
+bool parseRevSuffix(const std::string &suffix, SyncTarget &out) {
+	if (suffix.empty() || suffix == "#head") {
+		out.revKind = SyncRevKind::HeadChange;
+		out.revNum = 0;
+		return true;
+	}
+	if (suffix[0] == '@') {
+		int64_t n = 0;
+		if (!parsePositiveInt(suffix.substr(1), n)) {
+			out.error = "Invalid changelist in target: " + suffix;
+			return false;
+		}
+		out.revKind = SyncRevKind::AtChange;
+		out.revNum = n;
+		return true;
+	}
+	if (suffix[0] == '#') {
+		if (suffix == "#head") {
+			out.revKind = SyncRevKind::HeadChange;
+			out.revNum = 0;
+			return true;
+		}
+		int64_t n = 0;
+		if (!parsePositiveInt(suffix.substr(1), n)) {
+			out.error = "Invalid revision in target: " + suffix;
+			return false;
+		}
+		out.revKind = SyncRevKind::FileRev;
+		out.revNum = n;
+		return true;
+	}
+	out.error = "Invalid revision suffix: " + suffix;
+	return false;
+}
+
+bool setPathScope(const std::string &pathPart, SyncTarget &out) {
+	if (pathPart.empty()) {
+		return true;
+	}
+	std::string path = pathPart;
+	if (path.size() >= 3 && path.compare(path.size() - 3, 3, "...") == 0) {
+		out.exactPath = false;
+		out.pathPrefix = path.substr(0, path.size() - 3);
+		if (out.pathPrefix.size() < 3 || out.pathPrefix.rfind("//", 0) != 0) {
+			out.error = "Invalid path in target: " + pathPart;
+			return false;
+		}
+		if (out.pathPrefix.find("/../") != std::string::npos ||
+				out.pathPrefix.find('\\') != std::string::npos) {
+			out.error = "Invalid path in target: " + pathPart;
+			return false;
+		}
+		return true;
+	}
+	if (!sanitize::isValidDepotPath(path)) {
+		out.error = "Invalid depot path in target: " + pathPart;
+		return false;
+	}
+	out.exactPath = true;
+	out.pathPrefix = path;
+	return true;
+}
+
+} //namespace
+
+SyncTarget parseSyncTarget(const std::string &spec) {
+	SyncTarget out;
+	std::string s = sanitize::trim(spec);
+	if (s.size() > 256) {
+		out.error = "Target specification too long";
+		return out;
+	}
+	if (s.empty() || s == "#head") {
+		out.valid = true;
+		out.revKind = SyncRevKind::HeadChange;
+		return out;
+	}
+	if (s[0] == '@') {
+		if (!parseRevSuffix(s, out)) {
+			return out;
+		}
+		out.valid = true;
+		return out;
+	}
+	if (s[0] == '#') {
+		if (!parseRevSuffix(s, out)) {
+			return out;
+		}
+		out.valid = true;
+		return out;
+	}
+	if (s.rfind("//", 0) != 0) {
+		out.error = "Invalid target specification: " + s;
+		return out;
+	}
+
+	size_t revAt = std::string::npos;
+	for (size_t i = s.size(); i > 2;) {
+		--i;
+		if (s[i] == '#' || s[i] == '@') {
+			revAt = i;
+			break;
+		}
+	}
+
+	std::string pathPart = s;
+	std::string revPart;
+	if (revAt != std::string::npos) {
+		pathPart = s.substr(0, revAt);
+		revPart = s.substr(revAt);
+
+		SyncTarget tmp;
+		if (!parseRevSuffix(revPart, tmp)) {
+			out.error = tmp.error;
+			return out;
+		}
+		out.revKind = tmp.revKind;
+		out.revNum = tmp.revNum;
+	} else {
+		out.revKind = SyncRevKind::HeadChange;
+		out.revNum = 0;
+	}
+
+	if (pathPart.empty()) {
+		out.error = "Invalid target specification: " + s;
+		return out;
+	}
+	if (!setPathScope(pathPart, out)) {
+		return out;
+	}
+	out.valid = true;
+	return out;
+}
+
+bool syncPathMatches(const SyncTarget &target, const std::string &depotPath) {
+	if (target.pathPrefix.empty()) {
+		return true;
+	}
+	if (target.exactPath) {
+		return depotPath == target.pathPrefix;
+	}
+	if (depotPath.size() < target.pathPrefix.size()) {
+		return false;
+	}
+	return depotPath.compare(0, target.pathPrefix.size(), target.pathPrefix) == 0;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/sync_target.h
+++ b/modules/coldstorage/sdk/src/common/util/sync_target.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  sync_target.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace coldstorage {
+
+enum class SyncRevKind {
+	HeadChange,
+	AtChange,
+	FileRev,
+};
+
+struct SyncTarget {
+	bool valid = false;
+	std::string error;
+
+	std::string pathPrefix;
+	bool exactPath = false;
+	SyncRevKind revKind = SyncRevKind::HeadChange;
+	int64_t revNum = 0;
+};
+
+SyncTarget parseSyncTarget(const std::string &spec);
+
+bool syncPathMatches(const SyncTarget &target, const std::string &depotPath);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/text_diff.cpp
+++ b/modules/coldstorage/sdk/src/common/util/text_diff.cpp
@@ -1,0 +1,129 @@
+/**************************************************************************/
+/*  text_diff.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/util/text_diff.h"
+#include <algorithm>
+#include <sstream>
+
+namespace coldstorage {
+namespace {
+
+std::vector<std::string> splitLines(const std::string &text) {
+	std::vector<std::string> lines;
+	std::string cur;
+	for (char c : text) {
+		if (c == '\n') {
+			lines.push_back(cur);
+			cur.clear();
+		} else if (c != '\r') {
+			cur.push_back(c);
+		}
+	}
+	lines.push_back(cur);
+	return lines;
+}
+
+struct HunkLine {
+	char tag;
+	std::string text;
+};
+
+} //namespace
+
+bool looksBinary(const std::string &data) {
+	if (data.find('\0') != std::string::npos) {
+		return true;
+	}
+	return false;
+}
+
+std::string unifiedDiffLines(const std::vector<std::string> &oldLines,
+		const std::vector<std::string> &newLines,
+		const std::string &oldLabel, const std::string &newLabel,
+		const std::string &pathLabel) {
+	const size_t n = oldLines.size();
+	const size_t m = newLines.size();
+	std::vector<std::vector<size_t>> dp(n + 1, std::vector<size_t>(m + 1, 0));
+	for (size_t i = n; i-- > 0;) {
+		for (size_t j = m; j-- > 0;) {
+			if (oldLines[i] == newLines[j]) {
+				dp[i][j] = dp[i + 1][j + 1] + 1;
+			} else {
+				dp[i][j] = std::max(dp[i + 1][j], dp[i][j + 1]);
+			}
+		}
+	}
+
+	std::vector<HunkLine> ops;
+	size_t i = 0, j = 0;
+	while (i < n && j < m) {
+		if (oldLines[i] == newLines[j]) {
+			ops.push_back({ ' ', oldLines[i] });
+			++i;
+			++j;
+		} else if (dp[i + 1][j] >= dp[i][j + 1]) {
+			ops.push_back({ '-', oldLines[i] });
+			++i;
+		} else {
+			ops.push_back({ '+', newLines[j] });
+			++j;
+		}
+	}
+	while (i < n) {
+		ops.push_back({ '-', oldLines[i++] });
+	}
+	while (j < m) {
+		ops.push_back({ '+', newLines[j++] });
+	}
+
+	if (ops.empty()) {
+		return {};
+	}
+
+	std::ostringstream out;
+	out << "--- " << oldLabel << "\n";
+	out << "+++ " << newLabel << "\n";
+	out << "@@ " << pathLabel << " @@\n";
+	for (const auto &op : ops) {
+		out << op.tag << op.text << "\n";
+	}
+	return out.str();
+}
+
+std::string unifiedDiffText(const std::string &oldText, const std::string &newText,
+		const std::string &oldLabel, const std::string &newLabel,
+		const std::string &pathLabel) {
+	if (oldText == newText) {
+		return {};
+	}
+	return unifiedDiffLines(splitLines(oldText), splitLines(newText), oldLabel, newLabel,
+			pathLabel);
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk/src/common/util/text_diff.h
+++ b/modules/coldstorage/sdk/src/common/util/text_diff.h
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  text_diff.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace coldstorage {
+
+std::string unifiedDiffLines(const std::vector<std::string> &oldLines,
+		const std::vector<std::string> &newLines,
+		const std::string &oldLabel, const std::string &newLabel,
+		const std::string &pathLabel);
+
+std::string unifiedDiffText(const std::string &oldText, const std::string &newText,
+		const std::string &oldLabel, const std::string &newLabel,
+		const std::string &pathLabel);
+
+bool looksBinary(const std::string &data);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/net/tls_cert.cpp
+++ b/modules/coldstorage/sdk_shims/common/net/tls_cert.cpp
@@ -1,0 +1,114 @@
+/**************************************************************************/
+/*  tls_cert.cpp                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/net/tls_cert.h"
+
+#include <mbedtls/sha256.h>
+#include <mbedtls/x509_crt.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <sstream>
+
+namespace coldstorage {
+
+std::string normalizeFingerprint(const std::string &fp) {
+	std::string out;
+	out.reserve(fp.size());
+	for (unsigned char c : fp) {
+		if (std::isxdigit(c)) {
+			out.push_back(static_cast<char>(std::tolower(c)));
+		}
+	}
+	return out;
+}
+
+std::string getCertFingerprint(const std::string &certPath) {
+	mbedtls_x509_crt crt;
+	mbedtls_x509_crt_init(&crt);
+	if (mbedtls_x509_crt_parse_file(&crt, certPath.c_str()) != 0) {
+		mbedtls_x509_crt_free(&crt);
+		return {};
+	}
+	unsigned char hash[32];
+	if (mbedtls_sha256(crt.raw.p, crt.raw.len, hash, 0) != 0) {
+		mbedtls_x509_crt_free(&crt);
+		return {};
+	}
+	mbedtls_x509_crt_free(&crt);
+	std::ostringstream oss;
+	static const char *digits = "0123456789abcdef";
+	for (int i = 0; i < 32; ++i) {
+		if (i) {
+			oss << ':';
+		}
+		oss << digits[(hash[i] >> 4) & 0xf] << digits[hash[i] & 0xf];
+	}
+	return oss.str();
+}
+
+bool generateSelfSignedCert(const std::string &, const std::string &, const std::string &, int) {
+	return false;
+}
+
+bool generateCaCert(const std::string &, const std::string &, int) {
+	return false;
+}
+
+bool generateSignedCert(const std::string &, const std::string &, const std::string &,
+		const std::string &, const std::string &, int, bool) {
+	return false;
+}
+
+std::optional<std::time_t> getCertExpiry(const std::string &certPath) {
+	mbedtls_x509_crt crt;
+	mbedtls_x509_crt_init(&crt);
+	if (mbedtls_x509_crt_parse_file(&crt, certPath.c_str()) != 0) {
+		mbedtls_x509_crt_free(&crt);
+		return std::nullopt;
+	}
+
+	mbedtls_x509_crt_free(&crt);
+	return std::nullopt;
+}
+
+int daysUntilExpiry(const std::string &) {
+	return 0;
+}
+
+bool isCertExpired(const std::string &certPath) {
+	return daysUntilExpiry(certPath) < 0;
+}
+
+std::string formatCertExpiryDate(const std::string &) {
+	return {};
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/net/tls_cert.h
+++ b/modules/coldstorage/sdk_shims/common/net/tls_cert.h
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  tls_cert.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+#include <ctime>
+#include <optional>
+#include <string>
+
+namespace coldstorage {
+
+std::string normalizeFingerprint(const std::string &fp);
+std::string getCertFingerprint(const std::string &certPath);
+
+bool generateSelfSignedCert(const std::string &certPath, const std::string &keyPath,
+		const std::string &commonName, int validDays);
+
+bool generateCaCert(const std::string &caCertPath, const std::string &caKeyPath, int validDays);
+bool generateSignedCert(const std::string &caCertPath, const std::string &caKeyPath,
+		const std::string &subjectCn, const std::string &certPath,
+		const std::string &keyPath, int validDays, bool isClientCert);
+
+std::optional<std::time_t> getCertExpiry(const std::string &certPath);
+int daysUntilExpiry(const std::string &certPath);
+bool isCertExpired(const std::string &certPath);
+std::string formatCertExpiryDate(const std::string &certPath);
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/net/tls_context.cpp
+++ b/modules/coldstorage/sdk_shims/common/net/tls_context.cpp
@@ -1,0 +1,191 @@
+/**************************************************************************/
+/*  tls_context.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/net/tls_context.h"
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/x509_crt.h>
+
+#include <cstring>
+
+namespace coldstorage {
+
+namespace {
+
+struct DrbgHolders {
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	bool ready = false;
+
+	DrbgHolders() {
+		mbedtls_entropy_init(&entropy);
+		mbedtls_ctr_drbg_init(&ctr_drbg);
+		const char *pers = "coldstorage-blazium";
+		if (mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+					reinterpret_cast<const unsigned char *>(pers), std::strlen(pers)) == 0) {
+			ready = true;
+		}
+	}
+	~DrbgHolders() {
+		mbedtls_ctr_drbg_free(&ctr_drbg);
+		mbedtls_entropy_free(&entropy);
+	}
+};
+
+DrbgHolders &drbg() {
+	static DrbgHolders h;
+	return h;
+}
+
+} //namespace
+
+void TLSContext::initLibraries() {
+	(void)drbg();
+}
+
+TLSContext::TLSContext() = default;
+
+TLSContext::~TLSContext() {
+	freeContext();
+}
+
+void TLSContext::freeContext() {
+	if (conf_) {
+		mbedtls_ssl_config_free(static_cast<mbedtls_ssl_config *>(conf_));
+		delete static_cast<mbedtls_ssl_config *>(conf_);
+		conf_ = nullptr;
+	}
+	if (cacert_) {
+		mbedtls_x509_crt_free(static_cast<mbedtls_x509_crt *>(cacert_));
+		delete static_cast<mbedtls_x509_crt *>(cacert_);
+		cacert_ = nullptr;
+	}
+	if (clicert_) {
+		mbedtls_x509_crt_free(static_cast<mbedtls_x509_crt *>(clicert_));
+		delete static_cast<mbedtls_x509_crt *>(clicert_);
+		clicert_ = nullptr;
+	}
+	if (pkey_) {
+		mbedtls_pk_free(static_cast<mbedtls_pk_context *>(pkey_));
+		delete static_cast<mbedtls_pk_context *>(pkey_);
+		pkey_ = nullptr;
+	}
+}
+
+bool TLSContext::configureServer(const std::string &certFile, const std::string &keyFile,
+		const std::string &caFile) {
+	freeContext();
+	initLibraries();
+	if (!drbg().ready) {
+		return false;
+	}
+	mode_ = Mode::Server;
+	cert_file_ = certFile;
+	key_file_ = keyFile;
+	ca_file_ = caFile;
+
+	auto *conf = new mbedtls_ssl_config;
+	mbedtls_ssl_config_init(conf);
+	if (mbedtls_ssl_config_defaults(conf, MBEDTLS_SSL_IS_SERVER, MBEDTLS_SSL_TRANSPORT_STREAM,
+				MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
+		mbedtls_ssl_config_free(conf);
+		delete conf;
+		return false;
+	}
+	mbedtls_ssl_conf_rng(conf, mbedtls_ctr_drbg_random, &drbg().ctr_drbg);
+
+	auto *clicert = new mbedtls_x509_crt;
+	mbedtls_x509_crt_init(clicert);
+	if (mbedtls_x509_crt_parse_file(clicert, certFile.c_str()) != 0) {
+		mbedtls_x509_crt_free(clicert);
+		delete clicert;
+		mbedtls_ssl_config_free(conf);
+		delete conf;
+		return false;
+	}
+	auto *pkey = new mbedtls_pk_context;
+	mbedtls_pk_init(pkey);
+	if (mbedtls_pk_parse_keyfile(pkey, keyFile.c_str(), nullptr, mbedtls_ctr_drbg_random, &drbg().ctr_drbg) != 0) {
+		mbedtls_pk_free(pkey);
+		delete pkey;
+		mbedtls_x509_crt_free(clicert);
+		delete clicert;
+		mbedtls_ssl_config_free(conf);
+		delete conf;
+		return false;
+	}
+	mbedtls_ssl_conf_own_cert(conf, clicert, pkey);
+
+	if (!caFile.empty()) {
+		auto *cacert = new mbedtls_x509_crt;
+		mbedtls_x509_crt_init(cacert);
+		if (mbedtls_x509_crt_parse_file(cacert, caFile.c_str()) == 0) {
+			mbedtls_ssl_conf_ca_chain(conf, cacert, nullptr);
+			mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+			cacert_ = cacert;
+		} else {
+			mbedtls_x509_crt_free(cacert);
+			delete cacert;
+		}
+	}
+
+	conf_ = conf;
+	clicert_ = clicert;
+	pkey_ = pkey;
+	return true;
+}
+
+bool TLSContext::configureClient(const std::string &caFile, bool verifyPeer,
+		const std::string &certFile, const std::string &keyFile) {
+	// Store/validate options only. TlsTransport::connect builds the mbedtls
+	// config via setup_client_owned — avoid a dead duplicate conf_ here.
+	freeContext();
+	initLibraries();
+	if (!drbg().ready) {
+		return false;
+	}
+	if (verifyPeer && caFile.empty()) {
+		return false;
+	}
+	if ((!certFile.empty() && keyFile.empty()) || (certFile.empty() && !keyFile.empty())) {
+		return false;
+	}
+	mode_ = Mode::Client;
+	ca_file_ = caFile;
+	verify_peer_ = verifyPeer;
+	cert_file_ = certFile;
+	key_file_ = keyFile;
+	return true;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/net/tls_context.h
+++ b/modules/coldstorage/sdk_shims/common/net/tls_context.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  tls_context.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+#include <string>
+
+namespace coldstorage {
+
+class TLSContext {
+public:
+	enum class Mode { Server,
+		Client };
+
+	TLSContext();
+	~TLSContext();
+
+	TLSContext(const TLSContext &) = delete;
+	TLSContext &operator=(const TLSContext &) = delete;
+
+	static void initLibraries();
+
+	bool configureServer(const std::string &certFile, const std::string &keyFile,
+			const std::string &caFile = "");
+	bool configureClient(const std::string &caFile, bool verifyPeer,
+			const std::string &certFile = "",
+			const std::string &keyFile = "");
+
+	void *native() const { return conf_; }
+	Mode mode() const { return mode_; }
+
+	const std::string &caFile() const { return ca_file_; }
+	bool verifyPeer() const { return verify_peer_; }
+	const std::string &certFile() const { return cert_file_; }
+	const std::string &keyFile() const { return key_file_; }
+
+private:
+	void freeContext();
+
+	void *conf_ = nullptr;
+	void *cacert_ = nullptr;
+	void *clicert_ = nullptr;
+	void *pkey_ = nullptr;
+	Mode mode_ = Mode::Server;
+	bool verify_peer_ = true;
+	std::string ca_file_;
+	std::string cert_file_;
+	std::string key_file_;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/net/tls_transport.cpp
+++ b/modules/coldstorage/sdk_shims/common/net/tls_transport.cpp
@@ -1,0 +1,327 @@
+/**************************************************************************/
+/*  tls_transport.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/net/tls_transport.h"
+#include "common/net/tls_cert.h"
+#include "common/util/net_trace.h"
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/x509_crt.h>
+
+#include <cstring>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+namespace coldstorage {
+
+namespace {
+
+struct Drbg {
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr;
+	bool ok = false;
+	Drbg() {
+		mbedtls_entropy_init(&entropy);
+		mbedtls_ctr_drbg_init(&ctr);
+		const char *pers = "cs-tls-transport";
+		ok = mbedtls_ctr_drbg_seed(&ctr, mbedtls_entropy_func, &entropy,
+					 reinterpret_cast<const unsigned char *>(pers), std::strlen(pers)) == 0;
+	}
+	~Drbg() {
+		mbedtls_ctr_drbg_free(&ctr);
+		mbedtls_entropy_free(&entropy);
+	}
+};
+
+Drbg &drbg() {
+	static Drbg d;
+	return d;
+}
+
+int bio_send(void *ctx, const unsigned char *buf, size_t len) {
+	socket_t sock = *static_cast<socket_t *>(ctx);
+#ifdef _WIN32
+	int n = ::send(sock, reinterpret_cast<const char *>(buf), static_cast<int>(len), 0);
+#else
+	ssize_t n = ::send(sock, buf, len, 0);
+#endif
+	if (n < 0) {
+		return MBEDTLS_ERR_SSL_WANT_WRITE;
+	}
+	return static_cast<int>(n);
+}
+
+int bio_recv(void *ctx, unsigned char *buf, size_t len) {
+	socket_t sock = *static_cast<socket_t *>(ctx);
+#ifdef _WIN32
+	int n = ::recv(sock, reinterpret_cast<char *>(buf), static_cast<int>(len), 0);
+#else
+	ssize_t n = ::recv(sock, buf, len, 0);
+#endif
+	if (n < 0) {
+		return MBEDTLS_ERR_SSL_WANT_READ;
+	}
+	if (n == 0) {
+		return MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY;
+	}
+	return static_cast<int>(n);
+}
+
+struct OwnedTls {
+	mbedtls_ssl_config conf;
+	mbedtls_x509_crt cacert;
+	mbedtls_x509_crt clicert;
+	mbedtls_pk_context pkey;
+	bool has_ca = false;
+	bool has_cli = false;
+	socket_t sock_holder = kInvalidSocket;
+
+	OwnedTls() {
+		mbedtls_ssl_config_init(&conf);
+		mbedtls_x509_crt_init(&cacert);
+		mbedtls_x509_crt_init(&clicert);
+		mbedtls_pk_init(&pkey);
+	}
+	~OwnedTls() {
+		mbedtls_pk_free(&pkey);
+		mbedtls_x509_crt_free(&clicert);
+		mbedtls_x509_crt_free(&cacert);
+		mbedtls_ssl_config_free(&conf);
+	}
+};
+
+bool setup_client_owned(OwnedTls &o, const TLSContext &ctx) {
+	if (!drbg().ok) {
+		return false;
+	}
+	if (ctx.verifyPeer() && ctx.caFile().empty()) {
+		return false;
+	}
+	if (mbedtls_ssl_config_defaults(&o.conf, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+				MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
+		return false;
+	}
+	mbedtls_ssl_conf_rng(&o.conf, mbedtls_ctr_drbg_random, &drbg().ctr);
+	mbedtls_ssl_conf_authmode(&o.conf, ctx.verifyPeer() ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_NONE);
+	if (!ctx.caFile().empty()) {
+		if (mbedtls_x509_crt_parse_file(&o.cacert, ctx.caFile().c_str()) != 0) {
+			return false;
+		}
+		mbedtls_ssl_conf_ca_chain(&o.conf, &o.cacert, nullptr);
+		o.has_ca = true;
+	}
+	if (!ctx.certFile().empty() && !ctx.keyFile().empty()) {
+		if (mbedtls_x509_crt_parse_file(&o.clicert, ctx.certFile().c_str()) != 0) {
+			return false;
+		}
+		if (mbedtls_pk_parse_keyfile(&o.pkey, ctx.keyFile().c_str(), nullptr, mbedtls_ctr_drbg_random, &drbg().ctr) != 0) {
+			return false;
+		}
+		mbedtls_ssl_conf_own_cert(&o.conf, &o.clicert, &o.pkey);
+		o.has_cli = true;
+	}
+	return true;
+}
+
+} //namespace
+
+TlsTransport::TlsTransport(socket_t sock, void *ssl, void *conf, void *cacert, void *clicert, void *pkey) :
+		sock_(sock), ssl_(ssl), conf_(conf), cacert_(cacert), clicert_(clicert), pkey_(pkey) {}
+
+TlsTransport::~TlsTransport() {
+	close();
+}
+
+TransportPtr TlsTransport::accept(socket_t, const TLSContext &) {
+	return nullptr;
+}
+
+TransportPtr TlsTransport::connect(socket_t sock, const std::string &host, const TLSContext &ctx) {
+	if (ctx.mode() != TLSContext::Mode::Client) {
+		return nullptr;
+	}
+	auto *owned = new OwnedTls;
+	if (!setup_client_owned(*owned, ctx)) {
+		delete owned;
+		return nullptr;
+	}
+	auto *ssl = new mbedtls_ssl_context;
+	mbedtls_ssl_init(ssl);
+	if (mbedtls_ssl_setup(ssl, &owned->conf) != 0) {
+		mbedtls_ssl_free(ssl);
+		delete ssl;
+		delete owned;
+		return nullptr;
+	}
+	if (!host.empty()) {
+		if (mbedtls_ssl_set_hostname(ssl, host.c_str()) != 0) {
+			CS_NET_TRACE("TlsTransport", "set_hostname failed");
+			mbedtls_ssl_free(ssl);
+			delete ssl;
+			delete owned;
+			return nullptr;
+		}
+	}
+	owned->sock_holder = sock;
+	mbedtls_ssl_set_bio(ssl, &owned->sock_holder, bio_send, bio_recv, nullptr);
+
+	int ret;
+	while ((ret = mbedtls_ssl_handshake(ssl)) != 0) {
+		if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+			CS_NET_TRACE("TlsTransport", "handshake failed ret=" << ret);
+			mbedtls_ssl_free(ssl);
+			delete ssl;
+			delete owned;
+			return nullptr;
+		}
+	}
+
+	return TransportPtr(new TlsTransport(sock, ssl, owned, nullptr, nullptr, nullptr));
+}
+
+bool TlsTransport::readAll(uint8_t *data, size_t len) {
+	size_t got = 0;
+	auto *ssl = static_cast<mbedtls_ssl_context *>(ssl_);
+	while (got < len) {
+		int n = mbedtls_ssl_read(ssl, data + got, len - got);
+		if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) {
+			continue;
+		}
+		if (n <= 0) {
+			return false;
+		}
+		got += static_cast<size_t>(n);
+	}
+	return true;
+}
+
+bool TlsTransport::writeAll(const uint8_t *data, size_t len) {
+	size_t sent = 0;
+	auto *ssl = static_cast<mbedtls_ssl_context *>(ssl_);
+	while (sent < len) {
+		int n = mbedtls_ssl_write(ssl, data + sent, len - sent);
+		if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) {
+			continue;
+		}
+		if (n <= 0) {
+			return false;
+		}
+		sent += static_cast<size_t>(n);
+	}
+	return true;
+}
+
+void TlsTransport::close() {
+	if (ssl_) {
+		mbedtls_ssl_close_notify(static_cast<mbedtls_ssl_context *>(ssl_));
+		mbedtls_ssl_free(static_cast<mbedtls_ssl_context *>(ssl_));
+		delete static_cast<mbedtls_ssl_context *>(ssl_);
+		ssl_ = nullptr;
+	}
+	if (conf_) {
+		delete static_cast<OwnedTls *>(conf_);
+		conf_ = nullptr;
+	}
+	if (sock_ != kInvalidSocket) {
+#ifdef _WIN32
+		closesocket(sock_);
+#else
+		::close(sock_);
+#endif
+		sock_ = kInvalidSocket;
+	}
+}
+
+bool TlsTransport::setRecvTimeout(int seconds) {
+	recv_timeout_ms_ = seconds > 0 ? seconds * 1000 : 0;
+#ifdef _WIN32
+	DWORD ms = static_cast<DWORD>(recv_timeout_ms_);
+	setsockopt(sock_, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&ms), sizeof(ms));
+#else
+	timeval tv{};
+	tv.tv_sec = seconds;
+	setsockopt(sock_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+#endif
+	return true;
+}
+
+std::string TlsTransport::peerFingerprint() const {
+	if (!ssl_) {
+		return {};
+	}
+	const mbedtls_x509_crt *crt = mbedtls_ssl_get_peer_cert(static_cast<const mbedtls_ssl_context *>(ssl_));
+	if (!crt) {
+		return {};
+	}
+	unsigned char hash[32];
+	if (mbedtls_sha256(crt->raw.p, crt->raw.len, hash, 0) != 0) {
+		return {};
+	}
+	std::string hex;
+	static const char *digits = "0123456789abcdef";
+	for (int i = 0; i < 32; ++i) {
+		if (i) {
+			hex += ':';
+		}
+		hex += digits[(hash[i] >> 4) & 0xf];
+		hex += digits[hash[i] & 0xf];
+	}
+	return hex;
+}
+
+std::optional<std::string> TlsTransport::peerCertIdentity(const std::string &field) const {
+	if (!ssl_) {
+		return std::nullopt;
+	}
+	const mbedtls_x509_crt *crt = mbedtls_ssl_get_peer_cert(static_cast<const mbedtls_ssl_context *>(ssl_));
+	if (!crt) {
+		return std::nullopt;
+	}
+	char buf[256];
+	if (field == "CN" || field == "cn") {
+		if (mbedtls_x509_dn_gets(buf, sizeof(buf), &crt->subject) < 0) {
+			return std::nullopt;
+		}
+		return std::string(buf);
+	}
+	return std::nullopt;
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/net/tls_transport.h
+++ b/modules/coldstorage/sdk_shims/common/net/tls_transport.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  tls_transport.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+#include "common/net/stream_transport.h"
+#include "common/net/tls_context.h"
+#include <optional>
+#include <string>
+
+namespace coldstorage {
+
+class TlsTransport : public StreamTransport {
+public:
+	static TransportPtr accept(socket_t sock, const TLSContext &ctx);
+	static TransportPtr connect(socket_t sock, const std::string &host, const TLSContext &ctx);
+
+	~TlsTransport() override;
+
+	TlsTransport(const TlsTransport &) = delete;
+	TlsTransport &operator=(const TlsTransport &) = delete;
+
+	bool readAll(uint8_t *data, size_t len) override;
+	bool writeAll(const uint8_t *data, size_t len) override;
+	void close() override;
+	bool setRecvTimeout(int seconds) override;
+	socket_t rawSocket() const override { return sock_; }
+	std::string peerFingerprint() const override;
+	std::optional<std::string> peerCertIdentity(const std::string &field) const override;
+
+private:
+	TlsTransport(socket_t sock, void *ssl, void *conf, void *cacert, void *clicert, void *pkey);
+
+	socket_t sock_;
+	void *ssl_ = nullptr;
+	void *conf_ = nullptr;
+	void *cacert_ = nullptr;
+	void *clicert_ = nullptr;
+	void *pkey_ = nullptr;
+	int recv_timeout_ms_ = 0;
+};
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/util/crypto.cpp
+++ b/modules/coldstorage/sdk_shims/common/util/crypto.cpp
@@ -1,0 +1,245 @@
+/**************************************************************************/
+/*  crypto.cpp                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "common/util/crypto.h"
+
+#include "core/crypto/crypto_core.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include <mbedtls/md.h>
+#include <mbedtls/sha256.h>
+
+namespace coldstorage {
+
+namespace {
+
+std::string to_hex(const uint8_t *data, size_t len) {
+	std::ostringstream oss;
+	for (size_t i = 0; i < len; ++i) {
+		oss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(data[i]);
+	}
+	return oss.str();
+}
+
+} //namespace
+
+std::string sha256(const std::string &data) {
+	return sha256(reinterpret_cast<const uint8_t *>(data.data()), data.size());
+}
+
+std::string sha256(const uint8_t *data, size_t len) {
+	unsigned char hash[32];
+	CryptoCore::sha256(data, len, hash);
+	return to_hex(hash, 32);
+}
+
+std::string sha256File(const std::string &path, int64_t *sizeOut) {
+	std::ifstream in(path, std::ios::binary);
+	if (!in.is_open()) {
+		throw std::runtime_error("Cannot open file for hash: " + path);
+	}
+	CryptoCore::SHA256Context ctx;
+	ctx.start();
+	char buf[64 * 1024];
+	int64_t total = 0;
+	while (in) {
+		in.read(buf, sizeof(buf));
+		auto got = static_cast<size_t>(in.gcount());
+		if (got == 0) {
+			break;
+		}
+		ctx.update(reinterpret_cast<const uint8_t *>(buf), got);
+		total += static_cast<int64_t>(got);
+	}
+	unsigned char hash[32];
+	ctx.finish(hash);
+	if (sizeOut) {
+		*sizeOut = total;
+	}
+	return to_hex(hash, 32);
+}
+
+std::string sha256FileRange(const std::string &path, int64_t offset, int64_t length) {
+	if (offset < 0 || length < 0) {
+		throw std::runtime_error("Invalid hash range");
+	}
+	if (length == 0) {
+		return sha256(std::string{});
+	}
+	std::ifstream in(path, std::ios::binary);
+	if (!in.is_open()) {
+		throw std::runtime_error("Cannot open file for hash range: " + path);
+	}
+	in.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+	if (!in) {
+		throw std::runtime_error("Cannot seek for hash range: " + path);
+	}
+	CryptoCore::SHA256Context ctx;
+	ctx.start();
+	char buf[64 * 1024];
+	int64_t remaining = length;
+	while (remaining > 0 && in) {
+		auto chunk = static_cast<std::streamsize>(std::min<int64_t>(remaining, sizeof(buf)));
+		in.read(buf, chunk);
+		auto got = static_cast<size_t>(in.gcount());
+		if (got == 0) {
+			break;
+		}
+		ctx.update(reinterpret_cast<const uint8_t *>(buf), got);
+		remaining -= static_cast<int64_t>(got);
+	}
+	if (remaining != 0) {
+		throw std::runtime_error("Short read for hash range: " + path);
+	}
+	unsigned char hash[32];
+	ctx.finish(hash);
+	return to_hex(hash, 32);
+}
+
+struct Sha256Hasher::State {
+	CryptoCore::SHA256Context ctx;
+	bool started = false;
+	bool finished = false;
+};
+
+Sha256Hasher::Sha256Hasher() {
+	state_ = new State;
+	state_->ctx.start();
+	state_->started = true;
+}
+
+Sha256Hasher::~Sha256Hasher() {
+	delete state_;
+	state_ = nullptr;
+}
+
+void Sha256Hasher::update(const uint8_t *data, size_t len) {
+	if (!state_ || state_->finished || !data || len == 0) {
+		return;
+	}
+	state_->ctx.update(data, len);
+}
+
+void Sha256Hasher::update(const char *data, size_t len) {
+	update(reinterpret_cast<const uint8_t *>(data), len);
+}
+
+std::string Sha256Hasher::finalHex() {
+	if (!state_ || state_->finished) {
+		return {};
+	}
+	unsigned char hash[32];
+	state_->ctx.finish(hash);
+	state_->finished = true;
+	return to_hex(hash, 32);
+}
+
+class Sha256OStream::Buf : public std::streambuf {
+public:
+	Sha256Hasher hasher;
+	std::string digest;
+	bool finalized = false;
+
+	int overflow(int ch) override {
+		if (ch == traits_type::eof()) {
+			return traits_type::not_eof(ch);
+		}
+		char c = static_cast<char>(ch);
+		hasher.update(&c, 1);
+		return ch;
+	}
+	std::streamsize xsputn(const char *s, std::streamsize n) override {
+		if (s && n > 0) {
+			hasher.update(s, static_cast<size_t>(n));
+		}
+		return n;
+	}
+};
+
+Sha256OStream::Sha256OStream() :
+		std::ostream(nullptr) {
+	buf_ = new Buf;
+	rdbuf(buf_);
+}
+
+Sha256OStream::~Sha256OStream() {
+	delete buf_;
+	buf_ = nullptr;
+}
+
+std::string Sha256OStream::digest() {
+	if (!buf_) {
+		return {};
+	}
+	if (!buf_->finalized) {
+		flush();
+		buf_->digest = buf_->hasher.finalHex();
+		buf_->finalized = true;
+	}
+	return buf_->digest;
+}
+
+std::string hmac_sha256(const std::string &key, const std::string &data) {
+	unsigned char out[32];
+	const mbedtls_md_info_t *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+	if (!info) {
+		return {};
+	}
+	mbedtls_md_hmac(info, reinterpret_cast<const unsigned char *>(key.data()), key.size(),
+			reinterpret_cast<const unsigned char *>(data.data()), data.size(), out);
+	return to_hex(out, 32);
+}
+
+std::string hash_password(const std::string &password) {
+	return "cs$" + sha256(password);
+}
+
+bool verify_password(const std::string &password, const std::string &hash) {
+	if (hash.rfind("cs$", 0) == 0) {
+		return hash == ("cs$" + sha256(password));
+	}
+	return false;
+}
+
+std::string random_token(size_t bytes) {
+	std::vector<uint8_t> buf(bytes);
+	CryptoCore::RandomGenerator rng;
+	if (rng.init() != OK || rng.get_random_bytes(buf.data(), bytes) != OK) {
+		throw std::runtime_error("random_token failed");
+	}
+	return to_hex(buf.data(), bytes);
+}
+
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/common/version/version.h
+++ b/modules/coldstorage/sdk_shims/common/version/version.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  version.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+namespace coldstorage {
+namespace version {
+
+constexpr int MAJOR = 1;
+constexpr int MINOR = 0;
+constexpr int PATCH = 0;
+
+constexpr const char *VERSION = "1.0.0";
+constexpr const char *PRERELEASE = "";
+constexpr const char *BUILD_META = "blazium";
+constexpr const char *LABEL = "1.0.0";
+constexpr const char *FULL = "1.0.0+blazium";
+constexpr const char *PRODUCT_BANNER = "ColdStorage 1.0.0";
+
+constexpr int PROTOCOL_VERSION = 1;
+
+constexpr const char *MIN_CLIENT = "1.0.0";
+constexpr const char *BUILD_TIMESTAMP = __DATE__ " " __TIME__;
+
+constexpr const char *PRODUCT_NAME = "ColdStorage";
+constexpr const char *SERVER_NAME = "ColdStorage Server";
+constexpr const char *CLIENT_NAME = "ColdStorage CLI";
+constexpr const char *SDK_NAME = "ColdStorage SDK";
+constexpr const char *COPYRIGHT = "Copyright (c) 2018-2026 Randolph William Aarseth II, Bioblaze Payne - Blazium Games";
+
+} //namespace version
+} //namespace coldstorage

--- a/modules/coldstorage/sdk_shims/nlohmann/json.hpp
+++ b/modules/coldstorage/sdk_shims/nlohmann/json.hpp
@@ -1,0 +1,534 @@
+/**************************************************************************/
+/*  json.hpp                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/json.h"
+#include "core/math/math_funcs.h"
+#include "core/variant/variant.h"
+
+#include <cstdint>
+#include <initializer_list>
+#include <istream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace nlohmann {
+
+class json {
+public:
+	class exception : public std::runtime_error {
+	public:
+		explicit exception(const char *what_arg) :
+				std::runtime_error(what_arg) {}
+		explicit exception(const std::string &what_arg) :
+				std::runtime_error(what_arg) {}
+	};
+
+	json() :
+			data_(Variant()) {}
+	json(std::nullptr_t) :
+			data_(Variant()) {}
+	json(bool v) :
+			data_(v) {}
+	json(int v) :
+			data_(v) {}
+	json(int64_t v) :
+			data_(v) {}
+	json(size_t v) :
+			data_((int64_t)v) {}
+	json(double v) :
+			data_(v) {}
+	json(const char *v) :
+			data_(String::utf8(v ? v : "")) {}
+	json(const std::string &v) :
+			data_(String::utf8(v.c_str())) {}
+	json(const String &v) :
+			data_(v) {}
+	json(const Dictionary &v) :
+			data_(v) {}
+	json(const Array &v) :
+			data_(v) {}
+	json(const Variant &v) :
+			data_(v) {}
+	json(const std::vector<std::string> &v) {
+		Array a;
+		a.resize(v.size());
+		for (size_t i = 0; i < v.size(); i++) {
+			a[(int)i] = String::utf8(v[i].c_str());
+		}
+		data_ = a;
+	}
+	json(const std::vector<json> &v) {
+		Array a;
+		a.resize(v.size());
+		for (size_t i = 0; i < v.size(); i++) {
+			a[(int)i] = v[i].data_;
+		}
+		data_ = a;
+	}
+
+	json(std::initializer_list<json> init) {
+		bool as_object = init.size() > 0;
+		for (const json &el : init) {
+			if (!el.is_array() || el.size() != 2 || !el[0].is_string()) {
+				as_object = false;
+				break;
+			}
+		}
+		if (as_object) {
+			Dictionary d;
+			for (const json &el : init) {
+				d[_to_godot_key(el[0])] = el[1].data_;
+			}
+			data_ = d;
+		} else {
+			Array a;
+			a.resize(init.size());
+			int i = 0;
+			for (const json &el : init) {
+				a[i++] = el.data_;
+			}
+			data_ = a;
+		}
+	}
+
+	static json object() {
+		return json(Dictionary());
+	}
+	static json array() {
+		return json(Array());
+	}
+
+	static Variant _coerce_exact_ints(const Variant &v) {
+		// Godot JSON may parse all numbers as FLOAT when
+		// filesystem/import/json/always_parse_numbers_as_double is true.
+		// Restore exact integers within the float mantissa for protocol fields.
+		switch (v.get_type()) {
+			case Variant::FLOAT: {
+				const double d = (double)v;
+				if (Math::is_finite(d) && d >= (double)INT64_MIN && d <= (double)INT64_MAX) {
+					const double nearest = Math::round(d);
+					if (d == nearest && Math::abs(d) <= 9007199254740992.0) { // 2^53
+						return (int64_t)nearest;
+					}
+				}
+				return v;
+			}
+			case Variant::ARRAY: {
+				Array a = v;
+				Array out;
+				out.resize(a.size());
+				for (int i = 0; i < a.size(); i++) {
+					out[i] = _coerce_exact_ints(a[i]);
+				}
+				return out;
+			}
+			case Variant::DICTIONARY: {
+				Dictionary d = v;
+				Dictionary out;
+				const Array keys = d.keys();
+				for (int i = 0; i < keys.size(); i++) {
+					const Variant key = keys[i];
+					out[key] = _coerce_exact_ints(d[key]);
+				}
+				return out;
+			}
+			default:
+				return v;
+		}
+	}
+
+	static json parse(const std::string &s) {
+		Ref<JSON> parser;
+		parser.instantiate();
+		const Error e = parser->parse(String::utf8(s.c_str()));
+		if (e != OK) {
+			throw exception(std::string(parser->get_error_message().utf8().get_data()));
+		}
+		return json(_coerce_exact_ints(parser->get_data()));
+	}
+
+	const Variant &variant() const { return data_; }
+	Variant &variant() { return data_; }
+
+	bool is_null() const { return data_.get_type() == Variant::NIL; }
+	bool is_object() const { return data_.get_type() == Variant::DICTIONARY; }
+	bool is_array() const { return data_.get_type() == Variant::ARRAY; }
+	bool is_string() const { return data_.get_type() == Variant::STRING; }
+	bool is_boolean() const { return data_.get_type() == Variant::BOOL; }
+	bool is_number() const {
+		return data_.get_type() == Variant::INT || data_.get_type() == Variant::FLOAT;
+	}
+	bool empty() const {
+		if (is_null()) {
+			return true;
+		}
+		if (is_object()) {
+			return Dictionary(data_).is_empty();
+		}
+		if (is_array()) {
+			return Array(data_).is_empty();
+		}
+		if (is_string()) {
+			return String(data_).is_empty();
+		}
+		return false;
+	}
+	size_t size() const {
+		if (is_object()) {
+			return Dictionary(data_).size();
+		}
+		if (is_array()) {
+			return Array(data_).size();
+		}
+		return 0;
+	}
+
+	bool contains(const char *key) const {
+		if (!is_object()) {
+			return false;
+		}
+		return Dictionary(data_).has(String::utf8(key));
+	}
+	bool contains(const std::string &key) const { return contains(key.c_str()); }
+
+	std::string dump(int indent = -1) const {
+		String out;
+		if (indent >= 0) {
+			out = JSON::stringify(data_, String(" ").repeat(indent), false, true);
+		} else {
+			out = JSON::stringify(data_, "", false, true);
+		}
+		return std::string(out.utf8().get_data());
+	}
+
+	json at(const char *key) const {
+		if (!is_object() || !contains(key)) {
+			throw exception(std::string("key not found: ") + key);
+		}
+		return json(Dictionary(data_)[String::utf8(key)]);
+	}
+	json at(const std::string &key) const { return at(key.c_str()); }
+
+	json operator[](int index) const {
+		if (!is_array()) {
+			throw exception("not an array");
+		}
+		Array a = data_;
+		if (index < 0 || index >= a.size()) {
+			throw exception("array index out of range");
+		}
+		return json(a[index]);
+	}
+
+	json operator[](const char *key) {
+		_ensure_object();
+		Dictionary d = data_;
+		const String k = String::utf8(key);
+		if (!d.has(k)) {
+			d[k] = Variant();
+		}
+		json child(d[k]);
+		child.parent_dict_ = d;
+		child.parent_key_ = k;
+		child.has_parent_ = true;
+		return child;
+	}
+	json operator[](const std::string &key) { return (*this)[key.c_str()]; }
+
+	json operator[](const char *key) const {
+		if (!is_object()) {
+			return json();
+		}
+		Dictionary d = data_;
+		const String k = String::utf8(key);
+		if (!d.has(k)) {
+			return json();
+		}
+		return json(d[k]);
+	}
+	json operator[](const std::string &key) const { return (*this)[key.c_str()]; }
+
+	json(const json &other) :
+			data_(other.data_) {}
+
+	json &operator=(const json &other) {
+		data_ = other.data_;
+		_write_through();
+		return *this;
+	}
+	json &operator=(bool v) {
+		data_ = v;
+		_write_through();
+		return *this;
+	}
+	json &operator=(int v) {
+		data_ = v;
+		_write_through();
+		return *this;
+	}
+	json &operator=(int64_t v) {
+		data_ = v;
+		_write_through();
+		return *this;
+	}
+	json &operator=(size_t v) {
+		data_ = (int64_t)v;
+		_write_through();
+		return *this;
+	}
+	json &operator=(double v) {
+		data_ = v;
+		_write_through();
+		return *this;
+	}
+	json &operator=(const char *v) {
+		data_ = String::utf8(v ? v : "");
+		_write_through();
+		return *this;
+	}
+	json &operator=(const std::string &v) {
+		data_ = String::utf8(v.c_str());
+		_write_through();
+		return *this;
+	}
+	json &operator=(std::initializer_list<json> init) {
+		*this = json(init);
+		_write_through();
+		return *this;
+	}
+	json &operator=(const std::vector<std::string> &v) {
+		*this = json(v);
+		_write_through();
+		return *this;
+	}
+	json &operator=(const std::vector<json> &v) {
+		*this = json(v);
+		_write_through();
+		return *this;
+	}
+
+	std::string value(const char *key, const char *default_value) const {
+		if (!contains(key)) {
+			return default_value ? default_value : "";
+		}
+		return (*this)[key].get<std::string>();
+	}
+	std::string value(const char *key, const std::string &default_value) const {
+		if (!contains(key)) {
+			return default_value;
+		}
+		return (*this)[key].get<std::string>();
+	}
+	json value(const char *key, const json &default_value) const {
+		if (!contains(key)) {
+			return default_value;
+		}
+		return (*this)[key];
+	}
+	template <typename T>
+	T value(const char *key, T default_value) const {
+		if (!contains(key)) {
+			return default_value;
+		}
+		return (*this)[key].get<T>();
+	}
+	template <typename T>
+	T value(const std::string &key, T default_value) const {
+		return value(key.c_str(), default_value);
+	}
+
+	template <typename T>
+	T get() const {
+		return _get_impl(static_cast<T *>(nullptr));
+	}
+
+	class iterator {
+		friend class json;
+		const json *owner_ = nullptr;
+		int index_ = 0;
+		bool is_obj_ = false;
+
+		iterator(const json *owner, int index, bool is_obj) :
+				owner_(owner), index_(index), is_obj_(is_obj) {}
+
+	public:
+		iterator() = default;
+
+		std::string key() const {
+			if (!owner_ || !is_obj_) {
+				return std::to_string(index_);
+			}
+			return _variant_to_std_string(Dictionary(owner_->data_).get_key_at_index(index_));
+		}
+		json value() const {
+			if (!owner_) {
+				return json();
+			}
+			if (is_obj_) {
+				Dictionary d = owner_->data_;
+				return json(d[d.get_key_at_index(index_)]);
+			}
+			return json(Array(owner_->data_)[index_]);
+		}
+		json operator*() const { return value(); }
+
+		iterator &operator++() {
+			++index_;
+			return *this;
+		}
+		bool operator!=(const iterator &other) const {
+			return index_ != other.index_ || owner_ != other.owner_;
+		}
+		bool operator==(const iterator &other) const { return !(*this != other); }
+	};
+
+	iterator begin() const {
+		if (is_object()) {
+			return iterator(this, 0, true);
+		}
+		if (is_array()) {
+			return iterator(this, 0, false);
+		}
+		return end();
+	}
+	iterator end() const {
+		if (is_object()) {
+			return iterator(this, Dictionary(data_).size(), true);
+		}
+		if (is_array()) {
+			return iterator(this, Array(data_).size(), false);
+		}
+		return iterator(this, 0, false);
+	}
+
+	friend std::istream &operator>>(std::istream &in, json &j) {
+		std::string s((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+		j = json::parse(s);
+		return in;
+	}
+
+private:
+	Variant data_;
+	Dictionary parent_dict_;
+	String parent_key_;
+	bool has_parent_ = false;
+
+	void _ensure_object() {
+		if (!is_object()) {
+			data_ = Dictionary();
+			_write_through();
+		}
+	}
+
+	void _write_through() {
+		if (has_parent_) {
+			parent_dict_[parent_key_] = data_;
+		}
+	}
+
+	static String _to_godot_key(const json &j) {
+		if (j.is_string()) {
+			return String(j.data_);
+		}
+		return String::utf8(j.get<std::string>().c_str());
+	}
+
+	static std::string _variant_to_std_string(const Variant &v) {
+		if (v.get_type() == Variant::STRING) {
+			return std::string(String(v).utf8().get_data());
+		}
+		return std::string(String(v).utf8().get_data());
+	}
+
+	std::string _get_impl(std::string *) const {
+		if (is_string()) {
+			return _variant_to_std_string(data_);
+		}
+		if (is_null()) {
+			return {};
+		}
+		return _variant_to_std_string(data_);
+	}
+	bool _get_impl(bool *) const { return (bool)data_; }
+	int _get_impl(int *) const {
+		if (data_.get_type() == Variant::INT) {
+			return (int)(int64_t)data_;
+		}
+		if (data_.get_type() == Variant::FLOAT) {
+			return (int)Math::round((double)data_);
+		}
+		return (int)data_;
+	}
+	int64_t _get_impl(int64_t *) const {
+		if (data_.get_type() == Variant::INT) {
+			return (int64_t)data_;
+		}
+		if (data_.get_type() == Variant::FLOAT) {
+			return (int64_t)Math::round((double)data_);
+		}
+		return (int64_t)data_;
+	}
+	size_t _get_impl(size_t *) const {
+		int64_t v = _get_impl(static_cast<int64_t *>(nullptr));
+		return v < 0 ? 0 : (size_t)v;
+	}
+	double _get_impl(double *) const { return (double)data_; }
+	json _get_impl(json *) const { return *this; }
+
+	std::vector<std::string> _get_impl(std::vector<std::string> *) const {
+		std::vector<std::string> out;
+		if (!is_array()) {
+			return out;
+		}
+		Array a = data_;
+		out.reserve(a.size());
+		for (int i = 0; i < a.size(); i++) {
+			out.push_back(_variant_to_std_string(a[i]));
+		}
+		return out;
+	}
+	std::vector<json> _get_impl(std::vector<json> *) const {
+		std::vector<json> out;
+		if (!is_array()) {
+			return out;
+		}
+		Array a = data_;
+		out.reserve(a.size());
+		for (int i = 0; i < a.size(); i++) {
+			out.push_back(json(a[i]));
+		}
+		return out;
+	}
+};
+
+} //namespace nlohmann


### PR DESCRIPTION
## Summary
- Adds editor-only `modules/coldstorage` that compiles the ColdStorage client SDK into Blazium (mbedtls TLS, CryptoCore hashes, engine JSON shim — no vendored OpenSSL/nlohmann/libsodium).
- Registers `ColdStorageVCS` as a first-party `EditorVCSInterface` provider with Project-menu configuration, toolbar status, CLI autoconnect/validate/auto-pull, and `VCSMetadata::COLDSTORAGE` project templates.
- Unblocks public ColdStorage service/CLI release by shipping the matching Blazium editor integration path (connect, sync/pull, stage/submit) against `cstoraged`.

## Test plan
- [x] `scons platform=windows target=editor module_coldstorage_enabled=yes`
- [x] Editor lists `ColdStorageVCS` under Version Control settings
- [x] Project > ColdStorage Configuration: connect/test against a local `cstoraged`
- [x] `--enable-coldstorage --coldstorage-host=... --coldstorage-user=... --coldstorage-password=...` autoconnects after editor ready
- [x] `--coldstorage-auto-pull` syncs workspace after validated connect
- [x] New project / metadata dialog can create `.csignore` + `.cstorage` (ColdStorage VCS metadata)
- [ ] Stage → commit (submit) → pull against a real depot round-trips