### PR TITLE
Add hub_build/hub_register flags and JustAMCP remote_control bridge

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -217,6 +217,20 @@ opts.Add("vsproj_name", "Name of the Visual Studio solution", "blazium")
 opts.Add("import_env_vars", "A comma-separated list of environment variables to copy from the outer environment.", "")
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
+opts.Add(
+    BoolVariable(
+        "hub_build",
+        "Enable Hub-capable export template features (includes remote_control in templates)",
+        False,
+    )
+)
+opts.Add(
+    BoolVariable(
+        "hub_register",
+        "Post-build: register the linked editor with Blazium Hub via blazium-cli handle-uri (editor only; not runtime)",
+        False,
+    )
+)
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
 opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
@@ -1007,6 +1021,8 @@ if env["disable_advanced_gui"]:
         Exit(255)
     else:
         env.Append(CPPDEFINES=["ADVANCED_GUI_DISABLED"])
+if env.get("hub_register", False) and not env.editor_build:
+    print_warning("Build option `hub_register=yes` is ignored for non-editor builds.")
 if env["minizip"]:
     env.Append(CPPDEFINES=["MINIZIP_ENABLED"])
 if env["brotli"]:

--- a/SConstruct
+++ b/SConstruct
@@ -231,6 +231,18 @@ opts.Add(
         False,
     )
 )
+opts.Add(
+    BoolVariable(
+        "update_version_from_git",
+        "Before build, set EXTERNAL_* version from nearest v* git tag (+ commits) via misc/scripts/update_version_from_git.py",
+        False,
+    )
+)
+opts.Add(
+    "update_version_status",
+    "Override external_status when update_version_from_git=yes (empty = script default)",
+    "",
+)
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
 opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
@@ -984,6 +996,29 @@ if env.editor_build:
     # And check if they are met.
     if not env.module_check_dependencies("editor"):
         print_error("Not all modules required by editor builds are enabled.")
+        Exit(255)
+
+if env.get("update_version_from_git", False):
+    try:
+        from misc.scripts import update_version_from_git as uvfg
+
+        repo_root = uvfg.find_repo_root(str(methods.base_folder))
+        status_override = env.get("update_version_status", "")
+        if status_override == "":
+            status_override = None
+        git_version = uvfg.compute_version(repo_root, status_override)
+        uvfg.apply_version_to_environ(git_version)
+        uvfg.update_version_py(os.path.join(repo_root, "version.py"), git_version)
+        print_info(
+            "update_version_from_git: "
+            f"{git_version['external_major']}.{git_version['external_minor']}.{git_version['external_patch']}"
+            f"-{git_version['external_status']} "
+            f"(tag {git_version['tag']} +{git_version['commits_after_tag']} commits)"
+        )
+        print_info("Leave version.py uncommitted; restore with: git checkout -- version.py")
+    except SystemExit as exc:
+        msg = exc.code if isinstance(exc.code, str) else (str(exc) if exc.args else "update_version_from_git failed")
+        print_error(msg)
         Exit(255)
 
 env.version_info = methods.get_version_info(env.module_version_string)

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1751,6 +1751,8 @@
 		</member>
 		<member name="blazium/justamcp/toolsets/Project" type="bool" setter="" getter="" default="true">
 		</member>
+		<member name="blazium/justamcp/toolsets/RemoteControl" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="blazium/justamcp/toolsets/Resource" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="blazium/justamcp/toolsets/Runtime" type="bool" setter="" getter="" default="true">

--- a/methods.py
+++ b/methods.py
@@ -627,6 +627,18 @@ def Run(env, function):
     return Action(function, "$GENCOMSTR")
 
 
+def add_hub_register_post_action(env, prog):
+    """After linking an editor binary, optionally register it with Blazium Hub via blazium-cli."""
+    if not getattr(env, "editor_build", False):
+        return
+    if not env.get("hub_register", False):
+        return
+    # Late import so non-hub_register builds do not require the helper module.
+    from misc.scripts import hub_register_editor
+
+    env.AddPostAction(prog, env.Run(hub_register_editor.scons_post_action))
+
+
 def detect_darwin_sdk_path(platform, env):
     sdk_name = ""
     if platform == "macos":

--- a/misc/scripts/hub_register_editor.py
+++ b/misc/scripts/hub_register_editor.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Post-build Hub registration for `scons hub_register=yes` editor builds.
+
+Invokes `blazium-cli handle-uri blazium://register?...` for the linked editor
+binary. Missing CLI or non-zero exit only warns (build still succeeds).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Iterable, List, Optional
+from urllib.parse import quote, urlencode
+
+
+def build_register_uri(
+    path: str,
+    version: str,
+    channel: str,
+    platform: str,
+    arch: str,
+    mono: bool,
+) -> str:
+    query = urlencode(
+        {
+            "path": path,
+            "version": version,
+            "channel": channel,
+            "platform": platform,
+            "arch": arch,
+            "mono": "true" if mono else "false",
+        },
+        quote_via=quote,
+    )
+    return f"blazium://register?{query}"
+
+
+def _cli_name() -> str:
+    return "blazium-cli.exe" if os.name == "nt" else "blazium-cli"
+
+
+def _existing(path: str) -> Optional[str]:
+    if path and os.path.isfile(path):
+        return os.path.abspath(path)
+    return None
+
+
+def find_blazium_cli() -> Optional[str]:
+    env_cli = os.environ.get("BLAZIUM_CLI", "").strip()
+    found = _existing(env_cli)
+    if found:
+        return found
+
+    name = _cli_name()
+    candidates: List[str] = []
+
+    blazium_root = os.environ.get("BLAZIUM", "").strip()
+    if blazium_root:
+        candidates.append(os.path.join(blazium_root, "bin", name))
+        candidates.append(os.path.join(blazium_root, name))
+
+    if os.name == "nt":
+        pf = os.environ.get("ProgramFiles", "")
+        local = os.environ.get("LOCALAPPDATA", "")
+        if pf:
+            candidates.append(os.path.join(pf, "Blazium", name))
+        if local:
+            candidates.append(os.path.join(local, "Blazium", name))
+    else:
+        candidates.append("/opt/blazium/bin/blazium-cli")
+        candidates.append("/opt/blazium/blazium-cli")
+        candidates.append("/usr/local/bin/blazium-cli")
+        candidates.append("/usr/bin/blazium-cli")
+
+    for c in candidates:
+        found = _existing(c)
+        if found:
+            return found
+
+    which = shutil.which("blazium-cli") or shutil.which("blazium-cli.exe")
+    return _existing(which) if which else None
+
+
+def derive_channel(build_name: str, external_status: str = "") -> str:
+    blob = f"{build_name} {external_status}".lower()
+    if "custom" in blob or "dev" in blob:
+        return "custom"
+    return "release"
+
+
+def map_platform(platform: str) -> str:
+    if platform == "linuxbsd":
+        return "linux"
+    return platform
+
+
+def register_editor(
+    editor_path: str,
+    platform: str,
+    arch: str,
+    mono: bool,
+    version: str,
+    channel: str,
+) -> int:
+    editor_path = os.path.abspath(editor_path)
+    if not os.path.isfile(editor_path):
+        print(f'hub_register: editor binary not found: "{editor_path}" (skipping)', file=sys.stderr)
+        return 0
+
+    cli = find_blazium_cli()
+    if not cli:
+        print(
+            "hub_register: blazium-cli not found (set BLAZIUM_CLI, BLAZIUM, or install Hub); skipping registration.",
+            file=sys.stderr,
+        )
+        return 0
+
+    uri = build_register_uri(
+        path=editor_path,
+        version=version,
+        channel=channel,
+        platform=map_platform(platform),
+        arch=arch,
+        mono=mono,
+    )
+    print(f'hub_register: registering via "{cli}" handle-uri')
+    print(f"hub_register: {uri}")
+    try:
+        completed = subprocess.run([cli, "handle-uri", uri], check=False)
+    except OSError as exc:
+        print(f"hub_register: failed to run blazium-cli: {exc}", file=sys.stderr)
+        return 0
+
+    if completed.returncode != 0:
+        print(
+            f"hub_register: blazium-cli exited {completed.returncode} (build continues)",
+            file=sys.stderr,
+        )
+        return 0
+
+    print("hub_register: registration succeeded")
+    return 0
+
+
+def scons_post_action(target, source, env) -> None:
+    """SCons AddPostAction callback (warn-only; never fails the build)."""
+    editor = os.path.abspath(str(target[0]))
+    vi = getattr(env, "version_info", None) or {}
+    version = "{}.{}.{}".format(
+        vi.get("external_major", 0),
+        vi.get("external_minor", 0),
+        vi.get("external_patch", 0),
+    )
+    channel = derive_channel(str(vi.get("build", "")), str(vi.get("external_status", "")))
+    platform = str(env.get("platform", ""))
+    arch = str(env.get("arch", ""))
+    mono = bool(env.get("module_mono_enabled", False))
+    register_editor(editor, platform, arch, mono, version, channel)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) < 1:
+        print(
+            "Usage: hub_register_editor.py <editor-path> [platform] [arch] [mono] [version] [channel]",
+            file=sys.stderr,
+        )
+        return 1
+    editor = args[0]
+    platform = args[1] if len(args) > 1 else ("windows" if os.name == "nt" else "linux")
+    arch = args[2] if len(args) > 2 else ("x86_64" if sys.maxsize > 2**32 else "x86_32")
+    mono = (args[3].lower() in ("1", "true", "yes")) if len(args) > 3 else False
+    version = args[4] if len(args) > 4 else "0.0.0"
+    channel = args[5] if len(args) > 5 else "release"
+    return register_editor(editor, platform, arch, mono, version, channel)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/misc/scripts/update_version_from_git.py
+++ b/misc/scripts/update_version_from_git.py
@@ -13,6 +13,11 @@ Usage (from repository root)::
     python misc/scripts/update_version_from_git.py --dry-run
     python misc/scripts/update_version_from_git.py --status nightly
 
+Or during the SCons build (sets EXTERNAL_* for the build and writes version.py)::
+
+    scons update_version_from_git=yes
+    scons update_version_from_git=yes update_version_status=nightly
+
 Leaves version.py uncommitted on purpose; do not check the modified file in.
 """
 
@@ -83,6 +88,15 @@ def compute_version(repo: str, status_override: str | None) -> dict[str, str | i
         "external_status": status,
         "external_sha": sha,
     }
+
+
+def apply_version_to_environ(version: dict[str, str | int]) -> None:
+    """Set EXTERNAL_* process env vars consumed by methods.get_version_info()."""
+    os.environ["EXTERNAL_MAJOR"] = str(version["external_major"])
+    os.environ["EXTERNAL_MINOR"] = str(version["external_minor"])
+    os.environ["EXTERNAL_PATCH"] = str(version["external_patch"])
+    os.environ["EXTERNAL_STATUS"] = str(version["external_status"])
+    os.environ["EXTERNAL_SHA"] = str(version["external_sha"])
 
 
 def update_version_py(path: str, version: dict[str, str | int]) -> None:

--- a/modules/justamcp/config.py
+++ b/modules/justamcp/config.py
@@ -4,6 +4,7 @@ def can_build(env, platform):
     env.module_add_dependencies("justamcp", ["httpserver"], False)
     env.module_add_dependencies("justamcp", ["assettags"], False)
     env.module_add_dependencies("justamcp", ["semanticsearch"], False)
+    env.module_add_dependencies("justamcp", ["remote_control"], False)
     return env.editor_build
 
 

--- a/modules/justamcp/justamcp_editor_filesystem.cpp
+++ b/modules/justamcp/justamcp_editor_filesystem.cpp
@@ -41,7 +41,7 @@ void refresh_path(const String &p_path) {
 	if (p_path.is_empty() || !EditorFileSystem::get_singleton()) {
 		return;
 	}
-	// EditorFileSystem is a Node; never call it off the main thread.
+
 	if (Thread::is_main_thread()) {
 		EditorFileSystem::get_singleton()->update_file(p_path);
 	} else {

--- a/modules/justamcp/justamcp_json_rpc_transport.h
+++ b/modules/justamcp/justamcp_json_rpc_transport.h
@@ -43,7 +43,7 @@ class JustAMCPJsonRpcTransport {
 public:
 	static Dictionary handle_json_rpc(JustAMCPServer *p_server, const String &p_body, Ref<HTTPResponse> p_response, const String &p_caller_session_id = String());
 	static Dictionary handle_json_rpc_parsed(JustAMCPServer *p_server, const Dictionary &p_payload, Ref<HTTPResponse> p_response, const String &p_caller_session_id = String());
-	// Strip internal router keys before HTTP/SSE emission (Cursor Zod rejects "handled").
+
 	static Dictionary sanitize_wire_rpc(const Dictionary &p_rpc);
 
 private:

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -294,7 +294,6 @@ JustAMCPServer::JustAMCPServer() {
 }
 
 JustAMCPServer::~JustAMCPServer() {
-	// Ephemeral ClassDB instances that did not claim the singleton never installed handlers or children.
 	if (singleton != this && !prompt_executor && !resource_executor && !task_manager
 #if defined(MODULE_HTTPSERVER_ENABLED)
 			&& !session_manager

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -237,6 +237,7 @@ public:
 #endif
 
 	bool is_server_started() const { return server_started; }
+	int get_listening_port() const { return active_listening_port; }
 	int get_pending_tool_queue_size();
 
 	JustAMCPServer();

--- a/modules/justamcp/justamcp_server_tool_lifecycle.cpp
+++ b/modules/justamcp/justamcp_server_tool_lifecycle.cpp
@@ -145,8 +145,7 @@ void JustAMCPServer::_on_request_cancelled(const Variant &p_request_id, const St
 			cancel_associated_task = true;
 			task_id_to_cancel = target->task_id;
 		}
-		// Dispatcher cleared pending_task_dispatch and still owns the entry until it
-		// finishes create/re-lock; deleting here races with that thread.
+
 		if (target->is_task_augmented && !target->pending_task_dispatch && target->task_id.is_empty()) {
 			defer_cleanup_to_dispatcher = true;
 		}
@@ -173,7 +172,7 @@ void JustAMCPServer::_on_request_cancelled(const Variant &p_request_id, const St
 			if (!still) {
 				return;
 			}
-			// Dispatcher may have claimed the entry after our first unlock.
+
 			if (still->is_task_augmented && !still->pending_task_dispatch && still->task_id.is_empty()) {
 				return;
 			}

--- a/modules/justamcp/justamcp_server_tool_queue.cpp
+++ b/modules/justamcp/justamcp_server_tool_queue.cpp
@@ -310,7 +310,6 @@ void JustAMCPServer::_dispatch_task_augmented_tools_call(const Variant &p_reques
 			}
 #endif
 			if (!still_entry) {
-				// Entry already removed/deleted by another path; do not touch it.
 				return;
 			}
 			entry->rpc_result = _justamcp_task_dispatch_cancelled_rpc(p_request_id);
@@ -350,8 +349,7 @@ void JustAMCPServer::_schedule_process_pending_tools() {
 		return;
 	}
 	pending_tools_drain_scheduled = true;
-	// Prefer call_deferred so POST-SSE tools/call emits the first JSON-RPC message
-	// without waiting for the next rendered process_frame (Cursor discovery timeouts).
+
 	call_deferred(SNAME("_process_pending_tools"));
 }
 
@@ -410,19 +408,14 @@ void JustAMCPServer::_process_pending_tools() {
 		JustAMCPToolQueueState::sync_processing_flag(mcp_tool_queue.current_write, mcp_tool_queue.current_readonly_inflight, mcp_tool_queue.processing);
 	}
 
-	// Offload worker-safe tools (including wait) whenever the readonly lane is active.
-	// Do not require max_readonly > 0: concurrency 0 still used to mean "serialize readonly",
-	// but sleep/IO-safe tools must not freeze the main thread with delay_usec / blocking work.
 	const bool schedule_worker = readonly_lane && JustAMCPReadonlyTools::is_worker_safe_tool(entry->tool_name);
 	if (schedule_worker && JustAMCPToolDispatch::try_schedule_worker_execute(this, entry->request_id, entry->tool_name, entry->args)) {
 		if (max_readonly > 1) {
-			// Fan out more worker-safe tools in this flush; main-thread tools yield via next-frame scheduling.
 			call_deferred(SNAME("_process_pending_tools"));
 		}
 		return;
 	}
 
-	// One main-thread tool per drain; completion schedules the next on process_frame.
 	emit_signal("tool_requested", entry->request_id, entry->tool_name, entry->args);
 }
 

--- a/modules/justamcp/justamcp_session_manager.h
+++ b/modules/justamcp/justamcp_session_manager.h
@@ -95,7 +95,6 @@ public:
 
 	void clear_all();
 
-	// Latest supported MCP protocol; used when the client omits or sends an unknown version.
 	static String latest_protocol_version() { return String("2025-11-25"); }
 	static String negotiate_protocol_version(const String &p_client_version);
 

--- a/modules/justamcp/justamcp_session_manager_http_get.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_get.cpp
@@ -106,7 +106,7 @@ bool MCPSessionManager::handle_mcp_get(const Ref<HTTPRequestContext> &p_context,
 		return true;
 	}
 	_touch_session(*session);
-	// Prefer session-negotiated version when the client omits MCP-Protocol-Version.
+
 	owner->transport_negotiated_protocol = session->negotiated_protocol;
 	lock.temp_unlock();
 

--- a/modules/justamcp/justamcp_session_manager_http_post.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_post.cpp
@@ -204,8 +204,7 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 	const bool is_initialize = method == "initialize";
 
 	String session_id = get_header(p_context, "MCP-Session-Id");
-	// Always treat initialize as Streamable HTTP so clients that send only
-	// Accept: application/json still receive MCP-Session-Id for tools/list.
+
 	const bool streamable_client = !session_id.is_empty() || is_initialize || accepts_json_and_sse(p_context);
 
 	if (!streamable_client) {
@@ -222,16 +221,13 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 			return true;
 		}
 		_touch_session(*session);
-		// Prefer session-negotiated version when the client omits MCP-Protocol-Version.
+
 		owner->transport_negotiated_protocol = session->negotiated_protocol;
 	} else if (!is_initialize) {
 		p_response->set_status(400);
 		p_response->set_body("Missing MCP-Session-Id");
 		return true;
 	}
-
-	// MCP-Protocol-Version may be omitted after initialize; reuse session.negotiated_protocol
-	// (validate_protocol_header already rejects unsupported header values with 400).
 
 	if (is_initialize && session_id.is_empty()) {
 		MCPSession session;
@@ -252,9 +248,6 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 		p_response->add_header("MCP-Session-Id", session_id);
 	}
 
-	// Dual Accept upgrades to POST-SSE only for long-running RPCs. Sync discovery
-	// methods (tools/list, prompts/list, resources/*, ping, …) stay on the JSON/held
-	// path so Cursor live tool discovery is not starved waiting for an SSE message.
 	const bool async_rpc = (method == "tools/call");
 	const bool wants_sse = accepts_json_and_sse(p_context) && !is_notification && method != "initialize" && async_rpc;
 	if (wants_sse) {

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -30,6 +30,8 @@
 #include "register_types.h"
 #include "justamcp_project_settings.h"
 
+#include "modules/modules_enabled.gen.h"
+
 #include "justamcp_runtime.h"
 
 #ifdef TOOLS_ENABLED
@@ -51,6 +53,9 @@
 #include "tools/justamcp_asset_tags_tools.h"
 #include "tools/justamcp_category_registry.h"
 #include "tools/justamcp_mcp_client_bridge.h"
+#ifdef MODULE_REMOTE_CONTROL_ENABLED
+#include "tools/justamcp_remote_control_tools.h"
+#endif
 #include "tools/justamcp_node_tools.h"
 #include "tools/justamcp_particle_tools.h"
 #include "tools/justamcp_physics_tools.h"
@@ -278,8 +283,7 @@ void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 	}
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		JustAMCPProjectSettings::register_project_settings();
-		// Register EditorSettings early so EDITOR_GET / inspector never WARN on missing JustAMCP keys
-		// before the MCP server starts (register_editor_settings is idempotent).
+
 		if (EditorSettings::get_singleton()) {
 			JustAMCPProjectSettings::register_editor_settings();
 		}
@@ -323,6 +327,18 @@ void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 					mcp_client_bridge,
 					"mcp_client_tools");
 		}
+#ifdef MODULE_REMOTE_CONTROL_ENABLED
+		if (JustAMCPToolsetRegistry::get_singleton()) {
+			JustAMCPRemoteControlTools *remote_control_bridge = memnew(JustAMCPRemoteControlTools);
+			JustAMCPToolsetRegistry::get_singleton()->register_toolset_with_owner(
+					"RemoteControl",
+					"In-process bridge to the remote_control module.",
+					callable_mp(remote_control_bridge, &JustAMCPRemoteControlTools::provide_tool_schemas),
+					callable_mp(remote_control_bridge, &JustAMCPRemoteControlTools::execute_tool),
+					remote_control_bridge,
+					"remote_control_tools");
+		}
+#endif
 		_register_all_toolsets();
 		JustAMCPToolSchemaCache::get_schemas(false, false, false, false);
 		EditorPlugins::add_by_type<JustAMCPEditorPlugin>();

--- a/modules/justamcp/tests/test_justamcp_category_handled.cpp
+++ b/modules/justamcp/tests/test_justamcp_category_handled.cpp
@@ -105,7 +105,7 @@ void test_justamcp_sse_bound_worker_safe_uses_worker() {
 	entry->sse_connection_id = 42;
 
 	server.test_process_pending_tools();
-	// SSE-bound worker-safe tools must schedule on WorkerThreadPool, not the main-thread signal path.
+
 	CHECK(!s_tool_requested);
 	CHECK(s_tool_requested_name.is_empty());
 

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
@@ -167,7 +167,7 @@ void test_justamcp_http_protocol_header_falls_back_to_session() {
 		const String session_id = _init_session(server, session_manager, protocol);
 
 		const String list_body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}";
-		// Spec: if header is omitted, reuse the protocol negotiated at initialize.
+
 		Ref<HTTPResponse> missing;
 		missing.instantiate();
 		CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _json_headers(session_id), list_body), missing));

--- a/modules/justamcp/tests/test_justamcp_task_augmented_no_block.cpp
+++ b/modules/justamcp/tests/test_justamcp_task_augmented_no_block.cpp
@@ -50,7 +50,7 @@ void test_justamcp_task_augmented_http_returns_immediately() {
 	const Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc(&server, body, response);
 	const uint64_t elapsed_msec = OS::get_singleton()->get_ticks_msec() - start_msec;
 	CHECK(result.is_empty());
-	// ASAN/slow CI hosts can exceed a tight 50ms budget while still returning immediately.
+
 	CHECK(elapsed_msec < 500);
 	CHECK(server.get_pending_tool_queue_size() >= 1);
 	server.test_clear_tool_queue();

--- a/modules/justamcp/tests/test_justamcp_toolset_schema_gate.cpp
+++ b/modules/justamcp/tests/test_justamcp_toolset_schema_gate.cpp
@@ -62,7 +62,6 @@ void test_justamcp_toolset_schema_gate() {
 		}
 		expected_names.push_back(entry.display_name);
 
-		// Optional collaborative/autowork categories may register empty schema sets in headless tests.
 		if (entry.requires_multiuser || entry.requires_autowork) {
 			continue;
 		}

--- a/modules/justamcp/tools/justamcp_composite_routes.cpp
+++ b/modules/justamcp/tools/justamcp_composite_routes.cpp
@@ -251,7 +251,6 @@ Dictionary JustAMCPToolExecutor::execute_composite_tool(const String &p_internal
 		Dictionary ret;
 #ifdef TOOLS_ENABLED
 		if (EditorFileSystem::get_singleton()) {
-			// Always defer: sync scan() during process_frame tool drain freezes the editor.
 			EditorFileSystem::get_singleton()->call_deferred(SNAME("scan"));
 			ret["ok"] = true;
 			ret["message"] = "Editor filesystem rescan requested.";
@@ -446,7 +445,7 @@ Dictionary JustAMCPToolExecutor::execute_composite_tool(const String &p_internal
 			ms = int(double(p_args.get("seconds", 0.0)) * 1000.0);
 		}
 		ms = CLAMP(ms, 0, 5000);
-		// Prefer WorkerThreadPool (wait is worker-safe). Never block the main thread with a long delay_usec.
+
 		if (Thread::is_main_thread()) {
 			const uint64_t end_ms = OS::get_singleton()->get_ticks_msec() + uint64_t(ms);
 			while (OS::get_singleton()->get_ticks_msec() < end_ms) {

--- a/modules/justamcp/tools/justamcp_meta_tools.cpp
+++ b/modules/justamcp/tools/justamcp_meta_tools.cpp
@@ -103,8 +103,6 @@ Dictionary JustAMCPMetaTools::execute(JustAMCPToolExecutor *p_executor, const St
 		if (resource_executor) {
 			resource = resource_executor->read_resource("blazium://guide/" + topic);
 		} else {
-			// Avoid stack-allocating when the server executor exists: its dtor would
-			// disconnect the shared EditorFileSystem callback on the main thread.
 			JustAMCPResourceExecutor local_executor;
 			resource = local_executor.read_resource("blazium://guide/" + topic);
 		}

--- a/modules/justamcp/tools/justamcp_node_tools.cpp
+++ b/modules/justamcp/tools/justamcp_node_tools.cpp
@@ -237,7 +237,7 @@ Dictionary JustAMCPNodeTools::_delete_node(const Dictionary &p_params) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action("MCP: Delete " + node_name);
 		ur->add_do_method(parent, "remove_child", node);
-		// Undo runs reverse of registration: add_child must run before set_owner.
+
 		ur->add_undo_method(node, "set_owner", root);
 		ur->add_undo_method(parent, "add_child", node);
 		ur->add_undo_reference(node);

--- a/modules/justamcp/tools/justamcp_project_tools_settings.cpp
+++ b/modules/justamcp/tools/justamcp_project_tools_settings.cpp
@@ -36,8 +36,6 @@
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 
-// Prefer Ref<JSON>::parse over JSON::parse_string so plain strings (e.g. "JustAMCP")
-// do not ERR_PRINT via the global parse helper.
 static bool _justamcp_looks_like_json(const String &p_s) {
 	const String t = p_s.strip_edges();
 	if (t.is_empty()) {

--- a/modules/justamcp/tools/justamcp_remote_control_tools.cpp
+++ b/modules/justamcp/tools/justamcp_remote_control_tools.cpp
@@ -1,0 +1,185 @@
+/**************************************************************************/
+/*  justamcp_remote_control_tools.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_REMOTE_CONTROL_ENABLED
+
+#include "justamcp_remote_control_tools.h"
+
+#include "justamcp_tool_schema_builder.h"
+
+#include "modules/remote_control/remote_control_registry.h"
+#include "modules/remote_control/remote_control_server.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_settings.h"
+
+void JustAMCPRemoteControlTools::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("provide_tool_schemas", "register_only", "ignore_settings", "include_disabled_tools"), &JustAMCPRemoteControlTools::provide_tool_schemas, DEFVAL(false), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("execute_tool", "tool_name", "arguments"), &JustAMCPRemoteControlTools::execute_tool);
+}
+
+Dictionary JustAMCPRemoteControlTools::_make_error(const String &p_message) const {
+	Dictionary err;
+	err["ok"] = false;
+	err["error"] = p_message;
+	return err;
+}
+
+Array JustAMCPRemoteControlTools::provide_tool_schemas(bool p_register_only, bool p_ignore_settings, bool p_include_disabled_tools) {
+	return get_tool_schemas(p_register_only, p_ignore_settings, p_include_disabled_tools);
+}
+
+Array JustAMCPRemoteControlTools::get_tool_schemas(bool p_register_only, bool p_ignore_settings, bool p_include_disabled_tools) {
+	Array tools;
+	const String current_category = "remote_control_tools";
+	const bool is_core = false;
+
+	auto add_schema = [&](const String &p_name, const String &p_desc, const Vector<String> &p_props, const Vector<String> &p_req) {
+		const String full_name = "blazium_" + p_name;
+		if (p_register_only) {
+			JustAMCPToolSchemaBuilder::register_tool_settings(current_category, full_name, is_core);
+			return;
+		}
+		bool cat_enabled = true;
+		bool tool_enabled = true;
+		if (!p_ignore_settings) {
+			if (!JustAMCPToolSchemaBuilder::resolve_tool_enabled(current_category, full_name, p_ignore_settings, p_include_disabled_tools, cat_enabled, tool_enabled)) {
+				return;
+			}
+		}
+		tools.push_back(JustAMCPToolSchemaBuilder::build_tool_schema(full_name, p_desc, current_category, cat_enabled && tool_enabled, p_props, p_req));
+	};
+
+	add_schema("remote_control_status", "Return in-process remote_control server status.",
+			Vector<String>{}, Vector<String>{});
+	add_schema("remote_control_exec", "Execute a remote_control builtin/command in-process.",
+			Vector<String>{ "command", "string", "arguments", "object" }, Vector<String>{ "command" });
+	add_schema("remote_control_eval", "Evaluate an expression via remote_control (respects allow_eval).",
+			Vector<String>{ "expression", "string", "language", "string" }, Vector<String>{ "expression" });
+	add_schema("remote_control_instance", "Return remote_control instance id/port/token summary.",
+			Vector<String>{}, Vector<String>{});
+
+	return tools;
+}
+
+Dictionary JustAMCPRemoteControlTools::remote_control_status(const Dictionary &p_args) {
+	(void)p_args;
+	RemoteControlServer *server = RemoteControlServer::get_singleton();
+	if (!server) {
+		return _make_error("RemoteControlServer not available");
+	}
+	Dictionary result = server->get_status();
+	result["ok"] = true;
+	return result;
+}
+
+Dictionary JustAMCPRemoteControlTools::remote_control_exec(const Dictionary &p_args) {
+	const String command = p_args.get("command", "");
+	if (command.is_empty()) {
+		return _make_error("command is required");
+	}
+	if (!RemoteControlRegistry::get_singleton()) {
+		return _make_error("RemoteControlRegistry not available");
+	}
+	Dictionary args = p_args.get("arguments", Dictionary());
+	Dictionary result = RemoteControlRegistry::get_singleton()->execute(command, args);
+	if (!result.has("ok")) {
+		result["ok"] = true;
+	}
+	return result;
+}
+
+Dictionary JustAMCPRemoteControlTools::remote_control_eval(const Dictionary &p_args) {
+	const String expression = p_args.get("expression", "");
+	if (expression.is_empty()) {
+		return _make_error("expression is required");
+	}
+	RemoteControlServer *server = RemoteControlServer::get_singleton();
+	if (!server) {
+		return _make_error("RemoteControlServer not available");
+	}
+	if (!server->get_allow_eval()) {
+		return _make_error("Eval is disabled. Enable blazium/remote_control/allow_eval.");
+	}
+	const String language = p_args.get("language", "gdscript");
+	Dictionary result = server->eval_expression(expression, language);
+	if (!result.has("ok")) {
+		result["ok"] = true;
+	}
+	return result;
+}
+
+Dictionary JustAMCPRemoteControlTools::remote_control_instance(const Dictionary &p_args) {
+	(void)p_args;
+	RemoteControlServer *server = RemoteControlServer::get_singleton();
+	if (!server) {
+		return _make_error("RemoteControlServer not available");
+	}
+	Dictionary result;
+	result["ok"] = true;
+	result["started"] = server->is_started();
+	result["port"] = server->get_port();
+	result["instance_id"] = server->get_remote_instance_id();
+	result["allow_eval"] = server->get_allow_eval();
+
+	return result;
+}
+
+Dictionary JustAMCPRemoteControlTools::execute_tool(const String &p_tool_name, const Dictionary &p_args) {
+	String tool_name = p_tool_name;
+	if (tool_name.begins_with("blazium_")) {
+		tool_name = tool_name.substr(8);
+	}
+	if (tool_name == "remote_control_status") {
+		return remote_control_status(p_args);
+	}
+	if (tool_name == "remote_control_exec") {
+		return remote_control_exec(p_args);
+	}
+	if (tool_name == "remote_control_eval") {
+		return remote_control_eval(p_args);
+	}
+	if (tool_name == "remote_control_instance") {
+		return remote_control_instance(p_args);
+	}
+	return _make_error("Unknown remote_control tool: " + p_tool_name);
+}
+
+JustAMCPRemoteControlTools::JustAMCPRemoteControlTools() {
+}
+
+JustAMCPRemoteControlTools::~JustAMCPRemoteControlTools() {
+}
+
+#endif
+#endif

--- a/modules/justamcp/tools/justamcp_remote_control_tools.cpp
+++ b/modules/justamcp/tools/justamcp_remote_control_tools.cpp
@@ -98,9 +98,7 @@ Dictionary JustAMCPRemoteControlTools::remote_control_status(const Dictionary &p
 	if (!server) {
 		return _make_error("RemoteControlServer not available");
 	}
-	Dictionary result = server->get_status();
-	result["ok"] = true;
-	return result;
+	return server->get_status();
 }
 
 Dictionary JustAMCPRemoteControlTools::remote_control_exec(const Dictionary &p_args) {

--- a/modules/justamcp/tools/justamcp_remote_control_tools.h
+++ b/modules/justamcp/tools/justamcp_remote_control_tools.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  remote_control_editor_plugin.cpp                                      */
+/*  justamcp_remote_control_tools.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -27,80 +27,38 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#pragma once
+
 #ifdef TOOLS_ENABLED
 
-#include "remote_control_editor_plugin.h"
+#include "modules/modules_enabled.gen.h"
 
-#include "remote_control_server.h"
+#ifdef MODULE_REMOTE_CONTROL_ENABLED
 
-#include "editor/debugger/editor_debugger_node.h"
-#include "editor/debugger/script_editor_debugger.h"
+#include "core/object/class_db.h"
+#include "core/object/object.h"
 
-void RemoteControlEditorPlugin::_try_start() {
-	if (!RemoteControlServer::get_singleton()) {
-		return;
-	}
-	if (RemoteControlServer::get_singleton()->is_started()) {
-		_connect_debugger_hooks();
-		return;
-	}
-	if (RemoteControlServer::should_enable_from_cmdline_or_settings()) {
-		RemoteControlServer::get_singleton()->start();
-	}
-	_connect_debugger_hooks();
-}
+class JustAMCPRemoteControlTools : public Object {
+	GDCLASS(JustAMCPRemoteControlTools, Object);
 
-void RemoteControlEditorPlugin::_try_stop() {
-}
+protected:
+	static void _bind_methods();
 
-void RemoteControlEditorPlugin::_connect_debugger_hooks() {
-	if (debugger_hooks_connected) {
-		return;
-	}
-	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
-	if (!debugger_node) {
-		return;
-	}
-	debugger_node->connect("breaked", callable_mp(this, &RemoteControlEditorPlugin::_on_debugger_breaked));
-	debugger_hooks_connected = true;
-}
+	Dictionary _make_error(const String &p_message) const;
 
-void RemoteControlEditorPlugin::_on_debugger_breaked(bool p_breaked, bool p_can_debug) {
-	(void)p_can_debug;
-	if (!p_breaked || !RemoteControlServer::get_singleton()) {
-		return;
-	}
-	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
-	if (!debugger_node) {
-		return;
-	}
-	ScriptEditorDebugger *dbg = debugger_node->get_current_debugger();
-	if (!dbg) {
-		return;
-	}
-	const String reason = dbg->get_break_reason();
+public:
+	static Array get_tool_schemas(bool p_register_only = false, bool p_ignore_settings = false, bool p_include_disabled_tools = false);
+	Array provide_tool_schemas(bool p_register_only = false, bool p_ignore_settings = false, bool p_include_disabled_tools = false);
+	Dictionary execute_tool(const String &p_tool_name, const Dictionary &p_args);
 
-	const String lower = reason.to_lower();
-	if (!(lower.contains("error") || lower.contains("exception") || dbg->get_error_count() > 0)) {
-		return;
-	}
-	RemoteControlServer::get_singleton()->record_error_break(dbg->get_stack_script_file(), dbg->get_stack_script_line(), reason);
-}
+	Dictionary remote_control_status(const Dictionary &p_args);
+	Dictionary remote_control_exec(const Dictionary &p_args);
+	Dictionary remote_control_eval(const Dictionary &p_args);
+	Dictionary remote_control_instance(const Dictionary &p_args);
 
-void RemoteControlEditorPlugin::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			_try_start();
-		} break;
-		default:
-			break;
-	}
-}
+	JustAMCPRemoteControlTools();
+	~JustAMCPRemoteControlTools();
+};
 
-void RemoteControlEditorPlugin::_bind_methods() {
-}
-
-RemoteControlEditorPlugin::RemoteControlEditorPlugin() {
-}
-
+#endif
 #endif

--- a/modules/justamcp/tools/justamcp_resource_executor.cpp
+++ b/modules/justamcp/tools/justamcp_resource_executor.cpp
@@ -95,8 +95,7 @@ JustAMCPResourceExecutor::JustAMCPResourceExecutor() {
 	add_resource(memnew(JustAMCPResourceProjectFile));
 	add_resource(memnew(JustAMCPResourceVideoRecordings));
 	add_resource(memnew(JustAMCPResourceAutoworkResults));
-	// EditorFileSystem is a Node; connect only from the main thread. Ephemeral executors
-	// created on WorkerThreadPool (e.g. get_guide) must not touch EFS signals.
+
 	if (Thread::is_main_thread() && EditorFileSystem::get_singleton()) {
 		const Callable cb = callable_mp_static(&JustAMCPResourceExecutor::_on_filesystem_changed);
 		if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", cb)) {

--- a/modules/justamcp/tools/justamcp_resource_tools_io.cpp
+++ b/modules/justamcp/tools/justamcp_resource_tools_io.cpp
@@ -642,7 +642,7 @@ Dictionary JustAMCPResourceTools::resource_import_asset(const Dictionary &p_args
 	if (editor_plugin && editor_plugin->get_editor_interface() && EditorFileSystem::get_singleton()) {
 		Vector<String> files;
 		files.push_back(res_path);
-		// Always defer: sync reimport during process_frame tool drain freezes the editor.
+
 		EditorFileSystem::get_singleton()->call_deferred(SNAME("reimport_files"), files);
 		Dictionary ret;
 		ret["ok"] = true;

--- a/modules/justamcp/tools/justamcp_scene_tools.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools.cpp
@@ -124,7 +124,6 @@ String JustAMCPSceneTools::_to_scene_res_path(const String &p_project_path, cons
 		return p;
 	}
 
-	// Absolute filesystem paths (tests / external tooling) stay absolute when present.
 	if (p.is_absolute_path() && FileAccess::exists(p)) {
 		return p;
 	}

--- a/modules/justamcp/tools/justamcp_scene_tools_mutations_nodes.cpp
+++ b/modules/justamcp/tools/justamcp_scene_tools_mutations_nodes.cpp
@@ -334,7 +334,7 @@ Dictionary JustAMCPSceneTools::delete_node(const Dictionary &p_args) {
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("AI Local: Delete Node"), UndoRedo::MERGE_DISABLE, node);
 		ur->add_do_method(parent, "remove_child", node);
-		// Undo runs reverse of registration: add_child must run before set_owner.
+
 		ur->add_undo_method(node, "set_owner", root);
 		ur->add_undo_method(parent, "add_child", node, true);
 		ur->add_undo_reference(node);

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -147,14 +147,12 @@ Node *JustAMCPToolExecutor::get_test_scene_root() {
 
 JustAMCPToolExecutor::JustAMCPToolExecutor() {
 #ifdef TESTS_ENABLED
-	// Unit tests construct bare executors and expect tools immediately.
+
 	_init_tools();
 #endif
 }
 
 JustAMCPToolExecutor::~JustAMCPToolExecutor() {
-	// Stop accepting new worker jobs that would capture this pointer, then drain
-	// in-flight WorkerThreadPool tasks before tearing member tools down.
 	if (active_instance == this) {
 		active_instance = nullptr;
 	}

--- a/modules/remote_control/config.py
+++ b/modules/remote_control/config.py
@@ -1,7 +1,12 @@
 def can_build(env, platform):
     env.module_add_dependencies("remote_control", ["httpserver"], True)
     env.module_add_dependencies("remote_control", ["luau_module"], False)
-    return True
+    # JustAMCP is a compile-time optional peer (mcp_status builtin) via
+    # MODULE_JUSTAMCP_ENABLED — do not soft-dep here (circular with justamcp).
+    if env.editor_build:
+        return True
+    # Export templates: only when building Hub-capable templates.
+    return bool(env.get("hub_build", False))
 
 
 def configure(env):

--- a/modules/remote_control/remote_control_builtins.cpp
+++ b/modules/remote_control/remote_control_builtins.cpp
@@ -56,6 +56,14 @@
 #include "scene/gui/button.h"
 #endif
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_JUSTAMCP_ENABLED
+#ifdef TOOLS_ENABLED
+#include "modules/justamcp/justamcp_server.h"
+#endif
+#endif
+
 static Dictionary _ok(const Dictionary &p_extra = Dictionary()) {
 	Dictionary ret = p_extra;
 	ret["ok"] = true;
@@ -500,7 +508,7 @@ Dictionary remote_control_cmd_snapshot_scene(const Dictionary &p_args) {
 #if !defined(TOOLS_ENABLED)
 	return _snapshot_runtime_viewport(path);
 #else
-	// Runtime remote_control in a playing game process.
+
 	if (!EditorInterface::get_singleton()) {
 		Dictionary ret = _snapshot_runtime_viewport(path);
 		if (bool(ret.get("ok", false))) {
@@ -854,6 +862,43 @@ Dictionary remote_control_cmd_autowork_results(const Dictionary &p_args) {
 	return RemoteControlServer::get_singleton()->get_autowork_results();
 }
 
+Dictionary remote_control_cmd_focus_window(const Dictionary &p_args) {
+	(void)p_args;
+	if (!DisplayServer::get_singleton()) {
+		return _err("DisplayServer not available");
+	}
+	DisplayServer::get_singleton()->window_move_to_foreground();
+	DisplayServer::get_singleton()->window_request_attention();
+	Dictionary ret;
+	ret["focused"] = true;
+	return _ok(ret);
+}
+
+Dictionary remote_control_cmd_mcp_status(const Dictionary &p_args) {
+	(void)p_args;
+	Dictionary ret;
+#ifdef MODULE_JUSTAMCP_ENABLED
+#ifdef TOOLS_ENABLED
+	JustAMCPServer *server = JustAMCPServer::get_singleton();
+	const bool started = server && server->is_server_started();
+	ret["available"] = true;
+	ret["started"] = started;
+	ret["port"] = started && server ? server->get_listening_port() : -1;
+#else
+	ret["available"] = false;
+	ret["started"] = false;
+	ret["port"] = -1;
+	ret["reason"] = "JustAMCP is editor-only";
+#endif
+#else
+	ret["available"] = false;
+	ret["started"] = false;
+	ret["port"] = -1;
+	ret["reason"] = "JustAMCP module not compiled in";
+#endif
+	return _ok(ret);
+}
+
 void remote_control_register_builtin_commands(RemoteControlRegistry *p_registry) {
 	ERR_FAIL_NULL(p_registry);
 
@@ -896,4 +941,7 @@ void remote_control_register_builtin_commands(RemoteControlRegistry *p_registry)
 	p_registry->register_command("autowork_run", callable_mp_static(remote_control_cmd_autowork_run), "Start Autowork job");
 	p_registry->register_command("autowork_status", callable_mp_static(remote_control_cmd_autowork_status), "Autowork job status");
 	p_registry->register_command("autowork_results", callable_mp_static(remote_control_cmd_autowork_results), "Autowork job results");
+	p_registry->register_command("focus_window", callable_mp_static(remote_control_cmd_focus_window), "Bring editor/game window to front");
+	p_registry->register_command("bring_to_front", callable_mp_static(remote_control_cmd_focus_window), "Alias for focus_window");
+	p_registry->register_command("mcp_status", callable_mp_static(remote_control_cmd_mcp_status), "JustAMCP server status (port/started)");
 }

--- a/modules/remote_control/remote_control_editor_plugin.h
+++ b/modules/remote_control/remote_control_editor_plugin.h
@@ -44,6 +44,7 @@ class RemoteControlEditorPlugin : public EditorPlugin {
 	void _on_debugger_breaked(bool p_breaked, bool p_can_debug);
 
 protected:
+	static void _bind_methods();
 	void _notification(int p_what);
 
 public:

--- a/modules/remote_control/remote_control_server.h
+++ b/modules/remote_control/remote_control_server.h
@@ -48,8 +48,8 @@ public:
 private:
 	struct LogEntry {
 		uint64_t id = 0;
-		uint64_t ref_id = 0; // 0 = owns text; otherwise references another entry's text
-		int repeat = 0; // for ref entries: extra occurrences beyond the owner
+		uint64_t ref_id = 0;
+		int repeat = 0;
 		String text;
 		String level;
 		double time = 0.0;
@@ -76,7 +76,7 @@ private:
 
 	mutable Mutex autowork_mutex;
 	String autowork_job_id;
-	String autowork_job_state = "idle"; // idle|running|done|failed
+	String autowork_job_state = "idle";
 	Dictionary autowork_job_status;
 	Dictionary autowork_job_results;
 	String autowork_results_path = "user://autowork_results.json";

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -5,6 +5,8 @@ Import("env")
 
 import platform_linuxbsd_builders
 
+import methods
+
 common_linuxbsd = [
     "crash_handler_linuxbsd.cpp",
     "os_linuxbsd.cpp",
@@ -40,6 +42,7 @@ if env["dbus"]:
         common_linuxbsd.append("dbus-so_wrap.c")
 
 prog = env.add_program("#bin/blazium", ["godot_linuxbsd.cpp"] + common_linuxbsd)
+methods.add_hub_register_post_action(env, prog)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_linuxbsd_builders.make_debug_linuxbsd))

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -9,6 +9,7 @@ import subprocess
 
 import platform_macos_builders
 
+import methods
 from platform_methods import get_build_version, lipo
 
 
@@ -145,6 +146,7 @@ shutil.copy(
 )
 
 prog = env.add_program("#bin/blazium", files)
+methods.add_hub_register_post_action(env, prog)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_macos_builders.make_debug_macos))

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -77,6 +77,7 @@ sources += res_obj
 
 prog = env.add_program("#bin/blazium", sources, PROGSUFFIX=env["PROGSUFFIX"])
 arrange_program_clean(prog)
+methods.add_hub_register_post_action(env, prog)
 
 if env.msvc:
     env.Depends(prog, "godot.natvis")


### PR DESCRIPTION
## Summary
- Gate template `remote_control` on `hub_build`; bridge JustAMCP ↔ remote_control for focus/mcp status builtins.
- `hub_register=yes` is **SCons-only**: after linking an editor, post-build runs `blazium-cli handle-uri blazium://register?...` (warn-only if CLI missing). No in-editor startup registration.
- `update_version_from_git=yes` (optional `update_version_status=...`) computes Blazium `EXTERNAL_*` from the nearest `v*` git tag (+ commits) during configure, sets env overrides, and writes `version.py` so a single `scons` matches the standalone `misc/scripts/update_version_from_git.py` workflow.
- Document JustAMCP `RemoteControl` toolset in ProjectSettings.

## Test plan
- [x] Build `scons target=editor hub_register=yes` with `blazium-cli` on PATH (or `BLAZIUM` / `BLAZIUM_CLI`) and confirm post-build registration log
- [x] Build without `hub_register` — no registration attempt
- [x] Template with `hub_build=yes` includes remote_control; without flag omits it
- [x] JustAMCP can invoke focus/mcp_status through remote_control bridge
- [x] `scons update_version_from_git=yes` (or `-Q --help`) applies git-derived `external_*` / prints the computed version; leave `version.py` uncommitted
- [x] Without `update_version_from_git`, version behavior is unchanged
- [ ] Static checks / editor CI green