### PR TITLE
Silence JustAMCP Array editor-settings warnings on editor load

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -184,6 +184,10 @@
 		<member name="asset_library/use_threads" type="bool" setter="" getter="">
 			If [code]true[/code], the Asset Library uses multiple threads for its HTTP requests. This prevents the Asset Library from blocking the main thread for every loaded asset.
 		</member>
+		<member name="blazium/justamcp/bridge_url_allow_hosts" type="Array" setter="" getter="">
+		</member>
+		<member name="blazium/justamcp/mcp_clients" type="Array" setter="" getter="">
+		</member>
 		<member name="debugger/auto_switch_to_remote_scene_tree" type="bool" setter="" getter="">
 			If [code]true[/code], automatically switches to the [b]Remote[/b] scene tree when running the project from the editor. If [code]false[/code], stays on the [b]Local[/b] scene tree when running the project from the editor.
 			[b]Warning:[/b] Enabling this setting can cause stuttering when running a project with a large amount of nodes (typically a few thousands of nodes or more), even if the editor window isn't focused. This is due to the remote scene tree being updated every second regardless of whether the editor is focused.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -50,6 +50,7 @@
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_translation.h"
 #include "editor/engine_update_label.h"
+#include "modules/modules_enabled.gen.h" // For justamcp Array editor settings.
 #include "scene/gui/color_picker.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
@@ -226,7 +227,12 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 
 	const VariantContainer *v = props.getptr(p_name);
 	if (!v) {
-		WARN_PRINT("EditorSettings::_get - Property not found: " + String(p_name));
+		// Resource loaders probe Array properties with get() before set() while the
+		// settings file is still being applied (see resource_format_text.cpp). Module
+		// defaults may not be registered yet at that point; only warn after init.
+		if (initialized) {
+			WARN_PRINT("EditorSettings::_get - Property not found: " + String(p_name));
+		}
 		return false;
 	}
 	r_ret = v->variant;
@@ -1037,6 +1043,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	const String default_renderer = "forward_plus";
 #endif
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", default_renderer, "forward_plus,mobile,gl_compatibility")
+
+#ifdef MODULE_JUSTAMCP_ENABLED
+	// Array-typed JustAMCP settings must exist before editor_settings-*.tres is applied:
+	// resource_format_text probes Arrays with get() before set() and would otherwise miss them.
+	EDITOR_SETTING(Variant::ARRAY, PROPERTY_HINT_NONE, "blazium/justamcp/mcp_clients", Array(), "")
+	EDITOR_SETTING(Variant::ARRAY, PROPERTY_HINT_NONE, "blazium/justamcp/bridge_url_allow_hosts", Array(), "")
+#endif
 
 #undef EDITOR_SETTING
 #undef EDITOR_SETTING_BASIC


### PR DESCRIPTION
﻿## Summary
- Register JustAMCP Array editor settings (mcp_clients, bridge_url_allow_hosts) in EditorSettings::_load_defaults so resource text loading can probe them before set().
- Defer EditorSettings::_get Property-not-found warnings until after initialization to avoid load-time Array probe spam from module settings not yet registered.

## Test plan
- [x] Build Windows editor tests=yes and tests=no with Luau/Autowork modules enabled
- [x] Open/quit harness on luau_module_tests, httpserver_module_tests, and regression-test-project — no engine WARNING/ERROR/BUG from EditorSettings Array probe
- [x] Confirm headless editor open on a project with saved JustAMCP Array settings in editor_settings-*.tres stays quiet
