### PR TITLE
Bake editor App ID, Build ID, and analytics URL

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -238,8 +238,8 @@ opts.Add(
         False,
     )
 )
-opts.Add("editor_app_id", "Shared baked editor App ID (crash reporter + analytics)", "blazium-editor")
-opts.Add("editor_build_id", "Shared baked editor Build ID (empty = version hash at runtime)", "")
+opts.Add("editor_app_id", "Shared baked editor App ID (crash reporter + analytics)", "custom_blazium_engine")
+opts.Add("editor_build_id", "Shared baked editor Build ID (empty = git/VERSION_HASH)", "")
 opts.Add("editor_crash_reporter_app_id", "Alias for editor_app_id (empty uses editor_app_id)", "")
 opts.Add("editor_crash_reporter_app_name", "Baked editor crash reporter app_name", "Blazium Editor")
 opts.Add("editor_crash_reporter_build_id", "Alias for editor_build_id (empty uses editor_build_id)", "")
@@ -267,7 +267,7 @@ opts.Add(
 opts.Add("editor_analytics_app_id", "Alias for editor_app_id (empty uses editor_app_id)", "")
 opts.Add("editor_analytics_build_id", "Alias for editor_build_id (empty uses editor_build_id)", "")
 opts.Add("editor_analytics_build_channel", "Baked editor analytics build_channel", "dev")
-opts.Add("editor_analytics_endpoint", "Baked editor analytics ingest URL (empty = queue only)", "")
+opts.Add("editor_analytics_endpoint", "Baked editor analytics ingest URL (empty = disabled)", "")
 opts.Add(
     BoolVariable(
         "hub_register",
@@ -569,7 +569,7 @@ def _first_nonempty(*vals):
 editor_app_id = _first_nonempty(
     env.get("editor_crash_reporter_app_id", ""),
     env.get("editor_analytics_app_id", ""),
-    env.get("editor_app_id", "blazium-editor"),
+    env.get("editor_app_id", "custom_blazium_engine"),
 )
 editor_build_id = _first_nonempty(
     env.get("editor_crash_reporter_build_id", ""),

--- a/core/config/app_identity.cpp
+++ b/core/config/app_identity.cpp
@@ -32,6 +32,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/templates/list.h"
+#include "core/version.h"
 
 String AppIdentity::cmdline_flag_value(const String &p_flag) {
 	if (!OS::get_singleton() || p_flag.is_empty()) {
@@ -106,26 +107,7 @@ String AppIdentity::project_first(const Vector<String> &p_keys) {
 	return String();
 }
 
-String AppIdentity::resolve_app_id(const String &p_editor_override, const String &p_baked, const String &p_fallback) {
-	const String cli = cmdline_flag_value("app-id");
-	if (!cli.is_empty()) {
-		return cli;
-	}
-	const String analytics_cli = cmdline_equals_value("--analytics-app-id=");
-	if (!analytics_cli.is_empty()) {
-		return analytics_cli;
-	}
-	Vector<String> envs;
-	envs.push_back("BLAZIUM_APP_ID");
-	envs.push_back("BLAZIUM_CRASH_REPORTER_APP_ID");
-	envs.push_back("BLAZIUM_ANALYTICS_APP_ID");
-	const String env = env_first(envs);
-	if (!env.is_empty()) {
-		return env;
-	}
-	if (!p_editor_override.strip_edges().is_empty()) {
-		return p_editor_override.strip_edges();
-	}
+String AppIdentity::resolve_app_id(const String &p_baked, const String &p_fallback) {
 	if (!p_baked.strip_edges().is_empty()) {
 		return p_baked.strip_edges();
 	}
@@ -139,26 +121,7 @@ String AppIdentity::resolve_app_id(const String &p_editor_override, const String
 	return p_fallback;
 }
 
-String AppIdentity::resolve_build_id(const String &p_editor_override, const String &p_baked, const String &p_fallback) {
-	const String cli = cmdline_flag_value("build-id");
-	if (!cli.is_empty()) {
-		return cli;
-	}
-	const String analytics_cli = cmdline_equals_value("--analytics-build-id=");
-	if (!analytics_cli.is_empty()) {
-		return analytics_cli;
-	}
-	Vector<String> envs;
-	envs.push_back("BLAZIUM_BUILD_ID");
-	envs.push_back("BLAZIUM_CRASH_REPORTER_BUILD_ID");
-	envs.push_back("BLAZIUM_ANALYTICS_BUILD_ID");
-	const String env = env_first(envs);
-	if (!env.is_empty()) {
-		return env;
-	}
-	if (!p_editor_override.strip_edges().is_empty()) {
-		return p_editor_override.strip_edges();
-	}
+String AppIdentity::resolve_build_id(const String &p_baked, const String &p_fallback) {
 	if (!p_baked.strip_edges().is_empty()) {
 		return p_baked.strip_edges();
 	}
@@ -170,4 +133,12 @@ String AppIdentity::resolve_build_id(const String &p_editor_override, const Stri
 		return project;
 	}
 	return p_fallback;
+}
+
+String AppIdentity::editor_fallback_app_id() {
+	return String("custom_blazium_engine");
+}
+
+String AppIdentity::editor_fallback_build_id() {
+	return String(VERSION_HASH);
 }

--- a/core/config/app_identity.h
+++ b/core/config/app_identity.h
@@ -38,6 +38,8 @@ public:
 	static String cmdline_equals_value(const String &p_prefix);
 	static String env_first(const Vector<String> &p_names);
 	static String project_first(const Vector<String> &p_keys);
-	static String resolve_app_id(const String &p_editor_override, const String &p_baked, const String &p_fallback);
-	static String resolve_build_id(const String &p_editor_override, const String &p_baked, const String &p_fallback);
+	static String resolve_app_id(const String &p_baked, const String &p_fallback);
+	static String resolve_build_id(const String &p_baked, const String &p_fallback);
+	static String editor_fallback_app_id();
+	static String editor_fallback_build_id();
 };

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -245,7 +245,7 @@
 			If [code]true[/code], game analytics events omit [code]device_uid[/code]. Identity fields such as [code]app_id[/code] are still sent.
 		</member>
 		<member name="application/analytics/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id sent on every event and as [code]X-App-Id[/code]. Shared with [member application/crash_reporter/app_id] (crash reporter setting wins if both are set). Falls back to [member application/config/name] if empty.
+			Stable product id sent on every event and as [code]X-App-Id[/code] from exported games. Shared with [member application/crash_reporter/app_id] (crash reporter setting wins if both are set). Falls back to [member application/config/name] if empty. The editor App ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/analytics/app_version" type="String" setter="" getter="" default="&quot;&quot;">
 			Product version sent on every event. Falls back to [member application/config/version] if empty.
@@ -254,13 +254,13 @@
 			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
 		</member>
 		<member name="application/analytics/build_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Build identifier (git SHA or CI build number) sent as [code]X-Build-Id[/code]. Shared with [member application/crash_reporter/build_id] (crash reporter setting wins if both are set). Falls back to [member application/config/version] if empty.
+			Build identifier (git SHA or CI build number) sent as [code]X-Build-Id[/code] from exported games. Shared with [member application/crash_reporter/build_id] (crash reporter setting wins if both are set). Falls back to [member application/config/version] if empty. The editor Build ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/analytics/enabled" type="bool" setter="" getter="" default="false">
 			Master switch after a template is compiled with [code]analytics=yes[/code]. When [code]false[/code], events are not queued or sent.
 		</member>
 		<member name="application/analytics/endpoint" type="String" setter="" getter="" default="&quot;&quot;">
-			POST URL for analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only.
+			POST URL for game analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only. The editor ingest URL is baked with [code]editor_analytics_endpoint[/code]; an empty editor URL disables collection and sending.
 		</member>
 		<member name="application/analytics/require_user_consent" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], [method Analytics.set_consent] must accept before events are queued.
@@ -340,7 +340,7 @@
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
 		<member name="application/crash_reporter/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id sent with crash metadata and [code]X-App-Id[/code]. Shared with [member application/analytics/app_id]. Falls back to [member application/config/name] if empty.
+			Stable product id sent with crash metadata and [code]X-App-Id[/code] from exported games. Shared with [member application/analytics/app_id]. Falls back to [member application/config/name] if empty. The editor App ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/crash_reporter/app_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Display name copied into crash metadata. Falls back to [member application/config/name] if empty.
@@ -352,7 +352,7 @@
 			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
 		</member>
 		<member name="application/crash_reporter/build_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Build identifier sent with crash metadata and [code]X-Build-Id[/code]. Shared with [member application/analytics/build_id]. Falls back to [member application/config/version] if empty.
+			Build identifier sent with crash metadata and [code]X-Build-Id[/code] from exported games. Shared with [member application/analytics/build_id]. Falls back to [member application/config/version] if empty. The editor Build ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/crash_reporter/console_message" type="String" setter="" getter="" default="&quot;Crash dump created at: {path} Please attach this file when reporting issues.&quot;">
 			Printed after a dump is written. [code]{path}[/code] is replaced with the dump path.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -698,14 +698,10 @@ void Main::print_help(const char *p_binary) {
 	print_help_title("Analytics Options");
 	print_help_option("--analytics=<accepted|declined>", "Set analytics consent for this process (overrides settings).\n");
 	print_help_option("--analytics-mode=<anonymous|identified>", "Anonymous omits device_uid; identified sends OS.get_unique_id().\n");
-	print_help_option("--analytics-app-id=<id>", "Alias for --app-id (crash reporter and analytics).\n");
-	print_help_option("--analytics-build-id=<id>", "Alias for --build-id (crash reporter and analytics).\n");
 #endif
 
-	print_help_title("Identity Options");
-	print_help_option("--app-id <id>", "Override App ID for crash reporter and analytics.\n");
-	print_help_option("--build-id <id>", "Override Build ID for crash reporter and analytics.\n");
 #ifdef TOOLS_ENABLED
+	print_help_title("Crash Reporter Options");
 	print_help_option("--crash-reporter <path>", "Editor sidecar crash reporter executable (dumps + spawn; omitted = console only).\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #endif
 
@@ -1965,23 +1961,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (arg.begins_with("--crash-reporter=")) {
 #endif
-		} else if (arg == "--app-id") {
-			if (N) {
-				N = N->next();
-			} else {
-				OS::get_singleton()->print("Missing <id> argument for --app-id <id>.\n");
-				goto error;
-			}
-		} else if (arg.begins_with("--app-id=")) {
-		} else if (arg == "--build-id") {
-			if (N) {
-				N = N->next();
-			} else {
-				OS::get_singleton()->print("Missing <id> argument for --build-id <id>.\n");
-				goto error;
-			}
-		} else if (arg.begins_with("--build-id=")) {
-		} else if (arg.begins_with("--analytics-app-id=") || arg.begins_with("--analytics-build-id=")) {
 		} else {
 			main_args.push_back(arg);
 		}

--- a/modules/analytics/analytics.cpp
+++ b/modules/analytics/analytics.cpp
@@ -159,6 +159,9 @@ bool Analytics::_is_editor_context() const {
 bool Analytics::_can_queue() const {
 #ifdef ANALYTICS_ENABLED
 	if (_is_editor_context()) {
+		if (get_endpoint().strip_edges().is_empty()) {
+			return false;
+		}
 		return get_consent() == "accepted";
 	}
 	if (!_setting_bool("application/analytics/enabled", false)) {
@@ -411,36 +414,21 @@ void Analytics::set_anonymous(bool p_anonymous) {
 String Analytics::get_app_id() const {
 #ifdef TOOLS_ENABLED
 	if (_is_editor_context()) {
-		String editor_override;
-		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/app_id")) {
-			editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/app_id"));
-		}
-		const String baked = String(ANALYTICS_EDITOR_APP_ID);
-		return AppIdentity::resolve_app_id(editor_override, baked, String("blazium-editor"));
+		const String baked = String(ANALYTICS_EDITOR_APP_ID).strip_edges();
+		return baked.is_empty() ? AppIdentity::editor_fallback_app_id() : baked;
 	}
 #endif
-	return AppIdentity::resolve_app_id(String(), String(), _setting_string("application/config/name", String()));
+	return AppIdentity::resolve_app_id(String(), _setting_string("application/config/name", String()));
 }
 
 String Analytics::get_build_id() const {
 #ifdef TOOLS_ENABLED
 	if (_is_editor_context()) {
-		String editor_override;
-		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/build_id")) {
-			editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/build_id"));
-		}
-		String fallback = String(ANALYTICS_EDITOR_BUILD_ID);
-		if (fallback.is_empty() && Engine::get_singleton()) {
-			const Dictionary info = Engine::get_singleton()->get_version_info();
-			fallback = String(info.get("hash", String()));
-		}
-		if (fallback.is_empty()) {
-			fallback = String(VERSION_HASH);
-		}
-		return AppIdentity::resolve_build_id(editor_override, String(ANALYTICS_EDITOR_BUILD_ID), fallback);
+		const String baked = String(ANALYTICS_EDITOR_BUILD_ID).strip_edges();
+		return baked.is_empty() ? AppIdentity::editor_fallback_build_id() : baked;
 	}
 #endif
-	return AppIdentity::resolve_build_id(String(), String(), _setting_string("application/config/version", String()));
+	return AppIdentity::resolve_build_id(String(), _setting_string("application/config/version", String()));
 }
 
 String Analytics::get_app_version() const {
@@ -476,19 +464,9 @@ String Analytics::get_device_uid() const {
 String Analytics::get_endpoint() const {
 #ifdef TOOLS_ENABLED
 	if (_is_editor_context()) {
-		if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/endpoint")) {
-			const String override_ep = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/endpoint"));
-			if (!override_ep.is_empty()) {
-				return override_ep;
-			}
-		}
 		return String(ANALYTICS_EDITOR_ENDPOINT);
 	}
 #endif
-	const String env = _env("BLAZIUM_ANALYTICS_ENDPOINT");
-	if (!env.is_empty()) {
-		return env;
-	}
 	return _setting_string("application/analytics/endpoint", String());
 }
 

--- a/modules/analytics/analytics_project_settings.cpp
+++ b/modules/analytics/analytics_project_settings.cpp
@@ -29,10 +29,21 @@
 
 #include "analytics_project_settings.h"
 
+#include "core/config/app_identity.h"
 #include "core/config/project_settings.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
+
+#ifndef ANALYTICS_EDITOR_APP_ID
+#define ANALYTICS_EDITOR_APP_ID ""
+#endif
+#ifndef ANALYTICS_EDITOR_BUILD_ID
+#define ANALYTICS_EDITOR_BUILD_ID ""
+#endif
+#ifndef ANALYTICS_EDITOR_ENDPOINT
+#define ANALYTICS_EDITOR_ENDPOINT ""
+#endif
 #endif
 
 void analytics_register_project_settings() {
@@ -53,13 +64,24 @@ void analytics_register_editor_settings() {
 	if (!EditorSettings::get_singleton()) {
 		return;
 	}
+	EditorSettings *es = EditorSettings::get_singleton();
 	EDITOR_DEF_BASIC("blazium/analytics/consent", "unset");
 	EDITOR_DEF_BASIC("blazium/analytics/anonymous", true);
-	EDITOR_DEF_BASIC("blazium/analytics/endpoint", String());
-	EDITOR_DEF_BASIC("blazium/analytics/app_id", String());
-	EDITOR_DEF_BASIC("blazium/analytics/build_id", String());
-	if (EditorSettings::get_singleton()) {
-		EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/consent", PROPERTY_HINT_ENUM, "unset,accepted,declined"));
-	}
+	const String baked_app_id = String(ANALYTICS_EDITOR_APP_ID).strip_edges();
+	const String baked_build_id = String(ANALYTICS_EDITOR_BUILD_ID).strip_edges();
+	const String baked_endpoint = String(ANALYTICS_EDITOR_ENDPOINT).strip_edges();
+	const String display_app_id = baked_app_id.is_empty() ? AppIdentity::editor_fallback_app_id() : baked_app_id;
+	const String display_build_id = baked_build_id.is_empty() ? AppIdentity::editor_fallback_build_id() : baked_build_id;
+	EDITOR_DEF_BASIC("blazium/analytics/endpoint", baked_endpoint);
+	EDITOR_DEF_BASIC("blazium/analytics/app_id", display_app_id);
+	EDITOR_DEF_BASIC("blazium/analytics/build_id", display_build_id);
+	es->set_setting("blazium/analytics/endpoint", baked_endpoint);
+	es->set_setting("blazium/analytics/app_id", display_app_id);
+	es->set_setting("blazium/analytics/build_id", display_build_id);
+	es->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/consent", PROPERTY_HINT_ENUM, "unset,accepted,declined"));
+	const uint32_t read_only = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY;
+	es->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/app_id", PROPERTY_HINT_NONE, "", read_only));
+	es->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/build_id", PROPERTY_HINT_NONE, "", read_only));
+	es->add_property_hint(PropertyInfo(Variant::STRING, "blazium/analytics/endpoint", PROPERTY_HINT_NONE, "", read_only));
 }
 #endif

--- a/modules/analytics/doc_classes/Analytics.xml
+++ b/modules/analytics/doc_classes/Analytics.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[Analytics] queues JSON events and optionally POSTs them to an ingest endpoint. Editor builds compiled with [code]editor_analytics=yes[/code] record demographic/usage events after consent. Export templates compiled with [code]analytics=yes[/code] expose a small game SDK ([method track], session start/end).
-		Consent priority is CLI [code]--analytics=[/code], then [code]BLAZIUM_ANALYTICS_CONSENT[/code], then Editor Settings or [method set_consent]. Anonymous mode (default) omits [code]device_uid[/code]; identified mode sends [method OS.get_unique_id]. See [method get_resolved_config].
+		Editor [method get_app_id], [method get_build_id], and ingest URL are baked at compile time ([code]editor_app_id[/code], [code]editor_build_id[/code], [code]editor_analytics_endpoint[/code]) and cannot be changed from CLI, environment, or Editor Settings. If [code]editor_app_id[/code] is omitted, the editor uses [code]custom_blazium_engine[/code]. If [code]editor_build_id[/code] is omitted, the editor uses the engine git hash. An empty editor ingest URL disables collection and sending (no queue growth). Exported games read [member ProjectSettings.application/analytics/app_id], [member ProjectSettings.application/analytics/build_id], and [member ProjectSettings.application/analytics/endpoint]. Consent priority is CLI [code]--analytics=[/code], then [code]BLAZIUM_ANALYTICS_CONSENT[/code], then Editor Settings or [method set_consent]. Anonymous mode (default) omits [code]device_uid[/code]; identified mode sends [method OS.get_unique_id]. See [method get_resolved_config].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -19,7 +19,7 @@
 		<method name="get_app_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved product id sent on every event and as [code]X-App-Id[/code] on flush. Shared with [method CrashReporter.get_app_id].
+				Returns the product id sent on every event and as [code]X-App-Id[/code] on flush. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method CrashReporter.get_app_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_app_version" qualifiers="const">
@@ -37,7 +37,7 @@
 		<method name="get_build_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved build id sent on every event and as [code]X-Build-Id[/code] on flush. Shared with [method CrashReporter.get_build_id].
+				Returns the build id sent on every event and as [code]X-Build-Id[/code] on flush. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method CrashReporter.get_build_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_consent" qualifiers="const">
@@ -61,7 +61,7 @@
 		<method name="get_resolved_config" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
-				Returns identity, consent, endpoint, and queue path after CLI, environment, settings, and bake-in overrides.
+				Returns identity, consent, endpoint, and queue path. Editor identity and ingest URL are compile-time only; an empty editor URL disables collection. Game identity and URL come from Project Settings.
 			</description>
 		</method>
 		<method name="identify">

--- a/modules/analytics/tests/test_analytics.cpp
+++ b/modules/analytics/tests/test_analytics.cpp
@@ -40,6 +40,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"
+#include "core/version.h"
 
 static String _analytics_test_dir(const String &p_suffix) {
 	return OS::get_singleton()->get_cache_path().path_join("analytics_module_test").path_join(p_suffix);
@@ -201,16 +202,18 @@ void test_analytics_shared_identity() {
 		ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", "crash-ns-app");
 		ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", "crash-ns-build");
 	}
-	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "crash-ns-app");
-	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "crash-ns-build");
+	CHECK(AppIdentity::editor_fallback_app_id() == "custom_blazium_engine");
+	CHECK(AppIdentity::editor_fallback_build_id() == String(VERSION_HASH));
+	CHECK(AppIdentity::resolve_app_id(String(), "fallback") == "crash-ns-app");
+	CHECK(AppIdentity::resolve_build_id(String(), "fallback") == "crash-ns-build");
 	if (ProjectSettings::get_singleton()) {
 		ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", String());
 		ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", String());
 		ProjectSettings::get_singleton()->set("application/analytics/app_id", "analytics-ns-app");
 		ProjectSettings::get_singleton()->set("application/analytics/build_id", "analytics-ns-build");
 	}
-	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "analytics-ns-app");
-	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "analytics-ns-build");
+	CHECK(AppIdentity::resolve_app_id(String(), "fallback") == "analytics-ns-app");
+	CHECK(AppIdentity::resolve_build_id(String(), "fallback") == "analytics-ns-build");
 #ifdef MODULE_CRASH_REPORTER_ENABLED
 	CrashReporter *cr = CrashReporter::get_singleton();
 	REQUIRE(cr != nullptr);

--- a/modules/crash_reporter/crash_reporter.cpp
+++ b/modules/crash_reporter/crash_reporter.cpp
@@ -46,7 +46,6 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_paths.h"
-#include "editor/editor_settings.h"
 #endif
 
 CrashReporter *CrashReporter::singleton = nullptr;
@@ -220,29 +219,19 @@ bool CrashReporter::is_enabled() const {
 
 String CrashReporter::get_app_id() const {
 #ifdef TOOLS_ENABLED
-	String editor_override;
-	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/app_id")) {
-		editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/app_id"));
-	}
-	return AppIdentity::resolve_app_id(editor_override, CR_BAKED(APP_ID), String("blazium-editor"));
+	const String baked = CR_BAKED(APP_ID).strip_edges();
+	return baked.is_empty() ? AppIdentity::editor_fallback_app_id() : baked;
 #else
-	return AppIdentity::resolve_app_id(String(), String(), _setting_string("application/config/name", String()));
+	return AppIdentity::resolve_app_id(String(), _setting_string("application/config/name", String()));
 #endif
 }
 
 String CrashReporter::get_build_id() const {
 #ifdef TOOLS_ENABLED
-	String editor_override;
-	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/analytics/build_id")) {
-		editor_override = String(EditorSettings::get_singleton()->get_setting("blazium/analytics/build_id"));
-	}
-	String fallback = CR_BAKED(BUILD_ID);
-	if (fallback.is_empty()) {
-		fallback = String(VERSION_HASH);
-	}
-	return AppIdentity::resolve_build_id(editor_override, CR_BAKED(BUILD_ID), fallback);
+	const String baked = CR_BAKED(BUILD_ID).strip_edges();
+	return baked.is_empty() ? AppIdentity::editor_fallback_build_id() : baked;
 #else
-	return AppIdentity::resolve_build_id(String(), String(), _setting_string("application/config/version", String()));
+	return AppIdentity::resolve_build_id(String(), _setting_string("application/config/version", String()));
 #endif
 }
 

--- a/modules/crash_reporter/crash_reporter_project_settings.cpp
+++ b/modules/crash_reporter/crash_reporter_project_settings.cpp
@@ -31,6 +31,18 @@
 
 #include "core/config/project_settings.h"
 
+#ifdef TOOLS_ENABLED
+#include "core/config/app_identity.h"
+#include "editor/editor_settings.h"
+
+#ifndef CRASH_REPORTER_EDITOR_APP_ID
+#define CRASH_REPORTER_EDITOR_APP_ID ""
+#endif
+#ifndef CRASH_REPORTER_EDITOR_BUILD_ID
+#define CRASH_REPORTER_EDITOR_BUILD_ID ""
+#endif
+#endif
+
 void crash_reporter_register_project_settings() {
 	GLOBAL_DEF_BASIC("application/crash_reporter/enabled", false);
 	GLOBAL_DEF_BASIC("application/crash_reporter/app_id", String());
@@ -71,3 +83,27 @@ void crash_reporter_register_project_settings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/crash_reporter/console_message", PROPERTY_HINT_MULTILINE_TEXT),
 			String("Crash dump created at: {path}\nPlease attach this file when reporting issues."));
 }
+
+#ifdef TOOLS_ENABLED
+void crash_reporter_register_editor_settings() {
+	if (!EditorSettings::get_singleton()) {
+		return;
+	}
+	EditorSettings *es = EditorSettings::get_singleton();
+	String baked_app_id = String(CRASH_REPORTER_EDITOR_APP_ID).strip_edges();
+	if (baked_app_id.is_empty()) {
+		baked_app_id = AppIdentity::editor_fallback_app_id();
+	}
+	String baked_build_id = String(CRASH_REPORTER_EDITOR_BUILD_ID).strip_edges();
+	if (baked_build_id.is_empty()) {
+		baked_build_id = AppIdentity::editor_fallback_build_id();
+	}
+	EDITOR_DEF_BASIC("blazium/crash_reporter/app_id", baked_app_id);
+	EDITOR_DEF_BASIC("blazium/crash_reporter/build_id", baked_build_id);
+	es->set_setting("blazium/crash_reporter/app_id", baked_app_id);
+	es->set_setting("blazium/crash_reporter/build_id", baked_build_id);
+	const uint32_t read_only = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY;
+	es->add_property_hint(PropertyInfo(Variant::STRING, "blazium/crash_reporter/app_id", PROPERTY_HINT_NONE, "", read_only));
+	es->add_property_hint(PropertyInfo(Variant::STRING, "blazium/crash_reporter/build_id", PROPERTY_HINT_NONE, "", read_only));
+}
+#endif

--- a/modules/crash_reporter/crash_reporter_project_settings.h
+++ b/modules/crash_reporter/crash_reporter_project_settings.h
@@ -30,3 +30,6 @@
 #pragma once
 
 void crash_reporter_register_project_settings();
+#ifdef TOOLS_ENABLED
+void crash_reporter_register_editor_settings();
+#endif

--- a/modules/crash_reporter/doc_classes/CrashReporter.xml
+++ b/modules/crash_reporter/doc_classes/CrashReporter.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[CrashReporter] records native crashes as Breakpad minidumps when the engine is built with [code]crash_reporter=yes[/code] (export templates) or [code]editor_crash_reporter=yes[/code] (editor). Identity is [method get_app_id] plus [method get_build_id] (shared with [Analytics]). Ingest POSTs send [code]X-App-Id[/code] and [code]X-Build-Id[/code].
-		The editor prints dump paths to the console. Pass [code]--crash-reporter &lt;path&gt;[/code] when launching the editor to spawn a sidecar. Exported games use [member ProjectSettings.application/crash_reporter/reporter_path] with [code]upload_mode[/code] Sidecar or Both. See [method get_resolved_config].
+		Editor identity is baked at compile time ([code]editor_app_id[/code], [code]editor_build_id[/code]) and cannot be set from CLI, environment, or Editor Settings. If [code]editor_app_id[/code] is omitted, the editor uses [code]custom_blazium_engine[/code]. If [code]editor_build_id[/code] is omitted, the editor uses the engine git hash. Exported games read [member ProjectSettings.application/crash_reporter/app_id] and [member ProjectSettings.application/crash_reporter/build_id]. The editor prints dump paths to the console. Pass [code]--crash-reporter &lt;path&gt;[/code] when launching the editor to spawn a sidecar (the sidecar still receives the already-resolved ids). Exported games use [member ProjectSettings.application/crash_reporter/reporter_path] with [code]upload_mode[/code] Sidecar or Both. See [method get_resolved_config].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -26,7 +26,7 @@
 		<method name="get_app_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved product id sent with crash metadata and [code]X-App-Id[/code]. Shared with [method Analytics.get_app_id].
+				Returns the product id sent with crash metadata and [code]X-App-Id[/code]. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method Analytics.get_app_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_app_name" qualifiers="const">
@@ -50,7 +50,7 @@
 		<method name="get_build_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved build id sent with crash metadata and [code]X-Build-Id[/code]. Shared with [method Analytics.get_build_id].
+				Returns the build id sent with crash metadata and [code]X-Build-Id[/code]. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method Analytics.get_build_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_contact_url" qualifiers="const">
@@ -98,7 +98,7 @@
 		<method name="get_resolved_config" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
-				Returns all resolved crash-reporter settings after environment, bake-in, and Project Settings overrides.
+				Returns resolved crash-reporter settings. Editor identity is compile-time only; exported games use Project Settings. Sidecar path still comes from [code]--crash-reporter[/code] in the editor.
 			</description>
 		</method>
 		<method name="get_upload_mode" qualifiers="const">

--- a/modules/crash_reporter/register_types.cpp
+++ b/modules/crash_reporter/register_types.cpp
@@ -38,15 +38,20 @@
 static CrashReporter *crash_reporter = nullptr;
 
 void initialize_crash_reporter_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_CORE) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		GDREGISTER_CLASS(CrashReporter);
+		crash_reporter_register_project_settings();
+
+		crash_reporter = memnew(CrashReporter);
+		Engine::get_singleton()->add_singleton(Engine::Singleton("CrashReporter", crash_reporter));
 		return;
 	}
 
-	GDREGISTER_CLASS(CrashReporter);
-	crash_reporter_register_project_settings();
-
-	crash_reporter = memnew(CrashReporter);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("CrashReporter", crash_reporter));
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		crash_reporter_register_editor_settings();
+	}
+#endif
 }
 
 void uninitialize_crash_reporter_module(ModuleInitializationLevel p_level) {

--- a/modules/crash_reporter/tests/test_crash_reporter.cpp
+++ b/modules/crash_reporter/tests/test_crash_reporter.cpp
@@ -116,13 +116,15 @@ void test_crash_reporter_shared_identity() {
 	ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", String());
 	ProjectSettings::get_singleton()->set("application/analytics/app_id", "analytics-only-app");
 	ProjectSettings::get_singleton()->set("application/analytics/build_id", "analytics-only-build");
-	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "analytics-only-app");
-	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "analytics-only-build");
+	CHECK(AppIdentity::resolve_app_id(String(), "fallback") == "analytics-only-app");
+	CHECK(AppIdentity::resolve_build_id(String(), "fallback") == "analytics-only-build");
 
 	ProjectSettings::get_singleton()->set("application/crash_reporter/app_id", "crash-only-app");
 	ProjectSettings::get_singleton()->set("application/crash_reporter/build_id", "crash-only-build");
-	CHECK(AppIdentity::resolve_app_id(String(), String(), "fallback") == "crash-only-app");
-	CHECK(AppIdentity::resolve_build_id(String(), String(), "fallback") == "crash-only-build");
+	CHECK(AppIdentity::resolve_app_id(String(), "fallback") == "crash-only-app");
+	CHECK(AppIdentity::resolve_build_id(String(), "fallback") == "crash-only-build");
+	CHECK(AppIdentity::resolve_app_id("baked-app", "fallback") == "baked-app");
+	CHECK(AppIdentity::resolve_build_id("baked-build", "fallback") == "baked-build");
 
 #ifdef MODULE_ANALYTICS_ENABLED
 	Analytics *a = Analytics::get_singleton();


### PR DESCRIPTION
## Summary
- Editor App ID, Build ID, and analytics ingest URL come only from SCons bake-ins (`editor_app_id`, `editor_build_id`, `editor_analytics_endpoint`). Editor Settings show them as read-only.
- Remove engine CLI (`--app-id`, `--build-id`, `--analytics-app-id=`, `--analytics-build-id=`) and env identity overrides so neither the editor nor a template can set those IDs at launch.
- If `editor_app_id` is omitted, the editor uses `custom_blazium_engine`. If `editor_build_id` is omitted, the editor uses the engine git hash (`VERSION_HASH`).
- An empty editor analytics URL disables collection and sending (no on-disk queue growth).
- Exported games still use writable Project Settings (`application/crash_reporter/*`, `application/analytics/*`). Sidecar spawn still receives the already-resolved IDs.

## Test plan
- [x] Editor without `editor_app_id` / `editor_build_id` reports `custom_blazium_engine` and the git hash.
- [x] Editor without `editor_analytics_endpoint` does not queue or send events.
- [x] Editor Settings fields are read-only and match the bake-ins / fallbacks.
- [x] `--app-id`, `--build-id`, `BLAZIUM_APP_ID`, `BLAZIUM_BUILD_ID` no longer change editor or template identity.
- [x] Game project settings still set template App ID / Build ID / analytics endpoint.
- [x] Editor with `--crash-reporter path\to\crash_reporter.exe` still spawns the sidecar with resolved IDs.
- [x] Static checks and Linux editor `--doctool` pass.