### PR TITLE
Lock optional template identity and resolve sidecar next to the game

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -16,11 +16,20 @@ runs:
   using: composite
   steps:
     - name: Set up Python 3.x
+      id: setup-python
+      continue-on-error: true
       uses: actions/setup-python@v5
       with:
         # Semantic version range syntax or exact version of a Python version.
         python-version: ${{ inputs.python-version }}
         # Optional - x64 or x86 architecture, defaults to x64.
+        architecture: ${{ inputs.python-arch }}
+
+    - name: Set up Python 3.x (retry)
+      if: steps.setup-python.outcome == 'failure'
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
         architecture: ${{ inputs.python-arch }}
 
     - name: Setup SCons

--- a/SConstruct
+++ b/SConstruct
@@ -268,6 +268,18 @@ opts.Add("editor_analytics_app_id", "Alias for editor_app_id (empty uses editor_
 opts.Add("editor_analytics_build_id", "Alias for editor_build_id (empty uses editor_build_id)", "")
 opts.Add("editor_analytics_build_channel", "Baked editor analytics build_channel", "dev")
 opts.Add("editor_analytics_endpoint", "Baked editor analytics ingest URL (empty = disabled)", "")
+opts.Add("template_app_id", "Optional baked export-template App ID (empty = Project Settings remain writable)", "")
+opts.Add("template_build_id", "Optional baked export-template Build ID (empty = Project Settings remain writable)", "")
+opts.Add(
+    "template_analytics_endpoint",
+    "Optional baked export-template analytics URL (empty = Project Settings remain writable)",
+    "",
+)
+opts.Add(
+    "template_crash_reporter_endpoint",
+    "Optional baked export-template crash ingest URL (empty = Project Settings remain writable)",
+    "",
+)
 opts.Add(
     BoolVariable(
         "hub_register",
@@ -628,6 +640,34 @@ elif env.get("editor_analytics"):
     print_warning("editor_analytics=yes is ignored for export templates; use analytics=yes.")
 elif env.get("analytics"):
     env.Append(CPPDEFINES=["ANALYTICS_ENABLED"])
+
+
+def _scons_or_environ(scons_key, environ_key):
+    v = str(env.get(scons_key, "")).strip()
+    if v:
+        return v
+    return os.environ.get(environ_key, "").strip()
+
+
+template_app_id = _scons_or_environ("template_app_id", "BLAZIUM_TEMPLATE_APP_ID")
+template_build_id = _scons_or_environ("template_build_id", "BLAZIUM_TEMPLATE_BUILD_ID")
+template_analytics_endpoint = _scons_or_environ("template_analytics_endpoint", "BLAZIUM_TEMPLATE_ANALYTICS_ENDPOINT")
+template_crash_endpoint = _scons_or_environ("template_crash_reporter_endpoint", "BLAZIUM_TEMPLATE_CRASH_ENDPOINT")
+
+if env.editor_build:
+    if template_app_id or template_build_id or template_analytics_endpoint or template_crash_endpoint:
+        print_warning("template_* identity flags are ignored for editor builds.")
+else:
+    env.Append(
+        CPPDEFINES=[
+            _crash_reporter_cpp_string("CRASH_REPORTER_TEMPLATE_APP_ID", template_app_id),
+            _crash_reporter_cpp_string("CRASH_REPORTER_TEMPLATE_BUILD_ID", template_build_id),
+            _crash_reporter_cpp_string("CRASH_REPORTER_TEMPLATE_ENDPOINT", template_crash_endpoint),
+            _analytics_cpp_string("ANALYTICS_TEMPLATE_APP_ID", template_app_id),
+            _analytics_cpp_string("ANALYTICS_TEMPLATE_BUILD_ID", template_build_id),
+            _analytics_cpp_string("ANALYTICS_TEMPLATE_ENDPOINT", template_analytics_endpoint),
+        ]
+    )
 
 # This is not part of fast_unsafe because the only downside it has compared to
 # the default is that SCons won't mark files that were changed in the last second

--- a/core/config/app_identity.cpp
+++ b/core/config/app_identity.cpp
@@ -135,6 +135,21 @@ String AppIdentity::resolve_build_id(const String &p_baked, const String &p_fall
 	return p_fallback;
 }
 
+String AppIdentity::resolve_endpoint(const String &p_baked, const String &p_project_key, const String &p_fallback) {
+	if (!p_baked.strip_edges().is_empty()) {
+		return p_baked.strip_edges();
+	}
+	if (!p_project_key.is_empty()) {
+		Vector<String> keys;
+		keys.push_back(p_project_key);
+		const String project = project_first(keys);
+		if (!project.is_empty()) {
+			return project;
+		}
+	}
+	return p_fallback;
+}
+
 String AppIdentity::editor_fallback_app_id() {
 	return String("custom_blazium_engine");
 }

--- a/core/config/app_identity.h
+++ b/core/config/app_identity.h
@@ -40,6 +40,7 @@ public:
 	static String project_first(const Vector<String> &p_keys);
 	static String resolve_app_id(const String &p_baked, const String &p_fallback);
 	static String resolve_build_id(const String &p_baked, const String &p_fallback);
+	static String resolve_endpoint(const String &p_baked, const String &p_project_key, const String &p_fallback = String());
 	static String editor_fallback_app_id();
 	static String editor_fallback_build_id();
 };

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -245,7 +245,7 @@
 			If [code]true[/code], game analytics events omit [code]device_uid[/code]. Identity fields such as [code]app_id[/code] are still sent.
 		</member>
 		<member name="application/analytics/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id sent on every event and as [code]X-App-Id[/code] from exported games. Shared with [member application/crash_reporter/app_id] (crash reporter setting wins if both are set). Falls back to [member application/config/name] if empty. The editor App ID is baked at compile time and is not this setting.
+			Stable product id sent on every event and as [code]X-App-Id[/code] from exported games. Shared with [member application/crash_reporter/app_id] (crash reporter setting wins if both are set). Falls back to [member application/config/name] if empty. Read-only when the export template was built with a non-empty [code]template_app_id[/code]. The editor App ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/analytics/app_version" type="String" setter="" getter="" default="&quot;&quot;">
 			Product version sent on every event. Falls back to [member application/config/version] if empty.
@@ -254,13 +254,13 @@
 			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
 		</member>
 		<member name="application/analytics/build_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Build identifier (git SHA or CI build number) sent as [code]X-Build-Id[/code] from exported games. Shared with [member application/crash_reporter/build_id] (crash reporter setting wins if both are set). Falls back to [member application/config/version] if empty. The editor Build ID is baked at compile time and is not this setting.
+			Build identifier (git SHA or CI build number) sent as [code]X-Build-Id[/code] from exported games. Shared with [member application/crash_reporter/build_id] (crash reporter setting wins if both are set). Falls back to [member application/config/version] if empty. Read-only when the export template was built with a non-empty [code]template_build_id[/code]. The editor Build ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/analytics/enabled" type="bool" setter="" getter="" default="false">
 			Master switch after a template is compiled with [code]analytics=yes[/code]. When [code]false[/code], events are not queued or sent.
 		</member>
 		<member name="application/analytics/endpoint" type="String" setter="" getter="" default="&quot;&quot;">
-			POST URL for game analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only. The editor ingest URL is baked with [code]editor_analytics_endpoint[/code]; an empty editor URL disables collection and sending.
+			POST URL for game analytics ingest, e.g. [code]https://analytics.example.com/v1/events[/code]. Empty keeps events queued only. Read-only when the export template was built with a non-empty [code]template_analytics_endpoint[/code]. The editor ingest URL is baked with [code]editor_analytics_endpoint[/code]; an empty editor URL disables collection and sending.
 		</member>
 		<member name="application/analytics/require_user_consent" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], [method Analytics.set_consent] must accept before events are queued.
@@ -340,7 +340,7 @@
 			Icon set in [code].ico[/code] format used on Windows to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>
 		<member name="application/crash_reporter/app_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Stable product id sent with crash metadata and [code]X-App-Id[/code] from exported games. Shared with [member application/analytics/app_id]. Falls back to [member application/config/name] if empty. The editor App ID is baked at compile time and is not this setting.
+			Stable product id sent with crash metadata and [code]X-App-Id[/code] from exported games. Shared with [member application/analytics/app_id]. Falls back to [member application/config/name] if empty. Read-only when the export template was built with a non-empty [code]template_app_id[/code]. The editor App ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/crash_reporter/app_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Display name copied into crash metadata. Falls back to [member application/config/name] if empty.
@@ -352,7 +352,7 @@
 			Build channel used for server filtering ([code]dev[/code], [code]beta[/code], [code]release[/code], or custom).
 		</member>
 		<member name="application/crash_reporter/build_id" type="String" setter="" getter="" default="&quot;&quot;">
-			Build identifier sent with crash metadata and [code]X-Build-Id[/code] from exported games. Shared with [member application/analytics/build_id]. Falls back to [member application/config/version] if empty. The editor Build ID is baked at compile time and is not this setting.
+			Build identifier sent with crash metadata and [code]X-Build-Id[/code] from exported games. Shared with [member application/analytics/build_id]. Falls back to [member application/config/version] if empty. Read-only when the export template was built with a non-empty [code]template_build_id[/code]. The editor Build ID is baked at compile time and is not this setting.
 		</member>
 		<member name="application/crash_reporter/console_message" type="String" setter="" getter="" default="&quot;Crash dump created at: {path} Please attach this file when reporting issues.&quot;">
 			Printed after a dump is written. [code]{path}[/code] is replaced with the dump path.
@@ -373,7 +373,7 @@
 			Master switch after a template is compiled with [code]crash_reporter=yes[/code]. When [code]false[/code], dumps may still be written but spawn and upload are skipped.
 		</member>
 		<member name="application/crash_reporter/endpoint" type="String" setter="" getter="" default="&quot;&quot;">
-			POST URL for crash ingest, e.g. [code]https://crashes.example.com/v1/reports[/code]. Empty disables HTTP upload.
+			POST URL for crash ingest, e.g. [code]https://crashes.example.com/v1/reports[/code]. Empty disables HTTP upload. Read-only when the export template was built with a non-empty [code]template_crash_reporter_endpoint[/code].
 		</member>
 		<member name="application/crash_reporter/include_logs" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], a tail of the engine log is attached to uploads.
@@ -399,8 +399,17 @@
 		<member name="application/crash_reporter/reporter_args" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
 			Extra arguments appended after the engine-supplied sidecar CLI contract.
 		</member>
+		<member name="application/crash_reporter/reporter_filename" type="String" setter="" getter="" default="&quot;crash_reporter&quot;">
+			Sidecar executable name next to the exported game. Defaults to [code]crash_reporter[/code] ([code]crash_reporter.exe[/code] on Windows). Empty uses that default. Preferred over [member application/crash_reporter/reporter_path] when set. Editor builds ignore this and use [code]--crash-reporter[/code].
+		</member>
+		<member name="application/crash_reporter/reporter_filename.windows" type="String" setter="" getter="" default="&quot;crash_reporter.exe&quot;">
+			Windows override for [member application/crash_reporter/reporter_filename]. Defaults to [code]crash_reporter.exe[/code].
+		</member>
 		<member name="application/crash_reporter/reporter_path" type="String" setter="" getter="" default="&quot;&quot;">
-			Path to the exported crash reporter, relative to the game executable. Empty disables sidecar spawn.
+			Fallback sidecar path relative to the game executable (absolute paths are also allowed). Used when [member application/crash_reporter/reporter_filename] is empty. Editor builds ignore this and use [code]--crash-reporter[/code].
+		</member>
+		<member name="application/crash_reporter/reporter_sha256" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional lowercase hex SHA-256 of the sidecar binary. Empty skips the check. A mismatch or missing file skips spawn. Verified at startup, not inside the crash signal handler.
 		</member>
 		<member name="application/crash_reporter/require_user_consent" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], in-engine upload waits until the game calls [method CrashReporter.upload_pending].

--- a/modules/analytics/analytics.cpp
+++ b/modules/analytics/analytics.cpp
@@ -60,6 +60,15 @@
 #ifndef ANALYTICS_EDITOR_ENDPOINT
 #define ANALYTICS_EDITOR_ENDPOINT ""
 #endif
+#ifndef ANALYTICS_TEMPLATE_APP_ID
+#define ANALYTICS_TEMPLATE_APP_ID ""
+#endif
+#ifndef ANALYTICS_TEMPLATE_BUILD_ID
+#define ANALYTICS_TEMPLATE_BUILD_ID ""
+#endif
+#ifndef ANALYTICS_TEMPLATE_ENDPOINT
+#define ANALYTICS_TEMPLATE_ENDPOINT ""
+#endif
 
 Analytics *Analytics::singleton = nullptr;
 
@@ -418,7 +427,7 @@ String Analytics::get_app_id() const {
 		return baked.is_empty() ? AppIdentity::editor_fallback_app_id() : baked;
 	}
 #endif
-	return AppIdentity::resolve_app_id(String(), _setting_string("application/config/name", String()));
+	return AppIdentity::resolve_app_id(String(ANALYTICS_TEMPLATE_APP_ID), _setting_string("application/config/name", String()));
 }
 
 String Analytics::get_build_id() const {
@@ -428,7 +437,7 @@ String Analytics::get_build_id() const {
 		return baked.is_empty() ? AppIdentity::editor_fallback_build_id() : baked;
 	}
 #endif
-	return AppIdentity::resolve_build_id(String(), _setting_string("application/config/version", String()));
+	return AppIdentity::resolve_build_id(String(ANALYTICS_TEMPLATE_BUILD_ID), _setting_string("application/config/version", String()));
 }
 
 String Analytics::get_app_version() const {
@@ -467,7 +476,7 @@ String Analytics::get_endpoint() const {
 		return String(ANALYTICS_EDITOR_ENDPOINT);
 	}
 #endif
-	return _setting_string("application/analytics/endpoint", String());
+	return AppIdentity::resolve_endpoint(String(ANALYTICS_TEMPLATE_ENDPOINT), "application/analytics/endpoint");
 }
 
 String Analytics::get_queue_directory() const {

--- a/modules/analytics/analytics_project_settings.cpp
+++ b/modules/analytics/analytics_project_settings.cpp
@@ -46,13 +46,33 @@
 #endif
 #endif
 
+#ifndef ANALYTICS_TEMPLATE_APP_ID
+#define ANALYTICS_TEMPLATE_APP_ID ""
+#endif
+#ifndef ANALYTICS_TEMPLATE_BUILD_ID
+#define ANALYTICS_TEMPLATE_BUILD_ID ""
+#endif
+#ifndef ANALYTICS_TEMPLATE_ENDPOINT
+#define ANALYTICS_TEMPLATE_ENDPOINT ""
+#endif
+
+static void _def_identity_setting(const String &p_key, const String &p_baked) {
+	const String baked = p_baked.strip_edges();
+	GLOBAL_DEF_BASIC(p_key, baked);
+	if (baked.is_empty() || !ProjectSettings::get_singleton()) {
+		return;
+	}
+	ProjectSettings::get_singleton()->set(p_key, baked);
+	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, p_key, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY));
+}
+
 void analytics_register_project_settings() {
 	GLOBAL_DEF_BASIC("application/analytics/enabled", false);
 	GLOBAL_DEF_BASIC("application/analytics/require_user_consent", false);
 	GLOBAL_DEF_BASIC("application/analytics/anonymous", true);
-	GLOBAL_DEF_BASIC("application/analytics/endpoint", String());
-	GLOBAL_DEF_BASIC("application/analytics/app_id", String());
-	GLOBAL_DEF_BASIC("application/analytics/build_id", String());
+	_def_identity_setting("application/analytics/endpoint", String(ANALYTICS_TEMPLATE_ENDPOINT));
+	_def_identity_setting("application/analytics/app_id", String(ANALYTICS_TEMPLATE_APP_ID));
+	_def_identity_setting("application/analytics/build_id", String(ANALYTICS_TEMPLATE_BUILD_ID));
 	GLOBAL_DEF_BASIC("application/analytics/app_version", String());
 	GLOBAL_DEF_BASIC("application/analytics/build_channel", "release");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/analytics/timeout_sec", PROPERTY_HINT_RANGE, "1,120,1"), 15);

--- a/modules/analytics/doc_classes/Analytics.xml
+++ b/modules/analytics/doc_classes/Analytics.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[Analytics] queues JSON events and optionally POSTs them to an ingest endpoint. Editor builds compiled with [code]editor_analytics=yes[/code] record demographic/usage events after consent. Export templates compiled with [code]analytics=yes[/code] expose a small game SDK ([method track], session start/end).
-		Editor [method get_app_id], [method get_build_id], and ingest URL are baked at compile time ([code]editor_app_id[/code], [code]editor_build_id[/code], [code]editor_analytics_endpoint[/code]) and cannot be changed from CLI, environment, or Editor Settings. If [code]editor_app_id[/code] is omitted, the editor uses [code]custom_blazium_engine[/code]. If [code]editor_build_id[/code] is omitted, the editor uses the engine git hash. An empty editor ingest URL disables collection and sending (no queue growth). Exported games read [member ProjectSettings.application/analytics/app_id], [member ProjectSettings.application/analytics/build_id], and [member ProjectSettings.application/analytics/endpoint]. Consent priority is CLI [code]--analytics=[/code], then [code]BLAZIUM_ANALYTICS_CONSENT[/code], then Editor Settings or [method set_consent]. Anonymous mode (default) omits [code]device_uid[/code]; identified mode sends [method OS.get_unique_id]. See [method get_resolved_config].
+		Editor [method get_app_id], [method get_build_id], and ingest URL are baked at compile time ([code]editor_app_id[/code], [code]editor_build_id[/code], [code]editor_analytics_endpoint[/code]) and cannot be changed from CLI, environment, or Editor Settings. If [code]editor_app_id[/code] is omitted, the editor uses [code]custom_blazium_engine[/code]. If [code]editor_build_id[/code] is omitted, the editor uses the engine git hash. An empty editor ingest URL disables collection and sending (no queue growth). Export templates may optionally bake [code]template_app_id[/code], [code]template_build_id[/code], and [code]template_analytics_endpoint[/code]; a non-empty bake locks that field. An empty template analytics URL still means "use Project Settings", not "disable". Consent priority is CLI [code]--analytics=[/code], then [code]BLAZIUM_ANALYTICS_CONSENT[/code], then Editor Settings or [method set_consent]. Anonymous mode (default) omits [code]device_uid[/code]; identified mode sends [method OS.get_unique_id]. See [method get_resolved_config].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -19,7 +19,7 @@
 		<method name="get_app_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the product id sent on every event and as [code]X-App-Id[/code] on flush. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method CrashReporter.get_app_id]. There is no engine CLI override.
+				Returns the product id sent on every event and as [code]X-App-Id[/code] on flush. In the editor this is the SCons-baked value. In exported games a non-empty [code]template_app_id[/code] bake wins and is locked; otherwise Project Settings are used. Shared with [method CrashReporter.get_app_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_app_version" qualifiers="const">
@@ -37,7 +37,7 @@
 		<method name="get_build_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the build id sent on every event and as [code]X-Build-Id[/code] on flush. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method CrashReporter.get_build_id]. There is no engine CLI override.
+				Returns the build id sent on every event and as [code]X-Build-Id[/code] on flush. In the editor this is the SCons-baked value. In exported games a non-empty [code]template_build_id[/code] bake wins and is locked; otherwise Project Settings are used. Shared with [method CrashReporter.get_build_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_consent" qualifiers="const">
@@ -61,7 +61,7 @@
 		<method name="get_resolved_config" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
-				Returns identity, consent, endpoint, and queue path. Editor identity and ingest URL are compile-time only; an empty editor URL disables collection. Game identity and URL come from Project Settings.
+				Returns identity, consent, endpoint, and queue path. Editor identity and ingest URL are compile-time only; an empty editor URL disables collection. Game fields are locked when the matching [code]template_*[/code] bake is non-empty; otherwise they come from Project Settings.
 			</description>
 		</method>
 		<method name="identify">

--- a/modules/analytics/tests/test_analytics.cpp
+++ b/modules/analytics/tests/test_analytics.cpp
@@ -214,6 +214,16 @@ void test_analytics_shared_identity() {
 	}
 	CHECK(AppIdentity::resolve_app_id(String(), "fallback") == "analytics-ns-app");
 	CHECK(AppIdentity::resolve_build_id(String(), "fallback") == "analytics-ns-build");
+	CHECK(AppIdentity::resolve_app_id("baked-app", "fallback") == "baked-app");
+	CHECK(AppIdentity::resolve_build_id("baked-build", "fallback") == "baked-build");
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set("application/analytics/endpoint", "https://project.example/v1/events");
+	}
+	CHECK(AppIdentity::resolve_endpoint(String(), "application/analytics/endpoint") == "https://project.example/v1/events");
+	CHECK(AppIdentity::resolve_endpoint("https://baked.example/v1/events", "application/analytics/endpoint") == "https://baked.example/v1/events");
+	if (ProjectSettings::get_singleton()) {
+		ProjectSettings::get_singleton()->set("application/analytics/endpoint", String());
+	}
 #ifdef MODULE_CRASH_REPORTER_ENABLED
 	CrashReporter *cr = CrashReporter::get_singleton();
 	REQUIRE(cr != nullptr);

--- a/modules/crash_reporter/crash_reporter.cpp
+++ b/modules/crash_reporter/crash_reporter.cpp
@@ -185,6 +185,15 @@ int CrashReporter::_setting_int(const String &p_key, int p_fallback) const {
 #ifndef CRASH_REPORTER_EDITOR_CONTACT_URL
 #define CRASH_REPORTER_EDITOR_CONTACT_URL ""
 #endif
+#ifndef CRASH_REPORTER_TEMPLATE_APP_ID
+#define CRASH_REPORTER_TEMPLATE_APP_ID ""
+#endif
+#ifndef CRASH_REPORTER_TEMPLATE_BUILD_ID
+#define CRASH_REPORTER_TEMPLATE_BUILD_ID ""
+#endif
+#ifndef CRASH_REPORTER_TEMPLATE_ENDPOINT
+#define CRASH_REPORTER_TEMPLATE_ENDPOINT ""
+#endif
 
 bool CrashReporter::is_available() const {
 	return true;
@@ -222,7 +231,7 @@ String CrashReporter::get_app_id() const {
 	const String baked = CR_BAKED(APP_ID).strip_edges();
 	return baked.is_empty() ? AppIdentity::editor_fallback_app_id() : baked;
 #else
-	return AppIdentity::resolve_app_id(String(), _setting_string("application/config/name", String()));
+	return AppIdentity::resolve_app_id(String(CRASH_REPORTER_TEMPLATE_APP_ID), _setting_string("application/config/name", String()));
 #endif
 }
 
@@ -231,7 +240,7 @@ String CrashReporter::get_build_id() const {
 	const String baked = CR_BAKED(BUILD_ID).strip_edges();
 	return baked.is_empty() ? AppIdentity::editor_fallback_build_id() : baked;
 #else
-	return AppIdentity::resolve_build_id(String(), _setting_string("application/config/version", String()));
+	return AppIdentity::resolve_build_id(String(CRASH_REPORTER_TEMPLATE_BUILD_ID), _setting_string("application/config/version", String()));
 #endif
 }
 
@@ -299,11 +308,15 @@ String CrashReporter::get_privacy_policy_url() const {
 }
 
 String CrashReporter::get_endpoint() const {
-	const String baked = CR_BAKED(ENDPOINT);
-	const String from_env = _resolve_env_or_baked("BLAZIUM_CRASH_REPORTER_ENDPOINT", baked, String());
 #ifdef TOOLS_ENABLED
-	return from_env;
+	const String baked = CR_BAKED(ENDPOINT);
+	return _resolve_env_or_baked("BLAZIUM_CRASH_REPORTER_ENDPOINT", baked, String());
 #else
+	const String baked = String(CRASH_REPORTER_TEMPLATE_ENDPOINT).strip_edges();
+	if (!baked.is_empty()) {
+		return baked;
+	}
+	const String from_env = _resolve_env_or_baked("BLAZIUM_CRASH_REPORTER_ENDPOINT", String(), String());
 	if (!from_env.is_empty()) {
 		return from_env;
 	}
@@ -333,6 +346,15 @@ String CrashReporter::get_crash_directory() const {
 }
 
 String CrashReporter::_resolve_reporter_path() const {
+	if (reporter_path_cached) {
+		return cached_reporter_path;
+	}
+	reporter_path_cached = true;
+	cached_reporter_path = _compute_reporter_path();
+	return cached_reporter_path;
+}
+
+String CrashReporter::_compute_reporter_path() const {
 #ifdef TOOLS_ENABLED
 	const String cli = AppIdentity::cmdline_flag_value("crash-reporter");
 	if (cli.is_empty()) {
@@ -343,14 +365,30 @@ String CrashReporter::_resolve_reporter_path() const {
 	}
 	return OS::get_singleton()->get_executable_path().get_base_dir().path_join(cli);
 #else
-	String rel = _setting_string("application/crash_reporter/reporter_path", String());
-	if (rel.is_empty()) {
+	String filename = _setting_string("application/crash_reporter/reporter_filename", String()).strip_edges();
+	const String path_setting = _setting_string("application/crash_reporter/reporter_path", String()).strip_edges();
+	String rel;
+	if (!filename.is_empty()) {
+		rel = filename;
+	} else if (!path_setting.is_empty()) {
+		rel = path_setting;
+	} else {
+#ifdef WINDOWS_ENABLED
+		rel = "crash_reporter.exe";
+#else
+		rel = "crash_reporter";
+#endif
+	}
+	String path = rel;
+	if (!path.is_absolute_path() && OS::get_singleton()) {
+		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join(rel);
+	}
+	const String expected_sha = _setting_string("application/crash_reporter/reporter_sha256", String());
+	if (!CrashReporterUtil::sidecar_sha256_matches(path, expected_sha)) {
+		ERR_PRINT(vformat("Crash reporter sidecar SHA-256 mismatch or missing file, skip spawn: %s", path));
 		return String();
 	}
-	if (rel.is_absolute_path()) {
-		return rel;
-	}
-	return OS::get_singleton()->get_executable_path().get_base_dir().path_join(rel);
+	return path;
 #endif
 }
 

--- a/modules/crash_reporter/crash_reporter.h
+++ b/modules/crash_reporter/crash_reporter.h
@@ -61,7 +61,11 @@ private:
 	String _setting_string(const String &p_key, const String &p_fallback) const;
 	bool _setting_bool(const String &p_key, bool p_fallback) const;
 	int _setting_int(const String &p_key, int p_fallback) const;
+	mutable String cached_reporter_path;
+	mutable bool reporter_path_cached = false;
+
 	String _resolve_reporter_path() const;
+	String _compute_reporter_path() const;
 	void _cache_breakpad_identity();
 	void _enrich_pending_metadata();
 	Error _launch_reporter_internal(const String &p_report_id);

--- a/modules/crash_reporter/crash_reporter_project_settings.cpp
+++ b/modules/crash_reporter/crash_reporter_project_settings.cpp
@@ -43,23 +43,46 @@
 #endif
 #endif
 
+#ifndef CRASH_REPORTER_TEMPLATE_APP_ID
+#define CRASH_REPORTER_TEMPLATE_APP_ID ""
+#endif
+#ifndef CRASH_REPORTER_TEMPLATE_BUILD_ID
+#define CRASH_REPORTER_TEMPLATE_BUILD_ID ""
+#endif
+#ifndef CRASH_REPORTER_TEMPLATE_ENDPOINT
+#define CRASH_REPORTER_TEMPLATE_ENDPOINT ""
+#endif
+
+static void _def_identity_setting(const String &p_key, const String &p_baked) {
+	const String baked = p_baked.strip_edges();
+	GLOBAL_DEF_BASIC(p_key, baked);
+	if (baked.is_empty() || !ProjectSettings::get_singleton()) {
+		return;
+	}
+	ProjectSettings::get_singleton()->set(p_key, baked);
+	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, p_key, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY));
+}
+
 void crash_reporter_register_project_settings() {
 	GLOBAL_DEF_BASIC("application/crash_reporter/enabled", false);
-	GLOBAL_DEF_BASIC("application/crash_reporter/app_id", String());
+	_def_identity_setting("application/crash_reporter/app_id", String(CRASH_REPORTER_TEMPLATE_APP_ID));
 	GLOBAL_DEF_BASIC("application/crash_reporter/app_name", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/app_version", String());
-	GLOBAL_DEF_BASIC("application/crash_reporter/build_id", String());
+	_def_identity_setting("application/crash_reporter/build_id", String(CRASH_REPORTER_TEMPLATE_BUILD_ID));
 	GLOBAL_DEF_BASIC("application/crash_reporter/build_channel", "release");
 	GLOBAL_DEF_BASIC("application/crash_reporter/contact_url", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/privacy_policy_url", String());
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/crash_reporter/reporter_path", PROPERTY_HINT_FILE), String());
+	GLOBAL_DEF_BASIC("application/crash_reporter/reporter_filename", "crash_reporter");
+	GLOBAL_DEF_BASIC("application/crash_reporter/reporter_filename.windows", "crash_reporter.exe");
+	GLOBAL_DEF_BASIC("application/crash_reporter/reporter_sha256", String());
 	GLOBAL_DEF_BASIC("application/crash_reporter/reporter_args", PackedStringArray());
 	GLOBAL_DEF_BASIC("application/crash_reporter/spawn_on_crash", true);
 	GLOBAL_DEF_BASIC("application/crash_reporter/spawn_on_next_launch", true);
 	GLOBAL_DEF_BASIC("application/crash_reporter/spawn_open_console", false);
 
-	GLOBAL_DEF_BASIC("application/crash_reporter/endpoint", String());
+	_def_identity_setting("application/crash_reporter/endpoint", String(CRASH_REPORTER_TEMPLATE_ENDPOINT));
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/crash_reporter/timeout_sec", PROPERTY_HINT_RANGE, "1,300,1"), 30);
 	GLOBAL_DEF_BASIC("application/crash_reporter/verify_tls", true);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/crash_reporter/upload_mode", PROPERTY_HINT_ENUM, "Disabled,InEngine,Sidecar,Both"), 0);

--- a/modules/crash_reporter/crash_reporter_util.cpp
+++ b/modules/crash_reporter/crash_reporter_util.cpp
@@ -30,6 +30,7 @@
 #include "crash_reporter_util.h"
 
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/os/time.h"
 #include <cstring>
@@ -313,6 +314,17 @@ Vector<uint8_t> read_log_tail(const String &p_path, int p_tail_kb) {
 		f->get_buffer(data.ptrw(), data.size());
 	}
 	return data;
+}
+
+bool sidecar_sha256_matches(const String &p_path, const String &p_expected_sha256) {
+	const String expected = p_expected_sha256.strip_edges().to_lower();
+	if (expected.is_empty()) {
+		return true;
+	}
+	if (p_path.is_empty() || !FileAccess::exists(p_path)) {
+		return false;
+	}
+	return FileAccess::get_sha256(p_path).to_lower() == expected;
 }
 
 } //namespace CrashReporterUtil

--- a/modules/crash_reporter/crash_reporter_util.h
+++ b/modules/crash_reporter/crash_reporter_util.h
@@ -78,4 +78,7 @@ Error discard_report_files(const String &p_dump_path);
 Vector<uint8_t> read_file_capped(const String &p_path, int64_t p_max_bytes, Error *r_err = nullptr);
 Vector<uint8_t> read_log_tail(const String &p_path, int p_tail_kb);
 
+// Empty expected hash means no check. Expected is compared as lowercase hex.
+bool sidecar_sha256_matches(const String &p_path, const String &p_expected_sha256);
+
 } //namespace CrashReporterUtil

--- a/modules/crash_reporter/doc_classes/CrashReporter.xml
+++ b/modules/crash_reporter/doc_classes/CrashReporter.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[CrashReporter] records native crashes as Breakpad minidumps when the engine is built with [code]crash_reporter=yes[/code] (export templates) or [code]editor_crash_reporter=yes[/code] (editor). Identity is [method get_app_id] plus [method get_build_id] (shared with [Analytics]). Ingest POSTs send [code]X-App-Id[/code] and [code]X-Build-Id[/code].
-		Editor identity is baked at compile time ([code]editor_app_id[/code], [code]editor_build_id[/code]) and cannot be set from CLI, environment, or Editor Settings. If [code]editor_app_id[/code] is omitted, the editor uses [code]custom_blazium_engine[/code]. If [code]editor_build_id[/code] is omitted, the editor uses the engine git hash. Exported games read [member ProjectSettings.application/crash_reporter/app_id] and [member ProjectSettings.application/crash_reporter/build_id]. The editor prints dump paths to the console. Pass [code]--crash-reporter &lt;path&gt;[/code] when launching the editor to spawn a sidecar (the sidecar still receives the already-resolved ids). Exported games use [member ProjectSettings.application/crash_reporter/reporter_path] with [code]upload_mode[/code] Sidecar or Both. See [method get_resolved_config].
+		Editor identity is baked at compile time ([code]editor_app_id[/code], [code]editor_build_id[/code]) and cannot be set from CLI, environment, or Editor Settings. If [code]editor_app_id[/code] is omitted, the editor uses [code]custom_blazium_engine[/code]. If [code]editor_build_id[/code] is omitted, the editor uses the engine git hash. Export templates may optionally bake [code]template_app_id[/code], [code]template_build_id[/code], and [code]template_crash_reporter_endpoint[/code]; a non-empty bake locks that field (Project Settings show it read-only). Empty template bakes stay writable and use Project Settings. The editor prints dump paths to the console. Pass [code]--crash-reporter &lt;path&gt;[/code] when launching the editor to spawn a sidecar (the sidecar still receives the already-resolved ids). Exported games look next to the executable for [member ProjectSettings.application/crash_reporter/reporter_filename] (or [member ProjectSettings.application/crash_reporter/reporter_path]) when [code]upload_mode[/code] is Sidecar or Both. Optional [member ProjectSettings.application/crash_reporter/reporter_sha256] is checked at startup. See [method get_resolved_config].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -26,7 +26,7 @@
 		<method name="get_app_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the product id sent with crash metadata and [code]X-App-Id[/code]. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method Analytics.get_app_id]. There is no engine CLI override.
+				Returns the product id sent with crash metadata and [code]X-App-Id[/code]. In the editor this is the SCons-baked value. In exported games a non-empty [code]template_app_id[/code] bake wins and is locked; otherwise Project Settings are used. Shared with [method Analytics.get_app_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_app_name" qualifiers="const">
@@ -50,7 +50,7 @@
 		<method name="get_build_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the build id sent with crash metadata and [code]X-Build-Id[/code]. In the editor this is the SCons-baked value. In exported games it comes from Project Settings. Shared with [method Analytics.get_build_id]. There is no engine CLI override.
+				Returns the build id sent with crash metadata and [code]X-Build-Id[/code]. In the editor this is the SCons-baked value. In exported games a non-empty [code]template_build_id[/code] bake wins and is locked; otherwise Project Settings are used. Shared with [method Analytics.get_build_id]. There is no engine CLI override.
 			</description>
 		</method>
 		<method name="get_contact_url" qualifiers="const">
@@ -92,7 +92,7 @@
 		<method name="get_reporter_path" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the resolved sidecar reporter executable. In the editor this comes from [code]--crash-reporter[/code]; in exported games it comes from [member ProjectSettings.application/crash_reporter/reporter_path]. Empty when none is configured.
+				Returns the resolved sidecar reporter executable. In the editor this comes from [code]--crash-reporter[/code]. In exported games it is the file next to the executable named by [member ProjectSettings.application/crash_reporter/reporter_filename], falling back to [member ProjectSettings.application/crash_reporter/reporter_path]. A non-empty [member ProjectSettings.application/crash_reporter/reporter_sha256] must match or this returns empty.
 			</description>
 		</method>
 		<method name="get_resolved_config" qualifiers="const">

--- a/modules/crash_reporter/tests/test_crash_reporter.cpp
+++ b/modules/crash_reporter/tests/test_crash_reporter.cpp
@@ -125,6 +125,11 @@ void test_crash_reporter_shared_identity() {
 	CHECK(AppIdentity::resolve_build_id(String(), "fallback") == "crash-only-build");
 	CHECK(AppIdentity::resolve_app_id("baked-app", "fallback") == "baked-app");
 	CHECK(AppIdentity::resolve_build_id("baked-build", "fallback") == "baked-build");
+	CHECK(AppIdentity::resolve_endpoint(String(), "application/crash_reporter/endpoint") == String());
+	ProjectSettings::get_singleton()->set("application/crash_reporter/endpoint", "https://project.example/v1/reports");
+	CHECK(AppIdentity::resolve_endpoint(String(), "application/crash_reporter/endpoint") == "https://project.example/v1/reports");
+	CHECK(AppIdentity::resolve_endpoint("https://baked.example/v1/reports", "application/crash_reporter/endpoint") == "https://baked.example/v1/reports");
+	ProjectSettings::get_singleton()->set("application/crash_reporter/endpoint", String());
 
 #ifdef MODULE_ANALYTICS_ENABLED
 	Analytics *a = Analytics::get_singleton();
@@ -134,6 +139,25 @@ void test_crash_reporter_shared_identity() {
 	CHECK(String(cr->get_app_id()) == String(a->get_app_id()));
 	CHECK(String(cr->get_build_id()) == String(a->get_build_id()));
 #endif
+}
+
+void test_crash_reporter_sidecar_sha256() {
+	const String dir = OS::get_singleton()->get_cache_path().path_join("crash_reporter_sha_test");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	REQUIRE(da.is_valid());
+	da->make_dir_recursive(dir);
+	const String path = dir.path_join("sidecar.bin");
+	{
+		Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+		REQUIRE(f.is_valid());
+		f->store_buffer((const uint8_t *)"sidecar", 7);
+	}
+	const String sha = FileAccess::get_sha256(path);
+	CHECK(CrashReporterUtil::sidecar_sha256_matches(path, String()));
+	CHECK(CrashReporterUtil::sidecar_sha256_matches(path, sha));
+	CHECK(CrashReporterUtil::sidecar_sha256_matches(path, sha.to_upper()));
+	CHECK(!CrashReporterUtil::sidecar_sha256_matches(path, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+	CHECK(!CrashReporterUtil::sidecar_sha256_matches(path + ".missing", sha));
 }
 
 void test_crash_reporter_dump_apis() {

--- a/modules/crash_reporter/tests/test_crash_reporter.h
+++ b/modules/crash_reporter/tests/test_crash_reporter.h
@@ -35,6 +35,7 @@ void test_crash_reporter_multipart();
 void test_crash_reporter_state_and_scan();
 void test_crash_reporter_metadata_json();
 void test_crash_reporter_shared_identity();
+void test_crash_reporter_sidecar_sha256();
 void test_crash_reporter_dump_apis();
 
 TEST_CASE("[Modules][CrashReporter] multipart body") {
@@ -51,6 +52,10 @@ TEST_CASE("[Modules][CrashReporter] metadata JSON") {
 
 TEST_CASE("[Modules][CrashReporter] shared app_id and build_id") {
 	test_crash_reporter_shared_identity();
+}
+
+TEST_CASE("[Modules][CrashReporter] sidecar SHA-256 match") {
+	test_crash_reporter_sidecar_sha256();
 }
 
 TEST_CASE("[Modules][CrashReporter] dump APIs") {


### PR DESCRIPTION
## Summary
- Add optional `template_*` SCons/env bakes that lock App ID, Build ID, and ingest URLs per field when non-empty; empty fields stay writable in Project Settings.
- Resolve the game sidecar next to the executable via `reporter_filename` (`reporter_path` fallback) and verify optional SHA-256 at startup, not in the crash handler.
- Editor sidecar path remains `--crash-reporter`; official editor binaries keep empty template macros so third-party games stay editable.

## Test plan
- [ ] Module tests for baked-vs-project identity and sidecar SHA mismatch
- [ ] Confirm editor builds ignore `template_*` and still use `--crash-reporter`
- [ ] Confirm unlocked templates still read `application/crash_reporter/*` and `application/analytics/*`