### PR TITLE
JustAMCP: dual-era MCP 2026-07-28, Cursor 2025-11-25 surface, and per-era capability matrix

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -450,6 +450,9 @@
 		<member name="blazium/autowork/e2e_enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the Autowork framework will boot its WebSocket E2E server on startup, enabling orchestration from standard web runners (e.g. Playwright, Jest, Cypress).
 		</member>
+		<member name="blazium/justamcp/accepted_protocol_versions" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional comma-separated allowlist of MCP protocol versions this process will serve. Empty accepts every implemented version ([code]2026-07-28[/code] through [code]2024-11-05[/code]).
+		</member>
 		<member name="blazium/justamcp/allow_execute_tool_bypass" type="bool" setter="" getter="" default="false">
 		</member>
 		<member name="blazium/justamcp/bind_to_localhost_only" type="bool" setter="" getter="" default="true">
@@ -491,8 +494,20 @@
 		<member name="blazium/justamcp/mcp_log_buffer_size" type="int" setter="" getter="" default="500">
 			Maximum buffered MCP [code]notifications/message[/code] entries retained for replay when clients missed SSE.
 		</member>
+		<member name="blazium/justamcp/oauth_authorization_servers" type="String" setter="" getter="" default="&quot;&quot;">
+			Comma-separated authorization server issuer URLs advertised in OAuth Protected Resource Metadata.
+		</member>
+		<member name="blazium/justamcp/oauth_cimd_json" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional pinned Client ID Metadata Document JSON used to validate CIMD [code]client_id[/code] values.
+		</member>
 		<member name="blazium/justamcp/oauth_enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], MCP clients must authenticate with OAuth credentials before calling JustAMCP tools.
+		</member>
+		<member name="blazium/justamcp/oauth_resource" type="String" setter="" getter="" default="&quot;&quot;">
+			Canonical OAuth resource identifier for this MCP server. Empty defaults to the listening [code]/mcp[/code] URL.
+		</member>
+		<member name="blazium/justamcp/oauth_scopes_supported" type="String" setter="" getter="" default="&quot;mcp&quot;">
+			Comma-separated OAuth scopes advertised in Protected Resource Metadata.
 		</member>
 		<member name="blazium/justamcp/override_editor_settings" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], JustAMCP reads server, tool, prompt, and resource toggles from [ProjectSettings] instead of [EditorSettings]. Automatically enabled in headless mode and when using [code]--enable-mcp[/code].
@@ -548,6 +563,9 @@
 		</member>
 		<member name="blazium/justamcp/prompts/project_info" type="String" setter="" getter="">
 			Read-only MCP prompt template registered as [code]project_info[/code]. Description: Retrieves the core Godot Project metadata natively.
+		</member>
+		<member name="blazium/justamcp/protocol_version" type="String" setter="" getter="" default="&quot;2026-07-28&quot;">
+			Advertised latest MCP protocol version. [code]2026-07-28[/code] is the modern/stateless revision; [code]initialize[/code] still negotiates a legacy date ([code]2025-11-25[/code] and earlier) for Cursor and other handshake clients. Override with [code]--mcp-protocol-version[/code].
 		</member>
 		<member name="blazium/justamcp/readonly_worker_concurrency" type="int" setter="" getter="" default="2">
 		</member>
@@ -1772,6 +1790,9 @@
 		<member name="blazium/justamcp/toolsets/Theme" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="blazium/justamcp/toolsets/TileMap" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/url_elicitation_demo_url" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional URL used by the URL-mode elicitation demo. Empty disables URL elicitation demo requests.
 		</member>
 		<member name="blazium/justamcp/z_mcp_config" type="String" setter="" getter="" default="&quot;&quot;">
 			Advanced JustAMCP JSON configuration managed by the editor plugin UI. Stores supplemental MCP server options not exposed as individual project settings.

--- a/modules/justamcp/SCsub
+++ b/modules/justamcp/SCsub
@@ -14,6 +14,9 @@ env_justamcp.add_source_files(env.modules_sources, "tools/resources/*.cpp")
 
 if env["tests"]:
     env_justamcp.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_elicitation.cpp")
+    env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_oauth_discovery.cpp")
+    env_justamcp.add_source_files(env.modules_sources, "tests/test_justamcp_protocol_matrix.cpp")
 
     if env["disable_exceptions"]:
         env_justamcp.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/justamcp/doc_classes/JustAMCPPromptExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPPromptExecutor.xml
@@ -27,8 +27,9 @@
 			<return type="Dictionary" />
 			<param index="0" name="ref" type="Dictionary" />
 			<param index="1" name="argument" type="Dictionary" />
+			<param index="2" name="context" type="Dictionary" default="{}" />
 			<description>
-				Looks up the prompt named by [param ref] and returns completion values for [param argument]. Unknown prompts return an empty completion result.
+				Looks up the prompt named by [param ref] and returns completion values for [param argument]. [param context] is the optional MCP completion context from [code]2025-06-18[/code] and later. Unknown prompts return an empty completion result.
 			</description>
 		</method>
 		<method name="get_prompt">

--- a/modules/justamcp/doc_classes/JustAMCPServer.xml
+++ b/modules/justamcp/doc_classes/JustAMCPServer.xml
@@ -22,6 +22,13 @@
 		<link title="Model Context Protocol (MCP)">https://modelcontextprotocol.io/</link>
 	</tutorials>
 	<methods>
+		<method name="get_session_roots" qualifiers="const">
+			<return type="Array" />
+			<param index="0" name="session_id" type="String" />
+			<description>
+				Returns the workspace roots last reported by the client for [param session_id] after [code]roots/list[/code] or [code]notifications/roots/list_changed[/code].
+			</description>
+		</method>
 		<method name="is_server_started" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/modules/justamcp/justamcp_json_rpc_transport.cpp
+++ b/modules/justamcp/justamcp_json_rpc_transport.cpp
@@ -34,6 +34,7 @@
 #include "justamcp_json_rpc_transport.h"
 
 #include "justamcp_log_levels.h"
+#include "justamcp_mcp_spec.h"
 #include "justamcp_server.h"
 #include "justamcp_session_manager.h"
 #include "tools/justamcp_json_rpc_helpers.h"
@@ -46,6 +47,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "core/math/math_funcs.h"
+#include "core/os/mutex.h"
 #include "core/os/os.h"
 
 bool JustAMCPJsonRpcTransport::_is_http_transport(Ref<HTTPResponse> p_response) {
@@ -60,6 +62,7 @@ Dictionary JustAMCPJsonRpcTransport::sanitize_wire_rpc(const Dictionary &p_rpc) 
 	out.erase("handled");
 	out.erase("subscription_uri");
 	out.erase("subscription_action");
+	out.erase("_justamcp_batch_results");
 	return out;
 }
 
@@ -83,12 +86,13 @@ Dictionary JustAMCPJsonRpcTransport::handle_json_rpc(JustAMCPServer *p_server, c
 
 	Variant parsed = json->get_data();
 	if (parsed.get_type() == Variant::ARRAY) {
-		if (p_server->transport_negotiated_protocol == "2025-06-18" || p_server->transport_negotiated_protocol == "2025-11-25") {
+		const String protocol = p_server->transport_negotiated_protocol;
+		if (!justamcp_protocol_supports(protocol, JUSTAMCP_FEATURE_JSONRPC_BATCH)) {
 			Dictionary err;
 			err["jsonrpc"] = "2.0";
 			Dictionary error_dict;
 			error_dict["code"] = -32600;
-			error_dict["message"] = "JSON-RPC batch requests are not supported for protocol " + p_server->transport_negotiated_protocol;
+			error_dict["message"] = "JSON-RPC batch requests are not supported for protocol " + protocol;
 			err["error"] = error_dict;
 			if (p_response.is_valid() && !p_response->is_sent()) {
 				p_response->set_status(400);
@@ -96,6 +100,46 @@ Dictionary JustAMCPJsonRpcTransport::handle_json_rpc(JustAMCPServer *p_server, c
 			}
 			return err;
 		}
+		const Array batch = parsed;
+		if (batch.size() > 16) {
+			Dictionary err;
+			err["jsonrpc"] = "2.0";
+			Dictionary error_dict;
+			error_dict["code"] = -32600;
+			error_dict["message"] = "JSON-RPC batch exceeds the maximum of 16 requests.";
+			err["error"] = error_dict;
+			if (p_response.is_valid() && !p_response->is_sent()) {
+				p_response->set_status(400);
+				p_response->set_json(err);
+			}
+			return err;
+		}
+		Array responses;
+		for (int i = 0; i < batch.size(); i++) {
+			if (batch[i].get_type() != Variant::DICTIONARY) {
+				Dictionary invalid;
+				invalid["jsonrpc"] = "2.0";
+				Dictionary error_dict;
+				error_dict["code"] = -32600;
+				error_dict["message"] = "Invalid Request: JSON-RPC batch entry must be an object";
+				invalid["error"] = error_dict;
+				responses.push_back(invalid);
+				continue;
+			}
+			Dictionary entry_result = handle_json_rpc_parsed(p_server, batch[i], Ref<HTTPResponse>(), p_caller_session_id);
+			if (entry_result.is_empty()) {
+				continue;
+			}
+			responses.push_back(sanitize_wire_rpc(entry_result));
+		}
+		Dictionary wrapped;
+		wrapped["_justamcp_batch_results"] = responses;
+		if (p_response.is_valid() && !p_response->is_sent()) {
+			p_response->set_status(200);
+			p_response->set_content_type("application/json");
+			p_response->set_body(JSON::stringify(responses));
+		}
+		return wrapped;
 	}
 
 	if (parsed.get_type() != Variant::DICTIONARY) {
@@ -119,7 +163,18 @@ Dictionary JustAMCPJsonRpcTransport::handle_json_rpc_parsed(JustAMCPServer *p_se
 	if (!p_server) {
 		return Dictionary();
 	}
-	return _handle_json_rpc_payload(p_server, p_payload, p_response, p_caller_session_id);
+	Dictionary result = _handle_json_rpc_payload(p_server, p_payload, p_response, p_caller_session_id);
+	if (MCPSessionManager::is_modern_protocol_version(p_server->transport_negotiated_protocol)) {
+		const String method = p_payload.has("method") ? String(p_payload["method"]) : String();
+		if (result.has("error") && result["error"].get_type() == Variant::DICTIONARY && int(Dictionary(result["error"]).get("code", 0)) == -32601) {
+			if (p_response.is_valid() && !p_response->is_sent()) {
+				p_response->set_status(404);
+			}
+		} else {
+			MCPSessionManager::decorate_modern_rpc(result, method);
+		}
+	}
+	return result;
 }
 
 Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_server, const Dictionary &p_payload, Ref<HTTPResponse> p_response, const String &p_caller_session_id) {
@@ -129,6 +184,9 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 
 	Dictionary payload = p_payload;
 	if (!payload.has("method")) {
+		if (payload.has("id") && payload.has("result") && payload["result"].get_type() == Variant::DICTIONARY) {
+			p_server->handle_client_rpc_result(p_caller_session_id, payload);
+		}
 		return Dictionary();
 	}
 
@@ -175,6 +233,21 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 		}
 	}
 
+	const bool modern = MCPSessionManager::is_modern_protocol_version(p_server->transport_negotiated_protocol);
+	if (modern && payload.has("params") && payload["params"].get_type() == Variant::DICTIONARY) {
+		const Dictionary params = payload["params"];
+		if (params.has("_meta") && params["_meta"].get_type() == Variant::DICTIONARY) {
+			const Dictionary meta = params["_meta"];
+			if (meta.has("io.modelcontextprotocol/logLevel")) {
+				const String level = justamcp_log_level_canonical(String(meta["io.modelcontextprotocol/logLevel"]));
+				if (justamcp_log_level_is_valid(level)) {
+					MutexLock lock(p_server->minimum_log_level_mutex);
+					p_server->minimum_log_level = level;
+				}
+			}
+		}
+	}
+
 	const bool debug_logging = GLOBAL_GET("blazium/justamcp/enable_debug_logging");
 	if (debug_logging) {
 		p_server->_mcp_debug_log("Executing JSON-RPC Method: " + method + " (ID: " + request_id + ")");
@@ -195,7 +268,42 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 	};
 
 	if (method == "notifications/initialized") {
+		if (p_server->session_manager && !p_caller_session_id.is_empty()) {
+			p_server->session_manager->mark_session_initialized(p_caller_session_id);
+		}
 		return Dictionary();
+	}
+
+	if (method == "notifications/roots/list_changed") {
+		const Dictionary params = payload.has("params") && payload["params"].get_type() == Variant::DICTIONARY ? Dictionary(payload["params"]) : Dictionary();
+		if (p_server->session_manager) {
+			p_server->session_manager->handle_roots_list_changed(p_caller_session_id, params);
+		}
+		return Dictionary();
+	}
+
+	if (method == "server/discover") {
+#ifdef TOOLS_ENABLED
+		Dictionary routed = JustAMCPJsonRpcRouter::route_discover(p_server, req_id_var);
+		routed.erase("handled");
+		return routed;
+#else
+		return invalid_params("server/discover is unavailable.");
+#endif
+	}
+
+	if (modern && (method == "ping" || method == "logging/setLevel" || method == "resources/subscribe" || method == "resources/unsubscribe")) {
+		Dictionary err;
+		err["jsonrpc"] = "2.0";
+		err["id"] = req_id_var;
+		Dictionary error_dict;
+		error_dict["code"] = -32601;
+		error_dict["message"] = "Method not found: " + method;
+		err["error"] = error_dict;
+		if (p_response.is_valid() && !p_response->is_sent()) {
+			p_response->set_status(404);
+		}
+		return err;
 	}
 
 #ifdef TOOLS_ENABLED
@@ -341,7 +449,10 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 		Dictionary params = payload.has("params") ? Dictionary(payload["params"]) : Dictionary();
 		String req_id = params.has("requestId") ? String(Variant(params["requestId"])) : "";
 		Dictionary elicitation_result = params.has("result") ? Dictionary(params["result"]) : Dictionary();
-		p_server->call_deferred(SNAME("emit_signal"), "elicitation_completed", req_id, elicitation_result);
+		if (elicitation_result.is_empty() && params.has("action")) {
+			elicitation_result = params;
+		}
+		p_server->complete_elicitation(req_id, elicitation_result);
 		return Dictionary();
 	}
 

--- a/modules/justamcp/justamcp_mcp_spec.cpp
+++ b/modules/justamcp/justamcp_mcp_spec.cpp
@@ -1,0 +1,309 @@
+/**************************************************************************/
+/*  justamcp_mcp_spec.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "justamcp_mcp_spec.h"
+
+#include "justamcp_server.h"
+
+static const int JUSTAMCP_TOOL_NAME_MAX_LEN = 64;
+
+int justamcp_protocol_rank(const String &p_version) {
+	if (p_version == "2024-11-05") {
+		return 0;
+	}
+	if (p_version == "2025-03-26") {
+		return 1;
+	}
+	if (p_version == "2025-06-18") {
+		return 2;
+	}
+	if (p_version == "2025-11-25") {
+		return 3;
+	}
+	if (p_version == "2026-07-28") {
+		return 4;
+	}
+	return -1;
+}
+
+bool justamcp_protocol_at_least(const String &p_version, const String &p_minimum) {
+	const int rank = justamcp_protocol_rank(p_version);
+	const int min_rank = justamcp_protocol_rank(p_minimum);
+	return rank >= 0 && min_rank >= 0 && rank >= min_rank;
+}
+
+bool justamcp_protocol_supports(const String &p_version, JustAMCPProtocolFeature p_feature) {
+	switch (p_feature) {
+		case JUSTAMCP_FEATURE_COMPLETIONS:
+			return justamcp_protocol_at_least(p_version, "2025-03-26");
+		case JUSTAMCP_FEATURE_JSONRPC_BATCH:
+			return p_version == "2025-03-26";
+		case JUSTAMCP_FEATURE_ELICITATION_FORM:
+			return justamcp_protocol_at_least(p_version, "2025-06-18");
+		case JUSTAMCP_FEATURE_ELICITATION_URL:
+			return justamcp_protocol_at_least(p_version, "2025-11-25");
+		case JUSTAMCP_FEATURE_STRUCTURED_CONTENT:
+		case JUSTAMCP_FEATURE_RESOURCE_LINKS:
+		case JUSTAMCP_FEATURE_SERVER_TITLE:
+			return justamcp_protocol_at_least(p_version, "2025-06-18");
+		case JUSTAMCP_FEATURE_ICONS:
+			return justamcp_protocol_at_least(p_version, "2025-11-25");
+		case JUSTAMCP_FEATURE_TASKS_INITIALIZE:
+			return p_version == "2025-11-25";
+		default:
+			return false;
+	}
+}
+
+String justamcp_active_protocol_version() {
+	if (JustAMCPServer *server = JustAMCPServer::get_singleton()) {
+		const String negotiated = server->get_negotiated_protocol_version();
+		if (!negotiated.is_empty()) {
+			return negotiated;
+		}
+	}
+	return "2025-11-25";
+}
+
+Array justamcp_default_icons() {
+	Array icons;
+	Dictionary icon;
+	icon["src"] = "https://blazium.app/icon.png";
+	icon["mimeType"] = "image/png";
+	Array sizes;
+	sizes.push_back("64x64");
+	icon["sizes"] = sizes;
+	icons.push_back(icon);
+	return icons;
+}
+
+void justamcp_attach_icons(Dictionary &p_schema) {
+	if (!p_schema.has("icons")) {
+		p_schema["icons"] = justamcp_default_icons();
+	}
+}
+
+void justamcp_apply_protocol_to_schema(Dictionary &p_schema, const String &p_protocol) {
+	if (justamcp_protocol_supports(p_protocol, JUSTAMCP_FEATURE_ICONS)) {
+		if (!p_schema.has("icons")) {
+			p_schema["icons"] = justamcp_default_icons();
+		}
+	} else {
+		p_schema.erase("icons");
+	}
+}
+
+void justamcp_apply_protocol_to_list_result(Dictionary &p_result, const String &p_protocol) {
+	static const char *const list_keys[] = { "tools", "prompts", "resources", "resourceTemplates", nullptr };
+	for (int k = 0; list_keys[k]; k++) {
+		if (!p_result.has(list_keys[k]) || p_result[list_keys[k]].get_type() != Variant::ARRAY) {
+			continue;
+		}
+		Array items = p_result[list_keys[k]];
+		for (int i = 0; i < items.size(); i++) {
+			if (items[i].get_type() != Variant::DICTIONARY) {
+				continue;
+			}
+			Dictionary item = items[i];
+			justamcp_apply_protocol_to_schema(item, p_protocol);
+			items[i] = item;
+		}
+		p_result[list_keys[k]] = items;
+	}
+}
+
+Dictionary justamcp_resource_link_content(const String &p_uri, const String &p_name, const String &p_mime_type) {
+	Dictionary content;
+	content["type"] = "resource_link";
+	content["uri"] = p_uri;
+	if (!p_name.is_empty()) {
+		content["name"] = p_name;
+	}
+	if (!p_mime_type.is_empty()) {
+		content["mimeType"] = p_mime_type;
+	}
+	return content;
+}
+
+bool justamcp_is_valid_mcp_tool_name(const String &p_name) {
+	if (p_name.is_empty() || p_name.length() > JUSTAMCP_TOOL_NAME_MAX_LEN) {
+		return false;
+	}
+	const char32_t first = p_name[0];
+	if (first < 'a' || first > 'z') {
+		return false;
+	}
+	for (int i = 1; i < p_name.length(); i++) {
+		const char32_t c = p_name[i];
+		const bool ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+		if (!ok) {
+			return false;
+		}
+	}
+	return true;
+}
+
+String justamcp_invalid_mcp_tool_name_message(const String &p_name) {
+	return "Invalid tool name '" + p_name + "'. Tool names must match ^[a-z][a-z0-9_]*$ and be at most 64 characters.";
+}
+
+Dictionary justamcp_confirm_enum_schema() {
+	Dictionary schema;
+	schema["type"] = "object";
+	Dictionary properties;
+	Dictionary confirmed;
+	confirmed["type"] = "string";
+	confirmed["title"] = "Confirm";
+	confirmed["description"] = "Apply this change?";
+	Array values;
+	values.push_back("accept");
+	values.push_back("decline");
+	confirmed["enum"] = values;
+	Array names;
+	names.push_back("Yes, apply this change");
+	names.push_back("No, cancel");
+	confirmed["enumNames"] = names;
+	confirmed["default"] = "decline";
+	properties["confirmed"] = confirmed;
+	schema["properties"] = properties;
+	Array required;
+	required.push_back("confirmed");
+	schema["required"] = required;
+	return schema;
+}
+
+static bool _value_in_enum(const Array &p_enum, const Variant &p_value) {
+	for (int i = 0; i < p_enum.size(); i++) {
+		if (p_enum[i] == p_value) {
+			return true;
+		}
+	}
+	return false;
+}
+
+Dictionary justamcp_apply_schema_defaults(const Dictionary &p_schema, const Dictionary &p_content) {
+	Dictionary out = p_content.duplicate();
+	if (!p_schema.has("properties") || p_schema["properties"].get_type() != Variant::DICTIONARY) {
+		return out;
+	}
+	const Dictionary properties = p_schema["properties"];
+	const Array keys = properties.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		const String key = keys[i];
+		if (out.has(key)) {
+			continue;
+		}
+		const Dictionary prop = properties[key];
+		if (prop.has("default")) {
+			out[key] = prop["default"];
+		}
+	}
+	return out;
+}
+
+bool justamcp_validate_elicit_content(const Dictionary &p_schema, const Dictionary &p_content, String &r_error) {
+	const Dictionary content = justamcp_apply_schema_defaults(p_schema, p_content);
+	if (p_schema.has("required") && p_schema["required"].get_type() == Variant::ARRAY) {
+		const Array required = p_schema["required"];
+		for (int i = 0; i < required.size(); i++) {
+			const String key = required[i];
+			if (!content.has(key)) {
+				r_error = "Missing required elicitation field: " + key;
+				return false;
+			}
+		}
+	}
+	if (!p_schema.has("properties") || p_schema["properties"].get_type() != Variant::DICTIONARY) {
+		return true;
+	}
+	const Dictionary properties = p_schema["properties"];
+	const Array keys = properties.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		const String key = keys[i];
+		if (!content.has(key)) {
+			continue;
+		}
+		const Dictionary prop = properties[key];
+		const Variant value = content[key];
+		if (prop.has("enum") && prop["enum"].get_type() == Variant::ARRAY) {
+			const Array enums = prop["enum"];
+			if (value.get_type() == Variant::ARRAY) {
+				const Array selected = value;
+				for (int j = 0; j < selected.size(); j++) {
+					if (!_value_in_enum(enums, selected[j])) {
+						r_error = "Invalid enum value for " + key;
+						return false;
+					}
+				}
+			} else if (!_value_in_enum(enums, value)) {
+				r_error = "Invalid enum value for " + key;
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+bool justamcp_parse_elicit_result(const Dictionary &p_result, String &r_action, Dictionary &r_content, String &r_error) {
+	r_action = String(p_result.get("action", ""));
+	if (r_action != "accept" && r_action != "decline" && r_action != "cancel") {
+		r_error = "ElicitResult.action must be accept, decline, or cancel.";
+		return false;
+	}
+	if (p_result.has("content") && p_result["content"].get_type() == Variant::DICTIONARY) {
+		r_content = p_result["content"];
+	} else {
+		r_content = Dictionary();
+	}
+	return true;
+}
+
+bool justamcp_elicit_content_is_confirmed(const Dictionary &p_content) {
+	const Variant confirmed = p_content.get("confirmed", false);
+	if (confirmed.get_type() == Variant::BOOL) {
+		return bool(confirmed);
+	}
+	const String text = String(confirmed).strip_edges().to_lower();
+	return text == "accept" || text == "yes" || text == "true";
+}
+
+Dictionary justamcp_url_elicitation_error_rpc(const Variant &p_request_id, const String &p_elicitation_id, const String &p_url, const String &p_message) {
+	Dictionary rpc_result;
+	rpc_result["jsonrpc"] = "2.0";
+	rpc_result["id"] = p_request_id;
+	Dictionary error;
+	error["code"] = -32042;
+	error["message"] = p_message;
+	Dictionary error_data;
+	error_data["url"] = p_url;
+	error_data["elicitationId"] = p_elicitation_id;
+	error["data"] = error_data;
+	rpc_result["error"] = error;
+	return rpc_result;
+}

--- a/modules/justamcp/justamcp_mcp_spec.h
+++ b/modules/justamcp/justamcp_mcp_spec.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_router.h                                            */
+/*  justamcp_mcp_spec.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,32 +29,45 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
+#include "core/string/ustring.h"
+#include "core/variant/array.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-class JustAMCPResourceExecutor;
-class JustAMCPTaskManager;
-class JustAMCPPromptExecutor;
-class JustAMCPServer;
-
-class JustAMCPJsonRpcRouter {
-public:
-	static String extract_list_cursor(const Dictionary &p_payload);
-	static Dictionary finalize_list_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary finalize_action_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary make_invalid_params(const Variant &p_req_id, const String &p_message);
-	static Dictionary route(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPResourceExecutor *p_resources, JustAMCPTaskManager *p_tasks);
-	static Dictionary route_tools_list(const String &p_cursor, const Variant &p_req_id_var);
-	static Dictionary route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_prompts_get(const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_discover(JustAMCPServer *p_server, const Variant &p_req_id_var);
-	static Dictionary route_ping(const Variant &p_req_id_var);
-	static Dictionary route_logging_set_level(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_tasks_cancel(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_completion_complete(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
+enum JustAMCPProtocolFeature {
+	JUSTAMCP_FEATURE_COMPLETIONS,
+	JUSTAMCP_FEATURE_JSONRPC_BATCH,
+	JUSTAMCP_FEATURE_ELICITATION_FORM,
+	JUSTAMCP_FEATURE_ELICITATION_URL,
+	JUSTAMCP_FEATURE_STRUCTURED_CONTENT,
+	JUSTAMCP_FEATURE_RESOURCE_LINKS,
+	JUSTAMCP_FEATURE_SERVER_TITLE,
+	JUSTAMCP_FEATURE_ICONS,
+	JUSTAMCP_FEATURE_TASKS_INITIALIZE,
 };
 
-#endif
+int justamcp_protocol_rank(const String &p_version);
+bool justamcp_protocol_at_least(const String &p_version, const String &p_minimum);
+bool justamcp_protocol_supports(const String &p_version, JustAMCPProtocolFeature p_feature);
+String justamcp_active_protocol_version();
+
+// SEP-973: optional icons on tools, prompts, resources, and templates.
+Array justamcp_default_icons();
+void justamcp_attach_icons(Dictionary &p_schema);
+void justamcp_apply_protocol_to_schema(Dictionary &p_schema, const String &p_protocol);
+void justamcp_apply_protocol_to_list_result(Dictionary &p_result, const String &p_protocol);
+
+Dictionary justamcp_resource_link_content(const String &p_uri, const String &p_name = String(), const String &p_mime_type = String());
+
+// SEP-986: tool names are lowercase snake_case, max 64 characters.
+bool justamcp_is_valid_mcp_tool_name(const String &p_name);
+String justamcp_invalid_mcp_tool_name_message(const String &p_name);
+
+// SEP-1034 / SEP-1330: form elicitation schemas and ElicitResult validation.
+Dictionary justamcp_confirm_enum_schema();
+Dictionary justamcp_apply_schema_defaults(const Dictionary &p_schema, const Dictionary &p_content);
+bool justamcp_validate_elicit_content(const Dictionary &p_schema, const Dictionary &p_content, String &r_error);
+bool justamcp_parse_elicit_result(const Dictionary &p_result, String &r_action, Dictionary &r_content, String &r_error);
+bool justamcp_elicit_content_is_confirmed(const Dictionary &p_content);
+
+Dictionary justamcp_url_elicitation_error_rpc(const Variant &p_request_id, const String &p_elicitation_id, const String &p_url, const String &p_message);

--- a/modules/justamcp/justamcp_oauth_discovery.cpp
+++ b/modules/justamcp/justamcp_oauth_discovery.cpp
@@ -1,0 +1,210 @@
+/**************************************************************************/
+/*  justamcp_oauth_discovery.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "justamcp_oauth_discovery.h"
+
+#include "justamcp_server.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/json.h"
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif
+
+static bool _justamcp_oauth_use_project_settings() {
+	if (!ProjectSettings::get_singleton()) {
+		return true;
+	}
+	if (bool(GLOBAL_GET("blazium/justamcp/override_editor_settings"))) {
+		return true;
+	}
+#ifdef TOOLS_ENABLED
+	if (!EditorSettings::get_singleton()) {
+		return true;
+	}
+#endif
+	return false;
+}
+
+static Variant _justamcp_oauth_read_setting(const String &p_name, const Variant &p_default) {
+	if (_justamcp_oauth_use_project_settings()) {
+		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_name)) {
+			return GLOBAL_GET(p_name);
+		}
+		return p_default;
+	}
+#ifdef TOOLS_ENABLED
+	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting(p_name)) {
+		return EditorSettings::get_singleton()->get_setting(p_name);
+	}
+#endif
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_name)) {
+		return GLOBAL_GET(p_name);
+	}
+	return p_default;
+}
+
+bool JustAMCPOauthDiscovery::oauth_enabled() {
+	return bool(_justamcp_oauth_read_setting("blazium/justamcp/oauth_enabled", false));
+}
+
+String JustAMCPOauthDiscovery::setting_string(const String &p_name, const String &p_default) {
+	return String(_justamcp_oauth_read_setting(p_name, p_default));
+}
+
+int JustAMCPOauthDiscovery::listening_port() {
+	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->get_listening_port() > 0) {
+		return JustAMCPServer::get_singleton()->get_listening_port();
+	}
+	return int(_justamcp_oauth_read_setting("blazium/justamcp/server_port", 6506));
+}
+
+String JustAMCPOauthDiscovery::resource_url() {
+	const String configured = setting_string("blazium/justamcp/oauth_resource");
+	if (!configured.is_empty()) {
+		return configured;
+	}
+	return "http://127.0.0.1:" + itos(listening_port()) + "/mcp";
+}
+
+String JustAMCPOauthDiscovery::issuer_url() {
+	String resource = resource_url();
+	if (resource.ends_with("/mcp")) {
+		resource = resource.substr(0, resource.length() - 4);
+	}
+	while (resource.ends_with("/")) {
+		resource = resource.substr(0, resource.length() - 1);
+	}
+	return resource;
+}
+
+Array JustAMCPOauthDiscovery::authorization_servers() {
+	Array servers;
+	const String configured = setting_string("blazium/justamcp/oauth_authorization_servers");
+	if (!configured.is_empty()) {
+		const PackedStringArray parts = configured.split(",", false);
+		for (int i = 0; i < parts.size(); i++) {
+			const String url = String(parts[i]).strip_edges();
+			if (!url.is_empty()) {
+				servers.push_back(url);
+			}
+		}
+	}
+	if (servers.is_empty()) {
+		servers.push_back(issuer_url());
+	}
+	return servers;
+}
+
+Array JustAMCPOauthDiscovery::scopes_supported() {
+	Array scopes;
+	const String configured = setting_string("blazium/justamcp/oauth_scopes_supported", "mcp");
+	const PackedStringArray parts = configured.split(",", false);
+	for (int i = 0; i < parts.size(); i++) {
+		const String scope = String(parts[i]).strip_edges();
+		if (!scope.is_empty()) {
+			scopes.push_back(scope);
+		}
+	}
+	if (scopes.is_empty()) {
+		scopes.push_back("mcp");
+	}
+	return scopes;
+}
+
+Dictionary JustAMCPOauthDiscovery::protected_resource_metadata() {
+	Dictionary meta;
+	meta["resource"] = resource_url();
+	meta["authorization_servers"] = authorization_servers();
+	meta["scopes_supported"] = scopes_supported();
+	Array methods;
+	methods.push_back("header");
+	meta["bearer_methods_supported"] = methods;
+	return meta;
+}
+
+Dictionary JustAMCPOauthDiscovery::authorization_server_metadata() {
+	Dictionary meta;
+	const String issuer = issuer_url();
+	meta["issuer"] = issuer;
+	meta["authorization_endpoint"] = issuer + "/oauth/authorize";
+	meta["token_endpoint"] = issuer + "/oauth/token";
+	Array grants;
+	grants.push_back("client_credentials");
+	meta["grant_types_supported"] = grants;
+	Array auth_methods;
+	auth_methods.push_back("client_secret_basic");
+	auth_methods.push_back("client_secret_post");
+	meta["token_endpoint_auth_methods_supported"] = auth_methods;
+	meta["scopes_supported"] = scopes_supported();
+	Array response_types;
+	response_types.push_back("token");
+	meta["response_types_supported"] = response_types;
+	Array subject_types;
+	subject_types.push_back("public");
+	meta["subject_types_supported"] = subject_types;
+	Array algs;
+	algs.push_back("none");
+	meta["id_token_signing_alg_values_supported"] = algs;
+	return meta;
+}
+
+String JustAMCPOauthDiscovery::www_authenticate_header() {
+	const String metadata = issuer_url() + "/.well-known/oauth-protected-resource/mcp";
+	const Array scopes = scopes_supported();
+	const String scope = scopes.is_empty() ? String("mcp") : String(scopes[0]);
+	return "Bearer realm=\"mcp\", resource_metadata=\"" + metadata + "\", scope=\"" + scope + "\", error=\"insufficient_scope\"";
+}
+
+bool JustAMCPOauthDiscovery::client_id_is_cimd(const String &p_client_id) {
+	return p_client_id.begins_with("https://");
+}
+
+bool JustAMCPOauthDiscovery::validate_cimd_client_id(const String &p_client_id, String &r_error) {
+	if (!client_id_is_cimd(p_client_id)) {
+		return true;
+	}
+	const String pinned = setting_string("blazium/justamcp/oauth_cimd_json");
+	if (pinned.is_empty()) {
+		return true;
+	}
+	Ref<JSON> json;
+	json.instantiate();
+	if (json->parse(pinned) != OK || json->get_data().get_type() != Variant::DICTIONARY) {
+		r_error = "oauth_cimd_json is not a valid Client ID Metadata Document.";
+		return false;
+	}
+	const Dictionary doc = json->get_data();
+	const String doc_client_id = String(doc.get("client_id", ""));
+	if (doc_client_id != p_client_id) {
+		r_error = "CIMD client_id does not match the configured identifier.";
+		return false;
+	}
+	return true;
+}

--- a/modules/justamcp/justamcp_oauth_discovery.h
+++ b/modules/justamcp/justamcp_oauth_discovery.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_router.h                                            */
+/*  justamcp_oauth_discovery.h                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,32 +29,22 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
+#include "core/variant/array.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-class JustAMCPResourceExecutor;
-class JustAMCPTaskManager;
-class JustAMCPPromptExecutor;
-class JustAMCPServer;
-
-class JustAMCPJsonRpcRouter {
+class JustAMCPOauthDiscovery {
 public:
-	static String extract_list_cursor(const Dictionary &p_payload);
-	static Dictionary finalize_list_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary finalize_action_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary make_invalid_params(const Variant &p_req_id, const String &p_message);
-	static Dictionary route(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPResourceExecutor *p_resources, JustAMCPTaskManager *p_tasks);
-	static Dictionary route_tools_list(const String &p_cursor, const Variant &p_req_id_var);
-	static Dictionary route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_prompts_get(const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_discover(JustAMCPServer *p_server, const Variant &p_req_id_var);
-	static Dictionary route_ping(const Variant &p_req_id_var);
-	static Dictionary route_logging_set_level(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_tasks_cancel(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_completion_complete(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
+	static bool oauth_enabled();
+	static String setting_string(const String &p_name, const String &p_default = String());
+	static int listening_port();
+	static String resource_url();
+	static String issuer_url();
+	static Array authorization_servers();
+	static Array scopes_supported();
+	static Dictionary protected_resource_metadata();
+	static Dictionary authorization_server_metadata();
+	static String www_authenticate_header();
+	static bool client_id_is_cimd(const String &p_client_id);
+	static bool validate_cimd_client_id(const String &p_client_id, String &r_error);
 };
-
-#endif

--- a/modules/justamcp/justamcp_project_settings.cpp
+++ b/modules/justamcp/justamcp_project_settings.cpp
@@ -31,19 +31,30 @@
 
 #include "justamcp_project_settings.h"
 
-#include "core/config/project_settings.h"
-#include "editor/editor_settings.h"
 #include "tools/justamcp_prompt_executor.h"
 #include "tools/justamcp_resource_executor.h"
 #include "tools/justamcp_tool_executor.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_settings.h"
 
 void JustAMCPProjectSettings::register_project_settings() {
 	GLOBAL_DEF_BASIC("blazium/justamcp/override_editor_settings", false);
 	GLOBAL_DEF_BASIC("blazium/justamcp/server_enabled", false);
 	GLOBAL_DEF_BASIC("blazium/justamcp/server_port", 6506);
+	GLOBAL_DEF_BASIC("blazium/justamcp/protocol_version", "2026-07-28");
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "blazium/justamcp/protocol_version", PROPERTY_HINT_ENUM, "2026-07-28,2025-11-25,2025-06-18,2025-03-26,2024-11-05"));
+	}
+	GLOBAL_DEF_BASIC("blazium/justamcp/accepted_protocol_versions", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/oauth_enabled", false);
 	GLOBAL_DEF_BASIC("blazium/justamcp/client_id", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/client_secret", String());
+	GLOBAL_DEF_BASIC("blazium/justamcp/oauth_authorization_servers", String());
+	GLOBAL_DEF_BASIC("blazium/justamcp/oauth_scopes_supported", "mcp");
+	GLOBAL_DEF_BASIC("blazium/justamcp/oauth_resource", String());
+	GLOBAL_DEF_BASIC("blazium/justamcp/oauth_cimd_json", String());
+	GLOBAL_DEF_BASIC("blazium/justamcp/url_elicitation_demo_url", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/z_mcp_config", String());
 	GLOBAL_DEF_BASIC("blazium/justamcp/enable_debug_logging", false);
 	GLOBAL_DEF_BASIC("blazium/justamcp/forward_engine_logs", true);
@@ -87,6 +98,12 @@ void JustAMCPProjectSettings::register_editor_settings() {
 	EDITOR_DEF_BASIC("blazium/justamcp/server_port", 6506);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/server_port"));
 
+	EDITOR_DEF_BASIC("blazium/justamcp/protocol_version", "2026-07-28");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/protocol_version", PROPERTY_HINT_ENUM, "2026-07-28,2025-11-25,2025-06-18,2025-03-26,2024-11-05"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/accepted_protocol_versions", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/accepted_protocol_versions"));
+
 	EDITOR_DEF_BASIC("blazium/justamcp/oauth_enabled", false);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "blazium/justamcp/oauth_enabled"));
 
@@ -95,6 +112,21 @@ void JustAMCPProjectSettings::register_editor_settings() {
 
 	EDITOR_DEF_BASIC("blazium/justamcp/client_secret", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/client_secret"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/oauth_authorization_servers", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/oauth_authorization_servers"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/oauth_scopes_supported", "mcp");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/oauth_scopes_supported"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/oauth_resource", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/oauth_resource"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/oauth_cimd_json", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/oauth_cimd_json"));
+
+	EDITOR_DEF_BASIC("blazium/justamcp/url_elicitation_demo_url", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/url_elicitation_demo_url"));
 
 	EDITOR_DEF_BASIC("blazium/justamcp/z_mcp_config", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/justamcp/z_mcp_config"));

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -28,24 +28,16 @@
 /**************************************************************************/
 
 #include "justamcp_server.h"
-#include "core/config/project_settings.h"
-#include "core/io/json.h"
-#include "core/os/os.h"
-#include "core/os/time.h"
-#include "editor/editor_settings.h"
+
 #include "justamcp_cors_policy.h"
 #include "justamcp_json_rpc_transport.h"
-#include "justamcp_log_levels.h"
 #include "justamcp_notification_bus.h"
 #include "justamcp_pagination.h"
 #include "justamcp_project_settings.h"
 #include "justamcp_server_request_lookup.h"
 #include "justamcp_session_manager.h"
-#include "justamcp_tool_context.h"
 #include "justamcp_tool_dispatch.h"
 #include "justamcp_tool_queue_state.h"
-#include "modules/modules_enabled.gen.h"
-#include "servers/display_server.h"
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_json_rpc_router.h"
 #include "tools/justamcp_prompt_executor.h"
@@ -53,6 +45,15 @@
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_executor.h"
 #include "tools/justamcp_tool_schema_cache.h"
+
+#include "core/config/project_settings.h"
+#include "core/object/callable_method_pointer.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "editor/editor_settings.h"
+#include "servers/display_server.h"
+
+#include "modules/modules_enabled.gen.h"
 
 static bool _is_headless() {
 	if (DisplayServer::get_singleton() != nullptr) {
@@ -84,6 +85,7 @@ void JustAMCPServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_deferred_sse_replay", "connection_id", "last_event_id"), &JustAMCPServer::_deferred_sse_replay);
 	ClassDB::bind_method(D_METHOD("_emit_log_notification_deferred", "level", "logger", "data"), &JustAMCPServer::_emit_log_notification_deferred);
 	ClassDB::bind_method(D_METHOD("send_log_message", "level", "logger", "data"), &JustAMCPServer::send_log_message, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("get_session_roots", "session_id"), &JustAMCPServer::get_session_roots);
 	ClassDB::bind_method(D_METHOD("_on_request_cancelled", "request_id", "reason", "caller_session_id"), &JustAMCPServer::_on_request_cancelled, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("_enforce_in_flight_cancel_deadline", "request_id"), &JustAMCPServer::_enforce_in_flight_cancel_deadline);
 	ClassDB::bind_method(D_METHOD("_deferred_complete_tool_dict", "request_id", "result"), &JustAMCPServer::_deferred_complete_tool_dict);
@@ -201,6 +203,14 @@ void JustAMCPServer::test_handle_mcp_stateless_post(Ref<HTTPRequestContext> p_co
 
 void JustAMCPServer::test_handle_message_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
 	_handle_message_post(p_context, p_response);
+}
+
+void JustAMCPServer::test_handle_oauth_protected_resource(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
+	_handle_oauth_protected_resource(p_context, p_response);
+}
+
+void JustAMCPServer::test_handle_oauth_authorization_server(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
+	_handle_oauth_authorization_server(p_context, p_response);
 }
 #endif
 
@@ -477,6 +487,12 @@ void JustAMCPServer::_start_server() {
 		if (E->get() == "--mcp-client-secret" && E->next()) {
 			cmd_client_secret = E->next()->get();
 		}
+		if (E->get() == "--mcp-protocol-version" && E->next()) {
+			const String cmd_protocol = E->next()->get();
+			if (!MCPSessionManager::set_cli_protocol_version_override(cmd_protocol)) {
+				ERR_PRINT("JustAMCP: --mcp-protocol-version '" + cmd_protocol + "' is not supported. Keeping setting/default.");
+			}
+		}
 	}
 
 	if (!cmd_client_id.is_empty() && cmd_client_secret.is_empty()) {
@@ -553,6 +569,14 @@ void JustAMCPServer::_start_server() {
 		HTTPServer::get_singleton()->register_route("POST", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_post));
 		HTTPServer::get_singleton()->register_route("DELETE", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_delete));
 		HTTPServer::get_singleton()->register_route("OPTIONS", "/mcp", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+		HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-protected-resource", callable_mp(this, &JustAMCPServer::_handle_oauth_protected_resource));
+		HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-protected-resource/mcp", callable_mp(this, &JustAMCPServer::_handle_oauth_protected_resource));
+		HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-authorization-server", callable_mp(this, &JustAMCPServer::_handle_oauth_authorization_server));
+		HTTPServer::get_singleton()->register_route("GET", "/.well-known/openid-configuration", callable_mp(this, &JustAMCPServer::_handle_oauth_authorization_server));
+		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-protected-resource", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-protected-resource/mcp", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-authorization-server", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/openid-configuration", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
 
 		if (!HTTPServer::get_singleton()->is_connected("sse_connection_opened", callable_mp(this, &JustAMCPServer::_on_sse_connection_opened))) {
 			HTTPServer::get_singleton()->connect("sse_connection_opened", callable_mp(this, &JustAMCPServer::_on_sse_connection_opened));

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -35,6 +35,7 @@
 #include "core/os/mutex.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
+#include "core/variant/array.h"
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 #include "core/os/semaphore.h"
@@ -110,6 +111,17 @@ private:
 	HashSet<String> subscribed_resources;
 	mutable Mutex subscribed_resources_mutex;
 
+	struct PendingElicitation {
+		Variant tools_call_id;
+		String tool_name;
+		Dictionary args;
+		Dictionary schema;
+		String mode;
+		uint64_t created_usec = 0;
+	};
+	HashMap<String, PendingElicitation> pending_elicitations;
+	mutable Mutex pending_elicitation_mutex;
+
 	void _setup_settings();
 	void _start_server();
 	void _stop_server();
@@ -132,6 +144,9 @@ private:
 	void _handle_mcp_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 	void _handle_mcp_delete(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 	void _handle_mcp_stateless_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
+	void _handle_oauth_protected_resource(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
+	void _handle_oauth_authorization_server(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
+	void _apply_oauth_www_authenticate(Ref<HTTPResponse> p_response);
 	Dictionary _handle_json_rpc(const String &p_body, Ref<HTTPResponse> p_response);
 	Dictionary _transport_handle_json_rpc(const String &p_body, Ref<HTTPResponse> p_response);
 	void _send_sse_message(const String &p_json_string);
@@ -182,6 +197,12 @@ public:
 	void send_tool_result(const Variant &p_request_id, bool p_success, const Variant &p_result = Variant(), const String &p_error = "");
 	void send_elicitation_request(const String &p_request_id, const String &p_mode, const String &p_message, const Variant &p_url_or_schema);
 	void send_url_elicitation_error(const String &p_request_id, const String &p_elicitation_id, const String &p_url, const String &p_message);
+	void hold_tool_for_elicitation(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, const Dictionary &p_schema, const String &p_mode = "form");
+	void complete_elicitation(const String &p_request_id, const Dictionary &p_result);
+	void handle_client_rpc_result(const String &p_session_id, const Dictionary &p_payload);
+	Array get_session_roots(const String &p_session_id) const;
+	String get_negotiated_protocol_version() const { return transport_negotiated_protocol; }
+	bool has_pending_elicitation(const Variant &p_request_id) const;
 	void broadcast_prompts_list_changed();
 	void broadcast_tools_list_changed();
 	void broadcast_resources_list_changed();
@@ -234,6 +255,8 @@ public:
 	bool test_validate_mcp_oauth(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 	void test_handle_mcp_stateless_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 	void test_handle_message_post(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
+	void test_handle_oauth_protected_resource(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
+	void test_handle_oauth_authorization_server(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 #endif
 
 	bool is_server_started() const { return server_started; }

--- a/modules/justamcp/justamcp_server_http.cpp
+++ b/modules/justamcp/justamcp_server_http.cpp
@@ -30,6 +30,7 @@
 #include "justamcp_server.h"
 
 #include "justamcp_json_rpc_transport.h"
+#include "justamcp_oauth_discovery.h"
 #include "justamcp_session_manager.h"
 
 #include "core/config/project_settings.h"
@@ -127,7 +128,17 @@ bool JustAMCPServer::_validate_mcp_oauth(Ref<HTTPRequestContext> p_context, Ref<
 		if (required_client_id.is_empty() || required_client_secret.is_empty()) {
 			ERR_PRINT("JustAMCP: oauth_enabled requires both client_id and client_secret; rejecting request.");
 			p_response->set_status(401);
+			_apply_oauth_www_authenticate(p_response);
 			p_response->set_body("Unauthorized - OAuth credentials not configured");
+			return false;
+		}
+
+		String cimd_error;
+		if (!JustAMCPOauthDiscovery::validate_cimd_client_id(required_client_id, cimd_error)) {
+			ERR_PRINT("JustAMCP: " + cimd_error);
+			p_response->set_status(401);
+			_apply_oauth_www_authenticate(p_response);
+			p_response->set_body("Unauthorized - " + cimd_error);
 			return false;
 		}
 
@@ -173,6 +184,7 @@ bool JustAMCPServer::_validate_mcp_oauth(Ref<HTTPRequestContext> p_context, Ref<
 		if (!authorized) {
 			ERR_PRINT("JustAMCP: Unauthorized connection attempt.");
 			p_response->set_status(401);
+			_apply_oauth_www_authenticate(p_response);
 			p_response->set_body("Unauthorized - Invalid OAuth credentials");
 			return false;
 		}
@@ -330,9 +342,9 @@ void JustAMCPServer::_deferred_held_json_rpc(int p_client_id, const String &p_bo
 	Ref<HTTPResponse> response = p_response;
 	if (response.is_null()) {
 		response.instantiate();
-		if (!p_session_id.is_empty()) {
-			response->add_header("MCP-Session-Id", p_session_id);
-		}
+	}
+	if (!p_session_id.is_empty()) {
+		response->add_header("MCP-Session-Id", p_session_id);
 	}
 	Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc(this, p_body, response, p_session_id);
 	if (!p_session_id.is_empty() && session_manager) {
@@ -350,8 +362,17 @@ void JustAMCPServer::_deferred_held_json_rpc(int p_client_id, const String &p_bo
 			response->set_status(202);
 			response->set_body("");
 		} else {
-			response->set_status(200);
-			response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
+			if (result.has("_justamcp_batch_results") && result["_justamcp_batch_results"].get_type() == Variant::ARRAY) {
+				response->set_status(200);
+				response->set_content_type("application/json");
+				response->set_body(JSON::stringify(result["_justamcp_batch_results"]));
+			} else {
+				const int status = MCPSessionManager::is_modern_protocol_version(transport_negotiated_protocol)
+						? MCPSessionManager::modern_http_status_for_rpc(result)
+						: 200;
+				response->set_status(status);
+				response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
+			}
 		}
 	}
 	if (HTTPServer::get_singleton()) {
@@ -481,6 +502,34 @@ void JustAMCPServer::_send_sse_routed(const String &p_json_string, const String 
 
 void JustAMCPServer::_send_sse_message(const String &p_json_string) {
 	notification_bus.send_routed_json(p_json_string, String(), -1);
+}
+
+void JustAMCPServer::_apply_oauth_www_authenticate(Ref<HTTPResponse> p_response) {
+	if (p_response.is_valid()) {
+		p_response->add_header("WWW-Authenticate", JustAMCPOauthDiscovery::www_authenticate_header());
+	}
+}
+
+void JustAMCPServer::_handle_oauth_protected_resource(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
+	(void)p_context;
+	if (!JustAMCPOauthDiscovery::oauth_enabled()) {
+		p_response->set_status(404);
+		p_response->set_body("Not Found");
+		return;
+	}
+	p_response->set_status(200);
+	p_response->set_json(JustAMCPOauthDiscovery::protected_resource_metadata());
+}
+
+void JustAMCPServer::_handle_oauth_authorization_server(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
+	(void)p_context;
+	if (!JustAMCPOauthDiscovery::oauth_enabled()) {
+		p_response->set_status(404);
+		p_response->set_body("Not Found");
+		return;
+	}
+	p_response->set_status(200);
+	p_response->set_json(JustAMCPOauthDiscovery::authorization_server_metadata());
 }
 
 #endif

--- a/modules/justamcp/justamcp_server_results.cpp
+++ b/modules/justamcp/justamcp_server_results.cpp
@@ -29,12 +29,15 @@
 
 #include "justamcp_server.h"
 
+#include "justamcp_mcp_spec.h"
 #include "justamcp_server_request_lookup.h"
 #include "justamcp_session_manager.h"
 #include "justamcp_tool_context.h"
+#include "justamcp_tool_dispatch.h"
 #include "justamcp_tool_queue_state.h"
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_task_manager.h"
+#include "tools/justamcp_tool_executor.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
@@ -293,13 +296,21 @@ void JustAMCPServer::send_elicitation_request(const String &p_request_id, const 
 
 	Dictionary params;
 	params["requestId"] = p_request_id;
-	params["mode"] = p_mode;
 	params["message"] = p_message;
 
-	if (p_mode == "url") {
+	String mode = p_mode;
+	if (mode == "url" && !justamcp_protocol_supports(transport_negotiated_protocol, JUSTAMCP_FEATURE_ELICITATION_URL)) {
+		mode = "form";
+	}
+	params["mode"] = mode;
+	if (mode == "url") {
 		params["url"] = p_url_or_schema;
-	} else if (p_mode == "form") {
-		params["schema"] = p_url_or_schema;
+	} else if (mode == "form") {
+		if (p_url_or_schema.get_type() == Variant::DICTIONARY) {
+			params["schema"] = p_url_or_schema;
+		} else {
+			params["schema"] = justamcp_confirm_enum_schema();
+		}
 	}
 
 	rpc_request["params"] = params;
@@ -319,25 +330,136 @@ void JustAMCPServer::send_elicitation_request(const String &p_request_id, const 
 
 void JustAMCPServer::send_url_elicitation_error(const String &p_request_id, const String &p_elicitation_id, const String &p_url, const String &p_message) {
 #if defined(MODULE_HTTPSERVER_ENABLED)
-	Dictionary rpc_result;
-	rpc_result["jsonrpc"] = "2.0";
+	Variant request_id = p_request_id;
 	if (p_request_id.is_valid_int()) {
-		rpc_result["id"] = p_request_id.to_int();
-	} else {
-		rpc_result["id"] = p_request_id;
+		request_id = p_request_id.to_int();
+	}
+	justamcp_push_active_tool_request_id(request_id);
+	_complete_current_tool_request(justamcp_url_elicitation_error_rpc(request_id, p_elicitation_id, p_url, p_message));
+	justamcp_pop_active_tool_request_id();
+#else
+	(void)p_request_id;
+	(void)p_elicitation_id;
+	(void)p_url;
+	(void)p_message;
+#endif
+}
+
+void JustAMCPServer::hold_tool_for_elicitation(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, const Dictionary &p_schema, const String &p_mode) {
+	PendingElicitation pending;
+	pending.tools_call_id = p_request_id;
+	pending.tool_name = p_tool_name;
+	pending.args = p_args.duplicate();
+	pending.schema = p_schema.is_empty() ? justamcp_confirm_enum_schema() : p_schema;
+	pending.mode = p_mode.is_empty() ? String("form") : p_mode;
+	pending.created_usec = Time::get_singleton() ? Time::get_singleton()->get_ticks_usec() : 0;
+	const String key = JustAMCPJsonRpcHelpers::request_id_to_string(p_request_id);
+	{
+		MutexLock lock(pending_elicitation_mutex);
+		pending_elicitations[key] = pending;
+	}
+}
+
+void JustAMCPServer::complete_elicitation(const String &p_request_id, const Dictionary &p_result) {
+	String lookup = p_request_id;
+	if (lookup.begins_with("elicitation_")) {
+		lookup = lookup.substr(String("elicitation_").length());
+	}
+	Variant lookup_id = lookup;
+	if (lookup.is_valid_int()) {
+		lookup_id = lookup.to_int();
+	}
+	const String typed_key = JustAMCPJsonRpcHelpers::request_id_to_string(lookup_id);
+	PendingElicitation pending;
+	bool found = false;
+	{
+		MutexLock lock(pending_elicitation_mutex);
+		auto take = [&](const String &p_key) -> bool {
+			if (p_key.is_empty() || !pending_elicitations.has(p_key)) {
+				return false;
+			}
+			pending = pending_elicitations[p_key];
+			pending_elicitations.erase(p_key);
+			return true;
+		};
+		found = take(typed_key) || take(lookup) || take(p_request_id);
+		if (!found) {
+			for (const KeyValue<String, PendingElicitation> &E : pending_elicitations) {
+				if (JustAMCPJsonRpcHelpers::request_ids_equal(E.value.tools_call_id, lookup_id) || String(E.value.tools_call_id) == lookup) {
+					pending = E.value;
+					pending_elicitations.erase(E.key);
+					found = true;
+					break;
+				}
+			}
+		}
+	}
+	emit_signal("elicitation_completed", found ? JustAMCPJsonRpcHelpers::request_id_to_string(pending.tools_call_id) : p_request_id, p_result);
+	if (!found) {
+		return;
 	}
 
-	Dictionary error;
-	error["code"] = -32042;
-	error["message"] = p_message;
+	String action;
+	Dictionary content;
+	String parse_error;
+	if (!justamcp_parse_elicit_result(p_result, action, content, parse_error)) {
+		send_tool_result(pending.tools_call_id, false, parse_error, parse_error);
+		return;
+	}
+	if (action == "decline" || action == "cancel") {
+		const String msg = action == "cancel" ? "Elicitation cancelled." : "Elicitation declined.";
+		send_tool_result(pending.tools_call_id, false, msg, msg);
+		return;
+	}
 
-	Dictionary error_data;
-	error_data["url"] = p_url;
-	error_data["elicitationId"] = p_elicitation_id;
-	error["data"] = error_data;
+	String schema_error;
+	if (!justamcp_validate_elicit_content(pending.schema, content, schema_error)) {
+		send_tool_result(pending.tools_call_id, false, schema_error, schema_error);
+		return;
+	}
+	content = justamcp_apply_schema_defaults(pending.schema, content);
+	if (!justamcp_elicit_content_is_confirmed(content)) {
+		send_tool_result(pending.tools_call_id, false, "Elicitation was not confirmed.", "Elicitation was not confirmed.");
+		return;
+	}
 
-	rpc_result["error"] = error;
-
-	_complete_current_tool_request(rpc_result);
+	Dictionary retry_args = pending.args.duplicate();
+	retry_args["confirmed"] = true;
+#ifdef TOOLS_ENABLED
+	JustAMCPToolDispatch::execute_and_send(this, JustAMCPToolExecutor::get_active_instance(), pending.tools_call_id, pending.tool_name, retry_args);
+#else
+	send_tool_result(pending.tools_call_id, false, "Elicitation resume is unavailable.", "Elicitation resume is unavailable.");
 #endif
+}
+
+void JustAMCPServer::handle_client_rpc_result(const String &p_session_id, const Dictionary &p_payload) {
+	const Variant id = p_payload.get("id", Variant());
+	const String id_text = String(id);
+	const Dictionary result = p_payload.has("result") && p_payload["result"].get_type() == Variant::DICTIONARY ? Dictionary(p_payload["result"]) : Dictionary();
+	if (id_text.begins_with("roots_list_")) {
+		if (session_manager) {
+			session_manager->apply_roots_list_result(p_session_id, id, result);
+		}
+		return;
+	}
+	if (id_text.begins_with("elicitation_")) {
+		complete_elicitation(id_text, result);
+	}
+}
+
+Array JustAMCPServer::get_session_roots(const String &p_session_id) const {
+#if defined(MODULE_HTTPSERVER_ENABLED)
+	if (session_manager) {
+		return session_manager->get_session_roots(p_session_id);
+	}
+#else
+	(void)p_session_id;
+#endif
+	return Array();
+}
+
+bool JustAMCPServer::has_pending_elicitation(const Variant &p_request_id) const {
+	const String key = JustAMCPJsonRpcHelpers::request_id_to_string(p_request_id);
+	MutexLock lock(pending_elicitation_mutex);
+	return pending_elicitations.has(key);
 }

--- a/modules/justamcp/justamcp_server_tool_lifecycle.cpp
+++ b/modules/justamcp/justamcp_server_tool_lifecycle.cpp
@@ -254,6 +254,24 @@ void JustAMCPServer::_deferred_complete_tool_dict(const Variant &p_request_id, c
 		send_tool_result(p_request_id, false, cancelled, "cancelled");
 		return;
 	}
+	if (result.get("elicitation_required", false)) {
+		Dictionary schema = result.get("elicitation_schema", Dictionary());
+		const String mode = result.get("elicitation_mode", "form");
+		String tool_name;
+		Dictionary args;
+		{
+			MutexLock lock(mcp_tool_queue.mutex);
+			MCPToolQueueEntry *entry = JustAMCPServerRequestLookup::find_entry_by_request_id(
+					mcp_tool_queue.pending, mcp_tool_queue.current_write, mcp_tool_queue.current_readonly_inflight, p_request_id);
+			if (entry) {
+				tool_name = entry->tool_name;
+				args = entry->args;
+			}
+		}
+		hold_tool_for_elicitation(p_request_id, tool_name, args, schema, mode);
+		return;
+	}
+
 	const bool success = result.get("ok", false);
 	if (success) {
 		Dictionary payload = result.duplicate();

--- a/modules/justamcp/justamcp_session_manager.cpp
+++ b/modules/justamcp/justamcp_session_manager.cpp
@@ -28,19 +28,19 @@
 /**************************************************************************/
 
 #include "justamcp_session_manager.h"
-#include "modules/modules_enabled.gen.h"
 
-#include "justamcp_pagination.h"
 #include "justamcp_server.h"
-#include "tools/justamcp_json_rpc_helpers.h"
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/json.h"
-#include "core/os/time.h"
+#include "core/os/os.h"
+#include "core/templates/list.h"
 
-#if defined(MODULE_HTTPSERVER_ENABLED)
-#include "modules/httpserver/http_server.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
 #endif
 
 MCPSessionManager::MCPSessionManager(JustAMCPServer *p_owner) {
@@ -55,22 +55,302 @@ void MCPSessionManager::clear_all() {
 	post_sse_upgrade_sessions.clear();
 	all_sse_connection_ids.clear();
 	request_router.clear_all();
+#if defined(MODULE_HTTPSERVER_ENABLED)
+	pending_modern_listen = 0;
+#endif
+}
+
+static String _cli_protocol_version_override;
+static bool _cli_protocol_version_parsed = false;
+
+static const char *const _supported_protocol_versions[] = {
+	"2026-07-28",
+	"2025-11-25",
+	"2025-06-18",
+	"2025-03-26",
+	"2024-11-05",
+	nullptr
+};
+
+bool MCPSessionManager::is_supported_protocol_version(const String &p_version) {
+	for (int i = 0; _supported_protocol_versions[i]; i++) {
+		if (p_version == _supported_protocol_versions[i]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool MCPSessionManager::is_modern_protocol_version(const String &p_version) {
+	return p_version == "2026-07-28";
+}
+
+bool MCPSessionManager::is_legacy_protocol_version(const String &p_version) {
+	return is_supported_protocol_version(p_version) && !is_modern_protocol_version(p_version);
+}
+
+static String _configured_accepted_protocol_versions() {
+#ifdef TOOLS_ENABLED
+	bool use_project = true;
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
+		use_project = GLOBAL_GET("blazium/justamcp/override_editor_settings");
+	}
+	if (!use_project && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/accepted_protocol_versions")) {
+		return String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/accepted_protocol_versions"));
+	}
+#endif
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/accepted_protocol_versions")) {
+		return String(GLOBAL_GET("blazium/justamcp/accepted_protocol_versions"));
+	}
+	return String();
+}
+
+Vector<String> MCPSessionManager::supported_protocol_versions() {
+	Vector<String> versions;
+	for (int i = 0; _supported_protocol_versions[i]; i++) {
+		versions.push_back(_supported_protocol_versions[i]);
+	}
+	return versions;
+}
+
+Vector<String> MCPSessionManager::accepted_protocol_versions() {
+	const String configured = _configured_accepted_protocol_versions().strip_edges();
+	if (configured.is_empty()) {
+		return supported_protocol_versions();
+	}
+	Vector<String> accepted;
+	const Vector<String> parts = configured.split(",", false);
+	for (int i = 0; i < parts.size(); i++) {
+		const String version = parts[i].strip_edges();
+		if (is_supported_protocol_version(version) && accepted.find(version) < 0) {
+			accepted.push_back(version);
+		}
+	}
+	if (accepted.is_empty()) {
+		return supported_protocol_versions();
+	}
+	return accepted;
+}
+
+bool MCPSessionManager::is_accepted_protocol_version(const String &p_version) {
+	if (!is_supported_protocol_version(p_version)) {
+		return false;
+	}
+	const Vector<String> accepted = accepted_protocol_versions();
+	return accepted.find(p_version) >= 0;
+}
+
+String MCPSessionManager::first_protocol_version_token(const String &p_header) {
+	const Vector<String> parts = p_header.split(",", false);
+	for (int i = 0; i < parts.size(); i++) {
+		const String version = parts[i].strip_edges();
+		if (!version.is_empty()) {
+			return version;
+		}
+	}
+	return String();
+}
+
+Dictionary MCPSessionManager::header_mismatch_error(const Variant &p_id, const String &p_message) {
+	Dictionary err;
+	err["jsonrpc"] = "2.0";
+	if (p_id.get_type() != Variant::NIL) {
+		err["id"] = p_id;
+	}
+	Dictionary error_dict;
+	error_dict["code"] = -32020;
+	error_dict["message"] = p_message;
+	err["error"] = error_dict;
+	return err;
+}
+
+Dictionary MCPSessionManager::mcp_server_info() {
+	Dictionary info;
+	info["name"] = "blazium-mcp-server";
+	info["title"] = "Blazium MCP";
+	info["version"] = "1.0.0";
+	info["websiteUrl"] = "https://blazium.app";
+	return info;
+}
+
+String MCPSessionManager::decode_mcp_header_value(const String &p_value) {
+	const String value = p_value.strip_edges();
+	if (value.begins_with("=?base64?") && value.ends_with("?=") && value.length() >= 11) {
+		const String b64 = value.substr(9, value.length() - 11);
+		const CharString cstr = b64.ascii();
+		Vector<uint8_t> buf;
+		buf.resize(b64.length() / 4 * 3 + 1);
+		size_t decoded_len = 0;
+		uint8_t *w = buf.ptrw();
+		if (CryptoCore::b64_decode(&w[0], buf.size(), &decoded_len, (unsigned char *)cstr.get_data(), b64.length()) != OK) {
+			return value;
+		}
+		buf.resize(decoded_len);
+		return String::utf8((const char *)buf.ptr(), buf.size());
+	}
+	return value;
+}
+
+int MCPSessionManager::modern_http_status_for_rpc(const Dictionary &p_rpc) {
+	if (!p_rpc.has("error") || p_rpc["error"].get_type() != Variant::DICTIONARY) {
+		return 200;
+	}
+	const int code = int(Dictionary(p_rpc["error"]).get("code", 0));
+	if (code == -32601) {
+		return 404;
+	}
+	if (code == -32020 || code == -32022 || code == -32700 || code == -32600 || code == -32602) {
+		return 400;
+	}
+	return 200;
+}
+
+String MCPSessionManager::protocol_version_from_payload(const Dictionary &p_payload) {
+	if (!p_payload.has("params") || p_payload["params"].get_type() != Variant::DICTIONARY) {
+		return String();
+	}
+	const Dictionary params = p_payload["params"];
+	if (!params.has("_meta") || params["_meta"].get_type() != Variant::DICTIONARY) {
+		return String();
+	}
+	const Dictionary meta = params["_meta"];
+	if (meta.has("io.modelcontextprotocol/protocolVersion")) {
+		return String(meta["io.modelcontextprotocol/protocolVersion"]);
+	}
+	return String();
+}
+
+void MCPSessionManager::decorate_modern_rpc(Dictionary &p_rpc, const String &p_method) {
+	if (p_rpc.is_empty() || p_rpc.has("error") || !p_rpc.has("result") || p_rpc["result"].get_type() != Variant::DICTIONARY) {
+		return;
+	}
+	Dictionary result = p_rpc["result"];
+	if (!result.has("resultType")) {
+		result["resultType"] = "complete";
+	}
+	Dictionary meta = result.has("_meta") && result["_meta"].get_type() == Variant::DICTIONARY ? Dictionary(result["_meta"]) : Dictionary();
+	meta["io.modelcontextprotocol/serverInfo"] = mcp_server_info();
+	result["_meta"] = meta;
+	if (p_method == "server/discover" || p_method == "tools/list" || p_method == "prompts/list" || p_method == "resources/list" || p_method == "resources/read" || p_method == "resources/templates/list") {
+		if (!result.has("ttlMs")) {
+			result["ttlMs"] = 3600000;
+		}
+		if (!result.has("cacheScope")) {
+			result["cacheScope"] = "public";
+		}
+	}
+	p_rpc["result"] = result;
+}
+
+Dictionary MCPSessionManager::unsupported_protocol_version_error(const String &p_requested) {
+	Dictionary err;
+	err["jsonrpc"] = "2.0";
+	Dictionary error_dict;
+	error_dict["code"] = -32022;
+	error_dict["message"] = "Unsupported protocol version";
+	Dictionary data;
+	Array supported;
+	const Vector<String> accepted = accepted_protocol_versions();
+	for (int i = 0; i < accepted.size(); i++) {
+		supported.push_back(accepted[i]);
+	}
+	data["supported"] = supported;
+	data["requested"] = p_requested;
+	error_dict["data"] = data;
+	err["error"] = error_dict;
+	return err;
+}
+
+static void _ensure_cli_protocol_version_parsed() {
+	if (_cli_protocol_version_parsed) {
+		return;
+	}
+	_cli_protocol_version_parsed = true;
+	if (!OS::get_singleton()) {
+		return;
+	}
+	const List<String> &args = OS::get_singleton()->get_cmdline_args();
+	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
+		if (E->get() == "--mcp-protocol-version" && E->next()) {
+			const String version = E->next()->get();
+			if (MCPSessionManager::is_supported_protocol_version(version)) {
+				_cli_protocol_version_override = version;
+			} else {
+				ERR_PRINT("JustAMCP: --mcp-protocol-version '" + version + "' is not supported. Keeping setting/default.");
+			}
+			break;
+		}
+	}
+}
+
+bool MCPSessionManager::set_cli_protocol_version_override(const String &p_version) {
+	_cli_protocol_version_parsed = true;
+	if (!is_supported_protocol_version(p_version)) {
+		return false;
+	}
+	_cli_protocol_version_override = p_version;
+	return true;
+}
+
+void MCPSessionManager::clear_cli_protocol_version_override() {
+	_cli_protocol_version_override = String();
+	_cli_protocol_version_parsed = true;
+}
+
+static String _configured_protocol_version() {
+#ifdef TOOLS_ENABLED
+	bool use_project = true;
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
+		use_project = GLOBAL_GET("blazium/justamcp/override_editor_settings");
+	}
+	if (!use_project && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/protocol_version")) {
+		return String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/protocol_version"));
+	}
+#endif
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/protocol_version")) {
+		return String(GLOBAL_GET("blazium/justamcp/protocol_version"));
+	}
+	return String();
+}
+
+String MCPSessionManager::latest_protocol_version() {
+	_ensure_cli_protocol_version_parsed();
+	if (!_cli_protocol_version_override.is_empty()) {
+		return _cli_protocol_version_override;
+	}
+	const String configured = _configured_protocol_version();
+	if (configured.is_empty()) {
+		return String(hardcoded_latest_protocol_version());
+	}
+	if (is_supported_protocol_version(configured)) {
+		return configured;
+	}
+	ERR_PRINT("JustAMCP: invalid protocol_version '" + configured + "', falling back to " + String(hardcoded_latest_protocol_version()) + ".");
+	return String(hardcoded_latest_protocol_version());
+}
+
+String MCPSessionManager::latest_legacy_protocol_version() {
+	const Vector<String> accepted = accepted_protocol_versions();
+	for (int i = 0; i < accepted.size(); i++) {
+		if (is_legacy_protocol_version(accepted[i])) {
+			return accepted[i];
+		}
+	}
+	return String(hardcoded_latest_legacy_protocol_version());
 }
 
 String MCPSessionManager::negotiate_protocol_version(const String &p_client_version) {
-	static const char *preferred[] = {
-		"2025-11-25",
-		"2025-06-18",
-		"2025-03-26",
-		"2024-11-05",
-		nullptr
-	};
-	for (int i = 0; preferred[i]; i++) {
-		if (p_client_version == preferred[i]) {
-			return String(preferred[i]);
-		}
+	if (is_accepted_protocol_version(p_client_version)) {
+		return p_client_version;
 	}
 	return latest_protocol_version();
+}
+
+String MCPSessionManager::negotiate_legacy_initialize(const String &p_client_version) {
+	if (is_legacy_protocol_version(p_client_version) && is_accepted_protocol_version(p_client_version)) {
+		return p_client_version;
+	}
+	return latest_legacy_protocol_version();
 }
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
@@ -115,6 +395,9 @@ bool MCPSessionManager::is_allowed_origin_string(const String &p_origin) {
 	}
 
 	String origin = p_origin.strip_edges();
+	if (origin == "vscode-file://vscode-app" || origin == "https://cursor.sh" || origin == "https://www.cursor.com") {
+		return true;
+	}
 	String scheme;
 	if (origin.begins_with("https://")) {
 		scheme = "https";
@@ -181,24 +464,31 @@ bool MCPSessionManager::validate_origin(const Ref<HTTPRequestContext> &p_context
 }
 
 bool MCPSessionManager::validate_protocol_header(const Ref<HTTPRequestContext> &p_context, String &r_error) {
-	const String header = get_header(p_context, "MCP-Protocol-Version");
+	const String header = get_header(p_context, "MCP-Protocol-Version").strip_edges();
 	if (header.is_empty()) {
 		return true;
 	}
-	static const char *supported[] = {
-		"2025-11-25",
-		"2025-06-18",
-		"2025-03-26",
-		"2024-11-05",
-		nullptr
-	};
-	for (int i = 0; supported[i]; i++) {
-		if (header == supported[i]) {
-			return true;
+	// RFC 9110 combines duplicate request headers with commas. Cursor also
+	// concatenates mcp.json headers with the protocol version it already sends,
+	// producing values such as "2025-11-25, 2025-11-25".
+	const Vector<String> parts = header.split(",", false);
+	bool saw_version = false;
+	for (int i = 0; i < parts.size(); i++) {
+		const String version = parts[i].strip_edges();
+		if (version.is_empty()) {
+			continue;
 		}
+		if (!is_accepted_protocol_version(version)) {
+			r_error = "Unsupported MCP-Protocol-Version: " + header;
+			return false;
+		}
+		saw_version = true;
 	}
-	r_error = "Unsupported MCP-Protocol-Version: " + header;
-	return false;
+	if (!saw_version) {
+		r_error = "Unsupported MCP-Protocol-Version: " + header;
+		return false;
+	}
+	return true;
 }
 
 bool MCPSessionManager::accepts_json_and_sse_header(const String &p_accept) {
@@ -227,7 +517,7 @@ void MCPSessionManager::apply_cors_headers(Ref<HTTPResponse> p_response, const R
 		p_response->add_header("Access-Control-Allow-Origin", origin);
 	}
 	p_response->add_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-	p_response->add_header("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Session-Id, MCP-Protocol-Version, Last-Event-ID, Accept, X-Client-Id, X-Client-Secret");
+	p_response->add_header("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Session-Id, MCP-Protocol-Version, Last-Event-ID, Accept, X-Client-Id, X-Client-Secret, Mcp-Method, Mcp-Name, Mcp-Param-*");
 }
 
 void MCPSessionManager::handle_cors_preflight(const Ref<HTTPRequestContext> &p_context, Ref<HTTPResponse> p_response) const {
@@ -243,6 +533,27 @@ void MCPSessionManager::handle_cors_preflight(const Ref<HTTPRequestContext> &p_c
 
 void MCPSessionManager::on_sse_connection_opened(int p_connection_id, const String &p_path, const Dictionary &p_headers) {
 	if (p_path != "/mcp") {
+		return;
+	}
+
+	bool claimed_modern_listen = false;
+	{
+		MutexLock lock(mutex);
+		if (pending_modern_listen > 0) {
+			pending_modern_listen--;
+			all_sse_connection_ids.insert(p_connection_id);
+			claimed_modern_listen = true;
+		}
+	}
+	if (claimed_modern_listen) {
+		if (HTTPServer::get_singleton()) {
+			Dictionary ack;
+			ack["jsonrpc"] = "2.0";
+			ack["method"] = "notifications/subscriptions/acknowledged";
+			ack["params"] = Dictionary();
+			HTTPServer::get_singleton()->send_sse_event(p_connection_id, "message", JSON::stringify(ack));
+			HTTPServer::get_singleton()->send_sse_comment(p_connection_id, "keepalive");
+		}
 		return;
 	}
 

--- a/modules/justamcp/justamcp_session_manager.h
+++ b/modules/justamcp/justamcp_session_manager.h
@@ -29,15 +29,17 @@
 
 #pragma once
 
-#include "modules/modules_enabled.gen.h"
-
 #include "justamcp_event_store.h"
 #include "justamcp_request_router.h"
 
 #include "core/os/mutex.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
+#include "core/templates/vector.h"
+#include "core/variant/array.h"
 #include "core/variant/dictionary.h"
+
+#include "modules/modules_enabled.gen.h"
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 #include "modules/httpserver/http_request_context.h"
@@ -65,6 +67,8 @@ struct MCPSession {
 	HashMap<int, String> connection_to_stream;
 	int active_tool_connection_id = -1;
 	int last_registered_connection_id = -1;
+	Array roots;
+	String pending_roots_list_id;
 };
 
 class MCPSessionManager {
@@ -95,8 +99,28 @@ public:
 
 	void clear_all();
 
-	static String latest_protocol_version() { return String("2025-11-25"); }
+	static const char *hardcoded_latest_protocol_version() { return "2026-07-28"; }
+	static const char *hardcoded_latest_legacy_protocol_version() { return "2025-11-25"; }
+	static bool is_supported_protocol_version(const String &p_version);
+	static bool is_legacy_protocol_version(const String &p_version);
+	static bool is_modern_protocol_version(const String &p_version);
+	static bool is_accepted_protocol_version(const String &p_version);
+	static Vector<String> supported_protocol_versions();
+	static Vector<String> accepted_protocol_versions();
+	static String latest_protocol_version();
+	static String latest_legacy_protocol_version();
 	static String negotiate_protocol_version(const String &p_client_version);
+	static String negotiate_legacy_initialize(const String &p_client_version);
+	static bool set_cli_protocol_version_override(const String &p_version);
+	static void clear_cli_protocol_version_override();
+	static Dictionary unsupported_protocol_version_error(const String &p_requested);
+	static Dictionary header_mismatch_error(const Variant &p_id, const String &p_message);
+	static Dictionary mcp_server_info();
+	static String first_protocol_version_token(const String &p_header);
+	static String decode_mcp_header_value(const String &p_value);
+	static String protocol_version_from_payload(const Dictionary &p_payload);
+	static void decorate_modern_rpc(Dictionary &p_rpc, const String &p_method);
+	static int modern_http_status_for_rpc(const Dictionary &p_rpc);
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 	static String get_header(const Ref<HTTPRequestContext> &p_context, const String &p_name);
@@ -132,6 +156,11 @@ public:
 
 	bool session_exists(const String &p_session_id) const;
 	void mark_session_initialized(const String &p_session_id);
+	void request_session_roots(const String &p_session_id);
+	void set_session_roots(const String &p_session_id, const Array &p_roots);
+	Array get_session_roots(const String &p_session_id) const;
+	void apply_roots_list_result(const String &p_session_id, const Variant &p_id, const Dictionary &p_result);
+	void handle_roots_list_changed(const String &p_session_id, const Dictionary &p_params);
 	void deferred_replay_stream_events(int p_connection_id, const String &p_last_event_id);
 	Vector<int> collect_session_connections(const String &p_session_id) const;
 	Vector<int> collect_all_broadcast_connection_ids() const;
@@ -178,6 +207,9 @@ private:
 	void _process_post_sse_opened(int p_connection_id, const String &p_session_id);
 	int _resolve_active_tool_connection_for_session(const MCPSession &p_session) const;
 	void _process_get_sse_opened(int p_connection_id, const String &p_session_id, const String &p_last_event_id);
+	bool _handle_modern_post(const Ref<HTTPRequestContext> &p_context, Ref<HTTPResponse> p_response, const Dictionary &p_payload, const String &p_body, const String &p_requested_version);
+	bool _validate_modern_headers(const Ref<HTTPRequestContext> &p_context, const Dictionary &p_payload, String &r_error);
+	int pending_modern_listen = 0;
 
 #ifdef TESTS_ENABLED
 	mutable int test_send_json_on_connection_calls = 0;

--- a/modules/justamcp/justamcp_session_manager_core.cpp
+++ b/modules/justamcp/justamcp_session_manager_core.cpp
@@ -303,11 +303,89 @@ void MCPSessionManager::mark_session_initialized(const String &p_session_id) {
 	if (p_session_id.is_empty()) {
 		return;
 	}
+	bool first_init = false;
+	{
+		MutexLock lock(mutex);
+		MCPSession *session = _get_session(p_session_id);
+		if (session) {
+			first_init = !session->initialized;
+			session->initialized = true;
+		}
+	}
+	if (first_init) {
+		request_session_roots(p_session_id);
+	}
+}
+
+void MCPSessionManager::request_session_roots(const String &p_session_id) {
+	if (p_session_id.is_empty()) {
+		return;
+	}
+	const String req_id = "roots_list_" + p_session_id;
+	{
+		MutexLock lock(mutex);
+		MCPSession *session = _get_session(p_session_id);
+		if (!session) {
+			return;
+		}
+		session->pending_roots_list_id = req_id;
+	}
+	Dictionary rpc;
+	rpc["jsonrpc"] = "2.0";
+	rpc["id"] = req_id;
+	rpc["method"] = "roots/list";
+	rpc["params"] = Dictionary();
+	send_json_to_session(p_session_id, JSON::stringify(rpc));
+}
+
+void MCPSessionManager::set_session_roots(const String &p_session_id, const Array &p_roots) {
 	MutexLock lock(mutex);
 	MCPSession *session = _get_session(p_session_id);
 	if (session) {
-		session->initialized = true;
+		session->roots = p_roots;
 	}
+}
+
+Array MCPSessionManager::get_session_roots(const String &p_session_id) const {
+	MutexLock lock(mutex);
+	const MCPSession *session = _get_session(p_session_id);
+	if (!session) {
+		return Array();
+	}
+	return session->roots;
+}
+
+void MCPSessionManager::apply_roots_list_result(const String &p_session_id, const Variant &p_id, const Dictionary &p_result) {
+	const String id_text = String(p_id);
+	MutexLock lock(mutex);
+	MCPSession *session = nullptr;
+	if (!p_session_id.is_empty()) {
+		session = _get_session(p_session_id);
+	}
+	if (!session) {
+		for (KeyValue<String, MCPSession> &E : sessions) {
+			if (E.value.pending_roots_list_id == id_text) {
+				session = &E.value;
+				break;
+			}
+		}
+	}
+	if (!session) {
+		return;
+	}
+	if (p_result.has("roots") && p_result["roots"].get_type() == Variant::ARRAY) {
+		session->roots = p_result["roots"];
+	}
+	if (session->pending_roots_list_id == id_text) {
+		session->pending_roots_list_id = String();
+	}
+}
+
+void MCPSessionManager::handle_roots_list_changed(const String &p_session_id, const Dictionary &p_params) {
+	if (p_params.has("roots") && p_params["roots"].get_type() == Variant::ARRAY) {
+		set_session_roots(p_session_id, p_params["roots"]);
+	}
+	request_session_roots(p_session_id);
 }
 
 void MCPSessionManager::deferred_replay_stream_events(int p_connection_id, const String &p_last_event_id) {

--- a/modules/justamcp/justamcp_session_manager_http_delete.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_delete.cpp
@@ -56,6 +56,14 @@ bool MCPSessionManager::handle_mcp_delete(const Ref<HTTPRequestContext> &p_conte
 		return true;
 	}
 
+	const String requested = first_protocol_version_token(get_header(p_context, "MCP-Protocol-Version"));
+	if (is_modern_protocol_version(requested)) {
+		apply_cors_headers(p_response, p_context);
+		p_response->set_status(405);
+		p_response->set_body("DELETE is not supported for protocol " + requested);
+		return true;
+	}
+
 	const String session_id = get_header(p_context, "MCP-Session-Id");
 	if (session_id.is_empty()) {
 		p_response->set_status(400);

--- a/modules/justamcp/justamcp_session_manager_http_get.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_get.cpp
@@ -84,6 +84,13 @@ bool MCPSessionManager::handle_mcp_get(const Ref<HTTPRequestContext> &p_context,
 		p_response->set_status(403);
 		return true;
 	}
+	const String requested = first_protocol_version_token(get_header(p_context, "MCP-Protocol-Version"));
+	if (is_modern_protocol_version(requested)) {
+		apply_cors_headers(p_response, p_context);
+		p_response->set_status(405);
+		p_response->set_body("GET is not supported for protocol " + requested);
+		return true;
+	}
 	if (!accepts_event_stream(p_context)) {
 		p_response->set_status(406);
 		p_response->set_body("Accept must include text/event-stream");

--- a/modules/justamcp/justamcp_session_manager_http_post.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_post.cpp
@@ -162,12 +162,6 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 		return true;
 	}
 
-	String protocol_error;
-	if (!validate_protocol_header(p_context, protocol_error)) {
-		p_response->set_status(400);
-		p_response->set_body(protocol_error);
-		return true;
-	}
 	if (!validate_origin(p_context)) {
 		p_response->set_status(403);
 		return true;
@@ -203,6 +197,26 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 	const bool is_notification = !payload.has("id");
 	const bool is_initialize = method == "initialize";
 
+	String protocol_error;
+	if (!validate_protocol_header(p_context, protocol_error)) {
+		Dictionary err = unsupported_protocol_version_error(first_protocol_version_token(get_header(p_context, "MCP-Protocol-Version")));
+		if (payload.has("id")) {
+			err["id"] = payload["id"];
+		}
+		apply_cors_headers(p_response, p_context);
+		p_response->set_status(400);
+		p_response->set_json(err);
+		return true;
+	}
+
+	String requested_version = first_protocol_version_token(get_header(p_context, "MCP-Protocol-Version"));
+	if (requested_version.is_empty()) {
+		requested_version = protocol_version_from_payload(payload);
+	}
+	if (!is_initialize && !requested_version.is_empty() && !is_legacy_protocol_version(requested_version)) {
+		return _handle_modern_post(p_context, p_response, payload, body, requested_version);
+	}
+
 	String session_id = get_header(p_context, "MCP-Session-Id");
 
 	const bool streamable_client = !session_id.is_empty() || is_initialize || accepts_json_and_sse(p_context);
@@ -234,10 +248,10 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 		session.session_id = _generate_session_id();
 		session.created_usec = Time::get_singleton()->get_ticks_usec();
 		session.last_activity_usec = session.created_usec;
-		session.negotiated_protocol = negotiate_protocol_version(
+		session.negotiated_protocol = negotiate_legacy_initialize(
 				payload.has("params") && Dictionary(payload["params"]).has("protocolVersion")
 						? String(Dictionary(payload["params"])["protocolVersion"])
-						: latest_protocol_version());
+						: latest_legacy_protocol_version());
 		{
 			MutexLock lock(mutex);
 			sessions.insert(session.session_id, session);
@@ -313,6 +327,125 @@ bool MCPSessionManager::handle_mcp_post(const Ref<HTTPRequestContext> &p_context
 			p_response->set_body("");
 		} else {
 			p_response->set_status(200);
+			p_response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
+		}
+	}
+	return true;
+}
+
+bool MCPSessionManager::_validate_modern_headers(const Ref<HTTPRequestContext> &p_context, const Dictionary &p_payload, String &r_error) {
+	const String method = p_payload.has("method") ? String(p_payload["method"]) : String();
+	const String protocol = first_protocol_version_token(get_header(p_context, "MCP-Protocol-Version"));
+	if (protocol.is_empty()) {
+		r_error = "Missing MCP-Protocol-Version";
+		return false;
+	}
+	if (!is_modern_protocol_version(protocol) || !is_accepted_protocol_version(protocol)) {
+		r_error = "Unsupported MCP-Protocol-Version: " + protocol;
+		return false;
+	}
+	const String mcp_method = decode_mcp_header_value(get_header(p_context, "Mcp-Method"));
+	if (mcp_method.is_empty() || mcp_method != method) {
+		r_error = "Mcp-Method does not match JSON-RPC method";
+		return false;
+	}
+
+	Dictionary params;
+	if (p_payload.has("params") && p_payload["params"].get_type() == Variant::DICTIONARY) {
+		params = p_payload["params"];
+	}
+	if (method == "tools/call" || method == "prompts/get") {
+		const String expected = String(params.get("name", ""));
+		if (decode_mcp_header_value(get_header(p_context, "Mcp-Name")) != expected) {
+			r_error = "Mcp-Name does not match params.name";
+			return false;
+		}
+	} else if (method == "resources/read") {
+		const String expected = String(params.get("uri", ""));
+		if (decode_mcp_header_value(get_header(p_context, "Mcp-Name")) != expected) {
+			r_error = "Mcp-Name does not match params.uri";
+			return false;
+		}
+	}
+
+	const Dictionary headers = p_context->get_headers();
+	for (const Variant &key_var : headers.keys()) {
+		const String key = String(key_var);
+		const String lower = key.to_lower();
+		if (!lower.begins_with("mcp-param-")) {
+			continue;
+		}
+		const int prefix_idx = lower.find("mcp-param-");
+		const String raw_name = key.substr(prefix_idx + 10);
+		Variant expected;
+		if (params.has(raw_name)) {
+			expected = params[raw_name];
+		} else if (params.has(raw_name.to_lower())) {
+			expected = params[raw_name.to_lower()];
+		} else {
+			continue;
+		}
+		if (decode_mcp_header_value(String(headers[key_var])) != String(expected)) {
+			r_error = "Mcp-Param mismatch for " + raw_name;
+			return false;
+		}
+	}
+	return true;
+}
+
+bool MCPSessionManager::_handle_modern_post(const Ref<HTTPRequestContext> &p_context, Ref<HTTPResponse> p_response, const Dictionary &p_payload, const String &p_body, const String &p_requested_version) {
+	const Variant req_id = p_payload.has("id") ? p_payload["id"] : Variant();
+	if (!is_accepted_protocol_version(p_requested_version) || !is_modern_protocol_version(p_requested_version)) {
+		Dictionary err = unsupported_protocol_version_error(p_requested_version);
+		if (req_id.get_type() != Variant::NIL) {
+			err["id"] = req_id;
+		}
+		apply_cors_headers(p_response, p_context);
+		p_response->set_status(400);
+		p_response->set_json(err);
+		return true;
+	}
+
+	String header_error;
+	if (!_validate_modern_headers(p_context, p_payload, header_error)) {
+		apply_cors_headers(p_response, p_context);
+		p_response->set_status(400);
+		p_response->set_json(header_mismatch_error(req_id, header_error));
+		return true;
+	}
+
+	if (owner) {
+		owner->transport_negotiated_protocol = p_requested_version;
+	}
+
+	const String method = p_payload.has("method") ? String(p_payload["method"]) : String();
+	if (method == "subscriptions/listen") {
+		{
+			MutexLock lock(mutex);
+			pending_modern_listen++;
+		}
+		apply_cors_headers(p_response, p_context);
+		p_response->add_header("X-Accel-Buffering", "no");
+		p_response->start_sse();
+		return true;
+	}
+
+	apply_cors_headers(p_response, p_context);
+
+	const int client_id = p_context->get_client_id();
+	if (client_id >= 0 && HTTPServer::get_singleton()) {
+		p_response->hold();
+		owner->call_deferred("_deferred_held_json_rpc", client_id, p_body, String(), p_response);
+		return true;
+	}
+
+	Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc_parsed(owner, p_payload, p_response, String());
+	if (!p_response->is_sent()) {
+		if (result.is_empty()) {
+			p_response->set_status(202);
+			p_response->set_body("");
+		} else {
+			p_response->set_status(modern_http_status_for_rpc(result));
 			p_response->set_json(JustAMCPJsonRpcTransport::sanitize_wire_rpc(result));
 		}
 	}

--- a/modules/justamcp/justamcp_tool_dispatch.cpp
+++ b/modules/justamcp/justamcp_tool_dispatch.cpp
@@ -91,6 +91,13 @@ void JustAMCPToolDispatch::execute_and_send(JustAMCPServer *p_server, JustAMCPTo
 		return;
 	}
 
+	if (result.get("elicitation_required", false)) {
+		Dictionary schema = result.get("elicitation_schema", Dictionary());
+		const String mode = result.get("elicitation_mode", "form");
+		p_server->hold_tool_for_elicitation(p_request_id, p_tool_name, p_args, schema, mode);
+		return;
+	}
+
 	if (p_server->is_tool_cancel_requested(p_request_id) && !_justamcp_tool_error_is_cancelled(result)) {
 		result["ok"] = false;
 		result["error"] = "cancelled";

--- a/modules/justamcp/tests/test_justamcp_elicitation.cpp
+++ b/modules/justamcp/tests/test_justamcp_elicitation.cpp
@@ -1,0 +1,209 @@
+/**************************************************************************/
+/*  test_justamcp_elicitation.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TESTS_ENABLED
+
+#include "test_justamcp_fixture.h"
+
+#include "modules/modules_enabled.gen.h"
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
+
+#include "../justamcp_json_rpc_transport.h"
+#include "../justamcp_mcp_spec.h"
+#include "../justamcp_server.h"
+#include "../justamcp_session_manager.h"
+#include "../tools/justamcp_json_rpc_helpers.h"
+#include "../tools/justamcp_json_rpc_router.h"
+#ifdef TOOLS_ENABLED
+#include "../tools/justamcp_prompt_executor.h"
+#include "../tools/justamcp_resource_manifest.h"
+#include "../tools/justamcp_tool_executor.h"
+#endif
+
+#include "tests/test_macros.h"
+
+void test_justamcp_initialize_2025_advertises_elicitation() {
+	JustAMCPTestServerFixture fixture;
+	Dictionary payload;
+	Dictionary params;
+	params["protocolVersion"] = "2025-11-25";
+	params["capabilities"] = Dictionary();
+	payload["params"] = params;
+	Dictionary routed = JustAMCPJsonRpcRouter::route_initialize(&fixture.get_server(), payload, 1);
+	Dictionary result = routed["result"];
+	Dictionary capabilities = result["capabilities"];
+	CHECK(capabilities.has("elicitation"));
+	Dictionary elicitation = capabilities["elicitation"];
+	CHECK(elicitation.has("form"));
+	CHECK(elicitation.has("url"));
+}
+
+void test_justamcp_older_initialize_does_not_break() {
+	JustAMCPTestServerFixture fixture;
+	Dictionary payload;
+	Dictionary params;
+	params["protocolVersion"] = "2024-11-05";
+	params["capabilities"] = Dictionary();
+	payload["params"] = params;
+	Dictionary routed = JustAMCPJsonRpcRouter::route_initialize(&fixture.get_server(), payload, 1);
+	CHECK(bool(routed.get("handled", false)));
+	Dictionary result = routed["result"];
+	CHECK(String(result.get("protocolVersion", "")) == "2024-11-05");
+	Dictionary capabilities = result["capabilities"];
+	CHECK(capabilities.has("tools"));
+	CHECK(!capabilities.has("elicitation"));
+}
+
+void test_justamcp_roots_list_changed_updates_session() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	REQUIRE(session_manager != nullptr);
+	CHECK(session_manager->test_register_stream_for_session("roots-session", 4401));
+
+	session_manager->mark_session_initialized("roots-session");
+	CHECK(server.get_session_roots("roots-session").is_empty());
+
+	Dictionary root;
+	root["uri"] = "file:///workspace";
+	root["name"] = "workspace";
+	Array roots;
+	roots.push_back(root);
+	Dictionary result;
+	result["roots"] = roots;
+	Dictionary payload;
+	payload["jsonrpc"] = "2.0";
+	payload["id"] = "roots_list_roots-session";
+	payload["result"] = result;
+	JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, payload, Ref<HTTPResponse>(), "roots-session");
+	Array stored = server.get_session_roots("roots-session");
+	CHECK(stored.size() == 1);
+	CHECK(String(Dictionary(stored[0]).get("uri", "")) == "file:///workspace");
+
+	Dictionary changed_root;
+	changed_root["uri"] = "file:///other";
+	Array changed;
+	changed.push_back(changed_root);
+	Dictionary notify;
+	notify["jsonrpc"] = "2.0";
+	notify["method"] = "notifications/roots/list_changed";
+	Dictionary notify_params;
+	notify_params["roots"] = changed;
+	notify["params"] = notify_params;
+	JustAMCPJsonRpcTransport::handle_json_rpc_parsed(&server, notify, Ref<HTTPResponse>(), "roots-session");
+	stored = server.get_session_roots("roots-session");
+	CHECK(stored.size() == 1);
+	CHECK(String(Dictionary(stored[0]).get("uri", "")) == "file:///other");
+}
+
+void test_justamcp_elicitation_hold_and_decline() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	Dictionary queue_full;
+	MCPToolQueueEntry *entry = server.test_enqueue_tool_request(77, "blazium_tags_add", Dictionary(), queue_full);
+	REQUIRE(entry != nullptr);
+	server.test_clear_last_send_tool_result();
+
+	server.hold_tool_for_elicitation(77, "blazium_tags_add", Dictionary(), justamcp_confirm_enum_schema(), "form");
+	CHECK(server.has_pending_elicitation(77));
+	CHECK(server.test_peek_last_send_tool_result().is_empty());
+
+	Dictionary elicit;
+	elicit["action"] = "decline";
+	server.complete_elicitation("77", elicit);
+	CHECK(!server.has_pending_elicitation(77));
+	Dictionary completed = server.test_peek_last_send_tool_result();
+	CHECK(completed.has("result"));
+	CHECK(bool(Dictionary(completed["result"]).get("isError", false)));
+}
+
+void test_justamcp_url_elicitation_error_shape() {
+	Dictionary rpc = justamcp_url_elicitation_error_rpc(12, "elicitation_12", "https://example.test/consent", "URL elicitation required");
+	CHECK(rpc.has("error"));
+	Dictionary error = rpc["error"];
+	CHECK(int(error.get("code", 0)) == -32042);
+	CHECK(String(Dictionary(error.get("data", Dictionary())).get("url", "")).begins_with("https://"));
+
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	Dictionary queue_full;
+	MCPToolQueueEntry *entry = server.test_enqueue_tool_request(12, "blazium_logs_read", Dictionary(), queue_full);
+	REQUIRE(entry != nullptr);
+	server.test_clear_last_send_tool_result();
+	server.send_url_elicitation_error("12", "elicitation_12", "https://example.test/consent", "URL elicitation required");
+	Dictionary sent = server.test_peek_last_send_tool_result();
+	CHECK(sent.has("error"));
+	CHECK(int(Dictionary(sent["error"]).get("code", 0)) == -32042);
+}
+
+void test_justamcp_icons_and_invalid_tool_name() {
+	CHECK(justamcp_is_valid_mcp_tool_name("blazium_search_tools"));
+	CHECK(!justamcp_is_valid_mcp_tool_name("Bad-Name"));
+	CHECK(!justamcp_is_valid_mcp_tool_name(""));
+
+#ifdef TOOLS_ENABLED
+	Array resources = JustAMCPResourceManifest::get_static_resource_schemas();
+	REQUIRE(resources.size() > 0);
+	Dictionary first = resources[0];
+	CHECK(first.has("icons"));
+	Array templates = JustAMCPResourceManifest::get_static_resource_template_schemas();
+	REQUIRE(templates.size() > 0);
+	CHECK(Dictionary(templates[0]).has("icons"));
+
+	JustAMCPPromptExecutor prompts;
+	Dictionary listed = prompts.list_prompts();
+	Array prompt_list = listed.get("prompts", Array());
+	if (prompt_list.size() > 0) {
+		CHECK(Dictionary(prompt_list[0]).has("icons"));
+	}
+
+	JustAMCPToolExecutor executor;
+	Dictionary invalid = executor.execute_tool("Bad-Name", Dictionary());
+	CHECK(!bool(invalid.get("ok", true)));
+	CHECK(String(invalid.get("error", "")).contains("Invalid tool name"));
+	Dictionary formatted = JustAMCPJsonRpcHelpers::format_tool_result(false, invalid.get("error", ""), String(invalid.get("error", "")));
+	CHECK(formatted.has("result"));
+	CHECK(bool(Dictionary(formatted["result"]).get("isError", false)));
+	CHECK(!formatted.has("error"));
+#endif
+}
+
+#else
+
+void test_justamcp_initialize_2025_advertises_elicitation() {}
+void test_justamcp_older_initialize_does_not_break() {}
+void test_justamcp_roots_list_changed_updates_session() {}
+void test_justamcp_elicitation_hold_and_decline() {}
+void test_justamcp_url_elicitation_error_shape() {}
+void test_justamcp_icons_and_invalid_tool_name() {}
+
+#endif
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_elicitation.h
+++ b/modules/justamcp/tests/test_justamcp_elicitation.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_router.h                                            */
+/*  test_justamcp_elicitation.h                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,32 +29,35 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
+#include "tests/test_macros.h"
 
-#include "core/variant/dictionary.h"
-#include "core/variant/variant.h"
+void test_justamcp_initialize_2025_advertises_elicitation();
+void test_justamcp_older_initialize_does_not_break();
+void test_justamcp_roots_list_changed_updates_session();
+void test_justamcp_elicitation_hold_and_decline();
+void test_justamcp_url_elicitation_error_shape();
+void test_justamcp_icons_and_invalid_tool_name();
 
-class JustAMCPResourceExecutor;
-class JustAMCPTaskManager;
-class JustAMCPPromptExecutor;
-class JustAMCPServer;
+TEST_CASE("[Modules][JustAMCP] 2025-11-25 initialize advertises elicitation") {
+	test_justamcp_initialize_2025_advertises_elicitation();
+}
 
-class JustAMCPJsonRpcRouter {
-public:
-	static String extract_list_cursor(const Dictionary &p_payload);
-	static Dictionary finalize_list_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary finalize_action_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary make_invalid_params(const Variant &p_req_id, const String &p_message);
-	static Dictionary route(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPResourceExecutor *p_resources, JustAMCPTaskManager *p_tasks);
-	static Dictionary route_tools_list(const String &p_cursor, const Variant &p_req_id_var);
-	static Dictionary route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_prompts_get(const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_discover(JustAMCPServer *p_server, const Variant &p_req_id_var);
-	static Dictionary route_ping(const Variant &p_req_id_var);
-	static Dictionary route_logging_set_level(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_tasks_cancel(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_completion_complete(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-};
+TEST_CASE("[Modules][JustAMCP] older initialize does not break without elicitation") {
+	test_justamcp_older_initialize_does_not_break();
+}
 
-#endif
+TEST_CASE("[Modules][JustAMCP] roots list_changed updates session storage") {
+	test_justamcp_roots_list_changed_updates_session();
+}
+
+TEST_CASE("[Modules][JustAMCP] elicitation holds tools/call until decline") {
+	test_justamcp_elicitation_hold_and_decline();
+}
+
+TEST_CASE("[Modules][JustAMCP] URL elicitation error is -32042") {
+	test_justamcp_url_elicitation_error_shape();
+}
+
+TEST_CASE("[Modules][JustAMCP] icons attach and invalid tool name is a tool error") {
+	test_justamcp_icons_and_invalid_tool_name();
+}

--- a/modules/justamcp/tests/test_justamcp_oauth_discovery.cpp
+++ b/modules/justamcp/tests/test_justamcp_oauth_discovery.cpp
@@ -1,0 +1,157 @@
+/**************************************************************************/
+/*  test_justamcp_oauth_discovery.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TESTS_ENABLED
+
+#include "test_justamcp_fixture.h"
+
+#include "modules/modules_enabled.gen.h"
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
+
+#include "../justamcp_oauth_discovery.h"
+#include "../justamcp_server.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/json.h"
+#include "modules/httpserver/http_request_context.h"
+#include "modules/httpserver/http_response.h"
+#include "tests/test_macros.h"
+
+static String _header_value(const Ref<HTTPResponse> &p_response, const String &p_name) {
+	const Dictionary headers = p_response->get_headers();
+	if (headers.has(p_name)) {
+		return String(headers[p_name]);
+	}
+	const String lower = p_name.to_lower();
+	for (const Variant &key : headers.keys()) {
+		if (String(key).to_lower() == lower) {
+			return String(headers[key]);
+		}
+	}
+	return String();
+}
+
+void test_justamcp_oauth_401_www_authenticate() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	const bool prev_enabled = bool(ps->get_setting("blazium/justamcp/oauth_enabled", false));
+	const String prev_id = ps->get_setting("blazium/justamcp/client_id", "");
+	const String prev_secret = ps->get_setting("blazium/justamcp/client_secret", "");
+	ps->set_setting("blazium/justamcp/oauth_enabled", true);
+	ps->set_setting("blazium/justamcp/client_id", "test-client");
+	ps->set_setting("blazium/justamcp/client_secret", "test-secret");
+
+	Ref<HTTPRequestContext> ctx;
+	ctx.instantiate();
+	ctx->set_method("POST");
+	ctx->set_path("/mcp");
+	ctx->set_headers(Dictionary());
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	CHECK(!server.test_validate_mcp_oauth(ctx, response));
+	CHECK(response->get_status() == 401);
+	const String www = _header_value(response, "WWW-Authenticate");
+	CHECK(www.contains("Bearer"));
+	CHECK(www.contains("resource_metadata="));
+	CHECK(www.contains("oauth-protected-resource"));
+
+	ps->set_setting("blazium/justamcp/oauth_enabled", prev_enabled);
+	ps->set_setting("blazium/justamcp/client_id", prev_id);
+	ps->set_setting("blazium/justamcp/client_secret", prev_secret);
+}
+
+void test_justamcp_oauth_well_known_documents() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	const bool prev_enabled = bool(ps->get_setting("blazium/justamcp/oauth_enabled", false));
+	ps->set_setting("blazium/justamcp/oauth_enabled", true);
+
+	Ref<HTTPRequestContext> ctx;
+	ctx.instantiate();
+	ctx->set_method("GET");
+	ctx->set_path("/.well-known/oauth-protected-resource/mcp");
+	Ref<HTTPResponse> prm;
+	prm.instantiate();
+	server.test_handle_oauth_protected_resource(ctx, prm);
+	CHECK(prm->get_status() == 200);
+	Ref<JSON> json;
+	json.instantiate();
+	CHECK(json->parse(prm->get_body()) == OK);
+	Dictionary prm_body = json->get_data();
+	CHECK(prm_body.has("resource"));
+	CHECK(prm_body.has("authorization_servers"));
+	CHECK(prm_body.has("scopes_supported"));
+	CHECK(prm_body.has("bearer_methods_supported"));
+
+	Ref<HTTPResponse> as;
+	as.instantiate();
+	server.test_handle_oauth_authorization_server(ctx, as);
+	CHECK(as->get_status() == 200);
+	CHECK(json->parse(as->get_body()) == OK);
+	Dictionary as_body = json->get_data();
+	CHECK(as_body.has("issuer"));
+	CHECK(as_body.has("token_endpoint"));
+
+	Dictionary meta = JustAMCPOauthDiscovery::protected_resource_metadata();
+	CHECK(String(meta.get("resource", "")).ends_with("/mcp"));
+
+	ps->set_setting("blazium/justamcp/oauth_enabled", false);
+	Ref<HTTPResponse> missing;
+	missing.instantiate();
+	server.test_handle_oauth_protected_resource(ctx, missing);
+	CHECK(missing->get_status() == 404);
+
+	ps->set_setting("blazium/justamcp/oauth_enabled", prev_enabled);
+}
+
+void test_justamcp_oauth_cimd_client_id() {
+	CHECK(JustAMCPOauthDiscovery::client_id_is_cimd("https://example.test/client.json"));
+	CHECK(!JustAMCPOauthDiscovery::client_id_is_cimd("cursor-local"));
+
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	const String prev = ps->get_setting("blazium/justamcp/oauth_cimd_json", "");
+	ps->set_setting("blazium/justamcp/oauth_cimd_json", "{\"client_id\":\"https://example.test/client.json\"}");
+	String err;
+	CHECK(JustAMCPOauthDiscovery::validate_cimd_client_id("https://example.test/client.json", err));
+	CHECK(!JustAMCPOauthDiscovery::validate_cimd_client_id("https://other.test/client.json", err));
+	ps->set_setting("blazium/justamcp/oauth_cimd_json", prev);
+}
+
+#else
+
+void test_justamcp_oauth_401_www_authenticate() {}
+void test_justamcp_oauth_well_known_documents() {}
+void test_justamcp_oauth_cimd_client_id() {}
+
+#endif
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_oauth_discovery.h
+++ b/modules/justamcp/tests/test_justamcp_oauth_discovery.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_router.h                                            */
+/*  test_justamcp_oauth_discovery.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,32 +29,20 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
+#include "tests/test_macros.h"
 
-#include "core/variant/dictionary.h"
-#include "core/variant/variant.h"
+void test_justamcp_oauth_401_www_authenticate();
+void test_justamcp_oauth_well_known_documents();
+void test_justamcp_oauth_cimd_client_id();
 
-class JustAMCPResourceExecutor;
-class JustAMCPTaskManager;
-class JustAMCPPromptExecutor;
-class JustAMCPServer;
+TEST_CASE("[Modules][JustAMCP] OAuth 401 includes WWW-Authenticate") {
+	test_justamcp_oauth_401_www_authenticate();
+}
 
-class JustAMCPJsonRpcRouter {
-public:
-	static String extract_list_cursor(const Dictionary &p_payload);
-	static Dictionary finalize_list_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary finalize_action_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary make_invalid_params(const Variant &p_req_id, const String &p_message);
-	static Dictionary route(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPResourceExecutor *p_resources, JustAMCPTaskManager *p_tasks);
-	static Dictionary route_tools_list(const String &p_cursor, const Variant &p_req_id_var);
-	static Dictionary route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_prompts_get(const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_discover(JustAMCPServer *p_server, const Variant &p_req_id_var);
-	static Dictionary route_ping(const Variant &p_req_id_var);
-	static Dictionary route_logging_set_level(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_tasks_cancel(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_completion_complete(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-};
+TEST_CASE("[Modules][JustAMCP] OAuth well-known discovery documents") {
+	test_justamcp_oauth_well_known_documents();
+}
 
-#endif
+TEST_CASE("[Modules][JustAMCP] OAuth CIMD client_id URL") {
+	test_justamcp_oauth_cimd_client_id();
+}

--- a/modules/justamcp/tests/test_justamcp_protocol_matrix.cpp
+++ b/modules/justamcp/tests/test_justamcp_protocol_matrix.cpp
@@ -1,0 +1,166 @@
+/**************************************************************************/
+/*  test_justamcp_protocol_matrix.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TESTS_ENABLED
+
+#include "test_justamcp_fixture.h"
+
+#include "modules/modules_enabled.gen.h"
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
+
+#include "../justamcp_json_rpc_transport.h"
+#include "../justamcp_mcp_spec.h"
+#include "../justamcp_server.h"
+#include "../tools/justamcp_json_rpc_helpers.h"
+#include "../tools/justamcp_json_rpc_router.h"
+
+#include "tests/test_macros.h"
+
+#ifdef TOOLS_ENABLED
+#include "../tools/justamcp_resource_manifest.h"
+#endif
+
+static Dictionary _initialize_for(JustAMCPServer &p_server, const String &p_version) {
+	Dictionary payload;
+	Dictionary params;
+	params["protocolVersion"] = p_version;
+	params["capabilities"] = Dictionary();
+	payload["params"] = params;
+	return JustAMCPJsonRpcRouter::route_initialize(&p_server, payload, 1);
+}
+
+void test_justamcp_protocol_matrix_initialize_capabilities() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+
+	{
+		Dictionary routed = _initialize_for(server, "2024-11-05");
+		Dictionary caps = Dictionary(routed["result"])["capabilities"];
+		CHECK(caps.has("tools"));
+		CHECK(!caps.has("completions"));
+		CHECK(!caps.has("tasks"));
+		CHECK(!caps.has("elicitation"));
+		CHECK(!Dictionary(Dictionary(routed["result"])["serverInfo"]).has("title"));
+	}
+	{
+		Dictionary routed = _initialize_for(server, "2025-03-26");
+		Dictionary caps = Dictionary(routed["result"])["capabilities"];
+		CHECK(caps.has("completions"));
+		CHECK(!caps.has("tasks"));
+		CHECK(!caps.has("elicitation"));
+		CHECK(!Dictionary(Dictionary(routed["result"])["serverInfo"]).has("title"));
+	}
+	{
+		Dictionary routed = _initialize_for(server, "2025-06-18");
+		Dictionary caps = Dictionary(routed["result"])["capabilities"];
+		CHECK(caps.has("completions"));
+		CHECK(!caps.has("tasks"));
+		CHECK(caps.has("elicitation"));
+		CHECK(Dictionary(caps["elicitation"]).has("form"));
+		CHECK(!Dictionary(caps["elicitation"]).has("url"));
+		CHECK(Dictionary(Dictionary(routed["result"])["serverInfo"]).has("title"));
+	}
+	{
+		Dictionary routed = _initialize_for(server, "2025-11-25");
+		Dictionary caps = Dictionary(routed["result"])["capabilities"];
+		CHECK(caps.has("completions"));
+		CHECK(caps.has("tasks"));
+		CHECK(caps.has("elicitation"));
+		CHECK(Dictionary(caps["elicitation"]).has("form"));
+		CHECK(Dictionary(caps["elicitation"]).has("url"));
+		CHECK(Dictionary(Dictionary(routed["result"])["serverInfo"]).has("title"));
+	}
+}
+
+void test_justamcp_protocol_matrix_batch_execute_2025_03_26() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	server.test_set_transport_negotiated_protocol("2025-03-26");
+	Dictionary wrapped = JustAMCPJsonRpcTransport::handle_json_rpc(
+			&server,
+			"[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"},{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}]",
+			Ref<HTTPResponse>());
+	CHECK(wrapped.has("_justamcp_batch_results"));
+	Array responses = wrapped["_justamcp_batch_results"];
+	CHECK(responses.size() == 2);
+	CHECK(Dictionary(responses[0]).has("result"));
+	CHECK(Dictionary(responses[1]).has("result"));
+	CHECK(int(Dictionary(responses[0]).get("id", 0)) == 1);
+	CHECK(int(Dictionary(responses[1]).get("id", 0)) == 2);
+}
+
+void test_justamcp_protocol_matrix_icons_and_structured_content() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+
+	Dictionary listed;
+	Array tools;
+	Dictionary tool;
+	tool["name"] = "blazium_search_tools";
+	justamcp_attach_icons(tool);
+	tools.push_back(tool);
+	listed["tools"] = tools;
+
+	Dictionary old_list = listed.duplicate(true);
+	justamcp_apply_protocol_to_list_result(old_list, "2025-06-18");
+	CHECK(!Dictionary(Array(old_list["tools"])[0]).has("icons"));
+
+	Dictionary new_list = listed.duplicate(true);
+	justamcp_apply_protocol_to_list_result(new_list, "2025-11-25");
+	CHECK(Dictionary(Array(new_list["tools"])[0]).has("icons"));
+
+	server.test_set_transport_negotiated_protocol("2025-03-26");
+	Dictionary payload;
+	payload["ok"] = true;
+	payload["message"] = "hi";
+	Dictionary formatted = JustAMCPJsonRpcHelpers::format_tool_result(true, payload, "");
+	CHECK(formatted.has("result"));
+	CHECK(!Dictionary(formatted["result"]).has("structuredContent"));
+
+	server.test_set_transport_negotiated_protocol("2025-06-18");
+	Dictionary formatted_new = JustAMCPJsonRpcHelpers::format_tool_result(true, payload, "");
+	CHECK(Dictionary(formatted_new["result"]).has("structuredContent"));
+
+#ifdef TOOLS_ENABLED
+	Array resources = JustAMCPResourceManifest::get_static_resource_schemas();
+	REQUIRE(resources.size() > 0);
+	CHECK(Dictionary(resources[0]).has("icons"));
+#endif
+}
+
+#else
+
+void test_justamcp_protocol_matrix_initialize_capabilities() {}
+void test_justamcp_protocol_matrix_batch_execute_2025_03_26() {}
+void test_justamcp_protocol_matrix_icons_and_structured_content() {}
+
+#endif
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_protocol_matrix.h
+++ b/modules/justamcp/tests/test_justamcp_protocol_matrix.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  justamcp_json_rpc_router.h                                            */
+/*  test_justamcp_protocol_matrix.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,32 +29,20 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
+#include "tests/test_macros.h"
 
-#include "core/variant/dictionary.h"
-#include "core/variant/variant.h"
+void test_justamcp_protocol_matrix_initialize_capabilities();
+void test_justamcp_protocol_matrix_batch_execute_2025_03_26();
+void test_justamcp_protocol_matrix_icons_and_structured_content();
 
-class JustAMCPResourceExecutor;
-class JustAMCPTaskManager;
-class JustAMCPPromptExecutor;
-class JustAMCPServer;
+TEST_CASE("[Modules][JustAMCP] protocol matrix initialize capabilities") {
+	test_justamcp_protocol_matrix_initialize_capabilities();
+}
 
-class JustAMCPJsonRpcRouter {
-public:
-	static String extract_list_cursor(const Dictionary &p_payload);
-	static Dictionary finalize_list_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary finalize_action_result(const Dictionary &p_result, const Variant &p_req_id);
-	static Dictionary make_invalid_params(const Variant &p_req_id, const String &p_message);
-	static Dictionary route(const String &p_method, const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPResourceExecutor *p_resources, JustAMCPTaskManager *p_tasks);
-	static Dictionary route_tools_list(const String &p_cursor, const Variant &p_req_id_var);
-	static Dictionary route_prompts_list(const String &p_cursor, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_prompts_get(const Dictionary &p_payload, const Variant &p_req_id_var, JustAMCPPromptExecutor *p_prompts);
-	static Dictionary route_initialize(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_discover(JustAMCPServer *p_server, const Variant &p_req_id_var);
-	static Dictionary route_ping(const Variant &p_req_id_var);
-	static Dictionary route_logging_set_level(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_tasks_cancel(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-	static Dictionary route_completion_complete(JustAMCPServer *p_server, const Dictionary &p_payload, const Variant &p_req_id_var);
-};
+TEST_CASE("[Modules][JustAMCP] protocol matrix batch execute 2025-03-26") {
+	test_justamcp_protocol_matrix_batch_execute_2025_03_26();
+}
 
-#endif
+TEST_CASE("[Modules][JustAMCP] protocol matrix icons and structuredContent") {
+	test_justamcp_protocol_matrix_icons_and_structured_content();
+}

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.cpp
@@ -30,6 +30,7 @@
 #ifdef TESTS_ENABLED
 
 #include "test_justamcp_protocol_versions.h"
+
 #include "test_justamcp_fixture.h"
 
 #include "modules/modules_enabled.gen.h"
@@ -39,19 +40,24 @@
 #include "../justamcp_json_rpc_transport.h"
 #include "../justamcp_server.h"
 #include "../justamcp_session_manager.h"
+#include "../tools/justamcp_json_rpc_router.h"
 
+#include "core/config/project_settings.h"
 #include "core/io/json.h"
-#include "modules/httpserver/http_request_context.h"
-#include "modules/httpserver/http_response.h"
 #include "tests/test_macros.h"
 
-static const char *const k_supported_protocols[] = {
+#include "modules/httpserver/http_request_context.h"
+#include "modules/httpserver/http_response.h"
+
+static const char *const k_legacy_protocols[] = {
 	"2025-11-25",
 	"2025-06-18",
 	"2025-03-26",
 	"2024-11-05",
 	nullptr
 };
+
+static const char *const k_modern_protocol = "2026-07-28";
 
 static Ref<HTTPRequestContext> _make_ctx(const String &p_method, const Dictionary &p_headers, const String &p_body = String()) {
 	Ref<HTTPRequestContext> context;
@@ -117,14 +123,116 @@ static String _init_session(JustAMCPServer &p_server, MCPSessionManager *p_sm, c
 	return session_id;
 }
 
+static Dictionary _parse_json_body(const Ref<HTTPResponse> &p_response) {
+	if (p_response.is_null() || p_response->get_body().is_empty()) {
+		return Dictionary();
+	}
+	Ref<JSON> json;
+	json.instantiate();
+	if (json->parse(p_response->get_body()) != OK || json->get_data().get_type() != Variant::DICTIONARY) {
+		return Dictionary();
+	}
+	return json->get_data();
+}
+
+static Dictionary _modern_headers(const String &p_method, const String &p_name = String()) {
+	Dictionary headers;
+	headers["Accept"] = "application/json";
+	headers["Content-Type"] = "application/json";
+	headers["MCP-Protocol-Version"] = k_modern_protocol;
+	headers["Mcp-Method"] = p_method;
+	if (!p_name.is_empty()) {
+		headers["Mcp-Name"] = p_name;
+	}
+	return headers;
+}
+
+static String _modern_body(const String &p_method, int p_id = 1, const String &p_params = "{}") {
+	return "{\"jsonrpc\":\"2.0\",\"id\":" + itos(p_id) + ",\"method\":\"" + p_method + "\",\"params\":" + p_params + "}";
+}
+
 void test_justamcp_negotiate_protocol_versions() {
-	for (int i = 0; k_supported_protocols[i]; i++) {
-		const String version = k_supported_protocols[i];
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	TEST_FAIL_COND(ps == nullptr, "ProjectSettings is required");
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+	const String prev_version = String(ps->get_setting("blazium/justamcp/protocol_version", k_modern_protocol));
+	const String prev_accepted = String(ps->get_setting("blazium/justamcp/accepted_protocol_versions", ""));
+	MCPSessionManager::clear_cli_protocol_version_override();
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/protocol_version", k_modern_protocol);
+	ps->set_setting("blazium/justamcp/accepted_protocol_versions", "");
+
+	for (int i = 0; k_legacy_protocols[i]; i++) {
+		const String version = k_legacy_protocols[i];
+		CHECK(MCPSessionManager::is_legacy_protocol_version(version));
 		CHECK(MCPSessionManager::negotiate_protocol_version(version) == version);
 	}
-	CHECK(MCPSessionManager::latest_protocol_version() == "2025-11-25");
-	CHECK(MCPSessionManager::negotiate_protocol_version("2099-01-01") == "2025-11-25");
-	CHECK(MCPSessionManager::negotiate_protocol_version("") == "2025-11-25");
+	CHECK(MCPSessionManager::is_supported_protocol_version(k_modern_protocol));
+	CHECK(MCPSessionManager::is_modern_protocol_version(k_modern_protocol));
+	CHECK(MCPSessionManager::latest_protocol_version() == k_modern_protocol);
+	CHECK(MCPSessionManager::negotiate_protocol_version(k_modern_protocol) == k_modern_protocol);
+	CHECK(MCPSessionManager::negotiate_legacy_initialize(k_modern_protocol) == "2025-11-25");
+	CHECK(MCPSessionManager::negotiate_legacy_initialize("2025-11-25") == "2025-11-25");
+	CHECK(MCPSessionManager::negotiate_protocol_version("2099-01-01") == k_modern_protocol);
+	CHECK(MCPSessionManager::negotiate_protocol_version("") == k_modern_protocol);
+
+	ps->set_setting("blazium/justamcp/accepted_protocol_versions", prev_accepted);
+	ps->set_setting("blazium/justamcp/protocol_version", prev_version);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+}
+
+void test_justamcp_protocol_version_setting_and_cli() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	TEST_FAIL_COND(ps == nullptr, "ProjectSettings is required");
+
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+	const String prev_version = String(ps->get_setting("blazium/justamcp/protocol_version", "2025-11-25"));
+	MCPSessionManager::clear_cli_protocol_version_override();
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/protocol_version", "2024-11-05");
+	CHECK(MCPSessionManager::latest_protocol_version() == "2024-11-05");
+	CHECK(MCPSessionManager::negotiate_protocol_version("2099-01-01") == "2024-11-05");
+
+	CHECK(MCPSessionManager::set_cli_protocol_version_override("2025-03-26"));
+	CHECK(MCPSessionManager::latest_protocol_version() == "2025-03-26");
+	CHECK(!MCPSessionManager::set_cli_protocol_version_override("not-a-version"));
+	CHECK(MCPSessionManager::latest_protocol_version() == "2025-03-26");
+
+	MCPSessionManager::clear_cli_protocol_version_override();
+	ps->set_setting("blazium/justamcp/protocol_version", "bogus");
+	CHECK(MCPSessionManager::latest_protocol_version() == k_modern_protocol);
+
+	ps->set_setting("blazium/justamcp/protocol_version", prev_version);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+}
+
+void test_justamcp_initialize_result_shape() {
+	JustAMCPTestServerFixture fixture;
+	Dictionary payload;
+	Dictionary params;
+	params["protocolVersion"] = "2025-11-25";
+	params["capabilities"] = Dictionary();
+	payload["params"] = params;
+
+	Dictionary routed = JustAMCPJsonRpcRouter::route_initialize(&fixture.get_server(), payload, 1);
+	CHECK(bool(routed.get("handled", false)));
+	CHECK(routed.has("result"));
+	Dictionary result = routed["result"];
+	CHECK(result.has("instructions"));
+	CHECK(result.has("capabilities"));
+	CHECK(result.has("serverInfo"));
+	Dictionary capabilities = result["capabilities"];
+	CHECK(capabilities.has("completions"));
+	CHECK(capabilities.has("tools"));
+	CHECK(capabilities.has("elicitation"));
+	Dictionary elicitation = capabilities["elicitation"];
+	CHECK(elicitation.has("form"));
+	CHECK(elicitation.has("url"));
+	Dictionary server_info = result["serverInfo"];
+	CHECK(!server_info.has("instructions"));
+	CHECK(String(server_info.get("name", "")) == "blazium-mcp-server");
+	CHECK(String(server_info.get("title", "")) == "Blazium MCP");
+	CHECK(String(server_info.get("websiteUrl", "")) == "https://blazium.app");
 }
 
 void test_justamcp_validate_protocol_header_rejects_unknown() {
@@ -132,6 +240,11 @@ void test_justamcp_validate_protocol_header_rejects_unknown() {
 	ok_headers["MCP-Protocol-Version"] = "2025-06-18";
 	String err;
 	CHECK(MCPSessionManager::validate_protocol_header(_make_ctx("POST", ok_headers), err));
+
+	Dictionary modern_headers = _json_headers();
+	modern_headers["MCP-Protocol-Version"] = k_modern_protocol;
+	err = String();
+	CHECK(MCPSessionManager::validate_protocol_header(_make_ctx("POST", modern_headers), err));
 
 	Dictionary empty_headers = _json_headers();
 	err = String();
@@ -142,6 +255,17 @@ void test_justamcp_validate_protocol_header_rejects_unknown() {
 	err = String();
 	CHECK(!MCPSessionManager::validate_protocol_header(_make_ctx("POST", bad_headers), err));
 	CHECK(err.contains("Unsupported MCP-Protocol-Version"));
+
+	Dictionary combined_headers = _json_headers();
+	combined_headers["MCP-Protocol-Version"] = "2025-11-25, 2025-11-25";
+	err = String();
+	CHECK(MCPSessionManager::validate_protocol_header(_make_ctx("POST", combined_headers), err));
+
+	Dictionary mixed_headers = _json_headers();
+	mixed_headers["MCP-Protocol-Version"] = "2025-11-25, 1999-01-01";
+	err = String();
+	CHECK(!MCPSessionManager::validate_protocol_header(_make_ctx("POST", mixed_headers), err));
+	CHECK(err.contains("Unsupported MCP-Protocol-Version"));
 }
 
 void test_justamcp_http_initialize_all_protocol_versions() {
@@ -150,9 +274,18 @@ void test_justamcp_http_initialize_all_protocol_versions() {
 	MCPSessionManager *session_manager = server.test_get_session_manager();
 	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
 
-	for (int i = 0; k_supported_protocols[i]; i++) {
-		_init_session(server, session_manager, k_supported_protocols[i]);
+	for (int i = 0; k_legacy_protocols[i]; i++) {
+		const String session_id = _init_session(server, session_manager, k_legacy_protocols[i]);
+		CHECK(!session_id.is_empty());
 	}
+
+	Dictionary combined = _json_headers();
+	combined["MCP-Protocol-Version"] = "2025-11-25, 2025-11-25";
+	Ref<HTTPResponse> combined_response;
+	combined_response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", combined, _initialize_body("2025-11-25", 99)), combined_response));
+	CHECK(combined_response->get_status() == 200);
+	CHECK(!_response_header(combined_response, "MCP-Session-Id").is_empty());
 }
 
 void test_justamcp_http_protocol_header_falls_back_to_session() {
@@ -216,7 +349,7 @@ void test_justamcp_batch_rejected_for_newer_protocols() {
 	server.test_set_transport_negotiated_protocol("2024-11-05");
 	Dictionary older = JustAMCPJsonRpcTransport::handle_json_rpc(&server, "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}]", Ref<HTTPResponse>());
 	CHECK(older.has("error"));
-	CHECK(!String(older["error"].operator Dictionary().get("message", "")).contains("batch requests are not supported"));
+	CHECK(String(older["error"].operator Dictionary().get("message", "")).contains("batch"));
 }
 
 void test_justamcp_http_list_toolsets_smoke_per_strict_protocol() {
@@ -236,6 +369,159 @@ void test_justamcp_http_list_toolsets_smoke_per_strict_protocol() {
 		CHECK(response->get_status() != 400);
 		CHECK(response->get_status() != 404);
 	}
+}
+
+void test_justamcp_http_modern_discover_and_list() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	Ref<HTTPResponse> discover;
+	discover.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _modern_headers("server/discover"), _modern_body("server/discover")), discover));
+	CHECK(discover->get_status() == 200);
+	CHECK(_response_header(discover, "MCP-Session-Id").is_empty());
+	Dictionary discover_root = _parse_json_body(discover);
+	CHECK(discover_root.has("result"));
+	Dictionary discover_result = discover_root["result"];
+	CHECK(String(discover_result.get("resultType", "")) == "complete");
+	CHECK(discover_result.has("supportedVersions"));
+	CHECK(discover_result.has("ttlMs"));
+	CHECK(String(discover_result.get("cacheScope", "")) == "public");
+	Array supported = discover_result["supportedVersions"];
+	bool saw_modern = false;
+	bool saw_legacy = false;
+	for (int i = 0; i < supported.size(); i++) {
+		if (String(supported[i]) == k_modern_protocol) {
+			saw_modern = true;
+		}
+		if (String(supported[i]) == "2025-11-25") {
+			saw_legacy = true;
+		}
+	}
+	CHECK(saw_modern);
+	CHECK(saw_legacy);
+
+	Ref<HTTPResponse> list;
+	list.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _modern_headers("tools/list"), _modern_body("tools/list", 2)), list));
+	CHECK(list->get_status() == 200);
+	CHECK(_response_header(list, "MCP-Session-Id").is_empty());
+	Dictionary list_root = _parse_json_body(list);
+	CHECK(list_root.has("result"));
+	Dictionary list_result = list_root["result"];
+	CHECK(String(list_result.get("resultType", "")) == "complete");
+	CHECK(list_result.has("ttlMs"));
+	CHECK(String(list_result.get("cacheScope", "")) == "public");
+}
+
+void test_justamcp_http_modern_header_mismatch_and_unsupported() {
+	JustAMCPTestServerFixture fixture;
+	MCPSessionManager *session_manager = fixture.get_server().test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	Ref<HTTPResponse> mismatch;
+	mismatch.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _modern_headers("tools/list"), _modern_body("ping")), mismatch));
+	CHECK(mismatch->get_status() == 400);
+	Dictionary mismatch_root = _parse_json_body(mismatch);
+	CHECK(mismatch_root.has("error"));
+	CHECK(int(Dictionary(mismatch_root["error"]).get("code", 0)) == -32020);
+
+	Dictionary bad_headers = _json_headers();
+	bad_headers["MCP-Protocol-Version"] = "2027-01-01";
+	bad_headers["Mcp-Method"] = "server/discover";
+	Ref<HTTPResponse> unsupported;
+	unsupported.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", bad_headers, _modern_body("server/discover", 3)), unsupported));
+	CHECK(unsupported->get_status() == 400);
+	Dictionary unsupported_root = _parse_json_body(unsupported);
+	CHECK(unsupported_root.has("error"));
+	CHECK(int(Dictionary(unsupported_root["error"]).get("code", 0)) == -32022);
+	Dictionary data = Dictionary(unsupported_root["error"]).get("data", Dictionary());
+	CHECK(String(data.get("requested", "")) == "2027-01-01");
+	CHECK(data.has("supported"));
+}
+
+void test_justamcp_http_initialize_modern_client_stays_legacy() {
+	JustAMCPTestServerFixture fixture;
+	JustAMCPServer &server = fixture.get_server();
+	MCPSessionManager *session_manager = server.test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _json_headers(), _initialize_body(k_modern_protocol)), response));
+	CHECK(response->get_status() == 200);
+	CHECK(!_response_header(response, "MCP-Session-Id").is_empty());
+	CHECK(server.test_get_transport_negotiated_protocol() == "2025-11-25");
+	Dictionary root = _parse_json_body(response);
+	if (root.has("result")) {
+		CHECK(String(Dictionary(root["result"]).get("protocolVersion", "")) == "2025-11-25");
+	}
+}
+
+void test_justamcp_http_modern_get_delete_and_listen() {
+	JustAMCPTestServerFixture fixture;
+	MCPSessionManager *session_manager = fixture.get_server().test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	Ref<HTTPResponse> get_no_session;
+	get_no_session.instantiate();
+	Dictionary get_headers;
+	get_headers["Accept"] = "text/event-stream";
+	CHECK(session_manager->handle_mcp_get(_make_ctx("GET", get_headers), get_no_session));
+	CHECK(get_no_session->get_status() == 400);
+
+	Ref<HTTPResponse> get_modern;
+	get_modern.instantiate();
+	Dictionary modern_get;
+	modern_get["Accept"] = "text/event-stream";
+	modern_get["MCP-Protocol-Version"] = k_modern_protocol;
+	CHECK(session_manager->handle_mcp_get(_make_ctx("GET", modern_get), get_modern));
+	CHECK(get_modern->get_status() == 405);
+
+	Ref<HTTPResponse> delete_modern;
+	delete_modern.instantiate();
+	Dictionary modern_delete;
+	modern_delete["MCP-Protocol-Version"] = k_modern_protocol;
+	CHECK(session_manager->handle_mcp_delete(_make_ctx("DELETE", modern_delete), delete_modern));
+	CHECK(delete_modern->get_status() == 405);
+
+	Ref<HTTPResponse> listen;
+	listen.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _modern_headers("subscriptions/listen"), _modern_body("subscriptions/listen", 8)), listen));
+	CHECK(listen->is_sse_response());
+	CHECK(_response_header(listen, "MCP-Session-Id").is_empty());
+}
+
+void test_justamcp_accepted_protocol_versions_pinning() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	TEST_FAIL_COND(ps == nullptr, "ProjectSettings is required");
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+	const String prev_accepted = String(ps->get_setting("blazium/justamcp/accepted_protocol_versions", ""));
+	MCPSessionManager::clear_cli_protocol_version_override();
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/accepted_protocol_versions", "2025-11-25");
+
+	JustAMCPTestServerFixture fixture;
+	MCPSessionManager *session_manager = fixture.get_server().test_get_session_manager();
+	TEST_FAIL_COND(session_manager == nullptr, "Session manager is required");
+
+	CHECK(MCPSessionManager::is_accepted_protocol_version("2025-11-25"));
+	CHECK(!MCPSessionManager::is_accepted_protocol_version(k_modern_protocol));
+
+	Ref<HTTPResponse> response;
+	response.instantiate();
+	CHECK(session_manager->handle_mcp_post(_make_ctx("POST", _modern_headers("server/discover"), _modern_body("server/discover")), response));
+	CHECK(response->get_status() == 400);
+	Dictionary root = _parse_json_body(response);
+	CHECK(root.has("error"));
+	CHECK(int(Dictionary(root["error"]).get("code", 0)) == -32022);
+
+	ps->set_setting("blazium/justamcp/accepted_protocol_versions", prev_accepted);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
 }
 
 void test_justamcp_json_rpc_rejects_null_id() {
@@ -264,6 +550,12 @@ void test_justamcp_json_rpc_rejects_null_id() {
 void test_justamcp_negotiate_protocol_versions() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
 }
+void test_justamcp_protocol_version_setting_and_cli() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_initialize_result_shape() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
 void test_justamcp_validate_protocol_header_rejects_unknown() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
 }
@@ -283,6 +575,21 @@ void test_justamcp_http_list_toolsets_smoke_per_strict_protocol() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
 }
 void test_justamcp_json_rpc_rejects_null_id() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_modern_discover_and_list() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_modern_header_mismatch_and_unsupported() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_initialize_modern_client_stays_legacy() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_http_modern_get_delete_and_listen() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
+}
+void test_justamcp_accepted_protocol_versions_pinning() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required");
 }
 

--- a/modules/justamcp/tests/test_justamcp_protocol_versions.h
+++ b/modules/justamcp/tests/test_justamcp_protocol_versions.h
@@ -32,6 +32,8 @@
 #include "tests/test_macros.h"
 
 void test_justamcp_negotiate_protocol_versions();
+void test_justamcp_protocol_version_setting_and_cli();
+void test_justamcp_initialize_result_shape();
 void test_justamcp_validate_protocol_header_rejects_unknown();
 void test_justamcp_http_initialize_all_protocol_versions();
 void test_justamcp_http_protocol_header_falls_back_to_session();
@@ -39,9 +41,22 @@ void test_justamcp_http_protocol_header_optional_for_older_versions();
 void test_justamcp_batch_rejected_for_newer_protocols();
 void test_justamcp_http_list_toolsets_smoke_per_strict_protocol();
 void test_justamcp_json_rpc_rejects_null_id();
+void test_justamcp_http_modern_discover_and_list();
+void test_justamcp_http_modern_header_mismatch_and_unsupported();
+void test_justamcp_http_initialize_modern_client_stays_legacy();
+void test_justamcp_http_modern_get_delete_and_listen();
+void test_justamcp_accepted_protocol_versions_pinning();
 
 TEST_CASE("[Modules][JustAMCP] negotiate protocol versions") {
 	test_justamcp_negotiate_protocol_versions();
+}
+
+TEST_CASE("[Modules][JustAMCP] protocol version setting and CLI override") {
+	test_justamcp_protocol_version_setting_and_cli();
+}
+
+TEST_CASE("[Modules][JustAMCP] initialize result shape") {
+	test_justamcp_initialize_result_shape();
 }
 
 TEST_CASE("[Modules][JustAMCP] validate protocol header rejects unknown") {
@@ -70,4 +85,24 @@ TEST_CASE("[Modules][JustAMCP] http list toolsets smoke per strict protocol") {
 
 TEST_CASE("[Modules][JustAMCP] json-rpc rejects null id") {
 	test_justamcp_json_rpc_rejects_null_id();
+}
+
+TEST_CASE("[Modules][JustAMCP] http modern discover and tools/list") {
+	test_justamcp_http_modern_discover_and_list();
+}
+
+TEST_CASE("[Modules][JustAMCP] http modern header mismatch and unsupported version") {
+	test_justamcp_http_modern_header_mismatch_and_unsupported();
+}
+
+TEST_CASE("[Modules][JustAMCP] http initialize modern client stays legacy") {
+	test_justamcp_http_initialize_modern_client_stays_legacy();
+}
+
+TEST_CASE("[Modules][JustAMCP] http modern get delete and listen") {
+	test_justamcp_http_modern_get_delete_and_listen();
+}
+
+TEST_CASE("[Modules][JustAMCP] accepted protocol versions pinning") {
+	test_justamcp_accepted_protocol_versions_pinning();
 }

--- a/modules/justamcp/tools/justamcp_asset_tags_tools.cpp
+++ b/modules/justamcp/tools/justamcp_asset_tags_tools.cpp
@@ -29,8 +29,8 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "core/object/class_db.h"
 #include "justamcp_asset_tags_tools.h"
+#include "core/object/class_db.h"
 
 #include "modules/modules_enabled.gen.h"
 

--- a/modules/justamcp/tools/justamcp_asset_tags_tools.cpp
+++ b/modules/justamcp/tools/justamcp_asset_tags_tools.cpp
@@ -29,6 +29,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "core/object/class_db.h"
 #include "justamcp_asset_tags_tools.h"
 
 #include "modules/modules_enabled.gen.h"
@@ -41,6 +42,7 @@
 #include "resources/justamcp_tags_resource_provider.h"
 #endif
 
+#include "../justamcp_mcp_spec.h"
 #include "../justamcp_pagination.h"
 #include "../justamcp_server.h"
 
@@ -110,13 +112,24 @@ Dictionary JustAMCPAssetTagsTools::_require_elicitation(const String &p_action, 
 	if (p_args.get("confirmed", false)) {
 		return Dictionary();
 	}
+	const Dictionary schema = justamcp_confirm_enum_schema();
 	const String request_id = p_args.get("request_id", String::num_uint64(OS::get_singleton()->get_ticks_usec()));
 	if (JustAMCPServer *server = JustAMCPServer::get_singleton()) {
-		server->send_elicitation_request(request_id, "form", "Confirm asset tag mutation: " + p_action, Dictionary());
+		String demo_url;
+		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/url_elicitation_demo_url")) {
+			demo_url = String(GLOBAL_GET("blazium/justamcp/url_elicitation_demo_url"));
+		}
+		if (!demo_url.is_empty() && bool(p_args.get("url_elicit", false)) && justamcp_protocol_supports(server->get_negotiated_protocol_version(), JUSTAMCP_FEATURE_ELICITATION_URL)) {
+			server->send_url_elicitation_error(request_id, "elicitation_" + request_id, demo_url, "URL elicitation required for " + p_action);
+		} else {
+			server->send_elicitation_request(request_id, "form", "Confirm asset tag mutation: " + p_action, schema);
+		}
 	}
 	Dictionary err;
 	err["ok"] = false;
 	err["elicitation_required"] = true;
+	err["elicitation_schema"] = schema;
+	err["elicitation_mode"] = "form";
 	err["error"] = "Explicit user confirmation required for " + p_action + ". Retry with confirmed=true after approval.";
 	return err;
 }

--- a/modules/justamcp/tools/justamcp_json_rpc_helpers.cpp
+++ b/modules/justamcp/tools/justamcp_json_rpc_helpers.cpp
@@ -30,6 +30,7 @@
 #include "justamcp_json_rpc_helpers.h"
 
 #ifdef TOOLS_ENABLED
+#include "../justamcp_mcp_spec.h"
 #include "justamcp_tool_schema_cache.h"
 #endif
 
@@ -149,6 +150,25 @@ Dictionary JustAMCPJsonRpcHelpers::format_tool_result(bool p_success, const Vari
 			content.push_back(content_item);
 			result["content"] = content;
 			result["isError"] = false;
+		}
+		const String protocol = justamcp_active_protocol_version();
+		if (p_result.get_type() == Variant::DICTIONARY) {
+			Dictionary payload_dict = p_result;
+			if (justamcp_protocol_supports(protocol, JUSTAMCP_FEATURE_RESOURCE_LINKS) && payload_dict.has("resourceLinks") && payload_dict["resourceLinks"].get_type() == Variant::ARRAY) {
+				Array content = result.has("content") && result["content"].get_type() == Variant::ARRAY ? Array(result["content"]) : Array();
+				const Array links = payload_dict["resourceLinks"];
+				for (int i = 0; i < links.size(); i++) {
+					if (links[i].get_type() != Variant::DICTIONARY) {
+						continue;
+					}
+					const Dictionary link = links[i];
+					content.push_back(justamcp_resource_link_content(link.get("uri", ""), link.get("name", ""), link.get("mimeType", "")));
+				}
+				result["content"] = content;
+			}
+		}
+		if (!justamcp_protocol_supports(protocol, JUSTAMCP_FEATURE_STRUCTURED_CONTENT)) {
+			result.erase("structuredContent");
 		}
 		rpc_result["result"] = result;
 	} else {

--- a/modules/justamcp/tools/justamcp_json_rpc_router.cpp
+++ b/modules/justamcp/tools/justamcp_json_rpc_router.cpp
@@ -32,6 +32,7 @@
 #include "justamcp_json_rpc_router.h"
 
 #include "../justamcp_log_levels.h"
+#include "../justamcp_mcp_spec.h"
 #include "../justamcp_server.h"
 #include "../justamcp_session_manager.h"
 #include "justamcp_prompt_executor.h"
@@ -67,6 +68,7 @@ Dictionary JustAMCPJsonRpcRouter::finalize_list_result(const Dictionary &p_resul
 
 	Dictionary out = p_result.duplicate();
 	out.erase("ok");
+	justamcp_apply_protocol_to_list_result(out, justamcp_active_protocol_version());
 	Dictionary rpc_result;
 	rpc_result["handled"] = true;
 	rpc_result["jsonrpc"] = "2.0";
@@ -324,7 +326,7 @@ Dictionary JustAMCPJsonRpcRouter::route_initialize(JustAMCPServer *p_server, con
 	if (params.has("protocolVersion") && params["protocolVersion"].get_type() == Variant::STRING) {
 		client_protocol = String(params["protocolVersion"]);
 	}
-	p_server->transport_negotiated_protocol = MCPSessionManager::negotiate_protocol_version(client_protocol);
+	p_server->transport_negotiated_protocol = MCPSessionManager::negotiate_legacy_initialize(client_protocol);
 
 	Dictionary result;
 	result["protocolVersion"] = p_server->transport_negotiated_protocol;
@@ -340,21 +342,85 @@ Dictionary JustAMCPJsonRpcRouter::route_initialize(JustAMCPServer *p_server, con
 	resources_cap["subscribe"] = true;
 	capabilities["resources"] = resources_cap;
 	capabilities["logging"] = Dictionary();
-	Dictionary tasks_cap;
-	tasks_cap["list"] = Dictionary();
-	tasks_cap["cancel"] = Dictionary();
-	Dictionary requests;
-	Dictionary tools;
-	tools["call"] = Dictionary();
-	requests["tools"] = tools;
-	tasks_cap["requests"] = requests;
-	capabilities["tasks"] = tasks_cap;
+	const String negotiated = p_server->transport_negotiated_protocol;
+	if (justamcp_protocol_supports(negotiated, JUSTAMCP_FEATURE_COMPLETIONS)) {
+		capabilities["completions"] = Dictionary();
+	}
+	if (justamcp_protocol_supports(negotiated, JUSTAMCP_FEATURE_TASKS_INITIALIZE)) {
+		Dictionary tasks_cap;
+		tasks_cap["list"] = Dictionary();
+		tasks_cap["cancel"] = Dictionary();
+		Dictionary requests;
+		Dictionary tools;
+		tools["call"] = Dictionary();
+		requests["tools"] = tools;
+		tasks_cap["requests"] = requests;
+		capabilities["tasks"] = tasks_cap;
+	}
+	if (justamcp_protocol_supports(negotiated, JUSTAMCP_FEATURE_ELICITATION_FORM)) {
+		Dictionary elicitation_cap;
+		elicitation_cap["form"] = Dictionary();
+		if (justamcp_protocol_supports(negotiated, JUSTAMCP_FEATURE_ELICITATION_URL)) {
+			elicitation_cap["url"] = Dictionary();
+		}
+		capabilities["elicitation"] = elicitation_cap;
+	}
 	result["capabilities"] = capabilities;
+	result["instructions"] = "Use blazium_* tools and blazium:// resources. Prefer editor tools for scene/resource edits, runtime_* tools only when a game bridge is active, and guide resources such as blazium://guide/tool-index for workflow orientation.";
 	Dictionary serverInfo;
 	serverInfo["name"] = "blazium-mcp-server";
+	if (justamcp_protocol_supports(negotiated, JUSTAMCP_FEATURE_SERVER_TITLE)) {
+		serverInfo["title"] = "Blazium MCP";
+	}
 	serverInfo["version"] = "1.0.0";
-	serverInfo["instructions"] = "Use blazium_* tools and blazium:// resources. Prefer editor tools for scene/resource edits, runtime_* tools only when a game bridge is active, and guide resources such as blazium://guide/tool-index for workflow orientation.";
+	serverInfo["websiteUrl"] = "https://blazium.app";
 	result["serverInfo"] = serverInfo;
+
+	Dictionary rpc_result;
+	rpc_result["handled"] = true;
+	rpc_result["jsonrpc"] = "2.0";
+	rpc_result["id"] = p_req_id_var;
+	rpc_result["result"] = result;
+	return rpc_result;
+}
+
+Dictionary JustAMCPJsonRpcRouter::route_discover(JustAMCPServer *p_server, const Variant &p_req_id_var) {
+	Dictionary result;
+	Array supported;
+	const Vector<String> versions = MCPSessionManager::accepted_protocol_versions();
+	for (int i = 0; i < versions.size(); i++) {
+		supported.push_back(versions[i]);
+	}
+	result["supportedVersions"] = supported;
+
+	Dictionary capabilities;
+	Dictionary tools_cap;
+	tools_cap["listChanged"] = true;
+	capabilities["tools"] = tools_cap;
+	Dictionary prompts_cap;
+	prompts_cap["listChanged"] = true;
+	capabilities["prompts"] = prompts_cap;
+	Dictionary resources_cap;
+	resources_cap["listChanged"] = true;
+	capabilities["resources"] = resources_cap;
+	capabilities["completions"] = Dictionary();
+	Dictionary elicitation_cap;
+	elicitation_cap["form"] = Dictionary();
+	elicitation_cap["url"] = Dictionary();
+	capabilities["elicitation"] = elicitation_cap;
+	Dictionary extensions;
+	if (p_server && p_server->task_manager) {
+		extensions["io.modelcontextprotocol/tasks"] = Dictionary();
+	}
+	capabilities["extensions"] = extensions;
+	result["capabilities"] = capabilities;
+	result["instructions"] = "Use blazium_* tools and blazium:// resources. Prefer editor tools for scene/resource edits, runtime_* tools only when a game bridge is active, and guide resources such as blazium://guide/tool-index for workflow orientation.";
+	result["ttlMs"] = 3600000;
+	result["cacheScope"] = "public";
+	result["resultType"] = "complete";
+	Dictionary meta;
+	meta["io.modelcontextprotocol/serverInfo"] = MCPSessionManager::mcp_server_info();
+	result["_meta"] = meta;
 
 	Dictionary rpc_result;
 	rpc_result["handled"] = true;
@@ -442,9 +508,10 @@ Dictionary JustAMCPJsonRpcRouter::route_completion_complete(JustAMCPServer *p_se
 	const Dictionary params = p_payload.has("params") ? Dictionary(p_payload["params"]) : Dictionary();
 	const Dictionary ref = params.has("ref") ? Dictionary(params["ref"]) : Dictionary();
 	const Dictionary argument = params.has("argument") ? Dictionary(params["argument"]) : Dictionary();
+	const Dictionary context = params.has("context") && params["context"].get_type() == Variant::DICTIONARY ? Dictionary(params["context"]) : Dictionary();
 	Dictionary result;
 	if (p_server->prompt_executor) {
-		result = p_server->prompt_executor->complete_prompt(ref, argument);
+		result = p_server->prompt_executor->complete_prompt(ref, argument, context);
 	}
 	Dictionary rpc_result;
 	rpc_result["handled"] = true;

--- a/modules/justamcp/tools/justamcp_meta_tools.cpp
+++ b/modules/justamcp/tools/justamcp_meta_tools.cpp
@@ -31,6 +31,7 @@
 
 #include "justamcp_meta_tools.h"
 
+#include "../justamcp_mcp_spec.h"
 #include "../justamcp_server.h"
 #include "justamcp_resource_executor.h"
 #include "justamcp_tool_executor.h"
@@ -70,6 +71,11 @@ Dictionary JustAMCPMetaTools::execute(JustAMCPToolExecutor *p_executor, const St
 	}
 	if (p_internal_name == "execute_tool") {
 		const String target_tool = p_args.get("tool_name", "");
+		if (!justamcp_is_valid_mcp_tool_name(target_tool) && !justamcp_is_valid_mcp_tool_name(target_tool.begins_with("blazium_") ? target_tool : String("blazium_") + target_tool)) {
+			result["ok"] = false;
+			result["error"] = justamcp_invalid_mcp_tool_name_message(target_tool);
+			return result;
+		}
 		const Dictionary target_args = p_args.get("arguments", Dictionary());
 		bool allow_bypass = false;
 		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/allow_execute_tool_bypass")) {

--- a/modules/justamcp/tools/justamcp_project_tools.cpp
+++ b/modules/justamcp/tools/justamcp_project_tools.cpp
@@ -267,6 +267,12 @@ Dictionary JustAMCPProjectTools::map_scenes(const Dictionary &p_args) {
 	result["scenes"] = scenes;
 	result["total_scenes"] = scenes.size();
 	result["truncated"] = truncated;
+	Array resource_links;
+	Dictionary root_link;
+	root_link["uri"] = root_path;
+	root_link["name"] = "project-scenes";
+	resource_links.push_back(root_link);
+	result["resourceLinks"] = resource_links;
 	return result;
 }
 

--- a/modules/justamcp/tools/justamcp_prompt_executor.cpp
+++ b/modules/justamcp/tools/justamcp_prompt_executor.cpp
@@ -29,11 +29,11 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "core/object/class_db.h"
 #include "justamcp_prompt_executor.h"
 #include "../justamcp_mcp_spec.h"
 #include "../justamcp_pagination.h"
 #include "core/config/project_settings.h"
+#include "core/object/class_db.h"
 #include "editor/editor_settings.h"
 #include "prompts/justamcp_prompt_asset_tagging_workflow.h"
 #include "prompts/justamcp_prompt_autowork_failure_analyzer.h"

--- a/modules/justamcp/tools/justamcp_prompt_executor.cpp
+++ b/modules/justamcp/tools/justamcp_prompt_executor.cpp
@@ -29,7 +29,9 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "core/object/class_db.h"
 #include "justamcp_prompt_executor.h"
+#include "../justamcp_mcp_spec.h"
 #include "../justamcp_pagination.h"
 #include "core/config/project_settings.h"
 #include "editor/editor_settings.h"
@@ -50,7 +52,7 @@
 void JustAMCPPromptExecutor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_prompt", "name", "args"), &JustAMCPPromptExecutor::get_prompt);
 	ClassDB::bind_method(D_METHOD("list_prompts", "cursor"), &JustAMCPPromptExecutor::list_prompts, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("complete_prompt", "ref", "argument"), &JustAMCPPromptExecutor::complete_prompt);
+	ClassDB::bind_method(D_METHOD("complete_prompt", "ref", "argument", "context"), &JustAMCPPromptExecutor::complete_prompt, DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("add_prompt", "prompt"), &JustAMCPPromptExecutor::add_prompt);
 }
 
@@ -109,7 +111,9 @@ Dictionary JustAMCPPromptExecutor::list_prompts(const String &cursor) {
 	Array prompts;
 	for (int i = 0; i < registered_prompts.size(); i++) {
 		if (registered_prompts[i].is_valid()) {
-			prompts.push_back(registered_prompts[i]->get_prompt());
+			Dictionary prompt = registered_prompts[i]->get_prompt();
+			justamcp_attach_icons(prompt);
+			prompts.push_back(prompt);
 		}
 	}
 	return justamcp_pagination_slice_array(prompts, cursor, "prompts");
@@ -146,13 +150,17 @@ Dictionary JustAMCPPromptExecutor::get_prompt(const String &p_name, const Dictio
 	return result;
 }
 
-Dictionary JustAMCPPromptExecutor::complete_prompt(const Dictionary &p_ref, const Dictionary &p_argument) {
+Dictionary JustAMCPPromptExecutor::complete_prompt(const Dictionary &p_ref, const Dictionary &p_argument, const Dictionary &p_context) {
 	String ref_name = p_ref.has("name") ? String(Variant(p_ref["name"])) : "";
+	Dictionary argument = p_argument.duplicate();
+	if (!p_context.is_empty()) {
+		argument["context"] = p_context;
+	}
 
 	for (int i = 0; i < registered_prompts.size(); i++) {
 		if (registered_prompts[i].is_valid() && registered_prompts[i]->get_name() == ref_name) {
 			Dictionary result;
-			result["completion"] = registered_prompts[i]->complete(p_argument);
+			result["completion"] = registered_prompts[i]->complete(argument);
 			return result;
 		}
 	}

--- a/modules/justamcp/tools/justamcp_prompt_executor.h
+++ b/modules/justamcp/tools/justamcp_prompt_executor.h
@@ -31,7 +31,6 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "prompts/justamcp_prompt.h"
 
@@ -55,7 +54,7 @@ public:
 
 	Dictionary list_prompts(const String &cursor = "");
 	Dictionary get_prompt(const String &p_name, const Dictionary &p_args);
-	Dictionary complete_prompt(const Dictionary &p_ref, const Dictionary &p_argument);
+	Dictionary complete_prompt(const Dictionary &p_ref, const Dictionary &p_argument, const Dictionary &p_context = Dictionary());
 
 	JustAMCPPromptExecutor();
 	~JustAMCPPromptExecutor();

--- a/modules/justamcp/tools/justamcp_resource_manifest.cpp
+++ b/modules/justamcp/tools/justamcp_resource_manifest.cpp
@@ -31,6 +31,7 @@
 
 #include "justamcp_resource_manifest.h"
 
+#include "../justamcp_mcp_spec.h"
 #include "modules/modules_enabled.gen.h"
 
 #include "core/variant/array.h"
@@ -43,6 +44,7 @@ static Dictionary _manifest_resource_schema(const String &p_uri, const String &p
 	resource["name"] = p_name;
 	resource["description"] = p_description;
 	resource["mimeType"] = p_mime_type;
+	justamcp_attach_icons(resource);
 	return resource;
 }
 
@@ -52,6 +54,7 @@ static Dictionary _manifest_resource_template_schema(const String &p_uri_templat
 	resource["name"] = p_name;
 	resource["description"] = p_description;
 	resource["mimeType"] = p_mime_type;
+	justamcp_attach_icons(resource);
 	return resource;
 }
 

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -28,6 +28,7 @@
 /**************************************************************************/
 
 #include "justamcp_tool_executor.h"
+#include "../justamcp_mcp_spec.h"
 #include "../justamcp_pagination.h"
 #include "../justamcp_runtime.h"
 #include "../justamcp_server.h"
@@ -406,6 +407,10 @@ static Array _collect_tool_schemas(bool p_register_only, bool p_ignore_settings,
 
 	auto add_schema = [&](const String &p_name, const String &p_desc, const Vector<String> &p_props, const Vector<String> &p_req, const String &p_task_support = "forbidden", const String &p_thread_affinity = "") {
 		String full_name = "blazium_" + p_name;
+		if (!justamcp_is_valid_mcp_tool_name(full_name)) {
+			WARN_PRINT("JustAMCP: skipping invalid tool name at registration: " + full_name);
+			return;
+		}
 
 		if (p_register_only) {
 			if (current_category.is_empty() || !category_matches()) {
@@ -473,6 +478,7 @@ static Array _collect_tool_schemas(bool p_register_only, bool p_ignore_settings,
 			schema["required"] = req;
 		}
 		t["inputSchema"] = schema;
+		justamcp_attach_icons(t);
 		if (p_task_support != "forbidden" || p_thread_affinity == "worker") {
 			Dictionary execution;
 			if (p_task_support != "forbidden") {
@@ -635,6 +641,11 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		internal_name = internal_name.substr(8);
 	}
 	String full_name = "blazium_" + internal_name;
+	if (!justamcp_is_valid_mcp_tool_name(p_tool_name) && !justamcp_is_valid_mcp_tool_name(full_name)) {
+		result["ok"] = false;
+		result["error"] = justamcp_invalid_mcp_tool_name_message(p_tool_name);
+		return result;
+	}
 
 	Dictionary target_schema = JustAMCPToolSchemaCache::find_tool_schema(full_name, true);
 	bool tool_found = !target_schema.is_empty();

--- a/modules/justamcp/tools/justamcp_tool_schema_builder.cpp
+++ b/modules/justamcp/tools/justamcp_tool_schema_builder.cpp
@@ -31,6 +31,7 @@
 
 #include "justamcp_tool_schema_builder.h"
 
+#include "../justamcp_mcp_spec.h"
 #include "justamcp_settings_resolver.h"
 
 #include "core/config/project_settings.h"
@@ -82,6 +83,7 @@ Dictionary JustAMCPToolSchemaBuilder::build_tool_schema(const String &p_full_nam
 		schema["required"] = req;
 	}
 	t["inputSchema"] = schema;
+	justamcp_attach_icons(t);
 	if (p_task_support != "forbidden" || p_thread_affinity == "worker") {
 		Dictionary execution;
 		if (!p_task_support.is_empty() && p_task_support != "forbidden") {

--- a/modules/justamcp/tools/prompts/justamcp_prompt.cpp
+++ b/modules/justamcp/tools/prompts/justamcp_prompt.cpp
@@ -28,7 +28,9 @@
 /**************************************************************************/
 
 #ifdef TOOLS_ENABLED
+#include "core/object/class_db.h"
 #include "justamcp_prompt.h"
+#include "../../justamcp_mcp_spec.h"
 #include "../justamcp_resource_executor.h"
 
 void JustAMCPPrompt::_bind_methods() {
@@ -77,8 +79,12 @@ Dictionary JustAMCPPrompt::_make_resource_message(const String &p_uri) {
 	}
 
 	Dictionary content;
-	content["type"] = "resource";
-	content["resource"] = resource;
+	if (justamcp_protocol_supports(justamcp_active_protocol_version(), JUSTAMCP_FEATURE_RESOURCE_LINKS)) {
+		content = justamcp_resource_link_content(String(resource.get("uri", p_uri)), p_uri, String(resource.get("mimeType", "")));
+	} else {
+		content["type"] = "resource";
+		content["resource"] = resource;
+	}
 
 	Dictionary msg;
 	msg["role"] = "user";

--- a/modules/justamcp/tools/prompts/justamcp_prompt.cpp
+++ b/modules/justamcp/tools/prompts/justamcp_prompt.cpp
@@ -28,10 +28,10 @@
 /**************************************************************************/
 
 #ifdef TOOLS_ENABLED
-#include "core/object/class_db.h"
 #include "justamcp_prompt.h"
 #include "../../justamcp_mcp_spec.h"
 #include "../justamcp_resource_executor.h"
+#include "core/object/class_db.h"
 
 void JustAMCPPrompt::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_name"), &JustAMCPPrompt::get_name);


### PR DESCRIPTION
## Summary
- Advertise MCP `2026-07-28` as the latest version and serve modern requests statelessly, while Cursor and other handshake clients still negotiate `initialize` plus `MCP-Session-Id` on `2025-11-25`.
- Complete the Cursor-facing 2025-11-25 surface: workspace roots, form/URL elicitation hold, icons, SEP-986 tool names, and OAuth PRM/AS/CIMD discovery with `WWW-Authenticate` on 401.
- Gate capabilities, JSON-RPC batches (`2025-03-26` only), structuredContent, icons, elicitation modes, and tasks by the negotiated protocol date.

Include paths stay on the blazium-dev layout (`editor/editor_settings.h`, `servers/display_server.h`). GDScript module tests live outside this repo.

## Test plan
- [x] Editor `tests=yes` build on Windows
- [x] `--test --headless --test-case="*[JustAMCP]*"` (277 passed)
- [ ] Connect Cursor to JustAMCP and confirm `initialize` still uses a session on `2025-11-25`
- [ ] Confirm a modern client can call `server/discover` / stateless `2026-07-28` without a session
- [ ] Confirm OAuth discovery routes and 401 `WWW-Authenticate` when OAuth is enabled
