### PR TITLE
Treat JustAMCP section toggles as a tools/list budget

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -693,52 +693,55 @@
 		</member>
 		<member name="blazium/justamcp/pending_post_sse_timeout_sec" type="int" setter="" getter="" default="120">
 		</member>
-		<member name="blazium/justamcp/prompts/analyze_autowork_test_failures" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], JustAMCP includes prompts in [code]prompts/list[/code]. Individual prompt toggles under [code]blazium/justamcp/prompts/[/code] still apply. Search and get still reach unlisted prompts.
+		</member>
+		<member name="blazium/justamcp/prompts/analyze_autowork_test_failures" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]analyze_autowork_test_failures[/code]. Description: Diagnoses failing Autowork test output or Godot stack traces and returns structured root-cause analysis with corrected GDScript.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_autowork_fix_loop" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_autowork_fix_loop" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_autowork_fix_loop[/code]. Description: Runs Autowork tests, reads results, diagnoses failures, patches scripts when requested, validates, and reruns. Template v1.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_context" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_context" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_context[/code]. Description: Retrieves Blazium Engine JustAMCP context and points users to the richer blazium_project_intake workflow.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_diagnostics_triage" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_diagnostics_triage" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_diagnostics_triage[/code]. Description: Aggregates Blazium logs, runtime status, scene validation, project state, and performance context into a structured diagnosis. Template v1.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_gdscript_linter" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_gdscript_linter" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_gdscript_linter[/code]. Description: Audits and rewrites a GDScript file enforcing Godot 4.x / Blazium full static typing, typed arrays, @export, @onready, and typed signal conventions.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_multiplayer_architect" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_multiplayer_architect" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_multiplayer_architect[/code]. Description: Produces authoritative Blazium multiplayer networking code using Godot 4 RPCs, MultiplayerSpawner, and MultiplayerSynchronizer nodes.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_project_intake" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_project_intake" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_project_intake[/code]. Description: Loads Blazium project, scene, selection, and JustAMCP guide context before starting substantial engine work. Template v1.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_project_optimization" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_project_optimization" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_project_optimization[/code]. Description: Scans a GDScript file or scene for Godot performance anti-patterns and returns targeted drop-in fixes with explanations.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_runtime_test_loop" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_runtime_test_loop" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_runtime_test_loop[/code]. Description: Runs and inspects a Blazium scene through the editor/runtime bridge, including screenshots, logs, input, and clean shutdown. Template v1.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_scene_architect" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_scene_architect" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_scene_architect[/code]. Description: Designs a well-structured Godot 4 scene hierarchy using composition, PackedScene encapsulation, and signal-driven communication.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_scene_build_workflow" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_scene_build_workflow" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_scene_build_workflow[/code]. Description: Turns a gameplay feature request into a deterministic scene/script/signal/resource build workflow using JustAMCP tools. Template v1.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_shader_expert" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_shader_expert" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_shader_expert[/code]. Description: Translates a visual effect description into a complete, valid Godot .gdshader file. Strictly uses Godot Shading Language - never raw GLSL.
 		</member>
-		<member name="blazium/justamcp/prompts/blazium_ui_scaffolder" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/blazium_ui_scaffolder" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]blazium_ui_scaffolder[/code]. Description: Generates responsive Godot 4 UI layouts using Container nodes, anchors, and theme overrides. Never outputs hardcoded position or size values.
 		</member>
-		<member name="blazium/justamcp/prompts/editor_state" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/editor_state" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]editor_state[/code]. Description: Provides real-time insight into the actively opened Godot Editor environment.
 		</member>
-		<member name="blazium/justamcp/prompts/generate_autowork_test" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/generate_autowork_test" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]generate_autowork_test[/code]. Description: Generates a complete Autowork test_*.gd suite for a given GDScript target, mapping public methods to TestContext assertion cases.
 		</member>
-		<member name="blazium/justamcp/prompts/project_info" type="String" setter="" getter="">
+		<member name="blazium/justamcp/prompts/project_info" type="bool" setter="" getter="" default="true">
 			Read-only MCP prompt template registered as [code]project_info[/code]. Description: Retrieves the core Godot Project metadata natively.
 		</member>
 		<member name="blazium/justamcp/protocol_version" type="String" setter="" getter="" default="&quot;2026-07-28&quot;">
@@ -748,126 +751,129 @@
 		</member>
 		<member name="blazium/justamcp/request_route_ttl_sec" type="int" setter="" getter="" default="3600">
 		</member>
-		<member name="blazium/justamcp/resources/Asset Generation Guide" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], JustAMCP includes resources in [code]resources/list[/code]. Individual resource toggles under [code]blazium/justamcp/resources/[/code] still apply. Search and read still reach unlisted resources.
+		</member>
+		<member name="blazium/justamcp/resources/Asset Generation Guide" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Asset Generation Guide[/code]. Description: How SVG-to-PNG asset generation works and how sizing options are applied.
 		</member>
-		<member name="blazium/justamcp/resources/Asset Tag Dictionary" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Asset Tag Dictionary" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Asset Tag Dictionary (Paginated)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Asset Tag Dictionary (Paginated)" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Asset Tagging Guide" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Asset Tagging Guide" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Asset Tags" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Asset Tags" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Assets By Tag" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Assets By Tag" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Assets By Tag (Paginated)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Assets By Tag (Paginated)" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Autowork Latest Results" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Autowork Latest Results" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Autowork Latest Results[/code]. Description: Streams the latest JUnit/JSON test results generated by the Autowork Godot testing framework directly into memory.
 		</member>
-		<member name="blazium/justamcp/resources/Blazium Documentation Classes" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Blazium Documentation Classes" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Blazium Documentation Classes[/code]. Description: Internal class documentation summaries from the editor documentation database.
 		</member>
-		<member name="blazium/justamcp/resources/Blazium Project File" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Blazium Project File" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Blazium Project File[/code]. Description: Read any file inside the active res:// Blazium project path.
 		</member>
-		<member name="blazium/justamcp/resources/Class Documentation" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Class Documentation" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Class Documentation[/code]. Description: Read internal documentation for one Blazium class.
 		</member>
-		<member name="blazium/justamcp/resources/Current Scene" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Current Scene" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Current Scene[/code]. Description: Current scene path and play state.
 		</member>
-		<member name="blazium/justamcp/resources/Current Selection" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Current Selection" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Current Selection[/code]. Description: Currently selected editor nodes.
 		</member>
-		<member name="blazium/justamcp/resources/Documentation Search" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Documentation Search" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Documentation Search[/code]. Description: Search internal Blazium class and member documentation.
 		</member>
-		<member name="blazium/justamcp/resources/Editor State" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Editor State" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Editor State[/code]. Description: Current editor play mode, active scene, and selection summary.
 		</member>
-		<member name="blazium/justamcp/resources/Input Map" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Input Map" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Input Map[/code]. Description: Project input actions and their configured events.
 		</member>
-		<member name="blazium/justamcp/resources/MCP Log Notifications" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/MCP Log Notifications" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]MCP Log Notifications[/code]. Description: Paginated buffered MCP notifications/message history. Use blazium://logs/mcp/start for the first page.
 		</member>
-		<member name="blazium/justamcp/resources/MCP Sessions" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/MCP Sessions" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Materials" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Materials" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Materials[/code]. Description: Material resources found under res://.
 		</member>
-		<member name="blazium/justamcp/resources/Member Documentation" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Member Documentation" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Member Documentation[/code]. Description: Read internal documentation for one method, property, signal, constant, enum, annotation, or theme property.
 		</member>
-		<member name="blazium/justamcp/resources/Node Children" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Node Children" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Node Children[/code]. Description: Direct children for a node path such as blazium://node/Main/children.
 		</member>
-		<member name="blazium/justamcp/resources/Node Groups" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Node Groups" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Node Groups[/code]. Description: Groups assigned to a node path such as blazium://node/Main/Enemy/groups.
 		</member>
-		<member name="blazium/justamcp/resources/Node Properties" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Node Properties" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Node Properties[/code]. Description: Editor-visible properties for a node path such as blazium://node/Main/Camera3D/properties.
 		</member>
-		<member name="blazium/justamcp/resources/Performance" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Performance" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code skip-lint]Performance[/code]. Description: [Performance] singleton snapshot.
 		</member>
-		<member name="blazium/justamcp/resources/Project Info" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Project Info" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Project Info[/code]. Description: Project name, engine version, paths, active scene, and play state.
 		</member>
-		<member name="blazium/justamcp/resources/Project Settings" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Project Settings" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Project Settings[/code]. Description: Common project settings subset.
 		</member>
-		<member name="blazium/justamcp/resources/Recent Engine Logs" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Recent Engine Logs" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Recent Engine Logs[/code]. Description: Paginated recent engine log lines captured by JustAMCP. Use blazium://logs/recent/start for the first page.
 		</member>
-		<member name="blazium/justamcp/resources/Recent Logs" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Recent Logs" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Recent Logs[/code]. Description: Recent JustAMCP engine log lines.
 		</member>
-		<member name="blazium/justamcp/resources/Scene Editing Guide" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Scene Editing Guide" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Scene Editing Guide[/code]. Description: How to choose scene, node, resource, signal, and group editing tools.
 		</member>
-		<member name="blazium/justamcp/resources/Scene Hierarchy" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Scene Hierarchy" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Scene Hierarchy[/code]. Description: Flattened hierarchy for the active edited scene.
 		</member>
-		<member name="blazium/justamcp/resources/Script Source" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Script Source" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Script Source[/code]. Description: Read a script by omitting the res:// prefix, such as blazium://script/scripts/player.gd.
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Asset Entry" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Asset Entry" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Index Rebuild" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Index Rebuild" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Index Stats" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Index Stats" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Search" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Search" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Search (Limited)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Search (Limited)" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Search (Paginated)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Search (Paginated)" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Search (Tag Filtered)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Search (Tag Filtered)" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Similar Assets" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Similar Assets" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/Semantic Similar Assets (Limited)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Semantic Similar Assets (Limited)" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="blazium/justamcp/resources/System Logs (Paginated)" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/System Logs (Paginated)" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]System Logs (Paginated)[/code]. Description: Paginated engine log lines as JSON. Use blazium://system/logs/start for the first page.
 		</member>
-		<member name="blazium/justamcp/resources/Test Results" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Test Results" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Test Results[/code]. Description: Latest Autowork test results when available.
 		</member>
-		<member name="blazium/justamcp/resources/Testing Loop Guide" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Testing Loop Guide" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Testing Loop Guide[/code]. Description: How to run, drive, inspect, screenshot, and stop a running game through JustAMCP.
 		</member>
-		<member name="blazium/justamcp/resources/Tool Index Guide" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Tool Index Guide" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Tool Index Guide[/code]. Description: Goal-oriented guide to the main JustAMCP tool families.
 		</member>
-		<member name="blazium/justamcp/resources/Troubleshooting Guide" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Troubleshooting Guide" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Troubleshooting Guide[/code]. Description: Common failures and recovery steps for runtime, project, and tool workflows.
 		</member>
-		<member name="blazium/justamcp/resources/Video Recordings Cache" type="String" setter="" getter="">
+		<member name="blazium/justamcp/resources/Video Recordings Cache" type="bool" setter="" getter="" default="true">
 			Read-only MCP resource metadata for [code]Video Recordings Cache[/code]. Description: Returns an index of all sequential video snapshot frames captured by the runtime recording hook.
 		</member>
 		<member name="blazium/justamcp/server_enabled" type="bool" setter="" getter="" default="false">
@@ -1001,6 +1007,42 @@
 		</member>
 		<member name="blazium/justamcp/tools/animation_tools/blazium_set_blend_tree_node" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], exposes the [code]blazium_set_blend_tree_node[/code] tool from the Animation Tools family to MCP clients. Adds or replaces an AnimationNodeAnimation inside an AnimationNodeBlendTree.
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_add" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_add_to_asset" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_batch_set_on_assets" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_can_undo" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_find_assets" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_get_info" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_get_on_asset" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_get_unused" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_list" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_remove" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_remove_from_asset" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_rename" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_rescan" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_search_assets" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_set_on_asset" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_undo_last_change" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/asset_tags_tools/blazium_tags_update_comment" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="blazium/justamcp/tools/asset_tools" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables the Asset Tools tool family for JustAMCP MCP clients. Individual tools under [code]blazium/justamcp/tools/asset_tools/[/code] can be toggled separately.
@@ -1259,6 +1301,20 @@
 		<member name="blazium/justamcp/tools/mcp_client_tools/blazium_mcp_client_list_remote_tools" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="blazium/justamcp/tools/mcp_client_tools/blazium_mcp_client_read_remote_resource" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools/blazium_call_toolset" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools/blazium_describe_toolset" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools/blazium_execute_tool" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools/blazium_get_guide" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools/blazium_list_toolsets" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/meta_tools/blazium_search_tools" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="blazium/justamcp/tools/networking_tools" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables the Networking Tools tool family for JustAMCP MCP clients. Individual tools under [code]blazium/justamcp/tools/networking_tools/[/code] can be toggled separately.
@@ -1811,6 +1867,22 @@
 		</member>
 		<member name="blazium/justamcp/tools/script_tools/blazium_validate_script" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], exposes the [code]blazium_validate_script[/code] tool from the Script Tools family to MCP clients. Compiles a GDScript implicitly returning if valid or syntax errors mapped out.
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_find_similar" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_index_stats" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_rebuild_index" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_search" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_search_cancel" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_search_enqueue" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="blazium/justamcp/tools/semantic_search_tools/blazium_semantic_search_poll" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="blazium/justamcp/tools/shader_tools" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables the Shader Tools tool family for JustAMCP MCP clients. Individual tools under [code]blazium/justamcp/tools/shader_tools/[/code] can be toggled separately.

--- a/modules/justamcp/doc_classes/JustAMCPPromptExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPPromptExecutor.xml
@@ -43,8 +43,9 @@
 		<method name="list_prompts">
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
+			<param index="1" name="include_unlisted" type="bool" default="false" />
 			<description>
-				Returns a paginated MCP [code]prompts/list[/code] dictionary with [code]prompts[/code] and optional [code]nextCursor[/code]. Invalid [param cursor] values return an error dictionary with code [code]-32602[/code].
+				Returns a paginated MCP [code]prompts/list[/code] dictionary with [code]prompts[/code] and optional [code]nextCursor[/code]. Invalid [param cursor] values return an error dictionary with code [code]-32602[/code]. When [param include_unlisted] is [code]false[/code], prompts disabled by the Prompts section toggle or a per-prompt toggle are omitted.
 			</description>
 		</method>
 	</methods>

--- a/modules/justamcp/doc_classes/JustAMCPResourceExecutor.xml
+++ b/modules/justamcp/doc_classes/JustAMCPResourceExecutor.xml
@@ -26,15 +26,17 @@
 		<method name="list_resource_templates">
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
+			<param index="1" name="include_unlisted" type="bool" default="false" />
 			<description>
-				Returns a paginated MCP [code]resources/templates/list[/code] dictionary with [code]resourceTemplates[/code] and optional [code]nextCursor[/code].
+				Returns a paginated MCP [code]resources/templates/list[/code] dictionary with [code]resourceTemplates[/code] and optional [code]nextCursor[/code]. When [param include_unlisted] is [code]false[/code], templates disabled by the Resources section toggle or a per-resource toggle are omitted.
 			</description>
 		</method>
 		<method name="list_resources">
 			<return type="Dictionary" />
 			<param index="0" name="cursor" type="String" default="&quot;&quot;" />
+			<param index="1" name="include_unlisted" type="bool" default="false" />
 			<description>
-				Returns a paginated MCP [code]resources/list[/code] dictionary with [code]resources[/code] and optional [code]nextCursor[/code].
+				Returns a paginated MCP [code]resources/list[/code] dictionary with [code]resources[/code] and optional [code]nextCursor[/code]. When [param include_unlisted] is [code]false[/code], resources disabled by the Resources section toggle or a per-resource toggle are omitted.
 			</description>
 		</method>
 		<method name="read_resource">

--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -63,23 +63,25 @@ void JustAMCPConfigUI::_update_config() {
 	text_edit_cursor->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_CURSOR));
 	text_edit_opencode->set_text(JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_OPENCODE));
 
-	int total_tools = JustAMCPToolSchemaCache::get_schemas(false, true, true, true).size();
-	int active_tools = JustAMCPToolSchemaCache::get_schemas(false, false, true, false).size();
+	int total_tools = JustAMCPToolSchemaCache::get_schemas(false, true, false, true).size();
+	int active_tools = JustAMCPToolSchemaCache::get_schemas(false, false, false, false).size();
 
 	JustAMCPResourceExecutor res_exec;
-	int total_res = res_exec.list_resources().get("resources", Array()).operator Array().size();
+	int total_res = res_exec.list_resources("", true).get("resources", Array()).operator Array().size();
+	int listed_res = res_exec.list_resources("", false).get("resources", Array()).operator Array().size();
 
 	JustAMCPPromptExecutor prmpt_exec;
-	int total_prompts = prmpt_exec.list_prompts().get("prompts", Array()).operator Array().size();
+	int total_prompts = prmpt_exec.list_prompts("", true).get("prompts", Array()).operator Array().size();
+	int listed_prompts = prmpt_exec.list_prompts("", false).get("prompts", Array()).operator Array().size();
 
 	if (stats_tools_label) {
 		stats_tools_label->set_text("Tools (Active): " + itos(active_tools) + " / " + itos(total_tools));
 	}
 	if (stats_resources_label) {
-		stats_resources_label->set_text("Resources: " + itos(total_res));
+		stats_resources_label->set_text("Resources: " + itos(listed_res) + " / " + itos(total_res));
 	}
 	if (stats_prompts_label) {
-		stats_prompts_label->set_text("Prompts: " + itos(total_prompts));
+		stats_prompts_label->set_text("Prompts: " + itos(listed_prompts) + " / " + itos(total_prompts));
 	}
 }
 
@@ -183,72 +185,6 @@ bool JustAMCPConfigInspectorPlugin::parse_property(Object *p_object, const Varia
 	if (p_path == "blazium/justamcp/z_mcp_config" || p_path == "z_mcp_config") {
 		JustAMCPConfigUI *ui = memnew(JustAMCPConfigUI);
 		add_custom_control(ui);
-		return true;
-	}
-
-	String found_path = "";
-	String prop_value = "";
-
-	JustAMCPPromptExecutor p_exec;
-	Array prompts = p_exec.list_prompts().get("prompts", Array());
-	for (int i = 0; i < prompts.size(); i++) {
-		Dictionary p = prompts[i];
-		String n = p["name"];
-		String d = p["description"];
-		if (p_path == n || p_path.ends_with("prompts/" + n)) {
-			found_path = "blazium/justamcp/prompts/" + n;
-			prop_value = d;
-			break;
-		}
-	}
-
-	if (found_path.is_empty()) {
-		JustAMCPResourceExecutor r_exec;
-		Array res = r_exec.list_resources().get("resources", Array());
-		for (int i = 0; i < res.size(); i++) {
-			Dictionary r = res[i];
-			String n = r["name"];
-			String d = r["description"];
-			if (p_path == n || p_path.ends_with("resources/" + n)) {
-				found_path = "blazium/justamcp/resources/" + n;
-				prop_value = d;
-				break;
-			}
-		}
-
-		if (found_path.is_empty()) {
-			Array tmpl = r_exec.list_resource_templates().get("resourceTemplates", Array());
-			for (int i = 0; i < tmpl.size(); i++) {
-				Dictionary r = tmpl[i];
-				String n = r["name"];
-				String d = r["description"];
-				if (p_path == n || p_path.ends_with("resources/" + n)) {
-					found_path = "blazium/justamcp/resources/" + n;
-					prop_value = d;
-					break;
-				}
-			}
-		}
-	}
-
-	if (!found_path.is_empty()) {
-		VBoxContainer *vbox = memnew(VBoxContainer);
-		vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
-		Label *lbl = memnew(Label);
-		lbl->set_text(found_path.get_file());
-		vbox->add_child(lbl);
-
-		TextEdit *text_edit = memnew(TextEdit);
-		text_edit->set_editable(false);
-		text_edit->set_text(prop_value);
-		text_edit->set_custom_minimum_size(Size2(0, 60));
-		text_edit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		text_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		text_edit->add_theme_color_override("font_readonly_color", Color(0.8, 0.8, 0.8));
-		vbox->add_child(text_edit);
-
-		add_custom_control(vbox);
 		return true;
 	}
 

--- a/modules/justamcp/justamcp_project_settings.cpp
+++ b/modules/justamcp/justamcp_project_settings.cpp
@@ -207,6 +207,10 @@ void JustAMCPProjectSettings::register_editor_settings() {
 
 	EDITOR_DEF_BASIC("blazium/justamcp/in_flight_cancel_deadline_ms", 5000);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "blazium/justamcp/in_flight_cancel_deadline_ms", PROPERTY_HINT_RANGE, "0,120000,100"));
+
+	JustAMCPToolExecutor::register_tool_settings();
+	JustAMCPPromptExecutor::register_settings();
+	JustAMCPResourceExecutor::register_settings();
 }
 
 #endif

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -341,6 +341,9 @@ void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 		}
 #endif
 		_register_all_toolsets();
+		JustAMCPToolExecutor::register_tool_settings();
+		JustAMCPPromptExecutor::register_settings();
+		JustAMCPResourceExecutor::register_settings();
 		JustAMCPToolSchemaCache::get_schemas(false, false, false, false);
 		EditorPlugins::add_by_type<JustAMCPEditorPlugin>();
 	}

--- a/modules/justamcp/tests/test_justamcp_bridge_execute_no_main_block.cpp
+++ b/modules/justamcp/tests/test_justamcp_bridge_execute_no_main_block.cpp
@@ -62,7 +62,7 @@ void test_justamcp_bridge_execute_no_main_block() {
 	const uint64_t start_ms = OS::get_singleton()->get_ticks_msec();
 	Dictionary result = bridge.execute_tool("mcp_client_list_remote_tools", args);
 	const uint64_t elapsed_ms = OS::get_singleton()->get_ticks_msec() - start_ms;
-	CHECK(elapsed_ms < 50);
+	CHECK(elapsed_ms < justamcp_nonblocking_call_budget_ms());
 	CHECK(bool(result.get("_justamcp_async_pending", false)));
 
 	OS::get_singleton()->delay_usec(500000);

--- a/modules/justamcp/tests/test_justamcp_bridge_no_main_wait.cpp
+++ b/modules/justamcp/tests/test_justamcp_bridge_no_main_wait.cpp
@@ -69,7 +69,7 @@ void test_justamcp_bridge_no_main_wait() {
 	const String body = "{\"jsonrpc\":\"2.0\",\"id\":77,\"method\":\"tools/call\",\"params\":{\"name\":\"blazium_mcp_client_list_remote_tools\",\"arguments\":{\"bridge_name\":\"missing\"},\"task\":{\"ttl\":60000}}}";
 	const Dictionary result = JustAMCPJsonRpcTransport::handle_json_rpc(&server, body, response);
 	const uint64_t elapsed_ms = OS::get_singleton()->get_ticks_msec() - start_ms;
-	CHECK(elapsed_ms < 50);
+	CHECK(elapsed_ms < justamcp_nonblocking_call_budget_ms());
 
 	const bool async_or_task = result.is_empty() || result.has("result") || result.has("error");
 	CHECK(async_or_task);

--- a/modules/justamcp/tests/test_justamcp_bridge_no_sync_fallback_on_main.cpp
+++ b/modules/justamcp/tests/test_justamcp_bridge_no_sync_fallback_on_main.cpp
@@ -51,7 +51,7 @@ void test_justamcp_bridge_no_sync_fallback_on_main() {
 	const uint64_t start_ms = OS::get_singleton()->get_ticks_msec();
 	Dictionary result = bridge.execute_tool("mcp_client_list_remote_tools", args);
 	const uint64_t elapsed_ms = OS::get_singleton()->get_ticks_msec() - start_ms;
-	CHECK(elapsed_ms < 50);
+	CHECK(elapsed_ms < justamcp_nonblocking_call_budget_ms());
 	CHECK(bool(result.get("_justamcp_async_required", false)));
 	CHECK(!bool(result.get("ok", true)));
 }

--- a/modules/justamcp/tests/test_justamcp_fixture.h
+++ b/modules/justamcp/tests/test_justamcp_fixture.h
@@ -34,6 +34,16 @@
 #include "../justamcp_server.h"
 #include "../justamcp_session_manager.h"
 
+// Non-blocking MCP calls must return immediately. Sanitizers inflate wall time
+// enough that the 50ms budget flakes (CI saw 63ms under ASan/UBSan).
+static inline uint64_t justamcp_nonblocking_call_budget_ms() {
+#ifdef SANITIZERS_ENABLED
+	return 250;
+#else
+	return 50;
+#endif
+}
+
 class JustAMCPTestServerFixture {
 	JustAMCPServer server;
 

--- a/modules/justamcp/tests/test_justamcp_settings_resolver.cpp
+++ b/modules/justamcp/tests/test_justamcp_settings_resolver.cpp
@@ -30,10 +30,14 @@
 #ifdef TESTS_ENABLED
 
 #include "test_justamcp_settings_resolver.h"
+#include "../tools/justamcp_json_rpc_helpers.h"
+#include "../tools/justamcp_prompt_executor.h"
 #include "../tools/justamcp_resource_manifest.h"
 #include "../tools/justamcp_settings_resolver.h"
+#include "../tools/justamcp_tool_dispatcher.h"
 #include "../tools/justamcp_tool_executor.h"
 #include "../tools/justamcp_tool_schema_cache.h"
+#include "core/config/project_settings.h"
 #include "modules/modules_enabled.gen.h"
 #include "tests/test_macros.h"
 
@@ -68,5 +72,94 @@ void test_justamcp_resource_manifest() {
 	(void)counter;
 	CHECK(JustAMCPToolExecutor::get_active_instance() == nullptr);
 }
+
+#ifdef TOOLS_ENABLED
+static bool _schema_has_tool(const Array &p_schemas, const String &p_name) {
+	for (int i = 0; i < p_schemas.size(); i++) {
+		Dictionary tool = p_schemas[i];
+		if (String(tool.get("name", "")) == p_name) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void test_justamcp_list_vs_execute_and_active_count() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	CHECK(ps);
+
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+	const bool had_cat = ps->has_setting("blazium/justamcp/tools/editor_tools");
+	const Variant prev_cat = had_cat ? ps->get_setting("blazium/justamcp/tools/editor_tools") : Variant();
+	const bool had_tool = ps->has_setting("blazium/justamcp/tools/editor_tools/blazium_editor_play_scene");
+	const Variant prev_tool = had_tool ? ps->get_setting("blazium/justamcp/tools/editor_tools/blazium_editor_play_scene") : Variant();
+	const bool had_prompts = ps->has_setting("blazium/justamcp/prompts");
+	const Variant prev_prompts = had_prompts ? ps->get_setting("blazium/justamcp/prompts") : Variant();
+
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	JustAMCPSettingsResolver::set_category_default("editor_tools", false);
+	ps->set_setting("blazium/justamcp/tools/editor_tools", false);
+	ps->set_setting("blazium/justamcp/tools/editor_tools/blazium_editor_play_scene", true);
+
+	CHECK(!JustAMCPSettingsResolver::is_tool_listed("editor_tools", "blazium_editor_play_scene"));
+	CHECK(JustAMCPSettingsResolver::is_tool_executable("editor_tools", "blazium_editor_play_scene"));
+	CHECK(JustAMCPToolDispatcher::is_tool_enabled("blazium_editor_play_scene", "editor_tools"));
+
+	JustAMCPToolSchemaCache::invalidate();
+	const int total_before = JustAMCPToolSchemaCache::get_schemas(false, true, false, true).size();
+	const int active_before = JustAMCPToolSchemaCache::get_schemas(false, false, false, false).size();
+	CHECK(_schema_has_tool(JustAMCPToolSchemaCache::get_schemas(false, true, false, true), "blazium_editor_play_scene"));
+	CHECK(!_schema_has_tool(JustAMCPToolSchemaCache::get_schemas(false, false, false, false), "blazium_editor_play_scene"));
+
+	ps->set_setting("blazium/justamcp/tools/editor_tools", true);
+	JustAMCPJsonRpcHelpers::mark_mcp_tool_settings_dirty();
+	const int total_after = JustAMCPToolSchemaCache::get_schemas(false, true, false, true).size();
+	const int active_after = JustAMCPToolSchemaCache::get_schemas(false, false, false, false).size();
+	CHECK(total_after == total_before);
+	CHECK(active_after > active_before);
+	CHECK(_schema_has_tool(JustAMCPToolSchemaCache::get_schemas(false, false, false, false), "blazium_editor_play_scene"));
+
+	ps->set_setting("blazium/justamcp/tools/editor_tools/blazium_editor_play_scene", false);
+	CHECK(!JustAMCPSettingsResolver::is_tool_executable("editor_tools", "blazium_editor_play_scene"));
+	CHECK(!JustAMCPSettingsResolver::is_tool_listed("editor_tools", "blazium_editor_play_scene"));
+
+	JustAMCPToolExecutor::register_tool_settings();
+#ifdef MODULE_ASSETTAGS_ENABLED
+	CHECK(ps->has_setting("blazium/justamcp/tools/asset_tags_tools"));
+#endif
+
+	ps->set_setting("blazium/justamcp/prompts", false);
+	JustAMCPPromptExecutor prompt_exec;
+	const Array listed_prompts = prompt_exec.list_prompts("", false).get("prompts", Array());
+	const Array all_prompts = prompt_exec.list_prompts("", true).get("prompts", Array());
+	CHECK(listed_prompts.size() == 0);
+	CHECK(all_prompts.size() > 0);
+	Dictionary prompt_args;
+	Dictionary got = prompt_exec.get_prompt("blazium_context", prompt_args);
+	CHECK(got.get("ok", true));
+
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+	if (had_cat) {
+		ps->set_setting("blazium/justamcp/tools/editor_tools", prev_cat);
+	} else {
+		ps->clear("blazium/justamcp/tools/editor_tools");
+	}
+	if (had_tool) {
+		ps->set_setting("blazium/justamcp/tools/editor_tools/blazium_editor_play_scene", prev_tool);
+	} else {
+		ps->clear("blazium/justamcp/tools/editor_tools/blazium_editor_play_scene");
+	}
+	if (had_prompts) {
+		ps->set_setting("blazium/justamcp/prompts", prev_prompts);
+	} else {
+		ps->clear("blazium/justamcp/prompts");
+	}
+	JustAMCPToolSchemaCache::invalidate();
+}
+#else
+void test_justamcp_list_vs_execute_and_active_count() {
+	SUCCEED();
+}
+#endif
 
 #endif

--- a/modules/justamcp/tests/test_justamcp_settings_resolver.h
+++ b/modules/justamcp/tests/test_justamcp_settings_resolver.h
@@ -33,9 +33,14 @@
 
 void test_justamcp_settings_resolver();
 void test_justamcp_resource_manifest();
+void test_justamcp_list_vs_execute_and_active_count();
 
 TEST_CASE("[Modules][JustAMCP] settings resolver") {
 	test_justamcp_settings_resolver();
+}
+
+TEST_CASE("[Modules][JustAMCP] section list budget vs execute") {
+	test_justamcp_list_vs_execute_and_active_count();
 }
 
 TEST_CASE("[Modules][JustAMCP] resource manifest") {

--- a/modules/justamcp/tools/justamcp_json_rpc_helpers.cpp
+++ b/modules/justamcp/tools/justamcp_json_rpc_helpers.cpp
@@ -195,7 +195,7 @@ Dictionary JustAMCPJsonRpcHelpers::format_tool_result(bool p_success, const Vari
 
 void JustAMCPJsonRpcHelpers::mark_mcp_tool_settings_dirty() {
 	mcp_tool_settings_dirty = true;
-	JustAMCPToolSchemaCache::mark_all_cached_categories_dirty();
+	JustAMCPToolSchemaCache::invalidate();
 }
 
 bool JustAMCPJsonRpcHelpers::should_broadcast_tools_list_changed() {

--- a/modules/justamcp/tools/justamcp_mcp_client_bridge.cpp
+++ b/modules/justamcp/tools/justamcp_mcp_client_bridge.cpp
@@ -313,14 +313,7 @@ Array JustAMCPMCPClientBridge::get_tool_schemas(bool p_register_only, bool p_ign
 	auto add_schema = [&](const String &p_name, const String &p_desc, const Vector<String> &p_props, const Vector<String> &p_req, const String &p_task_support = "forbidden") {
 		const String full_name = "blazium_" + p_name;
 		if (p_register_only) {
-			const String cat_path = "blazium/justamcp/tools/" + current_category;
-			const String tool_path = cat_path + "/" + full_name;
-			GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, cat_path), is_core);
-			GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, tool_path), true);
-			if (EditorSettings::get_singleton()) {
-				EDITOR_DEF_BASIC(cat_path, is_core);
-				EDITOR_DEF_BASIC(tool_path, true);
-			}
+			JustAMCPToolSchemaBuilder::register_tool_settings(current_category, full_name, is_core);
 			return;
 		}
 		bool cat_enabled = true;

--- a/modules/justamcp/tools/justamcp_meta_tools.cpp
+++ b/modules/justamcp/tools/justamcp_meta_tools.cpp
@@ -34,6 +34,7 @@
 #include "../justamcp_mcp_spec.h"
 #include "../justamcp_server.h"
 #include "justamcp_resource_executor.h"
+#include "justamcp_settings_resolver.h"
 #include "justamcp_tool_executor.h"
 #include "justamcp_tool_schema_cache.h"
 #include "justamcp_toolset_registry.h"
@@ -55,11 +56,19 @@ Dictionary JustAMCPMetaTools::execute(JustAMCPToolExecutor *p_executor, const St
 
 	if (p_internal_name == "search_tools") {
 		const String query = p_args.get("query", "");
-		const Array all_schemas = JustAMCPToolSchemaCache::get_schemas(false, true, false, false);
+		const Array all_schemas = JustAMCPToolSchemaCache::get_schemas(false, true, false, true);
 		Array matched;
 		for (int i = 0; i < all_schemas.size(); i++) {
 			const Dictionary schema = all_schemas[i];
 			const String name = schema["name"];
+			String category;
+			if (schema.has("_meta")) {
+				const Dictionary meta = schema["_meta"];
+				category = meta.get("category", "");
+			}
+			if (!JustAMCPSettingsResolver::is_tool_executable(category, name)) {
+				continue;
+			}
 			const String desc = schema["description"];
 			if (query.is_empty() || name.containsn(query) || desc.containsn(query)) {
 				matched.push_back(schema);
@@ -77,10 +86,7 @@ Dictionary JustAMCPMetaTools::execute(JustAMCPToolExecutor *p_executor, const St
 			return result;
 		}
 		const Dictionary target_args = p_args.get("arguments", Dictionary());
-		bool allow_bypass = false;
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/allow_execute_tool_bypass")) {
-			allow_bypass = GLOBAL_GET("blazium/justamcp/allow_execute_tool_bypass");
-		}
+		const bool allow_bypass = JustAMCPSettingsResolver::resolve_allow_execute_tool_bypass();
 		if (allow_bypass) {
 			return p_executor->execute_tool_direct(target_tool, target_args);
 		}

--- a/modules/justamcp/tools/justamcp_prompt_executor.cpp
+++ b/modules/justamcp/tools/justamcp_prompt_executor.cpp
@@ -35,6 +35,7 @@
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "editor/editor_settings.h"
+#include "justamcp_settings_resolver.h"
 #include "prompts/justamcp_prompt_asset_tagging_workflow.h"
 #include "prompts/justamcp_prompt_autowork_failure_analyzer.h"
 #include "prompts/justamcp_prompt_autowork_test_generator.h"
@@ -51,15 +52,19 @@
 
 void JustAMCPPromptExecutor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_prompt", "name", "args"), &JustAMCPPromptExecutor::get_prompt);
-	ClassDB::bind_method(D_METHOD("list_prompts", "cursor"), &JustAMCPPromptExecutor::list_prompts, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("list_prompts", "cursor", "include_unlisted"), &JustAMCPPromptExecutor::list_prompts, DEFVAL(""), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("complete_prompt", "ref", "argument", "context"), &JustAMCPPromptExecutor::complete_prompt, DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("add_prompt", "prompt"), &JustAMCPPromptExecutor::add_prompt);
 }
 
 void JustAMCPPromptExecutor::register_settings() {
-	JustAMCPPromptExecutor exec;
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "blazium/justamcp/prompts"), true);
+	if (EditorSettings::get_singleton()) {
+		EDITOR_DEF_BASIC("blazium/justamcp/prompts", true);
+	}
 
-	Dictionary dict = exec.list_prompts();
+	JustAMCPPromptExecutor exec;
+	Dictionary dict = exec.list_prompts("", true);
 	if (dict.has("prompts")) {
 		Array prompts = dict["prompts"];
 		for (int i = 0; i < prompts.size(); i++) {
@@ -68,10 +73,10 @@ void JustAMCPPromptExecutor::register_settings() {
 			String desc = p["description"];
 			String path = "blazium/justamcp/prompts/" + name;
 
-			GLOBAL_DEF_NOVAL_BASIC(PropertyInfo(Variant::STRING, path, PROPERTY_HINT_MULTILINE_TEXT, desc, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), String());
+			GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, path, PROPERTY_HINT_NONE, desc), true);
 			if (EditorSettings::get_singleton()) {
-				EDITOR_DEF_BASIC(path, String());
-				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, path, PROPERTY_HINT_MULTILINE_TEXT, desc, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY));
+				EDITOR_DEF_BASIC(path, true);
+				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, path, PROPERTY_HINT_NONE, desc));
 			}
 		}
 	}
@@ -107,10 +112,14 @@ void JustAMCPPromptExecutor::add_prompt(const Ref<JustAMCPPrompt> &p_prompt) {
 	}
 }
 
-Dictionary JustAMCPPromptExecutor::list_prompts(const String &cursor) {
+Dictionary JustAMCPPromptExecutor::list_prompts(const String &cursor, bool p_include_unlisted) {
 	Array prompts;
 	for (int i = 0; i < registered_prompts.size(); i++) {
 		if (registered_prompts[i].is_valid()) {
+			const String name = registered_prompts[i]->get_name();
+			if (!p_include_unlisted && !JustAMCPSettingsResolver::is_prompt_listed(name)) {
+				continue;
+			}
 			Dictionary prompt = registered_prompts[i]->get_prompt();
 			justamcp_attach_icons(prompt);
 			prompts.push_back(prompt);

--- a/modules/justamcp/tools/justamcp_prompt_executor.h
+++ b/modules/justamcp/tools/justamcp_prompt_executor.h
@@ -52,7 +52,7 @@ public:
 
 	void add_prompt(const Ref<JustAMCPPrompt> &p_prompt);
 
-	Dictionary list_prompts(const String &cursor = "");
+	Dictionary list_prompts(const String &cursor = "", bool p_include_unlisted = false);
 	Dictionary get_prompt(const String &p_name, const Dictionary &p_args);
 	Dictionary complete_prompt(const Dictionary &p_ref, const Dictionary &p_argument, const Dictionary &p_context = Dictionary());
 

--- a/modules/justamcp/tools/justamcp_resource_executor.cpp
+++ b/modules/justamcp/tools/justamcp_resource_executor.cpp
@@ -40,6 +40,7 @@
 #include "editor/editor_file_system.h"
 #include "editor/editor_settings.h"
 #include "justamcp_resource_manifest.h"
+#include "justamcp_settings_resolver.h"
 #include "resources/justamcp_blazium_resource_registry.h"
 #include "resources/justamcp_materials_resource_provider.h"
 #include "resources/justamcp_resource_autowork_results.h"
@@ -47,16 +48,21 @@
 #include "resources/justamcp_resource_video_recordings.h"
 
 void JustAMCPResourceExecutor::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("list_resources", "cursor"), &JustAMCPResourceExecutor::list_resources, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("list_resource_templates", "cursor"), &JustAMCPResourceExecutor::list_resource_templates, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("list_resources", "cursor", "include_unlisted"), &JustAMCPResourceExecutor::list_resources, DEFVAL(""), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("list_resource_templates", "cursor", "include_unlisted"), &JustAMCPResourceExecutor::list_resource_templates, DEFVAL(""), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("read_resource", "uri"), &JustAMCPResourceExecutor::read_resource);
 	ClassDB::bind_method(D_METHOD("add_resource", "resource"), &JustAMCPResourceExecutor::add_resource);
 }
 
 void JustAMCPResourceExecutor::register_settings() {
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "blazium/justamcp/resources"), true);
+	if (EditorSettings::get_singleton()) {
+		EDITOR_DEF_BASIC("blazium/justamcp/resources", true);
+	}
+
 	JustAMCPResourceExecutor exec;
 
-	Dictionary resources_dict = exec.list_resources();
+	Dictionary resources_dict = exec.list_resources("", true);
 	if (resources_dict.has("resources")) {
 		Array resources = resources_dict["resources"];
 		for (int i = 0; i < resources.size(); i++) {
@@ -65,15 +71,15 @@ void JustAMCPResourceExecutor::register_settings() {
 			String desc = res["description"];
 			String path = "blazium/justamcp/resources/" + name;
 
-			GLOBAL_DEF_NOVAL_BASIC(PropertyInfo(Variant::STRING, path, PROPERTY_HINT_MULTILINE_TEXT, desc, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), String());
+			GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, path, PROPERTY_HINT_NONE, desc), true);
 			if (EditorSettings::get_singleton()) {
-				EDITOR_DEF_BASIC(path, String());
-				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, path, PROPERTY_HINT_MULTILINE_TEXT, desc, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY));
+				EDITOR_DEF_BASIC(path, true);
+				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, path, PROPERTY_HINT_NONE, desc));
 			}
 		}
 	}
 
-	Dictionary templates_dict = exec.list_resource_templates();
+	Dictionary templates_dict = exec.list_resource_templates("", true);
 	if (templates_dict.has("resourceTemplates")) {
 		Array templates = templates_dict["resourceTemplates"];
 		for (int i = 0; i < templates.size(); i++) {
@@ -82,10 +88,10 @@ void JustAMCPResourceExecutor::register_settings() {
 			String desc = templ["description"];
 			String path = "blazium/justamcp/resources/" + name;
 
-			GLOBAL_DEF_NOVAL_BASIC(PropertyInfo(Variant::STRING, path, PROPERTY_HINT_MULTILINE_TEXT, desc, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), String());
+			GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, path, PROPERTY_HINT_NONE, desc), true);
 			if (EditorSettings::get_singleton()) {
-				EDITOR_DEF_BASIC(path, String());
-				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, path, PROPERTY_HINT_MULTILINE_TEXT, desc, PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY));
+				EDITOR_DEF_BASIC(path, true);
+				EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, path, PROPERTY_HINT_NONE, desc));
 			}
 		}
 	}
@@ -192,36 +198,51 @@ String JustAMCPResourceExecutor::_canonicalize_resource_uri(const String &p_uri)
 	return p_uri;
 }
 
-Dictionary JustAMCPResourceExecutor::list_resources(const String &cursor) {
+Dictionary JustAMCPResourceExecutor::list_resources(const String &cursor, bool p_include_unlisted) {
 	Array resources;
 
 	for (int i = 0; i < registered_resources.size(); i++) {
 		if (registered_resources[i].is_valid() && !registered_resources[i]->is_template()) {
-			resources.push_back(registered_resources[i]->get_schema());
+			Dictionary schema = registered_resources[i]->get_schema();
+			if (!p_include_unlisted && !JustAMCPSettingsResolver::is_resource_listed(schema.get("name", ""))) {
+				continue;
+			}
+			resources.push_back(schema);
 		}
 	}
 
 	Array manifest_resources = JustAMCPResourceManifest::get_static_resource_schemas();
 	for (int i = 0; i < manifest_resources.size(); i++) {
-		resources.push_back(manifest_resources[i]);
+		Dictionary schema = manifest_resources[i];
+		if (!p_include_unlisted && !JustAMCPSettingsResolver::is_resource_listed(schema.get("name", ""))) {
+			continue;
+		}
+		resources.push_back(schema);
 	}
 
 	return justamcp_pagination_slice_array(resources, cursor, "resources");
 }
 
-Dictionary JustAMCPResourceExecutor::list_resource_templates(const String &cursor) {
-	Dictionary result;
+Dictionary JustAMCPResourceExecutor::list_resource_templates(const String &cursor, bool p_include_unlisted) {
 	Array templates;
 
 	for (int i = 0; i < registered_resources.size(); i++) {
 		if (registered_resources[i].is_valid() && registered_resources[i]->is_template()) {
-			templates.push_back(registered_resources[i]->get_schema());
+			Dictionary schema = registered_resources[i]->get_schema();
+			if (!p_include_unlisted && !JustAMCPSettingsResolver::is_resource_listed(schema.get("name", ""))) {
+				continue;
+			}
+			templates.push_back(schema);
 		}
 	}
 
 	Array manifest_templates = JustAMCPResourceManifest::get_static_resource_template_schemas();
 	for (int i = 0; i < manifest_templates.size(); i++) {
-		templates.push_back(manifest_templates[i]);
+		Dictionary schema = manifest_templates[i];
+		if (!p_include_unlisted && !JustAMCPSettingsResolver::is_resource_listed(schema.get("name", ""))) {
+			continue;
+		}
+		templates.push_back(schema);
 	}
 
 	return justamcp_pagination_slice_array(templates, cursor, "resourceTemplates");

--- a/modules/justamcp/tools/justamcp_resource_executor.h
+++ b/modules/justamcp/tools/justamcp_resource_executor.h
@@ -56,8 +56,8 @@ public:
 	static void _on_filesystem_changed();
 	void add_resource(const Ref<JustAMCPResource> &p_resource);
 
-	Dictionary list_resources(const String &cursor = "");
-	Dictionary list_resource_templates(const String &cursor = "");
+	Dictionary list_resources(const String &cursor = "", bool p_include_unlisted = false);
+	Dictionary list_resource_templates(const String &cursor = "", bool p_include_unlisted = false);
 	Dictionary read_resource(const String &p_uri);
 
 	JustAMCPResourceExecutor();

--- a/modules/justamcp/tools/justamcp_settings_resolver.cpp
+++ b/modules/justamcp/tools/justamcp_settings_resolver.cpp
@@ -32,7 +32,26 @@
 #include "justamcp_settings_resolver.h"
 
 #include "core/config/project_settings.h"
+#include "core/templates/hash_map.h"
 #include "editor/editor_settings.h"
+
+static HashMap<String, bool> &justamcp_category_defaults() {
+	static HashMap<String, bool> defaults;
+	return defaults;
+}
+
+static bool _justamcp_variant_as_bool(const Variant &p_value, bool p_default) {
+	if (p_value.get_type() == Variant::BOOL) {
+		return p_value;
+	}
+	if (p_value.get_type() == Variant::NIL) {
+		return p_default;
+	}
+	if (p_value.get_type() == Variant::STRING) {
+		return p_default;
+	}
+	return p_value.booleanize();
+}
 
 bool JustAMCPSettingsResolver::uses_project_override() {
 	if (!ProjectSettings::get_singleton() || !ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
@@ -41,46 +60,40 @@ bool JustAMCPSettingsResolver::uses_project_override() {
 	return GLOBAL_GET("blazium/justamcp/override_editor_settings");
 }
 
-bool JustAMCPSettingsResolver::resolve_category_enabled(const String &p_category, bool p_default) {
-	const String setting_path = "blazium/justamcp/tools/" + p_category;
+bool JustAMCPSettingsResolver::resolve_bool(const String &p_path, bool p_default) {
 	if (uses_project_override() || !EditorSettings::get_singleton()) {
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(setting_path)) {
-			return GLOBAL_GET(setting_path);
+		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_path)) {
+			return _justamcp_variant_as_bool(ProjectSettings::get_singleton()->get_setting(p_path), p_default);
 		}
 		return p_default;
 	}
-	if (EditorSettings::get_singleton()->has_setting(setting_path)) {
-		return EDITOR_GET(setting_path);
+	if (EditorSettings::get_singleton()->has_setting(p_path)) {
+		return _justamcp_variant_as_bool(EditorSettings::get_singleton()->get_setting(p_path), p_default);
 	}
 	return p_default;
+}
+
+void JustAMCPSettingsResolver::set_category_default(const String &p_category, bool p_is_core) {
+	if (p_category.is_empty()) {
+		return;
+	}
+	justamcp_category_defaults()[p_category] = p_is_core;
+}
+
+bool JustAMCPSettingsResolver::resolve_category_enabled(const String &p_category, bool p_default) {
+	bool def = p_default;
+	if (justamcp_category_defaults().has(p_category)) {
+		def = justamcp_category_defaults()[p_category];
+	}
+	return resolve_bool("blazium/justamcp/tools/" + p_category, def);
 }
 
 bool JustAMCPSettingsResolver::resolve_tool_enabled(const String &p_category, const String &p_full_name, bool p_default) {
-	const String setting_path = "blazium/justamcp/tools/" + p_category + "/" + p_full_name;
-	if (uses_project_override() || !EditorSettings::get_singleton()) {
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(setting_path)) {
-			return GLOBAL_GET(setting_path);
-		}
-		return p_default;
-	}
-	if (EditorSettings::get_singleton()->has_setting(setting_path)) {
-		return EDITOR_GET(setting_path);
-	}
-	return p_default;
+	return resolve_bool("blazium/justamcp/tools/" + p_category + "/" + p_full_name, p_default);
 }
 
 bool JustAMCPSettingsResolver::resolve_toolset_enabled(const String &p_name, bool p_default) {
-	const String setting_path = "blazium/justamcp/toolsets/" + p_name;
-	if (uses_project_override() || !EditorSettings::get_singleton()) {
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(setting_path)) {
-			return GLOBAL_GET(setting_path);
-		}
-		return p_default;
-	}
-	if (EditorSettings::get_singleton()->has_setting(setting_path)) {
-		return EDITOR_GET(setting_path);
-	}
-	return p_default;
+	return resolve_bool("blazium/justamcp/toolsets/" + p_name, p_default);
 }
 
 bool JustAMCPSettingsResolver::resolve_tool_enabled(const String &p_category, const String &p_full_name, bool p_ignore_settings, bool p_include_disabled_tools, bool &r_cat_enabled, bool &r_tool_enabled) {
@@ -95,6 +108,41 @@ bool JustAMCPSettingsResolver::resolve_tool_enabled(const String &p_category, co
 		return false;
 	}
 	return true;
+}
+
+bool JustAMCPSettingsResolver::is_tool_listed(const String &p_category, const String &p_full_name) {
+	if (p_category.is_empty()) {
+		return true;
+	}
+	return resolve_category_enabled(p_category, true) && resolve_tool_enabled(p_category, p_full_name, true);
+}
+
+bool JustAMCPSettingsResolver::is_tool_executable(const String &p_category, const String &p_full_name) {
+	if (p_full_name.is_empty()) {
+		return false;
+	}
+	if (p_category.is_empty()) {
+		return true;
+	}
+	return resolve_tool_enabled(p_category, p_full_name, true);
+}
+
+bool JustAMCPSettingsResolver::is_prompt_listed(const String &p_name) {
+	if (p_name.is_empty()) {
+		return false;
+	}
+	return resolve_bool("blazium/justamcp/prompts", true) && resolve_bool("blazium/justamcp/prompts/" + p_name, true);
+}
+
+bool JustAMCPSettingsResolver::is_resource_listed(const String &p_name) {
+	if (p_name.is_empty()) {
+		return false;
+	}
+	return resolve_bool("blazium/justamcp/resources", true) && resolve_bool("blazium/justamcp/resources/" + p_name, true);
+}
+
+bool JustAMCPSettingsResolver::resolve_allow_execute_tool_bypass() {
+	return resolve_bool("blazium/justamcp/allow_execute_tool_bypass", false);
 }
 
 #endif

--- a/modules/justamcp/tools/justamcp_settings_resolver.h
+++ b/modules/justamcp/tools/justamcp_settings_resolver.h
@@ -36,10 +36,17 @@
 class JustAMCPSettingsResolver {
 public:
 	static bool uses_project_override();
+	static bool resolve_bool(const String &p_path, bool p_default);
+	static void set_category_default(const String &p_category, bool p_is_core);
 	static bool resolve_category_enabled(const String &p_category, bool p_default = true);
 	static bool resolve_tool_enabled(const String &p_category, const String &p_full_name, bool p_default = true);
 	static bool resolve_toolset_enabled(const String &p_name, bool p_default = true);
 	static bool resolve_tool_enabled(const String &p_category, const String &p_full_name, bool p_ignore_settings, bool p_include_disabled_tools, bool &r_cat_enabled, bool &r_tool_enabled);
+	static bool is_tool_listed(const String &p_category, const String &p_full_name);
+	static bool is_tool_executable(const String &p_category, const String &p_full_name);
+	static bool is_prompt_listed(const String &p_name);
+	static bool is_resource_listed(const String &p_name);
+	static bool resolve_allow_execute_tool_bypass();
 };
 
 #endif

--- a/modules/justamcp/tools/justamcp_tool_dispatcher.cpp
+++ b/modules/justamcp/tools/justamcp_tool_dispatcher.cpp
@@ -39,12 +39,7 @@
 #include "justamcp_toolset_registry.h"
 
 bool JustAMCPToolDispatcher::is_tool_enabled(const String &p_full_name, const String &p_category) {
-	if (p_category.is_empty()) {
-		return true;
-	}
-	bool cat_enabled = true;
-	bool tool_enabled = true;
-	return JustAMCPSettingsResolver::resolve_tool_enabled(p_category, p_full_name, false, false, cat_enabled, tool_enabled);
+	return JustAMCPSettingsResolver::is_tool_executable(p_category, p_full_name);
 }
 
 bool JustAMCPToolDispatcher::matches_prefix_route(const String &p_internal_name) {

--- a/modules/justamcp/tools/justamcp_tool_executor.cpp
+++ b/modules/justamcp/tools/justamcp_tool_executor.cpp
@@ -67,6 +67,7 @@
 #include "justamcp_scene_tools.h"
 #include "justamcp_script_tools.h"
 #include "justamcp_semantic_search_tools.h"
+#include "justamcp_settings_resolver.h"
 #include "justamcp_shader_tools.h"
 #include "justamcp_spatial_tools.h"
 #include "justamcp_theme_tools.h"
@@ -492,7 +493,9 @@ static Array _collect_tool_schemas(bool p_register_only, bool p_ignore_settings,
 		tools.push_back(t);
 	};
 
-	if (p_category_only.is_empty()) {
+	if (p_category_only.is_empty() || p_category_only == "meta_tools") {
+		current_category = "meta_tools";
+		is_core = true;
 		add_schema("search_tools", "Searches the engine native capabilities for a specific tool name matching your needs.",
 				Vector<String>{ "query", "string" }, Vector<String>{ "query" }, "forbidden", "worker");
 		add_schema("execute_tool", "Dynamically bypasses context omission to execute ANY tool in the engine by name.",
@@ -659,16 +662,18 @@ Dictionary JustAMCPToolExecutor::execute_tool(const String &p_tool_name, const D
 		return result;
 	}
 
-	if (target_schema.has("_meta") && !allow_disabled_dispatch) {
+	String listed_category;
+	if (target_schema.has("_meta")) {
 		Dictionary meta = target_schema["_meta"];
-		if (!meta.get("enabled", true)) {
-			Dictionary err;
-			err["code"] = -32601;
-			err["message"] = "Tool is disabled: " + p_tool_name;
-			result["ok"] = false;
-			result["error"] = err;
-			return result;
-		}
+		listed_category = meta.get("category", "");
+	}
+	if (!allow_disabled_dispatch && !JustAMCPToolDispatcher::is_tool_enabled(full_name, listed_category)) {
+		Dictionary err;
+		err["code"] = -32601;
+		err["message"] = "Tool is disabled: " + p_tool_name;
+		result["ok"] = false;
+		result["error"] = err;
+		return result;
 	}
 
 	if (justamcp_is_cancel_requested()) {
@@ -795,10 +800,7 @@ Dictionary JustAMCPToolExecutor::execute_registry_category_tool(const String &p_
 }
 
 Dictionary JustAMCPToolExecutor::execute_tool_direct(const String &p_tool_name, const Dictionary &p_args) {
-	bool allow_bypass = false;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/allow_execute_tool_bypass")) {
-		allow_bypass = GLOBAL_GET("blazium/justamcp/allow_execute_tool_bypass");
-	}
+	const bool allow_bypass = JustAMCPSettingsResolver::resolve_allow_execute_tool_bypass();
 	const bool prev = allow_disabled_dispatch;
 	allow_disabled_dispatch = allow_bypass;
 	Dictionary result = execute_tool(p_tool_name, p_args);

--- a/modules/justamcp/tools/justamcp_tool_schema_builder.cpp
+++ b/modules/justamcp/tools/justamcp_tool_schema_builder.cpp
@@ -40,6 +40,7 @@
 void JustAMCPToolSchemaBuilder::register_tool_settings(const String &p_category, const String &p_full_name, bool p_is_core) {
 	const String cat_path = "blazium/justamcp/tools/" + p_category;
 	const String tool_path = cat_path + "/" + p_full_name;
+	JustAMCPSettingsResolver::set_category_default(p_category, p_is_core);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, cat_path), p_is_core);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, tool_path), true);
 	if (EditorSettings::get_singleton()) {

--- a/modules/justamcp/tools/justamcp_toolset_registry.cpp
+++ b/modules/justamcp/tools/justamcp_toolset_registry.cpp
@@ -161,18 +161,12 @@ Dictionary JustAMCPToolsetRegistry::describe_toolset(const String &p_name) const
 	}
 	const ToolsetEntry &entry = toolsets[p_name];
 	const bool enabled = _is_toolset_enabled_live(p_name);
-	if (!enabled) {
-		result["ok"] = false;
-		result["error"] = "Toolset is disabled: " + p_name;
-		result["enabled"] = false;
-		return result;
-	}
 	if (!entry.get_schemas.is_valid()) {
 		result["ok"] = false;
 		result["error"] = "Toolset has no schema provider: " + p_name;
 		return result;
 	}
-	Variant schemas = entry.get_schemas.call(false, false, true);
+	Variant schemas = entry.get_schemas.call(false, true, true);
 	result["ok"] = true;
 	result["toolset_name"] = p_name;
 	result["description"] = entry.description;
@@ -189,7 +183,10 @@ Array JustAMCPToolsetRegistry::collect_tool_schemas(const String &p_name, bool p
 		return Array();
 	}
 	const ToolsetEntry &entry = toolsets[p_name];
-	if (!_is_toolset_enabled_live(p_name) || !entry.get_schemas.is_valid()) {
+	if (!entry.get_schemas.is_valid()) {
+		return Array();
+	}
+	if (!p_register_only && !p_ignore_settings && !_is_toolset_enabled_live(p_name)) {
 		return Array();
 	}
 	const Variant schemas = entry.get_schemas.call(p_register_only, p_ignore_settings, p_include_disabled_tools);
@@ -207,11 +204,6 @@ Dictionary JustAMCPToolsetRegistry::call_toolset(const String &p_toolset_name, c
 		return result;
 	}
 	const ToolsetEntry &entry = toolsets[p_toolset_name];
-	if (!_is_toolset_enabled_live(p_toolset_name)) {
-		result["ok"] = false;
-		result["error"] = "Toolset is disabled: " + p_toolset_name;
-		return result;
-	}
 	if (!entry.execute_tool.is_valid()) {
 		result["ok"] = false;
 		result["error"] = "Toolset has no executor: " + p_toolset_name;
@@ -221,9 +213,7 @@ Dictionary JustAMCPToolsetRegistry::call_toolset(const String &p_toolset_name, c
 	if (!full_tool_name.begins_with("blazium_")) {
 		full_tool_name = "blazium_" + full_tool_name;
 	}
-	bool cat_enabled = true;
-	bool tool_enabled = true;
-	if (!entry.category.is_empty() && !JustAMCPSettingsResolver::resolve_tool_enabled(entry.category, full_tool_name, false, false, cat_enabled, tool_enabled)) {
+	if (!entry.category.is_empty() && !JustAMCPSettingsResolver::is_tool_executable(entry.category, full_tool_name)) {
 		result["ok"] = false;
 		result["error"] = "Tool is disabled: " + full_tool_name;
 		return result;


### PR DESCRIPTION
## Summary
- Section on/off now only controls `tools/list` and the settings Tools (Active) count, so clients can stay under tool-list caps without losing access to those tools.
- `search_tools`, `execute_tool`, `describe_toolset`, and `call_toolset` still reach tools whose section is off; the per-tool toggle remains the actual disable.
- Settings changes invalidate the schema cache so Tools (Active) updates immediately, and prompts/resources use the same list-vs-use split.

## Test plan
- [x] Enable a previously off Tool section (tools inside already on) and confirm Tools (Active) increases.
- [x] Confirm `search_tools` still returns a tool from an off section.
- [x] Confirm `execute_tool` / `call_toolset` succeed for a tool in an off section.
- [x] Confirm a per-tool off still rejects execute and is omitted from `tools/list`.
- [x] JustAMCP unit tests: 283 passed (`--test --test-case=*[JustAMCP]*`).