### PR TITLE
Fix CI web editor timeval and missing Breakpad compat headers

### DIFF
--- a/modules/coldstorage/sdk/src/common/net/plain_transport.cpp
+++ b/modules/coldstorage/sdk/src/common/net/plain_transport.cpp
@@ -35,6 +35,7 @@
 #include <winsock2.h>
 #else
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 #endif
 

--- a/thirdparty/breakpad/src/compat/elf.h
+++ b/thirdparty/breakpad/src/compat/elf.h
@@ -1,0 +1,6 @@
+#ifndef COMPAT_ELF_H_
+#define COMPAT_ELF_H_
+
+#include <elf.h>
+
+#endif  // COMPAT_ELF_H_

--- a/thirdparty/breakpad/src/compat/guiddef.h
+++ b/thirdparty/breakpad/src/compat/guiddef.h
@@ -1,0 +1,13 @@
+#ifndef COMPAT_GUIDDEF_H_
+#define COMPAT_GUIDDEF_H_
+
+#include "google_breakpad/common/minidump_format.h"
+
+typedef MDGUID GUID;
+
+#define COMPAT_GUID_DATA1 data1
+#define COMPAT_GUID_DATA2 data2
+#define COMPAT_GUID_DATA3 data3
+#define COMPAT_GUID_DATA4 data4
+
+#endif  // COMPAT_GUIDDEF_H_

--- a/thirdparty/breakpad/src/compat/inet.h
+++ b/thirdparty/breakpad/src/compat/inet.h
@@ -1,0 +1,6 @@
+#ifndef COMPAT_INET_H_
+#define COMPAT_INET_H_
+
+#include <arpa/inet.h>
+
+#endif  // COMPAT_INET_H_

--- a/thirdparty/breakpad/src/compat/link.h
+++ b/thirdparty/breakpad/src/compat/link.h
@@ -1,0 +1,6 @@
+#ifndef COMPAT_LINK_H_
+#define COMPAT_LINK_H_
+
+#include <link.h>
+
+#endif  // COMPAT_LINK_H_

--- a/thirdparty/breakpad/src/compat/linux.h
+++ b/thirdparty/breakpad/src/compat/linux.h
@@ -1,0 +1,10 @@
+#ifndef COMPAT_LINUX_H_
+#define COMPAT_LINUX_H_
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#endif  // COMPAT_LINUX_H_

--- a/thirdparty/breakpad/src/compat/mman.h
+++ b/thirdparty/breakpad/src/compat/mman.h
@@ -1,0 +1,10 @@
+#ifndef COMPAT_MMAN_H_
+#define COMPAT_MMAN_H_
+
+#include <sys/mman.h>
+
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+#endif  // COMPAT_MMAN_H_

--- a/thirdparty/breakpad/src/compat/syscall.h
+++ b/thirdparty/breakpad/src/compat/syscall.h
@@ -1,0 +1,6 @@
+#ifndef COMPAT_SYSCALL_H_
+#define COMPAT_SYSCALL_H_
+
+#include "third_party/lss/linux_syscall_support.h"
+
+#endif  // COMPAT_SYSCALL_H_


### PR DESCRIPTION
## Summary
- Include `<sys/time.h>` in ColdStorage `plain_transport.cpp` so the web editor build can complete `struct timeval` on Emscripten.
- Add the missing Breakpad `src/compat/` wrappers so Linux/mono editor builds (`editor_crash_reporter=yes`) find `compat/linux.h` and related headers.

This unblocks [ci_cd trigger_build #542](https://github.com/blazium-games/ci_cd/actions/runs/32453201870).

## Test plan
- [ ] Confirm web editor compile no longer fails on `plain_transport.cpp` timeval
- [ ] Confirm mono glue / Linux editor compile no longer fails on `compat/linux.h`
- [ ] Re-dispatch `ci_cd` `trigger_build` after merge so it picks up the new SHA