### PR TITLE
Identify crash reporter and analytics by App ID and Build ID

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -9,7 +9,7 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-android
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-android
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -9,7 +9,7 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-ios
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-ios
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -13,7 +13,7 @@ env:
   UBSAN_OPTIONS: suppressions=${{ github.workspace }}/misc/error_suppressions/ubsan.txt
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-linux
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-linux
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -9,7 +9,7 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-macos
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-macos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,8 +1,13 @@
 name: 🔗 GHA
-on: [push, pull_request, merge_group]
+on:
+  push:
+    branches:
+      - blazium-dev
+  pull_request:
+  merge_group:
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-runner
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-runner
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-static
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-static
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -10,7 +10,7 @@ env:
   EM_VERSION: 3.1.64
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-web
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-web
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -11,7 +11,7 @@ env:
   SCONS_CACHE_MSVC_CONFIG: true
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-windows
+  group: ci-pr-${{ github.event.pull_request.number || github.ref_name }}-windows
   cancel-in-progress: true
 
 jobs:

--- a/SConstruct
+++ b/SConstruct
@@ -238,8 +238,11 @@ opts.Add(
         False,
     )
 )
-opts.Add("editor_crash_reporter_app_id", "Baked editor crash reporter app_id", "blazium-editor")
+opts.Add("editor_app_id", "Shared baked editor App ID (crash reporter + analytics)", "blazium-editor")
+opts.Add("editor_build_id", "Shared baked editor Build ID (empty = version hash at runtime)", "")
+opts.Add("editor_crash_reporter_app_id", "Alias for editor_app_id (empty uses editor_app_id)", "")
 opts.Add("editor_crash_reporter_app_name", "Baked editor crash reporter app_name", "Blazium Editor")
+opts.Add("editor_crash_reporter_build_id", "Alias for editor_build_id (empty uses editor_build_id)", "")
 opts.Add("editor_crash_reporter_build_channel", "Baked editor crash reporter build_channel", "dev")
 opts.Add("editor_crash_reporter_endpoint", "Baked editor crash reporter ingest URL (empty = console only)", "")
 opts.Add(
@@ -247,7 +250,6 @@ opts.Add(
     "Baked editor crash reporter contact/bug URL",
     "https://github.com/blazium-games/blazium/issues",
 )
-opts.Add("editor_crash_reporter_api_key", "Baked editor crash reporter X-API-Key (public client key)", "")
 opts.Add(
     BoolVariable(
         "analytics",
@@ -262,11 +264,10 @@ opts.Add(
         False,
     )
 )
-opts.Add("editor_analytics_app_id", "Baked editor analytics app_id", "blazium-editor")
-opts.Add("editor_analytics_build_id", "Baked editor analytics build_id (empty = version hash)", "")
+opts.Add("editor_analytics_app_id", "Alias for editor_app_id (empty uses editor_app_id)", "")
+opts.Add("editor_analytics_build_id", "Alias for editor_build_id (empty uses editor_build_id)", "")
 opts.Add("editor_analytics_build_channel", "Baked editor analytics build_channel", "dev")
 opts.Add("editor_analytics_endpoint", "Baked editor analytics ingest URL (empty = queue only)", "")
-opts.Add("editor_analytics_api_key", "Baked editor analytics X-API-Key (public client key)", "")
 opts.Add(
     BoolVariable(
         "hub_register",
@@ -558,6 +559,24 @@ def _crash_reporter_cpp_string(name, value):
     return f'{name}=\\"{escaped}\\"'
 
 
+def _first_nonempty(*vals):
+    for v in vals:
+        if str(v).strip():
+            return v
+    return ""
+
+
+editor_app_id = _first_nonempty(
+    env.get("editor_crash_reporter_app_id", ""),
+    env.get("editor_analytics_app_id", ""),
+    env.get("editor_app_id", "blazium-editor"),
+)
+editor_build_id = _first_nonempty(
+    env.get("editor_crash_reporter_build_id", ""),
+    env.get("editor_analytics_build_id", ""),
+    env.get("editor_build_id", ""),
+)
+
 if env.editor_build:
     if env.get("crash_reporter"):
         print_warning("crash_reporter=yes is ignored for editor builds; use editor_crash_reporter=yes.")
@@ -565,10 +584,11 @@ if env.editor_build:
         env.Append(CPPDEFINES=["CRASH_REPORTER_ENABLED", "USE_BREAKPAD"])
         env.Append(
             CPPDEFINES=[
-                _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_APP_ID", env.get("editor_crash_reporter_app_id", "")),
+                _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_APP_ID", editor_app_id),
                 _crash_reporter_cpp_string(
                     "CRASH_REPORTER_EDITOR_APP_NAME", env.get("editor_crash_reporter_app_name", "")
                 ),
+                _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_BUILD_ID", editor_build_id),
                 _crash_reporter_cpp_string(
                     "CRASH_REPORTER_EDITOR_BUILD_CHANNEL", env.get("editor_crash_reporter_build_channel", "")
                 ),
@@ -577,9 +597,6 @@ if env.editor_build:
                 ),
                 _crash_reporter_cpp_string(
                     "CRASH_REPORTER_EDITOR_CONTACT_URL", env.get("editor_crash_reporter_contact_url", "")
-                ),
-                _crash_reporter_cpp_string(
-                    "CRASH_REPORTER_EDITOR_API_KEY", env.get("editor_crash_reporter_api_key", "")
                 ),
             ]
         )
@@ -601,11 +618,10 @@ if env.editor_build:
         env.Append(CPPDEFINES=["ANALYTICS_ENABLED"])
         env.Append(
             CPPDEFINES=[
-                _analytics_cpp_string("ANALYTICS_EDITOR_APP_ID", env.get("editor_analytics_app_id", "")),
-                _analytics_cpp_string("ANALYTICS_EDITOR_BUILD_ID", env.get("editor_analytics_build_id", "")),
+                _analytics_cpp_string("ANALYTICS_EDITOR_APP_ID", editor_app_id),
+                _analytics_cpp_string("ANALYTICS_EDITOR_BUILD_ID", editor_build_id),
                 _analytics_cpp_string("ANALYTICS_EDITOR_BUILD_CHANNEL", env.get("editor_analytics_build_channel", "")),
                 _analytics_cpp_string("ANALYTICS_EDITOR_ENDPOINT", env.get("editor_analytics_endpoint", "")),
-                _analytics_cpp_string("ANALYTICS_EDITOR_API_KEY", env.get("editor_analytics_api_key", "")),
             ]
         )
 elif env.get("editor_analytics"):

--- a/core/config/app_identity.cpp
+++ b/core/config/app_identity.cpp
@@ -1,0 +1,173 @@
+/**************************************************************************/
+/*  app_identity.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "app_identity.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+#include "core/templates/list.h"
+
+String AppIdentity::cmdline_flag_value(const String &p_flag) {
+	if (!OS::get_singleton() || p_flag.is_empty()) {
+		return String();
+	}
+	const String flag = p_flag.begins_with("--") ? p_flag : String("--") + p_flag;
+	const String equals = flag + "=";
+	const List<String> &args = OS::get_singleton()->get_cmdline_args();
+	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
+		const String &arg = E->get();
+		if (arg == flag && E->next()) {
+			return E->next()->get();
+		}
+		if (arg.begins_with(equals)) {
+			return arg.substr(equals.length());
+		}
+	}
+	const List<String> &user_args = OS::get_singleton()->get_cmdline_user_args();
+	for (const List<String>::Element *E = user_args.front(); E; E = E->next()) {
+		const String &arg = E->get();
+		if (arg == flag && E->next()) {
+			return E->next()->get();
+		}
+		if (arg.begins_with(equals)) {
+			return arg.substr(equals.length());
+		}
+	}
+	return String();
+}
+
+String AppIdentity::cmdline_equals_value(const String &p_prefix) {
+	if (!OS::get_singleton() || p_prefix.is_empty()) {
+		return String();
+	}
+	const List<String> &args = OS::get_singleton()->get_cmdline_args();
+	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
+		if (E->get().begins_with(p_prefix)) {
+			return E->get().substr(p_prefix.length());
+		}
+	}
+	return String();
+}
+
+String AppIdentity::env_first(const Vector<String> &p_names) {
+	if (!OS::get_singleton()) {
+		return String();
+	}
+	for (int i = 0; i < p_names.size(); i++) {
+		if (OS::get_singleton()->has_environment(p_names[i])) {
+			const String v = OS::get_singleton()->get_environment(p_names[i]).strip_edges();
+			if (!v.is_empty()) {
+				return v;
+			}
+		}
+	}
+	return String();
+}
+
+String AppIdentity::project_first(const Vector<String> &p_keys) {
+	if (!ProjectSettings::get_singleton()) {
+		return String();
+	}
+	for (int i = 0; i < p_keys.size(); i++) {
+		if (!ProjectSettings::get_singleton()->has_setting(p_keys[i])) {
+			continue;
+		}
+		const String v = String(ProjectSettings::get_singleton()->get_setting_with_override(p_keys[i])).strip_edges();
+		if (!v.is_empty()) {
+			return v;
+		}
+	}
+	return String();
+}
+
+String AppIdentity::resolve_app_id(const String &p_editor_override, const String &p_baked, const String &p_fallback) {
+	const String cli = cmdline_flag_value("app-id");
+	if (!cli.is_empty()) {
+		return cli;
+	}
+	const String analytics_cli = cmdline_equals_value("--analytics-app-id=");
+	if (!analytics_cli.is_empty()) {
+		return analytics_cli;
+	}
+	Vector<String> envs;
+	envs.push_back("BLAZIUM_APP_ID");
+	envs.push_back("BLAZIUM_CRASH_REPORTER_APP_ID");
+	envs.push_back("BLAZIUM_ANALYTICS_APP_ID");
+	const String env = env_first(envs);
+	if (!env.is_empty()) {
+		return env;
+	}
+	if (!p_editor_override.strip_edges().is_empty()) {
+		return p_editor_override.strip_edges();
+	}
+	if (!p_baked.strip_edges().is_empty()) {
+		return p_baked.strip_edges();
+	}
+	Vector<String> keys;
+	keys.push_back("application/crash_reporter/app_id");
+	keys.push_back("application/analytics/app_id");
+	const String project = project_first(keys);
+	if (!project.is_empty()) {
+		return project;
+	}
+	return p_fallback;
+}
+
+String AppIdentity::resolve_build_id(const String &p_editor_override, const String &p_baked, const String &p_fallback) {
+	const String cli = cmdline_flag_value("build-id");
+	if (!cli.is_empty()) {
+		return cli;
+	}
+	const String analytics_cli = cmdline_equals_value("--analytics-build-id=");
+	if (!analytics_cli.is_empty()) {
+		return analytics_cli;
+	}
+	Vector<String> envs;
+	envs.push_back("BLAZIUM_BUILD_ID");
+	envs.push_back("BLAZIUM_CRASH_REPORTER_BUILD_ID");
+	envs.push_back("BLAZIUM_ANALYTICS_BUILD_ID");
+	const String env = env_first(envs);
+	if (!env.is_empty()) {
+		return env;
+	}
+	if (!p_editor_override.strip_edges().is_empty()) {
+		return p_editor_override.strip_edges();
+	}
+	if (!p_baked.strip_edges().is_empty()) {
+		return p_baked.strip_edges();
+	}
+	Vector<String> keys;
+	keys.push_back("application/crash_reporter/build_id");
+	keys.push_back("application/analytics/build_id");
+	const String project = project_first(keys);
+	if (!project.is_empty()) {
+		return project;
+	}
+	return p_fallback;
+}

--- a/core/config/app_identity.h
+++ b/core/config/app_identity.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  crash_reporter_http.h                                                 */
+/*  app_identity.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             BLAZIUM ENGINE                             */
@@ -29,28 +29,15 @@
 
 #pragma once
 
-#include "core/error/error_list.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
 
-struct CrashReporterHTTPResult {
-	Error error = FAILED;
-	int response_code = 0;
-	String message;
-};
-
-class CrashReporterHTTP {
+class AppIdentity {
 public:
-	static CrashReporterHTTPResult upload_report(
-			const String &p_endpoint,
-			const String &p_app_id,
-			const String &p_build_id,
-			const String &p_user_agent,
-			const Vector<uint8_t> &p_body,
-			const String &p_content_type,
-			int p_timeout_sec,
-			bool p_verify_tls,
-			int p_retry_count,
-			int p_retry_backoff_sec,
-			bool *r_cancel = nullptr);
+	static String cmdline_flag_value(const String &p_flag);
+	static String cmdline_equals_value(const String &p_prefix);
+	static String env_first(const Vector<String> &p_names);
+	static String project_first(const Vector<String> &p_keys);
+	static String resolve_app_id(const String &p_editor_override, const String &p_baked, const String &p_fallback);
+	static String resolve_build_id(const String &p_editor_override, const String &p_baked, const String &p_fallback);
 };

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -244,11 +244,8 @@
 		<member name="application/analytics/anonymous" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], game analytics events omit [code]device_uid[/code]. Identity fields such as [code]app_id[/code] are still sent.
 		</member>
-		<member name="application/analytics/api_key" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional [code]X-API-Key[/code] sent with analytics POSTs. Treat as a public client key, not a secret.
-		</member>
 		<member name="application/analytics/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id sent on every event. Falls back to [member application/config/name] if empty.
+			Stable product id sent on every event and as [code]X-App-Id[/code]. Shared with [member application/crash_reporter/app_id] (crash reporter setting wins if both are set). Falls back to [member application/config/name] if empty.
 		</member>
 		<member name="application/analytics/app_version" type="String" setter="" getter="" default="&quot;&quot;">
 			Product version sent on every event. Falls back to [member application/config/version] if empty.
@@ -257,7 +254,7 @@
 			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
 		</member>
 		<member name="application/analytics/build_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Build identifier (git SHA or CI build number). Falls back to [member application/config/version] if empty.
+			Build identifier (git SHA or CI build number) sent as [code]X-Build-Id[/code]. Shared with [member application/crash_reporter/build_id] (crash reporter setting wins if both are set). Falls back to [member application/config/version] if empty.
 		</member>
 		<member name="application/analytics/enabled" type="bool" setter="" getter="" default="false">
 			Master switch after a template is compiled with [code]analytics=yes[/code]. When [code]false[/code], events are not queued or sent.
@@ -342,11 +339,8 @@
 		<member name="application/config/windows_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
-		<member name="application/crash_reporter/api_key" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional [code]X-API-Key[/code] sent with in-engine and sidecar crash uploads. Treat as a public client key, not a secret.
-		</member>
 		<member name="application/crash_reporter/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id for the ingest server. Falls back to [member application/config/name] if empty.
+			Stable product id sent with crash metadata and [code]X-App-Id[/code]. Shared with [member application/analytics/app_id]. Falls back to [member application/config/name] if empty.
 		</member>
 		<member name="application/crash_reporter/app_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Display name copied into crash metadata. Falls back to [member application/config/name] if empty.
@@ -356,6 +350,9 @@
 		</member>
 		<member name="application/crash_reporter/build_channel" type="String" setter="" getter="" default="&quot;release&quot;">
 			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
+		</member>
+		<member name="application/crash_reporter/build_id" type="String" setter="" getter="" default="&quot;&quot;">
+			Build identifier sent with crash metadata and [code]X-Build-Id[/code]. Shared with [member application/analytics/build_id]. Falls back to [member application/config/version] if empty.
 		</member>
 		<member name="application/crash_reporter/console_message" type="String" setter="" getter="" default="&quot;Crash dump created at: {path} Please attach this file when reporting issues.&quot;">
 			Printed after a dump is written. [code]{path}[/code] is replaced with the dump path.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -698,8 +698,15 @@ void Main::print_help(const char *p_binary) {
 	print_help_title("Analytics Options");
 	print_help_option("--analytics=<accepted|declined>", "Set analytics consent for this process (overrides settings).\n");
 	print_help_option("--analytics-mode=<anonymous|identified>", "Anonymous omits device_uid; identified sends OS.get_unique_id().\n");
-	print_help_option("--analytics-app-id=<id>", "Override analytics app_id for this process.\n");
-	print_help_option("--analytics-build-id=<id>", "Override analytics build_id for this process.\n");
+	print_help_option("--analytics-app-id=<id>", "Alias for --app-id (crash reporter and analytics).\n");
+	print_help_option("--analytics-build-id=<id>", "Alias for --build-id (crash reporter and analytics).\n");
+#endif
+
+	print_help_title("Identity Options");
+	print_help_option("--app-id <id>", "Override App ID for crash reporter and analytics.\n");
+	print_help_option("--build-id <id>", "Override Build ID for crash reporter and analytics.\n");
+#ifdef TOOLS_ENABLED
+	print_help_option("--crash-reporter <path>", "Editor sidecar crash reporter executable (dumps + spawn; omitted = console only).\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #endif
 
 #ifdef MODULE_REMOTE_CONTROL_ENABLED
@@ -1948,6 +1955,33 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
+#ifdef TOOLS_ENABLED
+		} else if (arg == "--crash-reporter") {
+			if (N) {
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing <path> argument for --crash-reporter <path>.\n");
+				goto error;
+			}
+		} else if (arg.begins_with("--crash-reporter=")) {
+#endif
+		} else if (arg == "--app-id") {
+			if (N) {
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing <id> argument for --app-id <id>.\n");
+				goto error;
+			}
+		} else if (arg.begins_with("--app-id=")) {
+		} else if (arg == "--build-id") {
+			if (N) {
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing <id> argument for --build-id <id>.\n");
+				goto error;
+			}
+		} else if (arg.begins_with("--build-id=")) {
+		} else if (arg.begins_with("--analytics-app-id=") || arg.begins_with("--analytics-build-id=")) {
 		} else {
 			main_args.push_back(arg);
 		}

--- a/modules/analytics/analytics.cpp
+++ b/modules/analytics/analytics.cpp
@@ -34,6 +34,7 @@
 
 #include <cstring>
 
+#include "core/config/app_identity.h"
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/json.h"
@@ -58,9 +59,6 @@
 #endif
 #ifndef ANALYTICS_EDITOR_ENDPOINT
 #define ANALYTICS_EDITOR_ENDPOINT ""
-#endif
-#ifndef ANALYTICS_EDITOR_API_KEY
-#define ANALYTICS_EDITOR_API_KEY ""
 #endif
 
 Analytics *Analytics::singleton = nullptr;
@@ -411,69 +409,38 @@ void Analytics::set_anonymous(bool p_anonymous) {
 }
 
 String Analytics::get_app_id() const {
-	const String cli = _cmdline_value("--analytics-app-id=");
-	if (!cli.is_empty()) {
-		return cli;
-	}
-	const String env = _env("BLAZIUM_ANALYTICS_APP_ID");
-	if (!env.is_empty()) {
-		return env;
-	}
 #ifdef TOOLS_ENABLED
 	if (_is_editor_context()) {
+		String editor_override;
 		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/app_id")) {
-			const String override_id = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/app_id"));
-			if (!override_id.is_empty()) {
-				return override_id;
-			}
+			editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/app_id"));
 		}
 		const String baked = String(ANALYTICS_EDITOR_APP_ID);
-		return baked.is_empty() ? String("blazium-editor") : baked;
+		return AppIdentity::resolve_app_id(editor_override, baked, String("blazium-editor"));
 	}
 #endif
-	const String project_id = _setting_string("application/analytics/app_id", String());
-	if (!project_id.is_empty()) {
-		return project_id;
-	}
-	return _setting_string("application/config/name", String());
+	return AppIdentity::resolve_app_id(String(), String(), _setting_string("application/config/name", String()));
 }
 
 String Analytics::get_build_id() const {
-	const String cli = _cmdline_value("--analytics-build-id=");
-	if (!cli.is_empty()) {
-		return cli;
-	}
-	const String env = _env("BLAZIUM_ANALYTICS_BUILD_ID");
-	if (!env.is_empty()) {
-		return env;
-	}
 #ifdef TOOLS_ENABLED
 	if (_is_editor_context()) {
+		String editor_override;
 		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/build_id")) {
-			const String override_id = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/build_id"));
-			if (!override_id.is_empty()) {
-				return override_id;
-			}
+			editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/build_id"));
 		}
-		const String baked = String(ANALYTICS_EDITOR_BUILD_ID);
-		if (!baked.is_empty()) {
-			return baked;
-		}
-		if (Engine::get_singleton()) {
+		String fallback = String(ANALYTICS_EDITOR_BUILD_ID);
+		if (fallback.is_empty() && Engine::get_singleton()) {
 			const Dictionary info = Engine::get_singleton()->get_version_info();
-			const String hash = String(info.get("hash", String()));
-			if (!hash.is_empty()) {
-				return hash;
-			}
+			fallback = String(info.get("hash", String()));
 		}
-		return String(VERSION_HASH);
+		if (fallback.is_empty()) {
+			fallback = String(VERSION_HASH);
+		}
+		return AppIdentity::resolve_build_id(editor_override, String(ANALYTICS_EDITOR_BUILD_ID), fallback);
 	}
 #endif
-	const String project_id = _setting_string("application/analytics/build_id", String());
-	if (!project_id.is_empty()) {
-		return project_id;
-	}
-	return _setting_string("application/config/version", String());
+	return AppIdentity::resolve_build_id(String(), String(), _setting_string("application/config/version", String()));
 }
 
 String Analytics::get_app_version() const {
@@ -523,25 +490,6 @@ String Analytics::get_endpoint() const {
 		return env;
 	}
 	return _setting_string("application/analytics/endpoint", String());
-}
-
-String Analytics::get_api_key() const {
-	const String env = _env("BLAZIUM_ANALYTICS_API_KEY");
-	if (!env.is_empty()) {
-		return env;
-	}
-#ifdef TOOLS_ENABLED
-	if (_is_editor_context()) {
-		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/api_key")) {
-			const String override_key = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/api_key"));
-			if (!override_key.is_empty()) {
-				return override_key;
-			}
-		}
-		return String(ANALYTICS_EDITOR_API_KEY);
-	}
-#endif
-	return _setting_string("application/analytics/api_key", String());
 }
 
 String Analytics::get_queue_directory() const {
@@ -614,7 +562,7 @@ void Analytics::flush() {
 		timeout_sec = MAX((int)GLOBAL_GET("application/analytics/timeout_sec"), 1);
 	}
 	const bool verify_tls = _setting_bool("application/analytics/verify_tls", true);
-	const AnalyticsHTTPResult result = AnalyticsHTTP::post_events(endpoint, get_api_key(), ua, bytes, timeout_sec, verify_tls);
+	const AnalyticsHTTPResult result = AnalyticsHTTP::post_events(endpoint, get_app_id(), get_build_id(), ua, bytes, timeout_sec, verify_tls);
 	if (result.error == OK) {
 		AnalyticsQueue::clear(get_queue_directory());
 		emit_signal(SNAME("flush_succeeded"), events.size());

--- a/modules/analytics/analytics.h
+++ b/modules/analytics/analytics.h
@@ -97,7 +97,6 @@ public:
 	String get_build_channel() const;
 	String get_device_uid() const;
 	String get_endpoint() const;
-	String get_api_key() const;
 	String get_queue_directory() const;
 
 	void track(const String &p_event, const Dictionary &p_properties = Dictionary());

--- a/modules/analytics/analytics_http.cpp
+++ b/modules/analytics/analytics_http.cpp
@@ -48,7 +48,7 @@ String AnalyticsHTTP::normalize_endpoint(const String &p_endpoint) {
 	return endpoint;
 }
 
-AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &p_endpoint, const String &p_api_key, const String &p_user_agent, const Vector<uint8_t> &p_body, int p_timeout_sec, bool p_verify_tls) {
+AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &p_endpoint, const String &p_app_id, const String &p_build_id, const String &p_user_agent, const Vector<uint8_t> &p_body, int p_timeout_sec, bool p_verify_tls) {
 	AnalyticsHTTPResult result;
 	const String endpoint = normalize_endpoint(p_endpoint);
 	String scheme;
@@ -106,8 +106,11 @@ AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &p_endpoint, const S
 	headers.push_back("Content-Type: application/json");
 	headers.push_back("User-Agent: " + p_user_agent);
 	headers.push_back("Accept: application/json");
-	if (!p_api_key.is_empty()) {
-		headers.push_back("X-API-Key: " + p_api_key);
+	if (!p_app_id.is_empty()) {
+		headers.push_back("X-App-Id: " + p_app_id);
+	}
+	if (!p_build_id.is_empty()) {
+		headers.push_back("X-Build-Id: " + p_build_id);
 	}
 
 	err = client->request(HTTPClient::METHOD_POST, path, headers, p_body.ptr(), p_body.size());
@@ -144,7 +147,7 @@ String AnalyticsHTTP::normalize_endpoint(const String &p_endpoint) {
 	return p_endpoint.strip_edges();
 }
 
-AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &, const String &, const String &, const Vector<uint8_t> &, int, bool) {
+AnalyticsHTTPResult AnalyticsHTTP::post_events(const String &, const String &, const String &, const String &, const Vector<uint8_t> &, int, bool) {
 	AnalyticsHTTPResult result;
 	result.error = ERR_UNAVAILABLE;
 	result.message = "Analytics HTTP is disabled in this build.";

--- a/modules/analytics/analytics_http.h
+++ b/modules/analytics/analytics_http.h
@@ -44,7 +44,8 @@ public:
 	static String normalize_endpoint(const String &p_endpoint);
 	static AnalyticsHTTPResult post_events(
 			const String &p_endpoint,
-			const String &p_api_key,
+			const String &p_app_id,
+			const String &p_build_id,
 			const String &p_user_agent,
 			const Vector<uint8_t> &p_body,
 			int p_timeout_sec,

--- a/modules/analytics/analytics_project_settings.cpp
+++ b/modules/analytics/analytics_project_settings.cpp
@@ -44,7 +44,6 @@ void analytics_register_project_settings() {
 	GLOBAL_DEF_BASIC("application/analytics/build_id", String());
 	GLOBAL_DEF_BASIC("application/analytics/app_version", String());
 	GLOBAL_DEF_BASIC("application/analytics/build_channel", "release");
-	GLOBAL_DEF_BASIC("application/analytics/api_key", String());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/analytics/timeout_sec", PROPERTY_HINT_RANGE, "1,120,1"), 15);
 	GLOBAL_DEF_BASIC("application/analytics/verify_tls", true);
 }
@@ -59,7 +58,6 @@ void analytics_register_editor_settings() {
 	EDITOR_DEF_BASIC("blazium/analytics/endpoint", String());
 	EDITOR_DEF_BASIC("blazium/analytics/app_id", String());
 	EDITOR_DEF_BASIC("blazium/analytics/build_id", String());
-	EDITOR_DEF_BASIC("blazium/analytics/api_key", String());
 	if (EditorSettings::get_singleton()) {
 		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/consent", PROPERTY_HINT_ENUM, "unset,accepted,declined"));
 	}

--- a/modules/analytics/doc_classes/Analytics.xml
+++ b/modules/analytics/doc_classes/Analytics.xml
@@ -19,7 +19,7 @@
 		<method name="get_app_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved product id sent on every event.
+				Returns the resolved product id sent on every event and as [code]X-App-Id[/code] on flush. Shared with [method CrashReporter.get_app_id].
 			</description>
 		</method>
 		<method name="get_app_version" qualifiers="const">
@@ -37,7 +37,7 @@
 		<method name="get_build_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved build id. Empty is allowed; [code]app_id[/code] and [code]engine_version[/code] are still sent.
+				Returns the resolved build id sent on every event and as [code]X-Build-Id[/code] on flush. Shared with [method CrashReporter.get_build_id].
 			</description>
 		</method>
 		<method name="get_consent" qualifiers="const">

--- a/modules/analytics/tests/test_analytics.cpp
+++ b/modules/analytics/tests/test_analytics.cpp
@@ -32,6 +32,11 @@
 #include "modules/analytics/analytics.h"
 #include "modules/analytics/analytics_queue.h"
 
+#ifdef MODULE_CRASH_REPORTER_ENABLED
+#include "modules/crash_reporter/crash_reporter.h"
+#endif
+
+#include "core/config/app_identity.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"
@@ -177,8 +182,43 @@ void test_analytics_payload_shape() {
 	CHECK(int(props.get("level", 0)) == 3);
 	const Dictionary cfg = a->get_resolved_config();
 	CHECK(cfg.has("app_id"));
+	CHECK(cfg.has("build_id"));
 	CHECK(cfg.has("endpoint"));
 	CHECK(cfg.has("queue_dir"));
+	CHECK(!cfg.has("api_key"));
+#else
+	CHECK(Analytics::get_singleton() != nullptr);
+#endif
+}
+
+void test_analytics_shared_identity() {
+#ifdef ANALYTICS_ENABLED
+	Analytics *a = Analytics::get_singleton();
+	REQUIRE(a != nullptr);
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set("application/analytics/app_id", String());
+		ProjectSettings::get_singleton()->set("application/analytics/build_id", String());
+		ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", "crash-ns-app");
+		ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", "crash-ns-build");
+	}
+	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "crash-ns-app");
+	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "crash-ns-build");
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", String());
+		ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", String());
+		ProjectSettings::get_singleton()->set("application/analytics/app_id", "analytics-ns-app");
+		ProjectSettings::get_singleton()->set("application/analytics/build_id", "analytics-ns-build");
+	}
+	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "analytics-ns-app");
+	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "analytics-ns-build");
+#ifdef MODULE_CRASH_REPORTER_ENABLED
+	CrashReporter *cr = CrashReporter::get_singleton();
+	REQUIRE(cr != nullptr);
+	CHECK(String(a->get_app_id()) == String(cr->get_app_id()));
+	CHECK(String(a->get_build_id()) == String(cr->get_build_id()));
+	CHECK(!cr->get_resolved_config().has("api_key"));
+#endif
+	CHECK(!a->get_resolved_config().has("api_key"));
 #else
 	CHECK(Analytics::get_singleton() != nullptr);
 #endif

--- a/modules/analytics/tests/test_analytics.h
+++ b/modules/analytics/tests/test_analytics.h
@@ -36,6 +36,7 @@ void test_analytics_consent_and_identity();
 void test_analytics_anonymous_omits_device_uid();
 void test_analytics_identified_includes_device_uid();
 void test_analytics_payload_shape();
+void test_analytics_shared_identity();
 
 TEST_CASE("[Modules][Analytics] queue JSONL roundtrip") {
 	test_analytics_queue_roundtrip();
@@ -55,4 +56,8 @@ TEST_CASE("[Modules][Analytics] identified includes OS unique id") {
 
 TEST_CASE("[Modules][Analytics] payload identity envelope") {
 	test_analytics_payload_shape();
+}
+
+TEST_CASE("[Modules][Analytics] shared app_id and build_id") {
+	test_analytics_shared_identity();
 }

--- a/modules/crash_reporter/breakpad_linuxbsd_windows.cpp
+++ b/modules/crash_reporter/breakpad_linuxbsd_windows.cpp
@@ -54,6 +54,7 @@ static char g_engine_hash[128] = { 0 };
 static char g_os[64] = { 0 };
 static char g_arch[64] = { 0 };
 static char g_build_channel[64] = { 0 };
+static char g_build_id[256] = { 0 };
 static char g_contact_url[512] = { 0 };
 static char g_reporter_path[1024] = { 0 };
 static bool g_spawn_on_crash = false;
@@ -109,13 +110,14 @@ static void _write_sidecar(const char *p_dump_path) {
 			"\t\"app_id\": \"%s\",\n"
 			"\t\"app_name\": \"%s\",\n"
 			"\t\"app_version\": \"%s\",\n"
+			"\t\"build_id\": \"%s\",\n"
 			"\t\"build_channel\": \"%s\",\n"
 			"\t\"contact_url\": \"%s\",\n"
 			"\t\"os\": \"%s\",\n"
 			"\t\"arch\": \"%s\",\n"
 			"\t\"dump_path\": \"%s\"\n"
 			"}\n",
-			id, g_engine_version, g_engine_hash, g_app_id, g_app_name, g_app_version, g_build_channel, g_contact_url, g_os, g_arch, p_dump_path);
+			id, g_engine_version, g_engine_hash, g_app_id, g_app_name, g_app_version, g_build_id, g_build_channel, g_contact_url, g_os, g_arch, p_dump_path);
 	fclose(f);
 }
 
@@ -142,8 +144,8 @@ static void _spawn_reporter_win(const char *p_dump_path) {
 	if (n >= 4) {
 		id[n - 4] = 0;
 	}
-	snprintf(cmd, sizeof(cmd), "\"%s\" --crash-dir \"%s\" --report-id \"%s\" --app-id \"%s\"",
-			g_reporter_path, g_dump_dir, id, g_app_id);
+	snprintf(cmd, sizeof(cmd), "\"%s\" --crash-dir \"%s\" --report-id \"%s\" --app-id \"%s\" --build-id \"%s\"",
+			g_reporter_path, g_dump_dir, id, g_app_id, g_build_id);
 	CreateProcessA(nullptr, cmd, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi);
 	if (pi.hThread) {
 		CloseHandle(pi.hThread);
@@ -231,7 +233,7 @@ void breakpad_set_dump_path(const char *p_utf8_path) {
 #endif
 }
 
-void breakpad_cache_identity(const char *p_app_id, const char *p_app_name, const char *p_app_version, const char *p_engine_version, const char *p_engine_hash, const char *p_os, const char *p_arch, const char *p_build_channel, const char *p_contact_url) {
+void breakpad_cache_identity(const char *p_app_id, const char *p_app_name, const char *p_app_version, const char *p_engine_version, const char *p_engine_hash, const char *p_os, const char *p_arch, const char *p_build_channel, const char *p_contact_url, const char *p_build_id) {
 	_copy_cstr(g_app_id, sizeof(g_app_id), p_app_id);
 	_copy_cstr(g_app_name, sizeof(g_app_name), p_app_name);
 	_copy_cstr(g_app_version, sizeof(g_app_version), p_app_version);
@@ -241,6 +243,7 @@ void breakpad_cache_identity(const char *p_app_id, const char *p_app_name, const
 	_copy_cstr(g_arch, sizeof(g_arch), p_arch);
 	_copy_cstr(g_build_channel, sizeof(g_build_channel), p_build_channel);
 	_copy_cstr(g_contact_url, sizeof(g_contact_url), p_contact_url);
+	_copy_cstr(g_build_id, sizeof(g_build_id), p_build_id);
 }
 
 void breakpad_cache_spawn(const char *p_reporter_utf8, bool p_spawn_on_crash) {

--- a/modules/crash_reporter/breakpad_linuxbsd_windows.h
+++ b/modules/crash_reporter/breakpad_linuxbsd_windows.h
@@ -34,7 +34,7 @@
 void initialize_breakpad(bool p_register_handlers);
 void disable_breakpad();
 void breakpad_set_dump_path(const char *p_utf8_path);
-void breakpad_cache_identity(const char *p_app_id, const char *p_app_name, const char *p_app_version, const char *p_engine_version, const char *p_engine_hash, const char *p_os, const char *p_arch, const char *p_build_channel, const char *p_contact_url);
+void breakpad_cache_identity(const char *p_app_id, const char *p_app_name, const char *p_app_version, const char *p_engine_version, const char *p_engine_hash, const char *p_os, const char *p_arch, const char *p_build_channel, const char *p_contact_url, const char *p_build_id);
 void breakpad_cache_spawn(const char *p_reporter_utf8, bool p_spawn_on_crash);
 void breakpad_handle_signal(int p_sig);
 void breakpad_handle_exception_pointers(void *p_exinfo);

--- a/modules/crash_reporter/crash_reporter.cpp
+++ b/modules/crash_reporter/crash_reporter.cpp
@@ -34,6 +34,7 @@
 #include "crash_reporter_project_settings.h"
 #include "crash_reporter_util.h"
 
+#include "core/config/app_identity.h"
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
@@ -45,6 +46,7 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_paths.h"
+#include "editor/editor_settings.h"
 #endif
 
 CrashReporter *CrashReporter::singleton = nullptr;
@@ -87,7 +89,7 @@ void CrashReporter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_contact_url"), &CrashReporter::get_contact_url);
 	ClassDB::bind_method(D_METHOD("get_privacy_policy_url"), &CrashReporter::get_privacy_policy_url);
 	ClassDB::bind_method(D_METHOD("get_reporter_path"), &CrashReporter::get_reporter_path);
-	ClassDB::bind_method(D_METHOD("get_api_key"), &CrashReporter::get_api_key);
+	ClassDB::bind_method(D_METHOD("get_build_id"), &CrashReporter::get_build_id);
 	ClassDB::bind_method(D_METHOD("get_upload_mode"), &CrashReporter::get_upload_mode);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &CrashReporter::is_enabled);
 	ClassDB::bind_method(D_METHOD("write_minidump"), &CrashReporter::write_minidump);
@@ -172,6 +174,9 @@ int CrashReporter::_setting_int(const String &p_key, int p_fallback) const {
 #ifndef CRASH_REPORTER_EDITOR_APP_NAME
 #define CRASH_REPORTER_EDITOR_APP_NAME ""
 #endif
+#ifndef CRASH_REPORTER_EDITOR_BUILD_ID
+#define CRASH_REPORTER_EDITOR_BUILD_ID ""
+#endif
 #ifndef CRASH_REPORTER_EDITOR_BUILD_CHANNEL
 #define CRASH_REPORTER_EDITOR_BUILD_CHANNEL ""
 #endif
@@ -180,9 +185,6 @@ int CrashReporter::_setting_int(const String &p_key, int p_fallback) const {
 #endif
 #ifndef CRASH_REPORTER_EDITOR_CONTACT_URL
 #define CRASH_REPORTER_EDITOR_CONTACT_URL ""
-#endif
-#ifndef CRASH_REPORTER_EDITOR_API_KEY
-#define CRASH_REPORTER_EDITOR_API_KEY ""
 #endif
 
 bool CrashReporter::is_available() const {
@@ -217,19 +219,30 @@ bool CrashReporter::is_enabled() const {
 }
 
 String CrashReporter::get_app_id() const {
-	const String baked = CR_BAKED(APP_ID);
-	const String from_env = _resolve_env_or_baked("BLAZIUM_CRASH_REPORTER_APP_ID", baked, String());
 #ifdef TOOLS_ENABLED
-	return from_env.is_empty() ? String("blazium-editor") : from_env;
+	String editor_override;
+	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/app_id")) {
+		editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/app_id"));
+	}
+	return AppIdentity::resolve_app_id(editor_override, CR_BAKED(APP_ID), String("blazium-editor"));
 #else
-	if (!from_env.is_empty()) {
-		return from_env;
+	return AppIdentity::resolve_app_id(String(), String(), _setting_string("application/config/name", String()));
+#endif
+}
+
+String CrashReporter::get_build_id() const {
+#ifdef TOOLS_ENABLED
+	String editor_override;
+	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/build_id")) {
+		editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/build_id"));
 	}
-	const String setting = _setting_string("application/crash_reporter/app_id", String());
-	if (!setting.is_empty()) {
-		return setting;
+	String fallback = CR_BAKED(BUILD_ID);
+	if (fallback.is_empty()) {
+		fallback = String(VERSION_HASH);
 	}
-	return _setting_string("application/config/name", String());
+	return AppIdentity::resolve_build_id(editor_override, CR_BAKED(BUILD_ID), fallback);
+#else
+	return AppIdentity::resolve_build_id(String(), String(), _setting_string("application/config/version", String()));
 #endif
 }
 
@@ -309,19 +322,6 @@ String CrashReporter::get_endpoint() const {
 #endif
 }
 
-String CrashReporter::get_api_key() const {
-	const String baked = CR_BAKED(API_KEY);
-	const String from_env = _resolve_env_or_baked("BLAZIUM_CRASH_REPORTER_API_KEY", baked, String());
-#ifdef TOOLS_ENABLED
-	return from_env;
-#else
-	if (!from_env.is_empty()) {
-		return from_env;
-	}
-	return _setting_string("application/crash_reporter/api_key", String());
-#endif
-}
-
 String CrashReporter::get_crash_directory() const {
 #ifdef TOOLS_ENABLED
 	if (OS::get_singleton() && OS::get_singleton()->has_environment("BLAZIUM_CRASH_REPORTER_CRASH_DIR")) {
@@ -345,7 +345,14 @@ String CrashReporter::get_crash_directory() const {
 
 String CrashReporter::_resolve_reporter_path() const {
 #ifdef TOOLS_ENABLED
-	return String();
+	const String cli = AppIdentity::cmdline_flag_value("crash-reporter");
+	if (cli.is_empty()) {
+		return String();
+	}
+	if (cli.is_absolute_path()) {
+		return cli;
+	}
+	return OS::get_singleton()->get_executable_path().get_base_dir().path_join(cli);
 #else
 	String rel = _setting_string("application/crash_reporter/reporter_path", String());
 	if (rel.is_empty()) {
@@ -364,6 +371,9 @@ String CrashReporter::get_reporter_path() const {
 
 int CrashReporter::get_upload_mode() const {
 #ifdef TOOLS_ENABLED
+	if (!_resolve_reporter_path().is_empty()) {
+		return UPLOAD_SIDECAR;
+	}
 	return UPLOAD_DISABLED;
 #else
 	return _setting_int("application/crash_reporter/upload_mode", UPLOAD_DISABLED);
@@ -384,11 +394,11 @@ Dictionary CrashReporter::get_resolved_config() const {
 	d["app_id"] = get_app_id();
 	d["app_name"] = get_app_name();
 	d["app_version"] = get_app_version();
+	d["build_id"] = get_build_id();
 	d["build_channel"] = get_build_channel();
 	d["contact_url"] = get_contact_url();
 	d["privacy_policy_url"] = get_privacy_policy_url();
 	d["endpoint"] = get_endpoint();
-	d["api_key"] = get_api_key();
 	d["reporter_path"] = get_reporter_path();
 	d["crash_directory"] = get_crash_directory();
 	d["upload_mode"] = get_upload_mode();
@@ -408,7 +418,8 @@ void CrashReporter::_cache_breakpad_identity() {
 	const CharString arch = Engine::get_singleton()->get_architecture_name().utf8();
 	const CharString channel = get_build_channel().utf8();
 	const CharString contact = get_contact_url().utf8();
-	breakpad_cache_identity(app_id.get_data(), app_name.get_data(), app_version.get_data(), engine_version.get_data(), engine_hash.get_data(), os_name.get_data(), arch.get_data(), channel.get_data(), contact.get_data());
+	const CharString build_id = get_build_id().utf8();
+	breakpad_cache_identity(app_id.get_data(), app_name.get_data(), app_version.get_data(), engine_version.get_data(), engine_hash.get_data(), os_name.get_data(), arch.get_data(), channel.get_data(), contact.get_data(), build_id.get_data());
 
 	const int mode = get_upload_mode();
 	const bool spawn = is_enabled() && _setting_bool("application/crash_reporter/spawn_on_crash", true) && (mode == UPLOAD_SIDECAR || mode == UPLOAD_BOTH);
@@ -424,6 +435,9 @@ void CrashReporter::_print_console_dump(const String &p_path) {
 	if (!get_app_id().is_empty()) {
 		print_error(vformat("Crash reporter app_id: %s", get_app_id()));
 	}
+	if (!get_build_id().is_empty()) {
+		print_error(vformat("Crash reporter build_id: %s", get_build_id()));
+	}
 	if (!get_endpoint().is_empty()) {
 		print_error(vformat("Crash reporter endpoint: %s", get_endpoint()));
 	}
@@ -438,6 +452,12 @@ void CrashReporter::_enrich_pending_metadata() {
 		const Dictionary row = pending[i];
 		const String meta_path = row.get("metadata_path", String());
 		Dictionary meta = row.get("metadata", Dictionary());
+		if (String(meta.get("app_id", String())).is_empty()) {
+			meta["app_id"] = get_app_id();
+		}
+		if (String(meta.get("build_id", String())).is_empty()) {
+			meta["build_id"] = get_build_id();
+		}
 		meta["os"] = OS::get_singleton()->get_name();
 		meta["arch"] = Engine::get_singleton()->get_architecture_name();
 		meta["locale"] = OS::get_singleton()->get_locale();
@@ -464,10 +484,6 @@ void CrashReporter::_enrich_pending_metadata() {
 }
 
 Error CrashReporter::_launch_reporter_internal(const String &p_report_id) {
-#ifdef TOOLS_ENABLED
-	(void)p_report_id;
-	return ERR_UNAVAILABLE;
-#else
 	const String path = _resolve_reporter_path();
 	if (path.is_empty() || !FileAccess::exists(path)) {
 		return ERR_FILE_NOT_FOUND;
@@ -487,9 +503,9 @@ Error CrashReporter::_launch_reporter_internal(const String &p_report_id) {
 		args.push_back("--app-id");
 		args.push_back(get_app_id());
 	}
-	if (!get_api_key().is_empty()) {
-		args.push_back("--api-key");
-		args.push_back(get_api_key());
+	if (!get_build_id().is_empty()) {
+		args.push_back("--build-id");
+		args.push_back(get_build_id());
 	}
 	if (!get_contact_url().is_empty()) {
 		args.push_back("--contact-url");
@@ -507,7 +523,6 @@ Error CrashReporter::_launch_reporter_internal(const String &p_report_id) {
 	}
 	const bool open_console = _setting_bool("application/crash_reporter/spawn_open_console", false);
 	return OS::get_singleton()->create_process(path, args, nullptr, open_console);
-#endif
 }
 
 Error CrashReporter::launch_reporter(const String &p_report_id) {
@@ -565,6 +580,7 @@ Error CrashReporter::upload_report(const String &p_id) {
 		Dictionary meta;
 		meta["id"] = p_id;
 		meta["app_id"] = get_app_id();
+		meta["build_id"] = get_build_id();
 		meta_json = CrashReporterUtil::metadata_to_json(meta);
 	}
 
@@ -580,7 +596,7 @@ Error CrashReporter::upload_report(const String &p_id) {
 	emit_signal(SNAME("upload_progress"), p_id, (int64_t)0, (int64_t)body.data.size());
 
 	const String ua = vformat("BlaziumCrashReporter/%s", VERSION_FULL_NAME);
-	const CrashReporterHTTPResult result = CrashReporterHTTP::upload_report(get_endpoint(), get_api_key(), ua, body.data, body.content_type, _setting_int("application/crash_reporter/timeout_sec", 30), _setting_bool("application/crash_reporter/verify_tls", true), _setting_int("application/crash_reporter/retry_count", 3), _setting_int("application/crash_reporter/retry_backoff_sec", 5), &upload_cancel);
+	const CrashReporterHTTPResult result = CrashReporterHTTP::upload_report(get_endpoint(), get_app_id(), get_build_id(), ua, body.data, body.content_type, _setting_int("application/crash_reporter/timeout_sec", 30), _setting_bool("application/crash_reporter/verify_tls", true), _setting_int("application/crash_reporter/retry_count", 3), _setting_int("application/crash_reporter/retry_backoff_sec", 5), &upload_cancel);
 
 	uploading = false;
 	if (result.error == OK) {
@@ -641,6 +657,12 @@ void CrashReporter::_startup_actions() {
 #endif
 
 #ifdef TOOLS_ENABLED
+	if (!_resolve_reporter_path().is_empty() && is_enabled()) {
+		_enrich_pending_metadata();
+		if (has_pending_reports() && _setting_bool("application/crash_reporter/spawn_on_next_launch", true)) {
+			_launch_reporter_internal(String());
+		}
+	}
 	return;
 #else
 	if (!is_enabled()) {

--- a/modules/crash_reporter/crash_reporter.h
+++ b/modules/crash_reporter/crash_reporter.h
@@ -101,7 +101,7 @@ public:
 	String get_contact_url() const;
 	String get_privacy_policy_url() const;
 	String get_reporter_path() const;
-	String get_api_key() const;
+	String get_build_id() const;
 	int get_upload_mode() const;
 	bool is_enabled() const;
 

--- a/modules/crash_reporter/crash_reporter_http.cpp
+++ b/modules/crash_reporter/crash_reporter_http.cpp
@@ -35,7 +35,7 @@
 
 #if defined(CRASH_REPORTER_ENABLED) && !defined(TOOLS_ENABLED)
 
-static CrashReporterHTTPResult _upload_once(const String &p_endpoint, const String &p_api_key, const String &p_user_agent, const Vector<uint8_t> &p_body, const String &p_content_type, int p_timeout_sec, bool p_verify_tls, bool *r_cancel) {
+static CrashReporterHTTPResult _upload_once(const String &p_endpoint, const String &p_app_id, const String &p_build_id, const String &p_user_agent, const Vector<uint8_t> &p_body, const String &p_content_type, int p_timeout_sec, bool p_verify_tls, bool *r_cancel) {
 	CrashReporterHTTPResult result;
 	String scheme;
 	String host;
@@ -97,8 +97,11 @@ static CrashReporterHTTPResult _upload_once(const String &p_endpoint, const Stri
 	headers.push_back("Content-Type: " + p_content_type);
 	headers.push_back("User-Agent: " + p_user_agent);
 	headers.push_back("Accept: application/json");
-	if (!p_api_key.is_empty()) {
-		headers.push_back("X-API-Key: " + p_api_key);
+	if (!p_app_id.is_empty()) {
+		headers.push_back("X-App-Id: " + p_app_id);
+	}
+	if (!p_build_id.is_empty()) {
+		headers.push_back("X-Build-Id: " + p_build_id);
 	}
 
 	err = client->request(HTTPClient::METHOD_POST, path, headers, p_body.ptr(), p_body.size());
@@ -134,7 +137,7 @@ static CrashReporterHTTPResult _upload_once(const String &p_endpoint, const Stri
 	return result;
 }
 
-CrashReporterHTTPResult CrashReporterHTTP::upload_report(const String &p_endpoint, const String &p_api_key, const String &p_user_agent, const Vector<uint8_t> &p_body, const String &p_content_type, int p_timeout_sec, bool p_verify_tls, int p_retry_count, int p_retry_backoff_sec, bool *r_cancel) {
+CrashReporterHTTPResult CrashReporterHTTP::upload_report(const String &p_endpoint, const String &p_app_id, const String &p_build_id, const String &p_user_agent, const Vector<uint8_t> &p_body, const String &p_content_type, int p_timeout_sec, bool p_verify_tls, int p_retry_count, int p_retry_backoff_sec, bool *r_cancel) {
 	CrashReporterHTTPResult last;
 	const int attempts = MAX(p_retry_count, 0) + 1;
 	for (int i = 0; i < attempts; i++) {
@@ -143,7 +146,7 @@ CrashReporterHTTPResult CrashReporterHTTP::upload_report(const String &p_endpoin
 			last.message = "Cancelled.";
 			return last;
 		}
-		last = _upload_once(p_endpoint, p_api_key, p_user_agent, p_body, p_content_type, p_timeout_sec, p_verify_tls, r_cancel);
+		last = _upload_once(p_endpoint, p_app_id, p_build_id, p_user_agent, p_body, p_content_type, p_timeout_sec, p_verify_tls, r_cancel);
 		if (last.error == OK || last.error == ERR_SKIP || last.error == ERR_INVALID_PARAMETER) {
 			return last;
 		}
@@ -156,7 +159,7 @@ CrashReporterHTTPResult CrashReporterHTTP::upload_report(const String &p_endpoin
 
 #else
 
-CrashReporterHTTPResult CrashReporterHTTP::upload_report(const String &, const String &, const String &, const Vector<uint8_t> &, const String &, int, bool, int, int, bool *) {
+CrashReporterHTTPResult CrashReporterHTTP::upload_report(const String &, const String &, const String &, const String &, const Vector<uint8_t> &, const String &, int, bool, int, int, bool *) {
 	CrashReporterHTTPResult result;
 	result.error = ERR_UNAVAILABLE;
 	result.message = "In-engine HTTP upload is only available in crash_reporter templates.";

--- a/modules/crash_reporter/crash_reporter_project_settings.cpp
+++ b/modules/crash_reporter/crash_reporter_project_settings.cpp
@@ -36,6 +36,7 @@ void crash_reporter_register_project_settings() {
 	GLOBAL_DEF_BASIC("application/crash_reporter/app_id", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/app_name", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/app_version", String());
+	GLOBAL_DEF_BASIC("application/crash_reporter/build_id", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/build_channel", "release");
 	GLOBAL_DEF_BASIC("application/crash_reporter/contact_url", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/privacy_policy_url", String());
@@ -47,7 +48,6 @@ void crash_reporter_register_project_settings() {
 	GLOBAL_DEF_BASIC("application/crash_reporter/spawn_open_console", false);
 
 	GLOBAL_DEF_BASIC("application/crash_reporter/endpoint", String());
-	GLOBAL_DEF_BASIC("application/crash_reporter/api_key", String());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/crash_reporter/timeout_sec", PROPERTY_HINT_RANGE, "1,300,1"), 30);
 	GLOBAL_DEF_BASIC("application/crash_reporter/verify_tls", true);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/crash_reporter/upload_mode", PROPERTY_HINT_ENUM, "Disabled,InEngine,Sidecar,Both"), 0);

--- a/modules/crash_reporter/doc_classes/CrashReporter.xml
+++ b/modules/crash_reporter/doc_classes/CrashReporter.xml
@@ -4,8 +4,8 @@
 		Engine singleton for crash dump detection, sidecar launch, and optional in-engine upload.
 	</brief_description>
 	<description>
-		[CrashReporter] records native crashes as Breakpad minidumps when the engine is built with [code]crash_reporter=yes[/code] (export templates) or [code]editor_crash_reporter=yes[/code] (editor). The editor prints dump paths to the console and never uploads. Flagged templates can spawn a custom reporter binary and/or POST pending dumps with [HTTPClient].
-		Configure identity, endpoint, and spawn behavior under [code]application/crash_reporter/*[/code] in Project Settings. See [method get_resolved_config].
+		[CrashReporter] records native crashes as Breakpad minidumps when the engine is built with [code]crash_reporter=yes[/code] (export templates) or [code]editor_crash_reporter=yes[/code] (editor). Identity is [method get_app_id] plus [method get_build_id] (shared with [Analytics]). Ingest POSTs send [code]X-App-Id[/code] and [code]X-Build-Id[/code].
+		The editor prints dump paths to the console. Pass [code]--crash-reporter &lt;path&gt;[/code] when launching the editor to spawn a sidecar. Exported games use [member ProjectSettings.application/crash_reporter/reporter_path] with [code]upload_mode[/code] Sidecar or Both. See [method get_resolved_config].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -23,16 +23,10 @@
 				Deletes the dump, metadata, and state files for [param id].
 			</description>
 		</method>
-		<method name="get_api_key" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns the resolved ingest API key.
-			</description>
-		</method>
 		<method name="get_app_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved product id sent with crash metadata.
+				Returns the resolved product id sent with crash metadata and [code]X-App-Id[/code]. Shared with [method Analytics.get_app_id].
 			</description>
 		</method>
 		<method name="get_app_name" qualifiers="const">
@@ -51,6 +45,12 @@
 			<return type="String" />
 			<description>
 				Returns the resolved build channel ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
+			</description>
+		</method>
+		<method name="get_build_id" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resolved build id sent with crash metadata and [code]X-Build-Id[/code]. Shared with [method Analytics.get_build_id].
 			</description>
 		</method>
 		<method name="get_contact_url" qualifiers="const">
@@ -92,7 +92,7 @@
 		<method name="get_reporter_path" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved sidecar reporter executable path, or an empty string if none is configured.
+				Returns the resolved sidecar reporter executable. In the editor this comes from [code]--crash-reporter[/code]; in exported games it comes from [member ProjectSettings.application/crash_reporter/reporter_path]. Empty when none is configured.
 			</description>
 		</method>
 		<method name="get_resolved_config" qualifiers="const">
@@ -153,7 +153,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="report_id" type="String" default="&quot;&quot;" />
 			<description>
-				Spawns the configured sidecar reporter. No-op in the editor.
+				Spawns the configured sidecar reporter. In the editor this requires [code]--crash-reporter &lt;path&gt;[/code].
 			</description>
 		</method>
 		<method name="mark_report_submitted">

--- a/modules/crash_reporter/tests/test_crash_reporter.cpp
+++ b/modules/crash_reporter/tests/test_crash_reporter.cpp
@@ -32,6 +32,12 @@
 #include "modules/crash_reporter/crash_reporter.h"
 #include "modules/crash_reporter/crash_reporter_util.h"
 
+#ifdef MODULE_ANALYTICS_ENABLED
+#include "modules/analytics/analytics.h"
+#endif
+
+#include "core/config/app_identity.h"
+#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/os.h"
@@ -85,12 +91,47 @@ void test_crash_reporter_metadata_json() {
 	Dictionary meta;
 	meta["id"] = "abc";
 	meta["app_id"] = "mygame";
+	meta["build_id"] = "build-9";
 	const String json = CrashReporterUtil::metadata_to_json(meta);
 	CHECK(json.contains("abc"));
 	const Dictionary parsed = CrashReporterUtil::parse_metadata_json(json);
 	CHECK(String(parsed.get("id", String())) == "abc");
 	CHECK(String(parsed.get("app_id", String())) == "mygame");
+	CHECK(String(parsed.get("build_id", String())) == "build-9");
 	CHECK(CrashReporterUtil::parse_metadata_json("not-json").is_empty());
+}
+
+void test_crash_reporter_shared_identity() {
+	CrashReporter *cr = CrashReporter::get_singleton();
+	REQUIRE(cr != nullptr);
+	const Dictionary cfg = cr->get_resolved_config();
+	CHECK(cfg.has("app_id"));
+	CHECK(cfg.has("build_id"));
+	CHECK(!cfg.has("api_key"));
+
+	if (!ProjectSettings::get_singleton()) {
+		return;
+	}
+	ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", String());
+	ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", String());
+	ProjectSettings::get_singleton()->set("application/analytics/app_id", "analytics-only-app");
+	ProjectSettings::get_singleton()->set("application/analytics/build_id", "analytics-only-build");
+	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "analytics-only-app");
+	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "analytics-only-build");
+
+	ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", "crash-only-app");
+	ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", "crash-only-build");
+	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "crash-only-app");
+	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "crash-only-build");
+
+#ifdef MODULE_ANALYTICS_ENABLED
+	Analytics *a = Analytics::get_singleton();
+	REQUIRE(a != nullptr);
+	const Dictionary acfg = a->get_resolved_config();
+	CHECK(!acfg.has("api_key"));
+	CHECK(String(cr->get_app_id()) == String(a->get_app_id()));
+	CHECK(String(cr->get_build_id()) == String(a->get_build_id()));
+#endif
 }
 
 void test_crash_reporter_dump_apis() {

--- a/modules/crash_reporter/tests/test_crash_reporter.h
+++ b/modules/crash_reporter/tests/test_crash_reporter.h
@@ -34,6 +34,7 @@
 void test_crash_reporter_multipart();
 void test_crash_reporter_state_and_scan();
 void test_crash_reporter_metadata_json();
+void test_crash_reporter_shared_identity();
 void test_crash_reporter_dump_apis();
 
 TEST_CASE("[Modules][CrashReporter] multipart body") {
@@ -46,6 +47,10 @@ TEST_CASE("[Modules][CrashReporter] state files and pending scan") {
 
 TEST_CASE("[Modules][CrashReporter] metadata JSON") {
 	test_crash_reporter_metadata_json();
+}
+
+TEST_CASE("[Modules][CrashReporter] shared app_id and build_id") {
+	test_crash_reporter_shared_identity();
 }
 
 TEST_CASE("[Modules][CrashReporter] dump APIs") {


### PR DESCRIPTION
## Summary
- Share App ID and Build ID resolution across crash reporter and analytics (CLI, env, editor settings, baked SCons IDs, then project settings).
- Send `X-App-Id` and `X-Build-Id` on crash and analytics HTTP ingest; remove API-key settings, env, and SCons bake-ins.
- Editor sidecar path is `--crash-reporter <path>`; exported games still use `application/crash_reporter/reporter_path`.
- Persist `build_id` in dump metadata, Breakpad sidecar JSON, and sidecar spawn args.

## Test plan
- [x] Game with only `application/analytics/{app_id,build_id}` (or only the crash_reporter pair) shows the same values on `CrashReporter.get_resolved_config()` and `Analytics.get_resolved_config()`.
- [x] Editor without `--crash-reporter` still dumps to console only.
- [x] Editor with `--crash-reporter path\to\crash_reporter.exe` can spawn the sidecar.
- [x] Exported template uses `reporter_path` and sends the two headers on upload.
- [x] Grep crash/analytics trees: no leftover `api_key` / `X-API-Key` / `CRASH_API_KEY` (macOS notarization only).