### PR TITLE
Fix JustAMCP editor listen so port 6506 actually binds

### DIFF
--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -293,13 +293,13 @@ void JustAMCPEditorPlugin::_notification(int p_what) {
 			if (!mcp_server) {
 				mcp_server = memnew(JustAMCPServer);
 				mcp_server->set_name("JustAMCPServer");
-				if (editor_node) {
-					editor_node->call_deferred(SNAME("add_child"), mcp_server);
-				} else {
+				add_child(mcp_server);
+				mcp_server->start_listening();
+			} else {
+				if (!mcp_server->is_inside_tree()) {
 					add_child(mcp_server);
 				}
-			} else if (editor_node && mcp_server->get_parent() != editor_node) {
-				editor_node->call_deferred(SNAME("add_child"), mcp_server);
+				mcp_server->start_listening();
 			}
 
 			tool_executor = memnew(JustAMCPToolExecutor);

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -135,6 +135,10 @@ bool JustAMCPServer::test_get_tool_queue_processing() const {
 	return mcp_tool_queue.processing;
 }
 
+void JustAMCPServer::test_start_server() {
+	_start_server_internal(true);
+}
+
 void JustAMCPServer::test_stop_server() {
 	_stop_server();
 }
@@ -344,14 +348,18 @@ JustAMCPServer::~JustAMCPServer() {
 
 void JustAMCPServer::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			_setup_settings();
+			_start_server();
+		} break;
 		case NOTIFICATION_READY: {
 			_setup_settings();
 #ifdef TOOLS_ENABLED
-			if (EditorSettings::get_singleton()) {
+			if (EditorSettings::get_singleton() && !EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &JustAMCPServer::_on_settings_changed))) {
 				EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &JustAMCPServer::_on_settings_changed));
 			}
 #endif
-			if (ProjectSettings::get_singleton()) {
+			if (ProjectSettings::get_singleton() && !ProjectSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &JustAMCPServer::_on_settings_changed))) {
 				ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &JustAMCPServer::_on_settings_changed));
 			}
 			_start_server();
@@ -423,17 +431,26 @@ void JustAMCPServer::_setup_settings() {
 #endif
 }
 
+void JustAMCPServer::start_listening() {
+	_start_server();
+}
+
 void JustAMCPServer::_start_server() {
+	_start_server_internal(false);
+}
+
+void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 	if (server_started) {
 		return;
 	}
 
 	const List<String> &args = OS::get_singleton()->get_cmdline_args();
-	if (!_justamcp_headless_project_server_requested()) {
+	if (!p_ignore_cmdline_block && !_justamcp_headless_project_server_requested()) {
 		for (const String &arg : args) {
 			if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
 					arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
 					arg == "--check-only" || arg.begins_with("--export")) {
+				print_line("JustAMCP: Server not started (cmdline " + arg + " skips MCP).");
 				return;
 			}
 		}
@@ -526,6 +543,7 @@ void JustAMCPServer::_start_server() {
 	}
 
 	if (!enabled) {
+		print_line("JustAMCP: Server not started (disabled; pass --enable-mcp or set blazium/justamcp/server_enabled).");
 		return;
 	}
 
@@ -544,56 +562,73 @@ void JustAMCPServer::_start_server() {
 	}
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
-	if (HTTPServer::get_singleton()) {
-		if (!HTTPServer::get_singleton()->is_listening()) {
-			String bind_address = bind_to_localhost ? "127.0.0.1" : "*";
-			HTTPServer::get_singleton()->listen(port, bind_address, false);
-		}
-
-		HTTPServer::get_singleton()->set_cors_enabled(true);
-		{
-			const String allowed_origin = String(GLOBAL_GET("blazium/justamcp/streamable_http_allowed_origin"));
-			const String cors_origin = justamcp_compute_startup_cors_origin(bind_to_localhost, oauth_enabled, allowed_origin);
-			if (!bind_to_localhost && cors_origin.is_empty()) {
-				WARN_PRINT("JustAMCP: bind_to_localhost_only is false without OAuth or streamable_http_allowed_origin; CORS Access-Control-Allow-Origin will not be set to *.");
-			}
-			HTTPServer::get_singleton()->set_cors_origin(cors_origin);
-		}
-
-		HTTPServer::get_singleton()->register_route("GET", "/sse", callable_mp(this, &JustAMCPServer::_handle_legacy_sse_connect));
-		HTTPServer::get_singleton()->register_route("POST", "/sse", callable_mp(this, &JustAMCPServer::_handle_legacy_sse_connect));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/sse", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-		HTTPServer::get_singleton()->register_route("POST", "/message", callable_mp(this, &JustAMCPServer::_handle_message_post));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/message", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-		HTTPServer::get_singleton()->register_route("GET", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_get));
-		HTTPServer::get_singleton()->register_route("POST", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_post));
-		HTTPServer::get_singleton()->register_route("DELETE", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_delete));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/mcp", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-		HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-protected-resource", callable_mp(this, &JustAMCPServer::_handle_oauth_protected_resource));
-		HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-protected-resource/mcp", callable_mp(this, &JustAMCPServer::_handle_oauth_protected_resource));
-		HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-authorization-server", callable_mp(this, &JustAMCPServer::_handle_oauth_authorization_server));
-		HTTPServer::get_singleton()->register_route("GET", "/.well-known/openid-configuration", callable_mp(this, &JustAMCPServer::_handle_oauth_authorization_server));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-protected-resource", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-protected-resource/mcp", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-authorization-server", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-		HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/openid-configuration", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
-
-		if (!HTTPServer::get_singleton()->is_connected("sse_connection_opened", callable_mp(this, &JustAMCPServer::_on_sse_connection_opened))) {
-			HTTPServer::get_singleton()->connect("sse_connection_opened", callable_mp(this, &JustAMCPServer::_on_sse_connection_opened));
-		}
-		if (!HTTPServer::get_singleton()->is_connected("sse_connection_closed", callable_mp(this, &JustAMCPServer::_on_sse_connection_closed))) {
-			HTTPServer::get_singleton()->connect("sse_connection_closed", callable_mp(this, &JustAMCPServer::_on_sse_connection_closed));
-		}
-
-		server_started = true;
-		active_listening_port = port;
-#ifdef TOOLS_ENABLED
-		_ensure_headless_tool_executor();
-		JustAMCPToolSchemaCache::get_schemas(false, false, false, false);
-#endif
-		print_line("JustAMCP: Server Activated on port " + itos(port));
-		emit_signal("server_status_changed", true);
+	if (!HTTPServer::get_singleton()) {
+		ERR_PRINT("JustAMCP: HTTPServer singleton is missing; cannot start MCP server.");
+		return;
 	}
+
+	if (!HTTPServer::get_singleton()->is_listening()) {
+		String bind_address = bind_to_localhost ? "127.0.0.1" : "*";
+		Error listen_err = OK;
+#ifdef TESTS_ENABLED
+		if (test_forced_listen_error != OK) {
+			listen_err = test_forced_listen_error;
+		} else
+#endif
+		{
+			listen_err = HTTPServer::get_singleton()->listen(port, bind_address, false);
+		}
+		if (listen_err != OK) {
+			ERR_PRINT("JustAMCP: Failed to listen on port " + itos(port) + " (error " + itos(listen_err) + ").");
+			return;
+		}
+	} else {
+		print_line("JustAMCP: HTTPServer already listening; registering MCP routes on the existing socket.");
+	}
+
+	HTTPServer::get_singleton()->set_cors_enabled(true);
+	{
+		const String allowed_origin = String(GLOBAL_GET("blazium/justamcp/streamable_http_allowed_origin"));
+		const String cors_origin = justamcp_compute_startup_cors_origin(bind_to_localhost, oauth_enabled, allowed_origin);
+		if (!bind_to_localhost && cors_origin.is_empty()) {
+			WARN_PRINT("JustAMCP: bind_to_localhost_only is false without OAuth or streamable_http_allowed_origin; CORS Access-Control-Allow-Origin will not be set to *.");
+		}
+		HTTPServer::get_singleton()->set_cors_origin(cors_origin);
+	}
+
+	HTTPServer::get_singleton()->register_route("GET", "/sse", callable_mp(this, &JustAMCPServer::_handle_legacy_sse_connect));
+	HTTPServer::get_singleton()->register_route("POST", "/sse", callable_mp(this, &JustAMCPServer::_handle_legacy_sse_connect));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/sse", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+	HTTPServer::get_singleton()->register_route("POST", "/message", callable_mp(this, &JustAMCPServer::_handle_message_post));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/message", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+	HTTPServer::get_singleton()->register_route("GET", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_get));
+	HTTPServer::get_singleton()->register_route("POST", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_post));
+	HTTPServer::get_singleton()->register_route("DELETE", "/mcp", callable_mp(this, &JustAMCPServer::_handle_mcp_delete));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/mcp", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+	HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-protected-resource", callable_mp(this, &JustAMCPServer::_handle_oauth_protected_resource));
+	HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-protected-resource/mcp", callable_mp(this, &JustAMCPServer::_handle_oauth_protected_resource));
+	HTTPServer::get_singleton()->register_route("GET", "/.well-known/oauth-authorization-server", callable_mp(this, &JustAMCPServer::_handle_oauth_authorization_server));
+	HTTPServer::get_singleton()->register_route("GET", "/.well-known/openid-configuration", callable_mp(this, &JustAMCPServer::_handle_oauth_authorization_server));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-protected-resource", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-protected-resource/mcp", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/oauth-authorization-server", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+	HTTPServer::get_singleton()->register_route("OPTIONS", "/.well-known/openid-configuration", callable_mp(this, &JustAMCPServer::_handle_cors_preflight));
+
+	if (!HTTPServer::get_singleton()->is_connected("sse_connection_opened", callable_mp(this, &JustAMCPServer::_on_sse_connection_opened))) {
+		HTTPServer::get_singleton()->connect("sse_connection_opened", callable_mp(this, &JustAMCPServer::_on_sse_connection_opened));
+	}
+	if (!HTTPServer::get_singleton()->is_connected("sse_connection_closed", callable_mp(this, &JustAMCPServer::_on_sse_connection_closed))) {
+		HTTPServer::get_singleton()->connect("sse_connection_closed", callable_mp(this, &JustAMCPServer::_on_sse_connection_closed));
+	}
+
+	server_started = true;
+	active_listening_port = port;
+	print_line("JustAMCP: Server Activated on port " + itos(port));
+	emit_signal("server_status_changed", true);
+#ifdef TOOLS_ENABLED
+	_ensure_headless_tool_executor();
+	JustAMCPToolSchemaCache::get_schemas(false, false, false, false);
+#endif
 #else
 	ERR_PRINT("HTTPServer module is not enabled! JustAMCP requires it to act as an MCP server.");
 #endif

--- a/modules/justamcp/justamcp_server.h
+++ b/modules/justamcp/justamcp_server.h
@@ -91,6 +91,7 @@ private:
 	mutable Mutex completed_tool_request_mutex;
 #ifdef TESTS_ENABLED
 	mutable Dictionary test_last_send_tool_result;
+	Error test_forced_listen_error = OK;
 #endif
 	String minimum_log_level = "info";
 	Mutex minimum_log_level_mutex;
@@ -124,6 +125,7 @@ private:
 
 	void _setup_settings();
 	void _start_server();
+	void _start_server_internal(bool p_ignore_cmdline_block);
 	void _stop_server();
 	void _on_settings_changed();
 	int _resolve_listening_port_from_settings() const;
@@ -233,6 +235,8 @@ public:
 	MCPToolQueueEntry *test_enqueue_tool_request(const Variant &p_request_id, const String &p_tool_name, const Dictionary &p_args, Dictionary &r_queue_full_error);
 	void test_set_in_flight_entries(MCPToolQueueEntry *p_write, MCPToolQueueEntry *p_readonly);
 	bool test_get_tool_queue_processing() const;
+	void test_start_server();
+	void test_set_forced_listen_error(Error p_error) { test_forced_listen_error = p_error; }
 	void test_stop_server();
 	void test_clear_tool_queue();
 	MCPToolQueueEntry *test_get_in_flight_write() const;
@@ -259,6 +263,7 @@ public:
 	void test_handle_oauth_authorization_server(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response);
 #endif
 
+	void start_listening();
 	bool is_server_started() const { return server_started; }
 	int get_listening_port() const { return active_listening_port; }
 	int get_pending_tool_queue_size();

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -127,6 +127,7 @@
 #include "tests/test_justamcp_schema_cache_concurrent.cpp"
 #include "tests/test_justamcp_schema_dirty_per_cache_key.cpp"
 #include "tests/test_justamcp_semantic_tools_async.cpp"
+#include "tests/test_justamcp_server_listen.cpp"
 #include "tests/test_justamcp_server_queue_lifecycle.cpp"
 #include "tests/test_justamcp_session_manager.cpp"
 #include "tests/test_justamcp_session_survives_stream_close.cpp"

--- a/modules/justamcp/tests/test_justamcp_server_listen.cpp
+++ b/modules/justamcp/tests/test_justamcp_server_listen.cpp
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/*  test_justamcp_server_listen.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_justamcp_server_listen.h"
+
+#ifdef TESTS_ENABLED
+
+#include "../justamcp_server.h"
+#include "core/config/project_settings.h"
+#include "modules/modules_enabled.gen.h"
+#include "tests/test_macros.h"
+
+#if defined(MODULE_HTTPSERVER_ENABLED)
+#include "modules/httpserver/http_server.h"
+#endif
+
+namespace {
+
+void _stop_httpserver_if_listening() {
+#if defined(MODULE_HTTPSERVER_ENABLED)
+	if (HTTPServer::get_singleton() && HTTPServer::get_singleton()->is_listening()) {
+		HTTPServer::get_singleton()->stop();
+	}
+#endif
+}
+
+struct JustAMCPListenSettingsGuard {
+	Variant prev_override;
+	Variant prev_enabled;
+	Variant prev_port;
+	Variant prev_bind;
+
+	JustAMCPListenSettingsGuard() {
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		ERR_FAIL_NULL(ps);
+		prev_override = ps->get_setting("blazium/justamcp/override_editor_settings");
+		prev_enabled = ps->get_setting("blazium/justamcp/server_enabled");
+		prev_port = ps->get_setting("blazium/justamcp/server_port");
+		prev_bind = ps->get_setting("blazium/justamcp/bind_to_localhost_only");
+	}
+
+	~JustAMCPListenSettingsGuard() {
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		if (!ps) {
+			return;
+		}
+		ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+		ps->set_setting("blazium/justamcp/server_enabled", prev_enabled);
+		ps->set_setting("blazium/justamcp/server_port", prev_port);
+		ps->set_setting("blazium/justamcp/bind_to_localhost_only", prev_bind);
+	}
+
+	void apply(bool p_enabled, int p_port) {
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		ERR_FAIL_NULL(ps);
+		ps->set_setting("blazium/justamcp/override_editor_settings", true);
+		ps->set_setting("blazium/justamcp/server_enabled", p_enabled);
+		ps->set_setting("blazium/justamcp/server_port", p_port);
+		ps->set_setting("blazium/justamcp/bind_to_localhost_only", true);
+	}
+};
+
+} // namespace
+
+void test_justamcp_server_start_listens() {
+#if !defined(MODULE_HTTPSERVER_ENABLED)
+	return;
+#else
+	REQUIRE(HTTPServer::get_singleton());
+	_stop_httpserver_if_listening();
+
+	JustAMCPListenSettingsGuard settings;
+	const int port = 16506;
+	settings.apply(true, port);
+
+	JustAMCPServer server;
+	server.test_start_server();
+	CHECK(server.is_server_started());
+	CHECK(server.get_listening_port() == port);
+	CHECK(HTTPServer::get_singleton()->is_listening());
+
+	server.test_stop_server();
+	CHECK(!server.is_server_started());
+	_stop_httpserver_if_listening();
+#endif
+}
+
+void test_justamcp_server_failed_listen_does_not_activate() {
+#if !defined(MODULE_HTTPSERVER_ENABLED)
+	return;
+#else
+	REQUIRE(HTTPServer::get_singleton());
+	_stop_httpserver_if_listening();
+
+	JustAMCPListenSettingsGuard settings;
+	const int port = 16507;
+	settings.apply(true, port);
+
+	JustAMCPServer server;
+	server.test_set_forced_listen_error(ERR_CANT_CREATE);
+	server.test_start_server();
+	CHECK(!server.is_server_started());
+	CHECK(server.get_listening_port() == -1);
+	CHECK(!HTTPServer::get_singleton()->is_listening());
+#endif
+}
+
+#endif

--- a/modules/justamcp/tests/test_justamcp_server_listen.h
+++ b/modules/justamcp/tests/test_justamcp_server_listen.h
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  test_justamcp_server_listen.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "tests/test_macros.h"
+
+void test_justamcp_server_start_listens();
+void test_justamcp_server_failed_listen_does_not_activate();
+
+TEST_CASE("[Modules][JustAMCP] server start listens") {
+	test_justamcp_server_start_listens();
+}
+
+TEST_CASE("[Modules][JustAMCP] failed listen does not claim Activated") {
+	test_justamcp_server_failed_listen_does_not_activate();
+}


### PR DESCRIPTION
## Summary
- Start JustAMCP as soon as the editor plugin creates the server node, instead of waiting on a deferred READY path that never bound 6506.
- Fail loudly if HTTPServer is missing or `listen()` is not OK, and print Activated only after a successful bind.
- Add tests that a successful start listens and a failed listen does not claim Activated.

## Test plan
- [x] Build editor: `python -m SCons platform=windows target=editor -j8`
- [x] Launch a project with JustAMCP enabled (or `--enable-mcp --editor`) and confirm `JustAMCP: Server Activated on port 6506`
- [x] Confirm port 6506 is listening and the engine Remote Control default stays off
- [x] MCP `initialize` plus `blazium_get_project_info` / `blazium_editor_get_errors` succeed
- [x] With `tests=yes`, run `[Modules][JustAMCP] server start listens` and `failed listen does not claim Activated`