### PR TITLE
Add opt-in Analytics module with identity, consent, and HTTP queue

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -250,6 +250,25 @@ opts.Add(
 opts.Add("editor_crash_reporter_api_key", "Baked editor crash reporter X-API-Key (public client key)", "")
 opts.Add(
     BoolVariable(
+        "analytics",
+        "Enable analytics SDK in export templates (session + custom track)",
+        False,
+    )
+)
+opts.Add(
+    BoolVariable(
+        "editor_analytics",
+        "Enable editor analytics (demographic/usage events; send only after consent)",
+        False,
+    )
+)
+opts.Add("editor_analytics_app_id", "Baked editor analytics app_id", "blazium-editor")
+opts.Add("editor_analytics_build_id", "Baked editor analytics build_id (empty = version hash)", "")
+opts.Add("editor_analytics_build_channel", "Baked editor analytics build_channel", "dev")
+opts.Add("editor_analytics_endpoint", "Baked editor analytics ingest URL (empty = queue only)", "")
+opts.Add("editor_analytics_api_key", "Baked editor analytics X-API-Key (public client key)", "")
+opts.Add(
+    BoolVariable(
         "hub_register",
         "Post-build: register the linked editor with Blazium Hub via blazium-cli handle-uri (editor only; not runtime)",
         False,
@@ -568,6 +587,31 @@ elif env.get("editor_crash_reporter"):
     print_warning("editor_crash_reporter=yes is ignored for export templates; use crash_reporter=yes.")
 elif env.get("crash_reporter"):
     env.Append(CPPDEFINES=["CRASH_REPORTER_ENABLED", "USE_BREAKPAD"])
+
+
+def _analytics_cpp_string(name, value):
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'{name}=\\"{escaped}\\"'
+
+
+if env.editor_build:
+    if env.get("analytics"):
+        print_warning("analytics=yes is ignored for editor builds; use editor_analytics=yes.")
+    if env.get("editor_analytics"):
+        env.Append(CPPDEFINES=["ANALYTICS_ENABLED"])
+        env.Append(
+            CPPDEFINES=[
+                _analytics_cpp_string("ANALYTICS_EDITOR_APP_ID", env.get("editor_analytics_app_id", "")),
+                _analytics_cpp_string("ANALYTICS_EDITOR_BUILD_ID", env.get("editor_analytics_build_id", "")),
+                _analytics_cpp_string("ANALYTICS_EDITOR_BUILD_CHANNEL", env.get("editor_analytics_build_channel", "")),
+                _analytics_cpp_string("ANALYTICS_EDITOR_ENDPOINT", env.get("editor_analytics_endpoint", "")),
+                _analytics_cpp_string("ANALYTICS_EDITOR_API_KEY", env.get("editor_analytics_api_key", "")),
+            ]
+        )
+elif env.get("editor_analytics"):
+    print_warning("editor_analytics=yes is ignored for export templates; use analytics=yes.")
+elif env.get("analytics"):
+    env.Append(CPPDEFINES=["ANALYTICS_ENABLED"])
 
 # This is not part of fast_unsafe because the only downside it has compared to
 # the default is that SCons won't mark files that were changed in the last second

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1547,6 +1547,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="Analytics" type="Analytics" setter="" getter="">
+			The [Analytics] singleton.
+		</member>
 		<member name="AudioServer" type="AudioServer" setter="" getter="">
 			The [AudioServer] singleton.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -309,6 +309,39 @@
 		<member name="application/config/windows_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
+		<member name="application/analytics/anonymous" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], game analytics events omit [code]device_uid[/code]. Identity fields such as [code]app_id[/code] are still sent.
+		</member>
+		<member name="application/analytics/api_key" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional [code]X-API-Key[/code] sent with analytics POSTs. Treat as a public client key, not a secret.
+		</member>
+		<member name="application/analytics/app_id" type="String" setter="" getter="" default="&quot;&quot;">
+			Stable product id sent on every event. Falls back to [member application/config/name] if empty.
+		</member>
+		<member name="application/analytics/app_version" type="String" setter="" getter="" default="&quot;&quot;">
+			Product version sent on every event. Falls back to [member application/config/version] if empty.
+		</member>
+		<member name="application/analytics/build_channel" type="String" setter="" getter="" default="&quot;release&quot;">
+			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
+		</member>
+		<member name="application/analytics/build_id" type="String" setter="" getter="" default="&quot;&quot;">
+			Build identifier (git SHA or CI build number). Falls back to [member application/config/version] if empty.
+		</member>
+		<member name="application/analytics/enabled" type="bool" setter="" getter="" default="false">
+			Master switch after a template is compiled with [code]analytics=yes[/code]. When [code]false[/code], events are not queued or sent.
+		</member>
+		<member name="application/analytics/endpoint" type="String" setter="" getter="" default="&quot;&quot;">
+			POST URL for analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only.
+		</member>
+		<member name="application/analytics/require_user_consent" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], [method Analytics.set_consent] must accept before events are queued.
+		</member>
+		<member name="application/analytics/timeout_sec" type="int" setter="" getter="" default="15">
+			HTTP timeout in seconds for [method Analytics.flush].
+		</member>
+		<member name="application/analytics/verify_tls" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], TLS certificates are verified on analytics HTTPS uploads.
+		</member>
 		<member name="application/crash_reporter/api_key" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional [code]X-API-Key[/code] sent with in-engine and sidecar crash uploads. Treat as a public client key, not a secret.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -241,6 +241,39 @@
 		<member name="animation/warnings/check_invalid_track_paths" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], [AnimationMixer] prints the warning of no matching object of the track path in the scene.
 		</member>
+		<member name="application/analytics/anonymous" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], game analytics events omit [code]device_uid[/code]. Identity fields such as [code]app_id[/code] are still sent.
+		</member>
+		<member name="application/analytics/api_key" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional [code]X-API-Key[/code] sent with analytics POSTs. Treat as a public client key, not a secret.
+		</member>
+		<member name="application/analytics/app_id" type="String" setter="" getter="" default="&quot;&quot;">
+			Stable product id sent on every event. Falls back to [member application/config/name] if empty.
+		</member>
+		<member name="application/analytics/app_version" type="String" setter="" getter="" default="&quot;&quot;">
+			Product version sent on every event. Falls back to [member application/config/version] if empty.
+		</member>
+		<member name="application/analytics/build_channel" type="String" setter="" getter="" default="&quot;release&quot;">
+			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
+		</member>
+		<member name="application/analytics/build_id" type="String" setter="" getter="" default="&quot;&quot;">
+			Build identifier (git SHA or CI build number). Falls back to [member application/config/version] if empty.
+		</member>
+		<member name="application/analytics/enabled" type="bool" setter="" getter="" default="false">
+			Master switch after a template is compiled with [code]analytics=yes[/code]. When [code]false[/code], events are not queued or sent.
+		</member>
+		<member name="application/analytics/endpoint" type="String" setter="" getter="" default="&quot;&quot;">
+			POST URL for analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only.
+		</member>
+		<member name="application/analytics/require_user_consent" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], [method Analytics.set_consent] must accept before events are queued.
+		</member>
+		<member name="application/analytics/timeout_sec" type="int" setter="" getter="" default="15">
+			HTTP timeout in seconds for [method Analytics.flush].
+		</member>
+		<member name="application/analytics/verify_tls" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], TLS certificates are verified on analytics HTTPS uploads.
+		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>
@@ -308,39 +341,6 @@
 		</member>
 		<member name="application/config/windows_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
-		</member>
-		<member name="application/analytics/anonymous" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], game analytics events omit [code]device_uid[/code]. Identity fields such as [code]app_id[/code] are still sent.
-		</member>
-		<member name="application/analytics/api_key" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional [code]X-API-Key[/code] sent with analytics POSTs. Treat as a public client key, not a secret.
-		</member>
-		<member name="application/analytics/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id sent on every event. Falls back to [member application/config/name] if empty.
-		</member>
-		<member name="application/analytics/app_version" type="String" setter="" getter="" default="&quot;&quot;">
-			Product version sent on every event. Falls back to [member application/config/version] if empty.
-		</member>
-		<member name="application/analytics/build_channel" type="String" setter="" getter="" default="&quot;release&quot;">
-			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
-		</member>
-		<member name="application/analytics/build_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Build identifier (git SHA or CI build number). Falls back to [member application/config/version] if empty.
-		</member>
-		<member name="application/analytics/enabled" type="bool" setter="" getter="" default="false">
-			Master switch after a template is compiled with [code]analytics=yes[/code]. When [code]false[/code], events are not queued or sent.
-		</member>
-		<member name="application/analytics/endpoint" type="String" setter="" getter="" default="&quot;&quot;">
-			POST URL for analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only.
-		</member>
-		<member name="application/analytics/require_user_consent" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], [method Analytics.set_consent] must accept before events are queued.
-		</member>
-		<member name="application/analytics/timeout_sec" type="int" setter="" getter="" default="15">
-			HTTP timeout in seconds for [method Analytics.flush].
-		</member>
-		<member name="application/analytics/verify_tls" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], TLS certificates are verified on analytics HTTPS uploads.
 		</member>
 		<member name="application/crash_reporter/api_key" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional [code]X-API-Key[/code] sent with in-engine and sidecar crash uploads. Treat as a public client key, not a secret.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -128,6 +128,9 @@
 #ifdef MODULE_CRASH_REPORTER_ENABLED
 #include "modules/crash_reporter/crash_reporter.h"
 #endif
+#ifdef MODULE_ANALYTICS_ENABLED
+#include "modules/analytics/analytics.h"
+#endif
 
 #if defined(MODULE_MONO_ENABLED) && defined(TOOLS_ENABLED)
 #include "modules/mono/editor/bindings_generator.h"
@@ -689,6 +692,14 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--mcp-port <port>", "Bind the JustAMCP server to a specific local port.\n");
 	print_help_option("--mcp-client-id <id>", "Force override the MCP OAuth Client ID dynamically.\n");
 	print_help_option("--mcp-client-secret <secret>", "Force override the MCP OAuth Client Secret dynamically.\n");
+#endif
+
+#ifdef MODULE_ANALYTICS_ENABLED
+	print_help_title("Analytics Options");
+	print_help_option("--analytics=<accepted|declined>", "Set analytics consent for this process (overrides settings).\n");
+	print_help_option("--analytics-mode=<anonymous|identified>", "Anonymous omits device_uid; identified sends OS.get_unique_id().\n");
+	print_help_option("--analytics-app-id=<id>", "Override analytics app_id for this process.\n");
+	print_help_option("--analytics-build-id=<id>", "Override analytics build_id for this process.\n");
 #endif
 
 #ifdef MODULE_REMOTE_CONTROL_ENABLED
@@ -2154,6 +2165,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef MODULE_CRASH_REPORTER_ENABLED
 	if (CrashReporter::get_singleton()) {
 		CrashReporter::get_singleton()->report_user_data_dir_ready();
+	}
+#endif
+#ifdef MODULE_ANALYTICS_ENABLED
+	if (Analytics::get_singleton()) {
+		Analytics::get_singleton()->report_user_data_dir_ready();
 	}
 #endif
 	register_core_extensions(); // core extensions must be registered after globals setup and before display

--- a/modules/analytics/SCsub
+++ b/modules/analytics/SCsub
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_analytics = env_modules.Clone()
+
+env_analytics.add_source_files(env.modules_sources, "register_types.cpp")
+env_analytics.add_source_files(env.modules_sources, "analytics.cpp")
+env_analytics.add_source_files(env.modules_sources, "analytics_project_settings.cpp")
+env_analytics.add_source_files(env.modules_sources, "analytics_http.cpp")
+env_analytics.add_source_files(env.modules_sources, "analytics_queue.cpp")
+
+if env.editor_build:
+    env_analytics.add_source_files(env.modules_sources, "analytics_editor_export_plugin.cpp")
+
+if env["tests"]:
+    env_analytics.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_analytics.add_source_files(env.modules_sources, "tests/test_analytics.cpp")
+    if env["disable_exceptions"]:
+        env_analytics.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/analytics/analytics.cpp
+++ b/modules/analytics/analytics.cpp
@@ -1,0 +1,674 @@
+/**************************************************************************/
+/*  analytics.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "analytics.h"
+
+#include "analytics_http.h"
+#include "analytics_queue.h"
+
+#include <cstring>
+
+#include "core/config/engine.h"
+#include "core/config/project_settings.h"
+#include "core/io/json.h"
+#include "core/os/os.h"
+#include "core/os/time.h"
+#include "core/version.h"
+#include "servers/display_server.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/editor_paths.h"
+#include "editor/editor_settings.h"
+#endif
+
+#ifndef ANALYTICS_EDITOR_APP_ID
+#define ANALYTICS_EDITOR_APP_ID ""
+#endif
+#ifndef ANALYTICS_EDITOR_BUILD_ID
+#define ANALYTICS_EDITOR_BUILD_ID ""
+#endif
+#ifndef ANALYTICS_EDITOR_BUILD_CHANNEL
+#define ANALYTICS_EDITOR_BUILD_CHANNEL ""
+#endif
+#ifndef ANALYTICS_EDITOR_ENDPOINT
+#define ANALYTICS_EDITOR_ENDPOINT ""
+#endif
+#ifndef ANALYTICS_EDITOR_API_KEY
+#define ANALYTICS_EDITOR_API_KEY ""
+#endif
+
+Analytics *Analytics::singleton = nullptr;
+
+Analytics *Analytics::get_singleton() {
+	return singleton;
+}
+
+static String _make_session_id() {
+	const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_unix_time() : 0;
+	const uint64_t ticks = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
+	const uint64_t pid = OS::get_singleton() ? (uint64_t)OS::get_singleton()->get_process_id() : 0;
+	return vformat("%08x-%04x-%04x-%04x-%012x",
+			(uint32_t)now,
+			(uint16_t)((ticks >> 32) & 0xffff),
+			(uint16_t)(((ticks >> 16) & 0x0fff) | 0x4000),
+			(uint16_t)((pid ^ (ticks >> 8)) & 0xffff),
+			ticks & 0x0000ffffffffffffull);
+}
+
+Analytics::Analytics() {
+	singleton = this;
+	session_id = _make_session_id();
+	session_start_msec = OS::get_singleton() ? OS::get_singleton()->get_ticks_msec() : 0;
+}
+
+Analytics::~Analytics() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+String Analytics::_cmdline_value(const String &p_prefix) const {
+	if (!OS::get_singleton()) {
+		return String();
+	}
+	List<String> args = OS::get_singleton()->get_cmdline_args();
+	for (const String &arg : args) {
+		if (arg.begins_with(p_prefix)) {
+			return arg.substr(p_prefix.length());
+		}
+	}
+	return String();
+}
+
+String Analytics::_env(const String &p_name) const {
+	if (!OS::get_singleton() || !OS::get_singleton()->has_environment(p_name)) {
+		return String();
+	}
+	return OS::get_singleton()->get_environment(p_name);
+}
+
+Analytics::Consent Analytics::_parse_consent(const String &p_value) const {
+	const String v = p_value.strip_edges().to_lower();
+	if (v == "accepted" || v == "accept" || v == "1" || v == "true" || v == "yes") {
+		return CONSENT_ACCEPTED;
+	}
+	if (v == "declined" || v == "decline" || v == "0" || v == "false" || v == "no") {
+		return CONSENT_DECLINED;
+	}
+	return CONSENT_UNSET;
+}
+
+bool Analytics::_parse_bool_env(const String &p_value, bool p_fallback) const {
+	const String v = p_value.strip_edges().to_lower();
+	if (v == "1" || v == "true" || v == "yes") {
+		return true;
+	}
+	if (v == "0" || v == "false" || v == "no") {
+		return false;
+	}
+	return p_fallback;
+}
+
+String Analytics::_setting_string(const String &p_key, const String &p_fallback) const {
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_key)) {
+		return String(GLOBAL_GET(p_key));
+	}
+	return p_fallback;
+}
+
+bool Analytics::_setting_bool(const String &p_key, bool p_fallback) const {
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_key)) {
+		return bool(GLOBAL_GET(p_key));
+	}
+	return p_fallback;
+}
+
+bool Analytics::_is_editor_context() const {
+#ifdef TOOLS_ENABLED
+	return Engine::get_singleton() && Engine::get_singleton()->is_editor_hint();
+#else
+	return false;
+#endif
+}
+
+bool Analytics::_can_queue() const {
+#ifdef ANALYTICS_ENABLED
+	if (_is_editor_context()) {
+		return get_consent() == "accepted";
+	}
+	if (!_setting_bool("application/analytics/enabled", false)) {
+		return false;
+	}
+	if (_setting_bool("application/analytics/require_user_consent", false) && get_consent() != "accepted") {
+		return false;
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+String Analytics::_iso_timestamp() const {
+	if (!Time::get_singleton()) {
+		return String();
+	}
+	return Time::get_singleton()->get_datetime_string_from_system(true, false) + "Z";
+}
+
+String Analytics::_size_string(const Size2i &p_size) const {
+	return vformat("%dx%d", p_size.x, p_size.y);
+}
+
+void Analytics::_attach_editor_context(Dictionary &r_props) const {
+	if (!OS::get_singleton()) {
+		return;
+	}
+	r_props["os_name"] = OS::get_singleton()->get_name();
+	const String os_version = OS::get_singleton()->get_version();
+	if (!os_version.is_empty()) {
+		r_props["os_version"] = os_version;
+	}
+	if (Engine::get_singleton()) {
+		r_props["arch"] = Engine::get_singleton()->get_architecture_name();
+	}
+	const String dist = OS::get_singleton()->get_distribution_name();
+	if (!dist.is_empty()) {
+		r_props["distribution"] = dist;
+	}
+	r_props["locale"] = OS::get_singleton()->get_locale();
+	if (DisplayServer::get_singleton() && DisplayServer::get_singleton()->get_screen_count() > 0) {
+		r_props["display_server"] = DisplayServer::get_singleton()->get_name();
+		r_props["screen_count"] = DisplayServer::get_singleton()->get_screen_count();
+		r_props["primary_screen_size"] = _size_string(DisplayServer::get_singleton()->screen_get_size(0));
+		r_props["hi_dpi"] = DisplayServer::get_singleton()->screen_get_scale(0) > 1.0f;
+	}
+	r_props["editor_video_driver"] = OS::get_singleton()->get_current_rendering_driver_name();
+	r_props["renderer"] = OS::get_singleton()->get_current_rendering_method();
+#ifdef REAL_T_IS_DOUBLE
+	r_props["precision"] = "double";
+#else
+	r_props["precision"] = "float";
+#endif
+}
+
+void Analytics::_attach_game_context(Dictionary &r_props) const {
+	if (!OS::get_singleton()) {
+		return;
+	}
+	r_props["os_name"] = OS::get_singleton()->get_name();
+	if (Engine::get_singleton()) {
+		r_props["arch"] = Engine::get_singleton()->get_architecture_name();
+	}
+	r_props["locale"] = OS::get_singleton()->get_locale();
+	if (DisplayServer::get_singleton()) {
+		r_props["display_server"] = DisplayServer::get_singleton()->get_name();
+		if (DisplayServer::get_singleton()->get_screen_count() > 0) {
+			r_props["screen_size"] = _size_string(DisplayServer::get_singleton()->screen_get_size(0));
+		}
+		if (DisplayServer::get_singleton()->get_window_list().size() > 0) {
+			r_props["window_size"] = _size_string(DisplayServer::get_singleton()->window_get_size());
+		}
+	}
+	const String renderer = OS::get_singleton()->get_current_rendering_method();
+	if (!renderer.is_empty()) {
+		r_props["renderer"] = renderer;
+	}
+}
+
+Dictionary Analytics::_build_event(const String &p_event, const Dictionary &p_properties) const {
+	Dictionary ev;
+	ev["app_id"] = get_app_id();
+	ev["build_id"] = get_build_id();
+	ev["app_version"] = get_app_version();
+	ev["build_channel"] = get_build_channel();
+	ev["engine_version"] = String(VERSION_FULL_NAME);
+	ev["session_id"] = session_id;
+	const bool anonymous = is_anonymous();
+	ev["anonymous"] = anonymous;
+	if (!anonymous) {
+		ev["device_uid"] = get_device_uid();
+	}
+	ev["event"] = p_event;
+	ev["timestamp"] = _iso_timestamp();
+	Dictionary props = p_properties.duplicate();
+	if (!anonymous) {
+		if (!user_id.is_empty()) {
+			props["user_id"] = user_id;
+		}
+		const Array keys = user_properties.keys();
+		for (int i = 0; i < keys.size(); i++) {
+			props[keys[i]] = user_properties[keys[i]];
+		}
+	} else {
+		props.erase("user_id");
+		props.erase("device_uid");
+	}
+	ev["properties"] = props;
+	return ev;
+}
+
+void Analytics::_enqueue(const String &p_event, const Dictionary &p_properties, bool p_editor_context) {
+	if (!_can_queue() || p_event.is_empty()) {
+		return;
+	}
+	Dictionary props = p_properties.duplicate();
+	if (p_editor_context) {
+		_attach_editor_context(props);
+	} else {
+		_attach_game_context(props);
+	}
+	const Error err = AnalyticsQueue::append(get_queue_directory(), _build_event(p_event, props));
+	if (err != OK) {
+		WARN_PRINT(vformat("Analytics: failed to queue event '%s' (%d).", p_event, err));
+	}
+}
+
+void Analytics::report_user_data_dir_ready() {
+	if (shutdown_notified || session_start_sent || _is_editor_context()) {
+		return;
+	}
+	if (_can_queue()) {
+		_enqueue("session_start", Dictionary(), false);
+		session_start_sent = true;
+	}
+}
+
+void Analytics::notify_editor_ready() {
+#ifdef TOOLS_ENABLED
+	if (shutdown_notified || editor_launched_sent || !_is_editor_context()) {
+		return;
+	}
+	if (_can_queue()) {
+		_enqueue("editor_launched", Dictionary(), true);
+		editor_launched_sent = true;
+	}
+#endif
+}
+
+void Analytics::notify_shutdown() {
+	if (shutdown_notified) {
+		return;
+	}
+	shutdown_notified = true;
+	const double session_sec = OS::get_singleton() ? (double)(OS::get_singleton()->get_ticks_msec() - session_start_msec) / 1000.0 : 0.0;
+	Dictionary props;
+	props["session_sec"] = session_sec;
+	if (editor_launched_sent) {
+		_enqueue("editor_session_ended", props, true);
+	}
+	if (session_start_sent) {
+		_enqueue("session_end", props, false);
+	}
+}
+
+bool Analytics::is_available() const {
+	return true;
+}
+
+bool Analytics::is_enabled() const {
+	return _can_queue();
+}
+
+String Analytics::get_consent() const {
+	const Consent cli = _parse_consent(_cmdline_value("--analytics="));
+	if (cli != CONSENT_UNSET) {
+		return cli == CONSENT_ACCEPTED ? "accepted" : "declined";
+	}
+	const Consent env = _parse_consent(_env("BLAZIUM_ANALYTICS_CONSENT"));
+	if (env != CONSENT_UNSET) {
+		return env == CONSENT_ACCEPTED ? "accepted" : "declined";
+	}
+	if (has_consent_override) {
+		if (consent_override == CONSENT_ACCEPTED) {
+			return "accepted";
+		}
+		if (consent_override == CONSENT_DECLINED) {
+			return "declined";
+		}
+	}
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context() && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/consent")) {
+		const Consent persisted = _parse_consent(String(EditorSettings::get_singleton()->get_setting("blazium/analytics/consent")));
+		if (persisted == CONSENT_ACCEPTED) {
+			return "accepted";
+		}
+		if (persisted == CONSENT_DECLINED) {
+			return "declined";
+		}
+	}
+#endif
+	return "unset";
+}
+
+void Analytics::set_consent(bool p_accepted) {
+	has_consent_override = true;
+	consent_override = p_accepted ? CONSENT_ACCEPTED : CONSENT_DECLINED;
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context() && EditorSettings::get_singleton()) {
+		EditorSettings::get_singleton()->set_setting("blazium/analytics/consent", p_accepted ? "accepted" : "declined");
+	}
+#endif
+}
+
+bool Analytics::is_anonymous() const {
+	const String mode = _cmdline_value("--analytics-mode=").strip_edges().to_lower();
+	if (mode == "anonymous") {
+		return true;
+	}
+	if (mode == "identified") {
+		return false;
+	}
+	const String env = _env("BLAZIUM_ANALYTICS_ANONYMOUS");
+	if (!env.is_empty()) {
+		return _parse_bool_env(env, true);
+	}
+	if (has_anonymous_override) {
+		return anonymous_override;
+	}
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context() && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/anonymous")) {
+		return bool(EditorSettings::get_singleton()->get_setting("blazium/analytics/anonymous"));
+	}
+#endif
+	return _setting_bool("application/analytics/anonymous", true);
+}
+
+void Analytics::set_anonymous(bool p_anonymous) {
+	has_anonymous_override = true;
+	anonymous_override = p_anonymous;
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context() && EditorSettings::get_singleton()) {
+		EditorSettings::get_singleton()->set_setting("blazium/analytics/anonymous", p_anonymous);
+	}
+#endif
+}
+
+String Analytics::get_app_id() const {
+	const String cli = _cmdline_value("--analytics-app-id=");
+	if (!cli.is_empty()) {
+		return cli;
+	}
+	const String env = _env("BLAZIUM_ANALYTICS_APP_ID");
+	if (!env.is_empty()) {
+		return env;
+	}
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/app_id")) {
+			const String override_id = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/app_id"));
+			if (!override_id.is_empty()) {
+				return override_id;
+			}
+		}
+		const String baked = String(ANALYTICS_EDITOR_APP_ID);
+		return baked.is_empty() ? String("blazium-editor") : baked;
+	}
+#endif
+	const String project_id = _setting_string("application/analytics/app_id", String());
+	if (!project_id.is_empty()) {
+		return project_id;
+	}
+	return _setting_string("application/config/name", String());
+}
+
+String Analytics::get_build_id() const {
+	const String cli = _cmdline_value("--analytics-build-id=");
+	if (!cli.is_empty()) {
+		return cli;
+	}
+	const String env = _env("BLAZIUM_ANALYTICS_BUILD_ID");
+	if (!env.is_empty()) {
+		return env;
+	}
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/build_id")) {
+			const String override_id = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/build_id"));
+			if (!override_id.is_empty()) {
+				return override_id;
+			}
+		}
+		const String baked = String(ANALYTICS_EDITOR_BUILD_ID);
+		if (!baked.is_empty()) {
+			return baked;
+		}
+		if (Engine::get_singleton()) {
+			const Dictionary info = Engine::get_singleton()->get_version_info();
+			const String hash = String(info.get("hash", String()));
+			if (!hash.is_empty()) {
+				return hash;
+			}
+		}
+		return String(VERSION_HASH);
+	}
+#endif
+	const String project_id = _setting_string("application/analytics/build_id", String());
+	if (!project_id.is_empty()) {
+		return project_id;
+	}
+	return _setting_string("application/config/version", String());
+}
+
+String Analytics::get_app_version() const {
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		return String(VERSION_FULL_NAME);
+	}
+#endif
+	const String project_version = _setting_string("application/analytics/app_version", String());
+	if (!project_version.is_empty()) {
+		return project_version;
+	}
+	return _setting_string("application/config/version", String());
+}
+
+String Analytics::get_build_channel() const {
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		const String baked = String(ANALYTICS_EDITOR_BUILD_CHANNEL);
+		return baked.is_empty() ? String("dev") : baked;
+	}
+#endif
+	return _setting_string("application/analytics/build_channel", "release");
+}
+
+String Analytics::get_device_uid() const {
+	if (is_anonymous() || !OS::get_singleton()) {
+		return String();
+	}
+	return OS::get_singleton()->get_unique_id();
+}
+
+String Analytics::get_endpoint() const {
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/endpoint")) {
+			const String override_ep = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/endpoint"));
+			if (!override_ep.is_empty()) {
+				return override_ep;
+			}
+		}
+		return String(ANALYTICS_EDITOR_ENDPOINT);
+	}
+#endif
+	const String env = _env("BLAZIUM_ANALYTICS_ENDPOINT");
+	if (!env.is_empty()) {
+		return env;
+	}
+	return _setting_string("application/analytics/endpoint", String());
+}
+
+String Analytics::get_api_key() const {
+	const String env = _env("BLAZIUM_ANALYTICS_API_KEY");
+	if (!env.is_empty()) {
+		return env;
+	}
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/api_key")) {
+			const String override_key = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/api_key"));
+			if (!override_key.is_empty()) {
+				return override_key;
+			}
+		}
+		return String(ANALYTICS_EDITOR_API_KEY);
+	}
+#endif
+	return _setting_string("application/analytics/api_key", String());
+}
+
+String Analytics::get_queue_directory() const {
+	const String env = _env("BLAZIUM_ANALYTICS_QUEUE_DIR");
+	if (!env.is_empty()) {
+		return env;
+	}
+#ifdef TOOLS_ENABLED
+	if (_is_editor_context()) {
+		String base;
+		if (EditorPaths::get_singleton()) {
+			base = EditorPaths::get_singleton()->get_data_dir();
+		} else if (OS::get_singleton()) {
+			base = OS::get_singleton()->get_data_path();
+		}
+		return base.path_join("analytics");
+	}
+#endif
+	if (OS::get_singleton()) {
+		return OS::get_singleton()->get_user_data_dir().path_join("analytics");
+	}
+	return String();
+}
+
+void Analytics::track(const String &p_event, const Dictionary &p_properties) {
+	_enqueue(p_event, p_properties, _is_editor_context());
+}
+
+void Analytics::identify(const String &p_user_id) {
+	if (is_anonymous()) {
+		return;
+	}
+	user_id = p_user_id;
+}
+
+void Analytics::set_user_properties(const Dictionary &p_properties) {
+	if (is_anonymous()) {
+		return;
+	}
+	user_properties = p_properties.duplicate();
+}
+
+void Analytics::flush() {
+	if (!_can_queue()) {
+		emit_signal(SNAME("flush_failed"), "Analytics is not enabled.");
+		return;
+	}
+	const String endpoint = get_endpoint();
+	if (endpoint.is_empty()) {
+		print_line("Analytics: flush dropped (empty endpoint); events remain queued.");
+		emit_signal(SNAME("flush_failed"), "Empty endpoint.");
+		return;
+	}
+	const TypedArray<Dictionary> events = AnalyticsQueue::load(get_queue_directory());
+	if (events.is_empty()) {
+		emit_signal(SNAME("flush_succeeded"), 0);
+		return;
+	}
+	Dictionary body;
+	body["events"] = events;
+	const String json = JSON::stringify(body, "", false);
+	const CharString utf8 = json.utf8();
+	Vector<uint8_t> bytes;
+	bytes.resize(utf8.length());
+	memcpy(bytes.ptrw(), utf8.get_data(), utf8.length());
+
+	const String ua = vformat("BlaziumAnalytics/%s", VERSION_FULL_NAME);
+	int timeout_sec = 15;
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("application/analytics/timeout_sec")) {
+		timeout_sec = MAX((int)GLOBAL_GET("application/analytics/timeout_sec"), 1);
+	}
+	const bool verify_tls = _setting_bool("application/analytics/verify_tls", true);
+	const AnalyticsHTTPResult result = AnalyticsHTTP::post_events(endpoint, get_api_key(), ua, bytes, timeout_sec, verify_tls);
+	if (result.error == OK) {
+		AnalyticsQueue::clear(get_queue_directory());
+		emit_signal(SNAME("flush_succeeded"), events.size());
+	} else {
+		emit_signal(SNAME("flush_failed"), result.message);
+	}
+}
+
+int Analytics::get_queue_size() const {
+	return AnalyticsQueue::size(get_queue_directory());
+}
+
+Dictionary Analytics::get_resolved_config() const {
+	Dictionary cfg;
+	cfg["available"] = is_available();
+	cfg["enabled"] = is_enabled();
+	cfg["consent"] = get_consent();
+	cfg["anonymous"] = is_anonymous();
+	cfg["app_id"] = get_app_id();
+	cfg["build_id"] = get_build_id();
+	cfg["app_version"] = get_app_version();
+	cfg["build_channel"] = get_build_channel();
+	cfg["engine_version"] = String(VERSION_FULL_NAME);
+	cfg["session_id"] = session_id;
+	cfg["device_uid"] = get_device_uid();
+	cfg["endpoint"] = get_endpoint();
+	cfg["queue_dir"] = get_queue_directory();
+	cfg["queue_size"] = get_queue_size();
+	cfg["editor_context"] = _is_editor_context();
+	return cfg;
+}
+
+void Analytics::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_available"), &Analytics::is_available);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &Analytics::is_enabled);
+	ClassDB::bind_method(D_METHOD("get_consent"), &Analytics::get_consent);
+	ClassDB::bind_method(D_METHOD("set_consent", "accepted"), &Analytics::set_consent);
+	ClassDB::bind_method(D_METHOD("is_anonymous"), &Analytics::is_anonymous);
+	ClassDB::bind_method(D_METHOD("set_anonymous", "anonymous"), &Analytics::set_anonymous);
+	ClassDB::bind_method(D_METHOD("get_app_id"), &Analytics::get_app_id);
+	ClassDB::bind_method(D_METHOD("get_build_id"), &Analytics::get_build_id);
+	ClassDB::bind_method(D_METHOD("get_app_version"), &Analytics::get_app_version);
+	ClassDB::bind_method(D_METHOD("get_build_channel"), &Analytics::get_build_channel);
+	ClassDB::bind_method(D_METHOD("get_device_uid"), &Analytics::get_device_uid);
+	ClassDB::bind_method(D_METHOD("track", "event", "properties"), &Analytics::track, DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("identify", "user_id"), &Analytics::identify);
+	ClassDB::bind_method(D_METHOD("set_user_properties", "properties"), &Analytics::set_user_properties);
+	ClassDB::bind_method(D_METHOD("flush"), &Analytics::flush);
+	ClassDB::bind_method(D_METHOD("get_queue_size"), &Analytics::get_queue_size);
+	ClassDB::bind_method(D_METHOD("get_resolved_config"), &Analytics::get_resolved_config);
+
+	ADD_SIGNAL(MethodInfo("flush_succeeded", PropertyInfo(Variant::INT, "count")));
+	ADD_SIGNAL(MethodInfo("flush_failed", PropertyInfo(Variant::STRING, "message")));
+
+	BIND_ENUM_CONSTANT(CONSENT_UNSET);
+	BIND_ENUM_CONSTANT(CONSENT_ACCEPTED);
+	BIND_ENUM_CONSTANT(CONSENT_DECLINED);
+}

--- a/modules/analytics/analytics.cpp
+++ b/modules/analytics/analytics.cpp
@@ -73,12 +73,13 @@ static String _make_session_id() {
 	const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_unix_time() : 0;
 	const uint64_t ticks = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
 	const uint64_t pid = OS::get_singleton() ? (uint64_t)OS::get_singleton()->get_process_id() : 0;
+	const uint64_t tail = ticks & ((uint64_t)0x0000ffffffffffff);
 	return vformat("%08x-%04x-%04x-%04x-%012x",
 			(uint32_t)now,
 			(uint16_t)((ticks >> 32) & 0xffff),
 			(uint16_t)(((ticks >> 16) & 0x0fff) | 0x4000),
 			(uint16_t)((pid ^ (ticks >> 8)) & 0xffff),
-			ticks & 0x0000ffffffffffffull);
+			tail);
 }
 
 Analytics::Analytics() {

--- a/modules/analytics/analytics.h
+++ b/modules/analytics/analytics.h
@@ -1,0 +1,114 @@
+/**************************************************************************/
+/*  analytics.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/variant/dictionary.h"
+
+class Analytics : public Object {
+	GDCLASS(Analytics, Object);
+
+public:
+	enum Consent {
+		CONSENT_UNSET = 0,
+		CONSENT_ACCEPTED = 1,
+		CONSENT_DECLINED = 2,
+	};
+
+private:
+	static Analytics *singleton;
+
+	String session_id;
+	uint64_t session_start_msec = 0;
+	bool shutdown_notified = false;
+	bool editor_launched_sent = false;
+	bool session_start_sent = false;
+	bool has_consent_override = false;
+	Consent consent_override = CONSENT_UNSET;
+	bool has_anonymous_override = false;
+	bool anonymous_override = true;
+	String user_id;
+	Dictionary user_properties;
+
+	String _cmdline_value(const String &p_prefix) const;
+	String _env(const String &p_name) const;
+	Consent _parse_consent(const String &p_value) const;
+	bool _parse_bool_env(const String &p_value, bool p_fallback) const;
+	String _setting_string(const String &p_key, const String &p_fallback) const;
+	bool _setting_bool(const String &p_key, bool p_fallback) const;
+	bool _is_editor_context() const;
+	bool _can_queue() const;
+	String _baked_editor(const String &p_macro_value, const String &p_fallback) const;
+	String _iso_timestamp() const;
+	String _size_string(const Size2i &p_size) const;
+	void _attach_editor_context(Dictionary &r_props) const;
+	void _attach_game_context(Dictionary &r_props) const;
+	Dictionary _build_event(const String &p_event, const Dictionary &p_properties) const;
+	void _enqueue(const String &p_event, const Dictionary &p_properties, bool p_editor_context);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static Analytics *get_singleton();
+
+	void report_user_data_dir_ready();
+	void notify_editor_ready();
+	void notify_shutdown();
+
+	bool is_available() const;
+	bool is_enabled() const;
+	String get_consent() const;
+	void set_consent(bool p_accepted);
+	bool is_anonymous() const;
+	void set_anonymous(bool p_anonymous);
+
+	String get_app_id() const;
+	String get_build_id() const;
+	String get_app_version() const;
+	String get_build_channel() const;
+	String get_device_uid() const;
+	String get_endpoint() const;
+	String get_api_key() const;
+	String get_queue_directory() const;
+
+	void track(const String &p_event, const Dictionary &p_properties = Dictionary());
+	void identify(const String &p_user_id);
+	void set_user_properties(const Dictionary &p_properties);
+	void flush();
+	int get_queue_size() const;
+	Dictionary get_resolved_config() const;
+
+	Analytics();
+	~Analytics();
+};
+
+VARIANT_ENUM_CAST(Analytics::Consent);

--- a/modules/analytics/analytics_editor_export_plugin.cpp
+++ b/modules/analytics/analytics_editor_export_plugin.cpp
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  analytics_editor_export_plugin.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "analytics_editor_export_plugin.h"
+
+#include "analytics.h"
+
+#include "core/os/os.h"
+#include "editor/export/editor_export_platform.h"
+
+void AnalyticsEditorExportPlugin::_export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags) {
+	(void)p_features;
+	(void)p_path;
+	(void)p_flags;
+	export_debug = p_debug;
+	export_start_msec = OS::get_singleton() ? OS::get_singleton()->get_ticks_msec() : 0;
+	export_platform = String();
+	const Ref<EditorExportPlatform> platform = get_export_platform();
+	if (platform.is_valid()) {
+		export_platform = platform->get_os_name();
+	}
+	if (!Analytics::get_singleton()) {
+		return;
+	}
+	Dictionary props;
+	props["export_platform"] = export_platform;
+	props["export_debug"] = export_debug;
+	Analytics::get_singleton()->track("editor_export_started", props);
+}
+
+void AnalyticsEditorExportPlugin::_export_end() {
+	if (!Analytics::get_singleton()) {
+		return;
+	}
+	Dictionary props;
+	props["export_platform"] = export_platform;
+	props["export_debug"] = export_debug;
+	props["success"] = true;
+	const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_ticks_msec() : export_start_msec;
+	props["export_sec"] = (double)(now - export_start_msec) / 1000.0;
+	Analytics::get_singleton()->track("editor_export_finished", props);
+}
+
+#endif

--- a/modules/analytics/analytics_editor_export_plugin.h
+++ b/modules/analytics/analytics_editor_export_plugin.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  analytics_editor_export_plugin.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "core/templates/hash_set.h"
+#include "editor/export/editor_export_plugin.h"
+
+class AnalyticsEditorExportPlugin : public EditorExportPlugin {
+	GDCLASS(AnalyticsEditorExportPlugin, EditorExportPlugin);
+
+	uint64_t export_start_msec = 0;
+	bool export_debug = false;
+	String export_platform;
+
+protected:
+	virtual void _export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags) override;
+	virtual void _export_end() override;
+
+public:
+	virtual String get_name() const override { return "Analytics"; }
+};
+
+#endif

--- a/modules/analytics/analytics_http.cpp
+++ b/modules/analytics/analytics_http.cpp
@@ -1,0 +1,154 @@
+/**************************************************************************/
+/*  analytics_http.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "analytics_http.h"
+
+#include "core/io/http_client.h"
+#include "core/os/os.h"
+
+#ifdef ANALYTICS_ENABLED
+
+String AnalyticsHTTP::normalize_endpoint(const String &p_endpoint) {
+	String endpoint = p_endpoint.strip_edges();
+	if (endpoint.is_empty()) {
+		return endpoint;
+	}
+	while (endpoint.ends_with("/")) {
+		endpoint = endpoint.substr(0, endpoint.length() - 1);
+	}
+	if (!endpoint.contains("/v1/events")) {
+		endpoint += "/v1/events";
+	}
+	return endpoint;
+}
+
+AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &p_endpoint, const String &p_api_key, const String &p_user_agent, const Vector<uint8_t> &p_body, int p_timeout_sec, bool p_verify_tls) {
+	AnalyticsHTTPResult result;
+	const String endpoint = normalize_endpoint(p_endpoint);
+	String scheme;
+	String host;
+	String path;
+	String fragment;
+	int port = 0;
+	Error err = endpoint.parse_url(scheme, host, port, path, fragment);
+	if (err != OK || host.is_empty()) {
+		result.error = ERR_INVALID_PARAMETER;
+		result.message = "Invalid endpoint URL.";
+		return result;
+	}
+	const bool ssl = scheme == "https://";
+	if (path.is_empty()) {
+		path = "/v1/events";
+	}
+	if (port == 0) {
+		port = ssl ? 443 : 80;
+	}
+
+	Ref<HTTPClient> client = HTTPClient::create();
+	client->set_blocking_mode(true);
+
+	Ref<TLSOptions> tls;
+	if (ssl) {
+		tls = p_verify_tls ? TLSOptions::client() : TLSOptions::client_unsafe(Ref<X509Certificate>());
+	}
+
+	err = client->connect_to_host(host, port, tls);
+	if (err != OK) {
+		result.error = err;
+		result.message = "Connect failed.";
+		return result;
+	}
+
+	const uint64_t start = OS::get_singleton()->get_ticks_msec();
+	const uint64_t timeout_ms = (uint64_t)MAX(p_timeout_sec, 1) * 1000;
+	while (client->get_status() == HTTPClient::STATUS_RESOLVING || client->get_status() == HTTPClient::STATUS_CONNECTING) {
+		if (OS::get_singleton()->get_ticks_msec() - start > timeout_ms) {
+			result.error = ERR_TIMEOUT;
+			result.message = "Connect timeout.";
+			return result;
+		}
+		client->poll();
+		OS::get_singleton()->delay_usec(1000);
+	}
+	if (client->get_status() != HTTPClient::STATUS_CONNECTED) {
+		result.error = ERR_CANT_CONNECT;
+		result.message = "Unable to connect.";
+		return result;
+	}
+
+	Vector<String> headers;
+	headers.push_back("Content-Type: application/json");
+	headers.push_back("User-Agent: " + p_user_agent);
+	headers.push_back("Accept: application/json");
+	if (!p_api_key.is_empty()) {
+		headers.push_back("X-API-Key: " + p_api_key);
+	}
+
+	err = client->request(HTTPClient::METHOD_POST, path, headers, p_body.ptr(), p_body.size());
+	if (err != OK) {
+		result.error = err;
+		result.message = "Request failed to start.";
+		return result;
+	}
+
+	while (client->get_status() == HTTPClient::STATUS_REQUESTING) {
+		if (OS::get_singleton()->get_ticks_msec() - start > timeout_ms) {
+			result.error = ERR_TIMEOUT;
+			result.message = "Request timeout.";
+			return result;
+		}
+		client->poll();
+		OS::get_singleton()->delay_usec(1000);
+	}
+
+	result.response_code = client->get_response_code();
+	if (result.response_code >= 200 && result.response_code < 300) {
+		result.error = OK;
+		result.message = "OK";
+	} else {
+		result.error = FAILED;
+		result.message = vformat("HTTP %d", result.response_code);
+	}
+	return result;
+}
+
+#else
+
+String AnalyticsHTTP::normalize_endpoint(const String &p_endpoint) {
+	return p_endpoint.strip_edges();
+}
+
+AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &, const String &, const String &, const Vector<uint8_t> &, int, bool) {
+	AnalyticsHTTPResult result;
+	result.error = ERR_UNAVAILABLE;
+	result.message = "Analytics HTTP is disabled in this build.";
+	return result;
+}
+
+#endif

--- a/modules/analytics/analytics_http.h
+++ b/modules/analytics/analytics_http.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  analytics_http.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_list.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+
+struct AnalyticsHTTPResult {
+	Error error = FAILED;
+	int response_code = 0;
+	String message;
+};
+
+class AnalyticsHTTP {
+public:
+	static String normalize_endpoint(const String &p_endpoint);
+	static AnalyticsHTTPResult post_events(
+			const String &p_endpoint,
+			const String &p_api_key,
+			const String &p_user_agent,
+			const Vector<uint8_t> &p_body,
+			int p_timeout_sec,
+			bool p_verify_tls);
+};

--- a/modules/analytics/analytics_project_settings.cpp
+++ b/modules/analytics/analytics_project_settings.cpp
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  analytics_project_settings.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "analytics_project_settings.h"
+
+#include "core/config/project_settings.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif
+
+void analytics_register_project_settings() {
+	GLOBAL_DEF_BASIC("application/analytics/enabled", false);
+	GLOBAL_DEF_BASIC("application/analytics/require_user_consent", false);
+	GLOBAL_DEF_BASIC("application/analytics/anonymous", true);
+	GLOBAL_DEF_BASIC("application/analytics/endpoint", String());
+	GLOBAL_DEF_BASIC("application/analytics/app_id", String());
+	GLOBAL_DEF_BASIC("application/analytics/build_id", String());
+	GLOBAL_DEF_BASIC("application/analytics/app_version", String());
+	GLOBAL_DEF_BASIC("application/analytics/build_channel", "release");
+	GLOBAL_DEF_BASIC("application/analytics/api_key", String());
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/analytics/timeout_sec", PROPERTY_HINT_RANGE, "1,120,1"), 15);
+	GLOBAL_DEF_BASIC("application/analytics/verify_tls", true);
+}
+
+#ifdef TOOLS_ENABLED
+void analytics_register_editor_settings() {
+	if (!EditorSettings::get_singleton()) {
+		return;
+	}
+	EDITOR_DEF_BASIC("blazium/analytics/consent", "unset");
+	EDITOR_DEF_BASIC("blazium/analytics/anonymous", true);
+	EDITOR_DEF_BASIC("blazium/analytics/endpoint", String());
+	EDITOR_DEF_BASIC("blazium/analytics/app_id", String());
+	EDITOR_DEF_BASIC("blazium/analytics/build_id", String());
+	EDITOR_DEF_BASIC("blazium/analytics/api_key", String());
+	if (EditorSettings::get_singleton()) {
+		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/consent", PROPERTY_HINT_ENUM, "unset,accepted,declined"));
+	}
+}
+#endif

--- a/modules/analytics/analytics_project_settings.h
+++ b/modules/analytics/analytics_project_settings.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  analytics_project_settings.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+void analytics_register_project_settings();
+#ifdef TOOLS_ENABLED
+void analytics_register_editor_settings();
+#endif

--- a/modules/analytics/analytics_queue.cpp
+++ b/modules/analytics/analytics_queue.cpp
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*  analytics_queue.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "analytics_queue.h"
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/io/json.h"
+
+String AnalyticsQueue::events_path(const String &p_dir) {
+	return p_dir.path_join("events.jsonl");
+}
+
+Error AnalyticsQueue::append(const String &p_dir, const Dictionary &p_event) {
+	if (p_dir.is_empty()) {
+		return ERR_INVALID_PARAMETER;
+	}
+	Error err = DirAccess::make_dir_recursive_absolute(p_dir);
+	if (err != OK && err != ERR_ALREADY_EXISTS) {
+		return err;
+	}
+	const String path = events_path(p_dir);
+	Ref<FileAccess> f;
+	if (FileAccess::exists(path)) {
+		f = FileAccess::open(path, FileAccess::READ_WRITE, &err);
+		if (f.is_valid()) {
+			f->seek_end();
+		}
+	} else {
+		f = FileAccess::open(path, FileAccess::WRITE, &err);
+	}
+	if (f.is_null()) {
+		return err != OK ? err : ERR_CANT_CREATE;
+	}
+	f->store_line(JSON::stringify(p_event, "", false));
+	return OK;
+}
+
+TypedArray<Dictionary> AnalyticsQueue::load(const String &p_dir) {
+	TypedArray<Dictionary> out;
+	const String path = events_path(p_dir);
+	if (!FileAccess::exists(path)) {
+		return out;
+	}
+	Error err = OK;
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::READ, &err);
+	if (f.is_null()) {
+		return out;
+	}
+	while (!f->eof_reached()) {
+		const String line = f->get_line().strip_edges();
+		if (line.is_empty()) {
+			continue;
+		}
+		Ref<JSON> json;
+		json.instantiate();
+		if (json->parse(line) != OK) {
+			continue;
+		}
+		const Variant data = json->get_data();
+		if (data.get_type() == Variant::DICTIONARY) {
+			out.push_back(data);
+		}
+	}
+	return out;
+}
+
+int AnalyticsQueue::size(const String &p_dir) {
+	return load(p_dir).size();
+}
+
+Error AnalyticsQueue::clear(const String &p_dir) {
+	const String path = events_path(p_dir);
+	if (!FileAccess::exists(path)) {
+		return OK;
+	}
+	return DirAccess::remove_absolute(path);
+}

--- a/modules/analytics/analytics_queue.h
+++ b/modules/analytics/analytics_queue.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  analytics_queue.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_list.h"
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/typed_array.h"
+
+class AnalyticsQueue {
+public:
+	static String events_path(const String &p_dir);
+	static Error append(const String &p_dir, const Dictionary &p_event);
+	static TypedArray<Dictionary> load(const String &p_dir);
+	static int size(const String &p_dir);
+	static Error clear(const String &p_dir);
+};

--- a/modules/analytics/config.py
+++ b/modules/analytics/config.py
@@ -1,0 +1,19 @@
+def can_build(env, platform):
+    # HTTP-only; all platforms. Editor always compiles (settings + singleton).
+    if env.editor_build:
+        return True
+    return bool(env.get("analytics", False))
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "Analytics",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/analytics/doc_classes/Analytics.xml
+++ b/modules/analytics/doc_classes/Analytics.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Analytics" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Opt-in analytics singleton for editor demographics and game session events.
+	</brief_description>
+	<description>
+		[Analytics] queues JSON events and optionally POSTs them to an ingest endpoint. Editor builds compiled with [code]editor_analytics=yes[/code] record demographic/usage events after consent. Export templates compiled with [code]analytics=yes[/code] expose a small game SDK ([method track], session start/end).
+		Consent priority is CLI [code]--analytics=[/code], then [code]BLAZIUM_ANALYTICS_CONSENT[/code], then Editor Settings or [method set_consent]. Anonymous mode (default) omits [code]device_uid[/code]; identified mode sends [method OS.get_unique_id]. See [method get_resolved_config].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="flush">
+			<return type="void" />
+			<description>
+				POSTs queued events to the resolved endpoint. Emits [signal flush_succeeded] or [signal flush_failed]. An empty endpoint leaves the queue on disk and logs that the flush was dropped.
+			</description>
+		</method>
+		<method name="get_app_id" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resolved product id sent on every event.
+			</description>
+		</method>
+		<method name="get_app_version" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resolved product version sent on every event.
+			</description>
+		</method>
+		<method name="get_build_channel" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resolved build channel ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
+			</description>
+		</method>
+		<method name="get_build_id" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resolved build id. Empty is allowed; [code]app_id[/code] and [code]engine_version[/code] are still sent.
+			</description>
+		</method>
+		<method name="get_consent" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns [code]unset[/code], [code]accepted[/code], or [code]declined[/code] after CLI, environment, and persisted settings.
+			</description>
+		</method>
+		<method name="get_device_uid" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns [method OS.get_unique_id] when identified, or an empty string when anonymous.
+			</description>
+		</method>
+		<method name="get_queue_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of events waiting in the on-disk JSONL queue.
+			</description>
+		</method>
+		<method name="get_resolved_config" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns identity, consent, endpoint, and queue path after CLI, environment, settings, and bake-in overrides.
+			</description>
+		</method>
+		<method name="identify">
+			<return type="void" />
+			<param index="0" name="user_id" type="String" />
+			<description>
+				Stores a game user id attached to later events. No-op in anonymous mode.
+			</description>
+		</method>
+		<method name="is_anonymous" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when events omit [code]device_uid[/code].
+			</description>
+		</method>
+		<method name="is_available" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the [Analytics] module is compiled in.
+			</description>
+		</method>
+		<method name="is_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when events may be queued (feature flag plus consent).
+			</description>
+		</method>
+		<method name="set_anonymous">
+			<return type="void" />
+			<param index="0" name="anonymous" type="bool" />
+			<description>
+				Sets anonymous mode for this process. New events omit or include [code]device_uid[/code] accordingly; already queued events keep the mode they were created with.
+			</description>
+		</method>
+		<method name="set_consent">
+			<return type="void" />
+			<param index="0" name="accepted" type="bool" />
+			<description>
+				Accepts or declines analytics. Editor builds persist this in Editor Settings.
+			</description>
+		</method>
+		<method name="set_user_properties">
+			<return type="void" />
+			<param index="0" name="properties" type="Dictionary" />
+			<description>
+				Merges game user properties into later events. No-op in anonymous mode.
+			</description>
+		</method>
+		<method name="track">
+			<return type="void" />
+			<param index="0" name="event" type="String" />
+			<param index="1" name="properties" type="Dictionary" default="{}" />
+			<description>
+				Queues [param event] with [param properties] plus automatic runtime context. Editor and game contexts use separate property sets.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="flush_failed">
+			<param index="0" name="message" type="String" />
+			<description>
+				Emitted when [method flush] cannot POST queued events.
+			</description>
+		</signal>
+		<signal name="flush_succeeded">
+			<param index="0" name="count" type="int" />
+			<description>
+				Emitted after a successful flush. [param count] is the number of events sent.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="CONSENT_UNSET" value="0" enum="Consent">
+			Consent has not been set.
+		</constant>
+		<constant name="CONSENT_ACCEPTED" value="1" enum="Consent">
+			Analytics sending is allowed.
+		</constant>
+		<constant name="CONSENT_DECLINED" value="2" enum="Consent">
+			Analytics sending is declined.
+		</constant>
+	</constants>
+</class>

--- a/modules/analytics/register_types.cpp
+++ b/modules/analytics/register_types.cpp
@@ -1,0 +1,93 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "analytics.h"
+#include "analytics_project_settings.h"
+
+#include "core/config/engine.h"
+#include "core/object/class_db.h"
+
+#ifdef TOOLS_ENABLED
+#include "analytics_editor_export_plugin.h"
+#include "editor/export/editor_export.h"
+#endif
+
+static Analytics *analytics = nullptr;
+#ifdef TOOLS_ENABLED
+static Ref<AnalyticsEditorExportPlugin> analytics_export_plugin;
+#endif
+
+void initialize_analytics_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		GDREGISTER_CLASS(Analytics);
+		analytics_register_project_settings();
+		analytics = memnew(Analytics);
+		Engine::get_singleton()->add_singleton(Engine::Singleton("Analytics", analytics));
+		return;
+	}
+
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		analytics_register_editor_settings();
+		if (EditorExport::get_singleton()) {
+			analytics_export_plugin.instantiate();
+			EditorExport::get_singleton()->add_export_plugin(analytics_export_plugin);
+		}
+		if (analytics) {
+			analytics->notify_editor_ready();
+		}
+	}
+#endif
+}
+
+void uninitialize_analytics_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		if (analytics) {
+			analytics->notify_shutdown();
+		}
+		if (analytics_export_plugin.is_valid() && EditorExport::get_singleton()) {
+			EditorExport::get_singleton()->remove_export_plugin(analytics_export_plugin);
+		}
+		analytics_export_plugin.unref();
+		return;
+	}
+#endif
+	if (p_level != MODULE_INITIALIZATION_LEVEL_CORE) {
+		return;
+	}
+	if (analytics) {
+		analytics->notify_shutdown();
+		Engine::get_singleton()->remove_singleton("Analytics");
+		memdelete(analytics);
+		analytics = nullptr;
+	}
+}

--- a/modules/analytics/register_types.h
+++ b/modules/analytics/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_analytics_module(ModuleInitializationLevel p_level);
+void uninitialize_analytics_module(ModuleInitializationLevel p_level);

--- a/modules/analytics/tests/test_analytics.cpp
+++ b/modules/analytics/tests/test_analytics.cpp
@@ -48,6 +48,7 @@ static void _reset_queue_dir(const String &p_dir) {
 	AnalyticsQueue::clear(p_dir);
 }
 
+#ifdef ANALYTICS_ENABLED
 static void _enable_game_analytics(bool p_require_consent) {
 	if (!ProjectSettings::get_singleton()) {
 		return;
@@ -58,6 +59,7 @@ static void _enable_game_analytics(bool p_require_consent) {
 	ProjectSettings::get_singleton()->set("application/analytics/app_id", "analytics-unit-test");
 	ProjectSettings::get_singleton()->set("application/analytics/build_id", "test");
 }
+#endif
 
 void test_analytics_queue_roundtrip() {
 	const String dir = _analytics_test_dir("queue");

--- a/modules/analytics/tests/test_analytics.cpp
+++ b/modules/analytics/tests/test_analytics.cpp
@@ -1,0 +1,183 @@
+/**************************************************************************/
+/*  test_analytics.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_analytics.h"
+
+#include "modules/analytics/analytics.h"
+#include "modules/analytics/analytics_queue.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/os/os.h"
+
+static String _analytics_test_dir(const String &p_suffix) {
+	return OS::get_singleton()->get_cache_path().path_join("analytics_module_test").path_join(p_suffix);
+}
+
+static void _reset_queue_dir(const String &p_dir) {
+	OS::get_singleton()->set_environment("BLAZIUM_ANALYTICS_QUEUE_DIR", p_dir);
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	REQUIRE(da.is_valid());
+	da->make_dir_recursive(p_dir);
+	AnalyticsQueue::clear(p_dir);
+}
+
+static void _enable_game_analytics(bool p_require_consent) {
+	if (!ProjectSettings::get_singleton()) {
+		return;
+	}
+	ProjectSettings::get_singleton()->set("application/analytics/enabled", true);
+	ProjectSettings::get_singleton()->set("application/analytics/require_user_consent", p_require_consent);
+	ProjectSettings::get_singleton()->set("application/analytics/anonymous", true);
+	ProjectSettings::get_singleton()->set("application/analytics/app_id", "analytics-unit-test");
+	ProjectSettings::get_singleton()->set("application/analytics/build_id", "test");
+}
+
+void test_analytics_queue_roundtrip() {
+	const String dir = _analytics_test_dir("queue");
+	_reset_queue_dir(dir);
+	Dictionary ev;
+	ev["app_id"] = "queue-test";
+	ev["event"] = "ping";
+	ev["anonymous"] = true;
+	CHECK(AnalyticsQueue::append(dir, ev) == OK);
+	CHECK(AnalyticsQueue::size(dir) == 1);
+	const TypedArray<Dictionary> loaded = AnalyticsQueue::load(dir);
+	REQUIRE(loaded.size() == 1);
+	const Dictionary row = loaded[0];
+	CHECK(String(row.get("app_id", String())) == "queue-test");
+	CHECK(String(row.get("event", String())) == "ping");
+	CHECK(AnalyticsQueue::clear(dir) == OK);
+	CHECK(AnalyticsQueue::size(dir) == 0);
+}
+
+void test_analytics_consent_and_identity() {
+#ifdef ANALYTICS_ENABLED
+	Analytics *a = Analytics::get_singleton();
+	REQUIRE(a != nullptr);
+	_enable_game_analytics(true);
+	const String dir = _analytics_test_dir("consent");
+	_reset_queue_dir(dir);
+	a->set_consent(false);
+	a->set_anonymous(true);
+	const int before = a->get_queue_size();
+	a->track("should_not_queue");
+	CHECK(a->get_queue_size() == before);
+	a->set_consent(true);
+	a->track("should_queue");
+	CHECK(a->get_queue_size() == before + 1);
+	CHECK(a->is_available());
+	CHECK(a->get_consent() == "accepted");
+#else
+	CHECK(Analytics::get_singleton() != nullptr);
+#endif
+}
+
+void test_analytics_anonymous_omits_device_uid() {
+#ifdef ANALYTICS_ENABLED
+	Analytics *a = Analytics::get_singleton();
+	REQUIRE(a != nullptr);
+	_enable_game_analytics(true);
+	const String dir = _analytics_test_dir("anon");
+	_reset_queue_dir(dir);
+	a->set_consent(true);
+	a->set_anonymous(true);
+	a->identify("player-1");
+	a->track("anon_event");
+	const TypedArray<Dictionary> loaded = AnalyticsQueue::load(dir);
+	REQUIRE(loaded.size() >= 1);
+	const Dictionary row = loaded[loaded.size() - 1];
+	CHECK(bool(row.get("anonymous", false)) == true);
+	CHECK(!row.has("device_uid"));
+	CHECK(a->get_device_uid().is_empty());
+	const Dictionary props = row.get("properties", Dictionary());
+	CHECK(!props.has("user_id"));
+#else
+	CHECK(Analytics::get_singleton() != nullptr);
+#endif
+}
+
+void test_analytics_identified_includes_device_uid() {
+#ifdef ANALYTICS_ENABLED
+	Analytics *a = Analytics::get_singleton();
+	REQUIRE(a != nullptr);
+	_enable_game_analytics(true);
+	const String dir = _analytics_test_dir("identified");
+	_reset_queue_dir(dir);
+	a->set_consent(true);
+	a->set_anonymous(false);
+	a->track("id_event");
+	const TypedArray<Dictionary> loaded = AnalyticsQueue::load(dir);
+	REQUIRE(loaded.size() >= 1);
+	const Dictionary row = loaded[loaded.size() - 1];
+	CHECK(bool(row.get("anonymous", true)) == false);
+	REQUIRE(row.has("device_uid"));
+	const String uid = String(row.get("device_uid", String()));
+	CHECK(!uid.is_empty());
+	CHECK(uid == OS::get_singleton()->get_unique_id());
+	CHECK(a->get_device_uid() == uid);
+#else
+	CHECK(Analytics::get_singleton() != nullptr);
+#endif
+}
+
+void test_analytics_payload_shape() {
+#ifdef ANALYTICS_ENABLED
+	Analytics *a = Analytics::get_singleton();
+	REQUIRE(a != nullptr);
+	_enable_game_analytics(true);
+	const String dir = _analytics_test_dir("shape");
+	_reset_queue_dir(dir);
+	a->set_consent(true);
+	a->set_anonymous(true);
+	Dictionary extra;
+	extra["level"] = 3;
+	a->track("level_complete", extra);
+	const TypedArray<Dictionary> loaded = AnalyticsQueue::load(dir);
+	REQUIRE(loaded.size() >= 1);
+	const Dictionary row = loaded[loaded.size() - 1];
+	CHECK(row.has("app_id"));
+	CHECK(row.has("build_id"));
+	CHECK(row.has("engine_version"));
+	CHECK(row.has("session_id"));
+	CHECK(row.has("anonymous"));
+	CHECK(String(row.get("event", String())) == "level_complete");
+	CHECK(row.has("timestamp"));
+	CHECK(row.has("properties"));
+	CHECK(!row.has("device_uid"));
+	const Dictionary props = row.get("properties", Dictionary());
+	CHECK(int(props.get("level", 0)) == 3);
+	const Dictionary cfg = a->get_resolved_config();
+	CHECK(cfg.has("app_id"));
+	CHECK(cfg.has("endpoint"));
+	CHECK(cfg.has("queue_dir"));
+#else
+	CHECK(Analytics::get_singleton() != nullptr);
+#endif
+}

--- a/modules/analytics/tests/test_analytics.h
+++ b/modules/analytics/tests/test_analytics.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  test_analytics.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "tests/test_macros.h"
+
+void test_analytics_queue_roundtrip();
+void test_analytics_consent_and_identity();
+void test_analytics_anonymous_omits_device_uid();
+void test_analytics_identified_includes_device_uid();
+void test_analytics_payload_shape();
+
+TEST_CASE("[Modules][Analytics] queue JSONL roundtrip") {
+	test_analytics_queue_roundtrip();
+}
+
+TEST_CASE("[Modules][Analytics] consent gates queue") {
+	test_analytics_consent_and_identity();
+}
+
+TEST_CASE("[Modules][Analytics] anonymous omits device_uid") {
+	test_analytics_anonymous_omits_device_uid();
+}
+
+TEST_CASE("[Modules][Analytics] identified includes OS unique id") {
+	test_analytics_identified_includes_device_uid();
+}
+
+TEST_CASE("[Modules][Analytics] payload identity envelope") {
+	test_analytics_payload_shape();
+}


### PR DESCRIPTION
## Summary
- Add an opt-in `analytics` module with `analytics=yes` for templates and `editor_analytics=yes` for the editor, plus baked app id / build / endpoint / API key flags.
- Expose the `Analytics` singleton: consent, anonymous vs identified `device_uid` (`OS.get_unique_id()`), identity envelope, JSONL queue, and HTTP flush. Editor events are demographic/usage; templates get a small game SDK (sessions + `track()`).
- No send without consent. Empty endpoint keeps events queued only. Companion test project and ingest server are separate public repos.

## Test plan
- [x] `python -m SCons platform=windows target=editor editor_analytics=yes tests=yes`
- [x] Run `--test --test-case=*Analytics*`
- [x] `go test ./...` in example_analytics_server
- [x] `docker compose -f analytics_module_test/docker-compose.yml --profile test up --build --abort-on-container-exit`
- [x] Host e2e: compose server + `run_module_tests.ps1` against `http://127.0.0.1:8091`
- [ ] Confirm editor does not send until `--analytics=accepted` or Editor Settings consent