### PR TITLE
Fix Linux x86_32 Breakpad assemble and ignore crash reporter on web/mobile

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -589,33 +589,43 @@ editor_build_id = _first_nonempty(
     env.get("editor_build_id", ""),
 )
 
+_crash_reporter_platforms = ("windows", "linuxbsd")
+
 if env.editor_build:
     if env.get("crash_reporter"):
         print_warning("crash_reporter=yes is ignored for editor builds; use editor_crash_reporter=yes.")
     if env.get("editor_crash_reporter"):
-        env.Append(CPPDEFINES=["CRASH_REPORTER_ENABLED", "USE_BREAKPAD"])
-        env.Append(
-            CPPDEFINES=[
-                _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_APP_ID", editor_app_id),
-                _crash_reporter_cpp_string(
-                    "CRASH_REPORTER_EDITOR_APP_NAME", env.get("editor_crash_reporter_app_name", "")
-                ),
-                _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_BUILD_ID", editor_build_id),
-                _crash_reporter_cpp_string(
-                    "CRASH_REPORTER_EDITOR_BUILD_CHANNEL", env.get("editor_crash_reporter_build_channel", "")
-                ),
-                _crash_reporter_cpp_string(
-                    "CRASH_REPORTER_EDITOR_ENDPOINT", env.get("editor_crash_reporter_endpoint", "")
-                ),
-                _crash_reporter_cpp_string(
-                    "CRASH_REPORTER_EDITOR_CONTACT_URL", env.get("editor_crash_reporter_contact_url", "")
-                ),
-            ]
-        )
+        if env["platform"] not in _crash_reporter_platforms:
+            print_warning(
+                f"editor_crash_reporter=yes is ignored on {env['platform']}; crash reporter is Windows/Linux only."
+            )
+        else:
+            env.Append(CPPDEFINES=["CRASH_REPORTER_ENABLED", "USE_BREAKPAD"])
+            env.Append(
+                CPPDEFINES=[
+                    _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_APP_ID", editor_app_id),
+                    _crash_reporter_cpp_string(
+                        "CRASH_REPORTER_EDITOR_APP_NAME", env.get("editor_crash_reporter_app_name", "")
+                    ),
+                    _crash_reporter_cpp_string("CRASH_REPORTER_EDITOR_BUILD_ID", editor_build_id),
+                    _crash_reporter_cpp_string(
+                        "CRASH_REPORTER_EDITOR_BUILD_CHANNEL", env.get("editor_crash_reporter_build_channel", "")
+                    ),
+                    _crash_reporter_cpp_string(
+                        "CRASH_REPORTER_EDITOR_ENDPOINT", env.get("editor_crash_reporter_endpoint", "")
+                    ),
+                    _crash_reporter_cpp_string(
+                        "CRASH_REPORTER_EDITOR_CONTACT_URL", env.get("editor_crash_reporter_contact_url", "")
+                    ),
+                ]
+            )
 elif env.get("editor_crash_reporter"):
     print_warning("editor_crash_reporter=yes is ignored for export templates; use crash_reporter=yes.")
 elif env.get("crash_reporter"):
-    env.Append(CPPDEFINES=["CRASH_REPORTER_ENABLED", "USE_BREAKPAD"])
+    if env["platform"] not in _crash_reporter_platforms:
+        print_warning(f"crash_reporter=yes is ignored on {env['platform']}; crash reporter is Windows/Linux only.")
+    else:
+        env.Append(CPPDEFINES=["CRASH_REPORTER_ENABLED", "USE_BREAKPAD"])
 
 
 def _analytics_cpp_string(name, value):

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -4,11 +4,30 @@ import os
 import shutil
 import subprocess
 import sys
+import time
+import urllib.error
 import urllib.request
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
 
-from misc.utility.color import Ansi
+from misc.utility.color import Ansi  # noqa: E402
+
+
+def _urlretrieve_retry(url, dest, attempts=5):
+    last_err = None
+    for i in range(attempts):
+        try:
+            urllib.request.urlretrieve(url, dest)
+            return
+        except (urllib.error.URLError, OSError) as e:
+            last_err = e
+            if i + 1 == attempts:
+                raise
+            delay = 2**i
+            print(f"Download failed ({e}); retrying in {delay}s ({i + 1}/{attempts}) ...")
+            time.sleep(delay)
+    raise last_err
+
 
 # Base Godot dependencies path
 # If cross-compiling (no LOCALAPPDATA), we install in `bin`
@@ -46,7 +65,7 @@ print(f"{Ansi.BOLD}[1/3] Mesa NIR{Ansi.RESET}")
 if os.path.isfile(mesa_archive):
     os.remove(mesa_archive)
 print(f"Downloading Mesa NIR {mesa_filename} ...")
-urllib.request.urlretrieve(
+_urlretrieve_retry(
     f"https://github.com/godotengine/godot-nir-static/releases/download/{mesa_version}/{mesa_filename}",
     mesa_archive,
 )
@@ -73,7 +92,7 @@ print(f"{Ansi.BOLD}[2/3] WinPixEventRuntime{Ansi.RESET}")
 if os.path.isfile(pix_archive):
     os.remove(pix_archive)
 print(f"Downloading WinPixEventRuntime {pix_version} ...")
-urllib.request.urlretrieve(f"https://www.nuget.org/api/v2/package/WinPixEventRuntime/{pix_version}", pix_archive)
+_urlretrieve_retry(f"https://www.nuget.org/api/v2/package/WinPixEventRuntime/{pix_version}", pix_archive)
 if os.path.exists(pix_folder):
     print(f"Removing existing local WinPixEventRuntime installation in {pix_folder} ...")
     shutil.rmtree(pix_folder)
@@ -104,7 +123,7 @@ print(f"{Ansi.BOLD}[3/3] DirectX 12 Agility SDK{Ansi.RESET}")
 if os.path.isfile(agility_sdk_archive):
     os.remove(agility_sdk_archive)
 print(f"Downloading DirectX 12 Agility SDK {agility_sdk_version} ...")
-urllib.request.urlretrieve(
+_urlretrieve_retry(
     f"https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/{agility_sdk_version}", agility_sdk_archive
 )
 if os.path.exists(agility_sdk_folder):

--- a/modules/crash_reporter/config.py
+++ b/modules/crash_reporter/config.py
@@ -1,4 +1,6 @@
 def can_build(env, platform):
+    # Breakpad client is Windows/Linux only. Never build this module for web
+    # (editor or templates), Android, iOS, or other platforms.
     if platform not in ("windows", "linuxbsd"):
         return False
     if env.editor_build:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -89,9 +89,13 @@ def configure(env: "SConsEnvironment"):
     if host_is_64_bit and env["arch"] == "x86_32":
         env.Append(CCFLAGS=["-m32"])
         env.Append(LINKFLAGS=["-m32"])
+        env.Append(ASFLAGS=["-m32"])
+        env.Append(ASPPFLAGS=["-m32"])
     elif not host_is_64_bit and env["arch"] == "x86_64":
         env.Append(CCFLAGS=["-m64"])
         env.Append(LINKFLAGS=["-m64"])
+        env.Append(ASFLAGS=["-m64"])
+        env.Append(ASPPFLAGS=["-m64"])
 
     # CPU architecture flags.
     if env["arch"] == "rv64":


### PR DESCRIPTION
## Summary
- Pass `-m32`/`-m64` through `ASFLAGS` and `ASPPFLAGS` so `breakpad_getcontext.S` matches the C++ arch on Linux 32-bit editor builds.
- Ignore `editor_crash_reporter` / `crash_reporter` on web, Android, and iOS so official editor flags do not enable Breakpad there.

This unblocks the Linux 32-bit editor jobs in [ci_cd trigger_build #543](https://github.com/blazium-games/ci_cd/actions/runs/32486203760).

## Test plan
- [ ] Linux editor `arch=x86_32` links (`breakpad_getcontext` is i386, not x86-64)
- [ ] Linux editor w/ Mono `arch=x86_32` links
- [ ] Web/Android/iOS editor and template builds do not compile the crash reporter module or define `USE_BREAKPAD`
- [ ] Re-dispatch `ci_cd` `trigger_build` after merge