### PR TITLE
Keep JustAMCP CLI port and Editor Settings in sync

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -693,7 +693,7 @@
 			Comma-separated OAuth scopes advertised in Protected Resource Metadata.
 		</member>
 		<member name="blazium/justamcp/override_editor_settings" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], JustAMCP reads server, tool, prompt, and resource toggles from [ProjectSettings] instead of [EditorSettings]. Automatically enabled in headless mode and when using [code]--enable-mcp[/code].
+			If [code]true[/code], JustAMCP reads server, tool, prompt, and resource toggles from [ProjectSettings] instead of [EditorSettings]. Headless sessions always use Project Settings. The [code]--enable-mcp[/code] flag enables the HTTP server without forcing this override.
 		</member>
 		<member name="blazium/justamcp/parallel_readonly_lane" type="bool" setter="" getter="" default="false">
 		</member>

--- a/modules/justamcp/doc_classes/JustAMCPRuntime.xml
+++ b/modules/justamcp/doc_classes/JustAMCPRuntime.xml
@@ -6,7 +6,7 @@
 	<description>
 		[JustAMCPRuntime] runs the local MCP endpoint and routes incoming commands to built-in tools, resources, prompts, or custom command callables. It is independent of the active [SceneTree], so it can keep serving editor automation while scenes are opened, closed, or changed.
 		[codeblock]
-		JustAMCPRuntime.port = 7777
+		JustAMCPRuntime.port = 6506
 		JustAMCPRuntime.enabled = true
 
 		JustAMCPRuntime.register_custom_command("double", func(value):
@@ -57,8 +57,8 @@
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="false">
 			When [code]true[/code], the runtime server is active and can accept MCP traffic. Setting it to [code]false[/code] stops serving runtime requests.
 		</member>
-		<member name="port" type="int" setter="set_port" getter="get_port" default="7777">
-			TCP port used by the JustAMCP runtime server. Change this before enabling the runtime when a project needs a non-default port.
+		<member name="port" type="int" setter="set_port" getter="get_port" default="6506">
+			TCP port used by the JustAMCP runtime server. Defaults to the same [code]6506[/code] as the editor HTTP server. Override at launch with [code]--mcp-port[/code], or change this before enabling the runtime.
 		</member>
 	</members>
 	<signals>

--- a/modules/justamcp/justamcp_cli_args.cpp
+++ b/modules/justamcp/justamcp_cli_args.cpp
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  justamcp_cli_args.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#include "justamcp_cli_args.h"
+
+#include "core/os/os.h"
+#include "core/string/ustring.h"
+#include "core/templates/list.h"
+#include "servers/display_server.h"
+
+#ifdef TESTS_ENABLED
+static int _test_mcp_port = -1;
+#endif
+
+static bool _justamcp_has_arg(const String &p_arg) {
+	for (const String &arg : OS::get_singleton()->get_cmdline_args()) {
+		if (arg == p_arg) {
+			return true;
+		}
+	}
+	return false;
+}
+
+int JustAMCPCliArgs::mcp_port() {
+#ifdef TESTS_ENABLED
+	if (_test_mcp_port > 0) {
+		return _test_mcp_port;
+	}
+#endif
+	const List<String> &args = OS::get_singleton()->get_cmdline_args();
+	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
+		if (E->get() == "--mcp-port" && E->next()) {
+			const int port = E->next()->get().to_int();
+			if (port > 0) {
+				return port;
+			}
+		}
+	}
+	return -1;
+}
+
+bool JustAMCPCliArgs::enable_mcp() {
+	return _justamcp_has_arg("--enable-mcp");
+}
+
+bool JustAMCPCliArgs::enable_mcp_game_control() {
+	return _justamcp_has_arg("--enable-mcp-game-control");
+}
+
+bool JustAMCPCliArgs::disable_game_mcp() {
+	return _justamcp_has_arg("--disable-game-mcp");
+}
+
+bool JustAMCPCliArgs::is_headless() {
+	if (DisplayServer::get_singleton() != nullptr) {
+		return DisplayServer::get_singleton()->get_name() == "headless";
+	}
+	return _justamcp_has_arg("--headless");
+}
+
+bool JustAMCPCliArgs::is_unit_test() {
+	return _justamcp_has_arg("--test") || _justamcp_has_arg("--tests");
+}
+
+bool JustAMCPCliArgs::skip_mcp_server() {
+	for (const String &arg : OS::get_singleton()->get_cmdline_args()) {
+		if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
+				arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
+				arg == "--check-only" || arg.begins_with("--export")) {
+			return true;
+		}
+	}
+	return false;
+}
+
+#ifdef TESTS_ENABLED
+void JustAMCPCliArgs::set_test_mcp_port(int p_port) {
+	_test_mcp_port = p_port;
+}
+
+void JustAMCPCliArgs::clear_test_overrides() {
+	_test_mcp_port = -1;
+}
+#endif

--- a/modules/justamcp/justamcp_cli_args.h
+++ b/modules/justamcp/justamcp_cli_args.h
@@ -1,0 +1,25 @@
+/**************************************************************************/
+/*  justamcp_cli_args.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+
+#pragma once
+
+class JustAMCPCliArgs {
+public:
+	static int mcp_port();
+	static bool enable_mcp();
+	static bool enable_mcp_game_control();
+	static bool disable_game_mcp();
+	static bool is_headless();
+	static bool is_unit_test();
+	static bool skip_mcp_server();
+
+#ifdef TESTS_ENABLED
+	static void set_test_mcp_port(int p_port);
+	static void clear_test_overrides();
+#endif
+};

--- a/modules/justamcp/justamcp_editor_plugin.cpp
+++ b/modules/justamcp/justamcp_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_prompt_executor.h"
 #include "tools/justamcp_resource_executor.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_tool_executor.h"
 #include "tools/justamcp_tool_schema_cache.h"
 
@@ -375,45 +376,13 @@ void JustAMCPEditorPlugin::_on_tool_requested(const Variant &p_request_id, const
 }
 
 String JustAMCPEditorPlugin::get_mcp_config_json(MCPConfigClient p_client) {
-	int port = 6506;
-	bool oauth_enabled = false;
-	String client_id = "";
-	String client_secret = "";
-
-	bool use_project_override = false;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
-		use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
+	int port = JustAMCPSettingsResolver::resolve_server_port();
+	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->get_listening_port() > 0) {
+		port = JustAMCPServer::get_singleton()->get_listening_port();
 	}
-
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		if (ProjectSettings::get_singleton()) {
-			if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/server_port")) {
-				port = static_cast<int>(GLOBAL_GET("blazium/justamcp/server_port"));
-			}
-			if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/oauth_enabled")) {
-				oauth_enabled = GLOBAL_GET("blazium/justamcp/oauth_enabled");
-			}
-			if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/client_id")) {
-				client_id = String(GLOBAL_GET("blazium/justamcp/client_id"));
-			}
-			if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/client_secret")) {
-				client_secret = String(GLOBAL_GET("blazium/justamcp/client_secret"));
-			}
-		}
-	} else if (EditorSettings::get_singleton()) {
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_port")) {
-			port = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_port");
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/oauth_enabled")) {
-			oauth_enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/oauth_enabled");
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/client_id")) {
-			client_id = String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/client_id"));
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/client_secret")) {
-			client_secret = String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/client_secret"));
-		}
-	}
+	const bool oauth_enabled = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/oauth_enabled", false);
+	const String client_id = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/client_id");
+	const String client_secret = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/client_secret");
 
 	const String mcp_url = "http://127.0.0.1:" + itos(port) + "/mcp";
 

--- a/modules/justamcp/justamcp_json_rpc_transport.cpp
+++ b/modules/justamcp/justamcp_json_rpc_transport.cpp
@@ -41,6 +41,7 @@
 #include "tools/justamcp_json_rpc_router.h"
 #include "tools/justamcp_prompt_executor.h"
 #include "tools/justamcp_resource_executor.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_schema_cache.h"
 
@@ -248,7 +249,7 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 		}
 	}
 
-	const bool debug_logging = GLOBAL_GET("blazium/justamcp/enable_debug_logging");
+	const bool debug_logging = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false);
 	if (debug_logging) {
 		p_server->_mcp_debug_log("Executing JSON-RPC Method: " + method + " (ID: " + request_id + ")");
 	}
@@ -543,24 +544,16 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 			}
 			const bool on_http = _is_http_transport(p_response);
 			if (p_task_augmented || on_http) {
-				if (!p_task_augmented && on_http && ProjectSettings::get_singleton() &&
-						ProjectSettings::get_singleton()->has_setting("blazium/justamcp/stateless_tool_blocking") &&
-						bool(GLOBAL_GET("blazium/justamcp/stateless_tool_blocking"))) {
+				if (!p_task_augmented && on_http && JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/stateless_tool_blocking", false)) {
 					return invalid_params("stateless_tool_blocking is not supported on HTTP transport. Use SSE/streamable responses or poll tasks/result with wait=false.");
 				}
 				return Dictionary();
 			}
-			bool blocking = false;
-			if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/stateless_tool_blocking")) {
-				blocking = bool(GLOBAL_GET("blazium/justamcp/stateless_tool_blocking"));
-			}
+			const bool blocking = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/stateless_tool_blocking", false);
 			if (!blocking) {
 				return Dictionary();
 			}
-			int timeout_ms = 120000;
-			if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/stateless_tool_timeout_ms")) {
-				timeout_ms = int(GLOBAL_GET("blazium/justamcp/stateless_tool_timeout_ms"));
-			}
+			const int timeout_ms = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/stateless_tool_timeout_ms", 120000);
 			if (p_server->_wait_for_stateless_tool_entry(p_entry, timeout_ms)) {
 				return p_entry->rpc_result;
 			}
@@ -569,16 +562,8 @@ Dictionary JustAMCPJsonRpcTransport::_handle_json_rpc_payload(JustAMCPServer *p_
 
 #ifdef TOOLS_ENABLED
 		if (has_task_param) {
-			int default_ttl = 600000;
-			int default_poll = 1000;
-			if (ProjectSettings::get_singleton()) {
-				if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_default_ttl_ms")) {
-					default_ttl = int(GLOBAL_GET("blazium/justamcp/task_default_ttl_ms"));
-				}
-				if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_poll_interval_ms")) {
-					default_poll = int(GLOBAL_GET("blazium/justamcp/task_poll_interval_ms"));
-				}
-			}
+			const int default_ttl = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/task_default_ttl_ms", 600000);
+			const int default_poll = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/task_poll_interval_ms", 1000);
 			const Dictionary task_params = params["task"];
 			const int ttl_ms = task_params.has("ttl") ? int(task_params["ttl"]) : default_ttl;
 			const int poll_ms = task_params.has("pollInterval") ? int(task_params["pollInterval"]) : default_poll;

--- a/modules/justamcp/justamcp_oauth_discovery.cpp
+++ b/modules/justamcp/justamcp_oauth_discovery.cpp
@@ -30,59 +30,23 @@
 #include "justamcp_oauth_discovery.h"
 
 #include "justamcp_server.h"
+#include "tools/justamcp_settings_resolver.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/json.h"
-#ifdef TOOLS_ENABLED
-#include "editor/editor_settings.h"
-#endif
-
-static bool _justamcp_oauth_use_project_settings() {
-	if (!ProjectSettings::get_singleton()) {
-		return true;
-	}
-	if (bool(GLOBAL_GET("blazium/justamcp/override_editor_settings"))) {
-		return true;
-	}
-#ifdef TOOLS_ENABLED
-	if (!EditorSettings::get_singleton()) {
-		return true;
-	}
-#endif
-	return false;
-}
-
-static Variant _justamcp_oauth_read_setting(const String &p_name, const Variant &p_default) {
-	if (_justamcp_oauth_use_project_settings()) {
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_name)) {
-			return GLOBAL_GET(p_name);
-		}
-		return p_default;
-	}
-#ifdef TOOLS_ENABLED
-	if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting(p_name)) {
-		return EditorSettings::get_singleton()->get_setting(p_name);
-	}
-#endif
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_name)) {
-		return GLOBAL_GET(p_name);
-	}
-	return p_default;
-}
 
 bool JustAMCPOauthDiscovery::oauth_enabled() {
-	return bool(_justamcp_oauth_read_setting("blazium/justamcp/oauth_enabled", false));
+	return JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/oauth_enabled", false);
 }
 
 String JustAMCPOauthDiscovery::setting_string(const String &p_name, const String &p_default) {
-	return String(_justamcp_oauth_read_setting(p_name, p_default));
+	return JustAMCPSettingsResolver::resolve_string(p_name, p_default);
 }
 
 int JustAMCPOauthDiscovery::listening_port() {
 	if (JustAMCPServer::get_singleton() && JustAMCPServer::get_singleton()->get_listening_port() > 0) {
 		return JustAMCPServer::get_singleton()->get_listening_port();
 	}
-	return int(_justamcp_oauth_read_setting("blazium/justamcp/server_port", 6506));
+	return JustAMCPSettingsResolver::resolve_server_port();
 }
 
 String JustAMCPOauthDiscovery::resource_url() {

--- a/modules/justamcp/justamcp_pagination.cpp
+++ b/modules/justamcp/justamcp_pagination.cpp
@@ -29,9 +29,9 @@
 
 #include "justamcp_pagination.h"
 
-#include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/marshalls.h"
+#include "tools/justamcp_settings_resolver.h"
 
 static const uint8_t CURSOR_MAGIC_0 = 'J';
 static const uint8_t CURSOR_MAGIC_1 = 'M';
@@ -39,19 +39,11 @@ static const uint8_t CURSOR_VERSION = 1;
 static const int CURSOR_PAYLOAD_SIZE = 7;
 
 int justamcp_pagination_page_size() {
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/list_page_size")) {
-		const int size = int(GLOBAL_GET("blazium/justamcp/list_page_size"));
-		return MAX(1, size);
-	}
-	return 50;
+	return MAX(1, JustAMCPSettingsResolver::resolve_int("blazium/justamcp/list_page_size", 50));
 }
 
 int justamcp_mcp_log_buffer_size() {
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/mcp_log_buffer_size")) {
-		const int size = int(GLOBAL_GET("blazium/justamcp/mcp_log_buffer_size"));
-		return MAX(1, size);
-	}
-	return 500;
+	return MAX(1, JustAMCPSettingsResolver::resolve_int("blazium/justamcp/mcp_log_buffer_size", 500));
 }
 
 String justamcp_pagination_cursor_from_uri_suffix(const String &p_suffix) {

--- a/modules/justamcp/justamcp_runtime.h
+++ b/modules/justamcp/justamcp_runtime.h
@@ -47,7 +47,7 @@ private:
 	Vector<Ref<StreamPeerTCP>> clients;
 	HashMap<Ref<StreamPeerTCP>, String> client_buffers;
 	Mutex clients_mutex;
-	int port = 7777;
+	int port = 6506;
 	bool enabled = false;
 	Thread *server_thread = nullptr;
 	std::atomic<bool> quit_thread{ false };

--- a/modules/justamcp/justamcp_runtime_tcp.cpp
+++ b/modules/justamcp/justamcp_runtime_tcp.cpp
@@ -34,11 +34,9 @@
 #include "core/object/message_queue.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
+#include "justamcp_cli_args.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_tool_executor.h"
-
-#ifdef TOOLS_ENABLED
-#include "editor/editor_settings.h"
-#endif
 
 void JustAMCPRuntime::_thread_poll_wrapper(void *p_user) {
 	JustAMCPRuntime *runtime = (JustAMCPRuntime *)p_user;
@@ -187,77 +185,20 @@ void JustAMCPRuntime::push_error_log(const String &p_message, bool p_is_error) {
 }
 
 void JustAMCPRuntime::_start_server() {
-	const List<String> &args = OS::get_singleton()->get_cmdline_args();
-	for (const String &arg : args) {
-		if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
-				arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
-				arg == "--check-only" || arg.begins_with("--export")) {
-			return;
-		}
+	if (JustAMCPCliArgs::skip_mcp_server()) {
+		return;
 	}
-
-	bool mcp_disabled = false;
-	for (const String &E : args) {
-		if (E == "--disable-game-mcp") {
-			mcp_disabled = true;
-			break;
-		}
-	}
-	if (mcp_disabled) {
+	if (JustAMCPCliArgs::disable_game_mcp() || JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/disable_game_mcp", false)) {
 		return;
 	}
 
-#ifdef TOOLS_ENABLED
-	bool is_headless = false;
-	for (const String &E : args) {
-		if (E == "--headless") {
-			is_headless = true;
-			break;
-		}
-	}
-
-	bool use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-
-	if (is_headless) {
-		use_project_override = true;
-	}
-
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		enabled = GLOBAL_GET("blazium/justamcp/server_enabled");
-		port = GLOBAL_GET("blazium/justamcp/server_port");
+	port = JustAMCPSettingsResolver::resolve_server_port();
+	const bool game_control = JustAMCPCliArgs::enable_mcp_game_control() ||
+			JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/game_control_enabled", false);
+	if (JustAMCPCliArgs::enable_mcp() || game_control) {
+		enabled = true;
 	} else {
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_enabled")) {
-			enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_enabled");
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_port")) {
-			port = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_port");
-		}
-	}
-#else
-
-	if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/disable_game_mcp")) {
-		if ((bool)GLOBAL_GET("blazium/justamcp/disable_game_mcp")) {
-			return;
-		}
-	}
-
-	bool game_control_enabled = false;
-	if (ProjectSettings::get_singleton()->has_setting("blazium/justamcp/game_control_enabled")) {
-		game_control_enabled = GLOBAL_GET("blazium/justamcp/game_control_enabled");
-	}
-	if (!game_control_enabled && !args.find("--enable-mcp-game-control")) {
-		return;
-	}
-
-	enabled = GLOBAL_GET("blazium/justamcp/server_enabled");
-	port = GLOBAL_GET("blazium/justamcp/server_port");
-#endif
-
-	if (OS::get_singleton()->get_cmdline_args().find("--enable-mcp")) {
-		enabled = true;
-	}
-	if (OS::get_singleton()->get_cmdline_args().find("--enable-mcp-game-control")) {
-		enabled = true;
+		enabled = JustAMCPSettingsResolver::resolve_server_enabled();
 	}
 
 	if (!enabled) {
@@ -268,10 +209,7 @@ void JustAMCPRuntime::_start_server() {
 		server->stop();
 	}
 
-	bool bind_to_localhost = true;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/bind_to_localhost_only")) {
-		bind_to_localhost = GLOBAL_GET("blazium/justamcp/bind_to_localhost_only");
-	}
+	const bool bind_to_localhost = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/bind_to_localhost_only", true);
 	String bind_address = bind_to_localhost ? "127.0.0.1" : "*";
 
 	Error err = server->listen(port, bind_address);

--- a/modules/justamcp/justamcp_server.cpp
+++ b/modules/justamcp/justamcp_server.cpp
@@ -29,6 +29,7 @@
 
 #include "justamcp_server.h"
 
+#include "justamcp_cli_args.h"
 #include "justamcp_cors_policy.h"
 #include "justamcp_json_rpc_transport.h"
 #include "justamcp_notification_bus.h"
@@ -42,6 +43,7 @@
 #include "tools/justamcp_json_rpc_router.h"
 #include "tools/justamcp_prompt_executor.h"
 #include "tools/justamcp_resource_executor.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_executor.h"
 #include "tools/justamcp_tool_schema_cache.h"
@@ -51,28 +53,14 @@
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "editor/editor_settings.h"
-#include "servers/display_server.h"
 
 #include "modules/modules_enabled.gen.h"
 
-static bool _is_headless() {
-	if (DisplayServer::get_singleton() != nullptr) {
-		return DisplayServer::get_singleton()->get_name() == "headless";
-	}
-	if (OS::get_singleton() && OS::get_singleton()->get_cmdline_args().find("--headless")) {
-		return true;
-	}
-	return false;
-}
-
 static bool _justamcp_headless_project_server_requested() {
-	if (!_is_headless()) {
+	if (!JustAMCPCliArgs::is_headless()) {
 		return false;
 	}
-	if (!ProjectSettings::get_singleton()) {
-		return false;
-	}
-	return GLOBAL_GET("blazium/justamcp/server_enabled");
+	return JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/server_enabled", false);
 }
 
 void JustAMCPServer::_bind_methods() {
@@ -235,7 +223,7 @@ void JustAMCPServer::_print_handler_callback(void *p_user_data, const String &p_
 	if (!server->server_started) {
 		return;
 	}
-	if (!ProjectSettings::get_singleton() || !GLOBAL_GET("blazium/justamcp/forward_engine_logs")) {
+	if (!JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/forward_engine_logs", false)) {
 		return;
 	}
 
@@ -371,36 +359,13 @@ void JustAMCPServer::_notification(int p_what) {
 }
 
 int JustAMCPServer::_resolve_listening_port_from_settings() const {
-	int port = 6506;
-#ifdef TOOLS_ENABLED
-	bool use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-	if (_is_headless()) {
-		use_project_override = true;
-	}
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		port = GLOBAL_GET("blazium/justamcp/server_port");
-	} else if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_port")) {
-		port = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_port");
-	}
-#endif
-	return port;
+	return JustAMCPSettingsResolver::resolve_server_port();
 }
 
 void JustAMCPServer::_on_settings_changed() {
 #ifdef TOOLS_ENABLED
 	JustAMCPJsonRpcHelpers::mark_mcp_tool_settings_dirty();
-	bool is_enabled = false;
-	bool use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-
-	if (_is_headless()) {
-		use_project_override = true;
-	}
-
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		is_enabled = GLOBAL_GET("blazium/justamcp/server_enabled");
-	} else if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_enabled")) {
-		is_enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_enabled");
-	}
+	bool is_enabled = JustAMCPSettingsResolver::resolve_server_enabled();
 
 	if (_justamcp_headless_project_server_requested()) {
 		is_enabled = true;
@@ -408,9 +373,7 @@ void JustAMCPServer::_on_settings_changed() {
 
 	if (!is_enabled && server_started) {
 		_stop_server();
-	}
-
-	else if (is_enabled && !server_started) {
+	} else if (is_enabled && !server_started) {
 		_start_server();
 	} else if (is_enabled && server_started) {
 		const int resolved_port = _resolve_listening_port_from_settings();
@@ -445,59 +408,19 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 	}
 
 	const List<String> &args = OS::get_singleton()->get_cmdline_args();
-	if (!p_ignore_cmdline_block && !_justamcp_headless_project_server_requested()) {
-		for (const String &arg : args) {
-			if (arg == "--test" || arg == "--tests" || arg.begins_with("--aw-") ||
-					arg == "--help" || arg == "-h" || arg == "/?" || arg == "--version" ||
-					arg == "--check-only" || arg.begins_with("--export")) {
-				print_line("JustAMCP: Server not started (cmdline " + arg + " skips MCP).");
-				return;
-			}
-		}
+	if (!p_ignore_cmdline_block && JustAMCPCliArgs::skip_mcp_server() && !_justamcp_headless_project_server_requested()) {
+		print_line("JustAMCP: Server not started (cmdline skips MCP).");
+		return;
 	}
 
-	bool enabled = false;
-	int port = 6506;
-	bool bind_to_localhost = true;
+	bool enabled = JustAMCPSettingsResolver::resolve_server_enabled();
+	int port = JustAMCPSettingsResolver::resolve_server_port();
+	bool bind_to_localhost = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/bind_to_localhost_only", true);
 
-#ifdef TOOLS_ENABLED
-	bool use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-
-	if (_is_headless()) {
-		use_project_override = true;
-	}
-
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		enabled = GLOBAL_GET("blazium/justamcp/server_enabled");
-		port = GLOBAL_GET("blazium/justamcp/server_port");
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/bind_to_localhost_only")) {
-			bind_to_localhost = GLOBAL_GET("blazium/justamcp/bind_to_localhost_only");
-		}
-	} else {
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_enabled")) {
-			enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_enabled");
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_port")) {
-			port = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_port");
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/bind_to_localhost_only")) {
-			bind_to_localhost = EditorSettings::get_singleton()->get_setting("blazium/justamcp/bind_to_localhost_only");
-		}
-	}
-#endif
-
-	bool cmd_enable_mcp = false;
-	int cmd_port = -1;
 	String cmd_client_id = "";
 	String cmd_client_secret = "";
 
 	for (const List<String>::Element *E = args.front(); E; E = E->next()) {
-		if (E->get() == "--enable-mcp") {
-			cmd_enable_mcp = true;
-		}
-		if (E->get() == "--mcp-port" && E->next()) {
-			cmd_port = E->next()->get().to_int();
-		}
 		if (E->get() == "--mcp-client-id" && E->next()) {
 			cmd_client_id = E->next()->get();
 		}
@@ -521,12 +444,6 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 		return;
 	}
 
-	if (cmd_enable_mcp) {
-		enabled = true;
-	}
-	if (cmd_port > 0) {
-		port = cmd_port;
-	}
 	if (!cmd_client_id.is_empty() && !cmd_client_secret.is_empty()) {
 		if (ProjectSettings::get_singleton()) {
 			ProjectSettings::get_singleton()->set_setting("blazium/justamcp/oauth_enabled", true);
@@ -547,15 +464,7 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 		return;
 	}
 
-	bool oauth_enabled = false;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/oauth_enabled")) {
-		oauth_enabled = GLOBAL_GET("blazium/justamcp/oauth_enabled");
-	}
-#ifdef TOOLS_ENABLED
-	if (!oauth_enabled && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/oauth_enabled")) {
-		oauth_enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/oauth_enabled");
-	}
-#endif
+	const bool oauth_enabled = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/oauth_enabled", false);
 	if (!bind_to_localhost && !oauth_enabled) {
 		ERR_PRINT("JustAMCP: Refusing to start server: bind_to_localhost_only is false without OAuth enabled. Enable OAuth or bind to localhost only.");
 		return;
@@ -588,7 +497,7 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 
 	HTTPServer::get_singleton()->set_cors_enabled(true);
 	{
-		const String allowed_origin = String(GLOBAL_GET("blazium/justamcp/streamable_http_allowed_origin"));
+		const String allowed_origin = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/streamable_http_allowed_origin");
 		const String cors_origin = justamcp_compute_startup_cors_origin(bind_to_localhost, oauth_enabled, allowed_origin);
 		if (!bind_to_localhost && cors_origin.is_empty()) {
 			WARN_PRINT("JustAMCP: bind_to_localhost_only is false without OAuth or streamable_http_allowed_origin; CORS Access-Control-Allow-Origin will not be set to *.");
@@ -636,7 +545,7 @@ void JustAMCPServer::_start_server_internal(bool p_ignore_cmdline_block) {
 
 #ifdef TOOLS_ENABLED
 void JustAMCPServer::_ensure_headless_tool_executor() {
-	if (!_is_headless()) {
+	if (!JustAMCPCliArgs::is_headless()) {
 		return;
 	}
 	if (!headless_tool_executor) {

--- a/modules/justamcp/justamcp_server_http.cpp
+++ b/modules/justamcp/justamcp_server_http.cpp
@@ -32,25 +32,14 @@
 #include "justamcp_json_rpc_transport.h"
 #include "justamcp_oauth_discovery.h"
 #include "justamcp_session_manager.h"
+#include "tools/justamcp_settings_resolver.h"
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/json.h"
 #include "core/os/os.h"
-#include "editor/editor_settings.h"
 #include "modules/httpserver/http_server.h"
-#include "servers/display_server.h"
-
-static bool _is_headless() {
-	if (DisplayServer::get_singleton() != nullptr) {
-		return DisplayServer::get_singleton()->get_name() == "headless";
-	}
-	if (OS::get_singleton() && OS::get_singleton()->get_cmdline_args().find("--headless")) {
-		return true;
-	}
-	return false;
-}
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 
@@ -73,10 +62,7 @@ static String _justamcp_redact_header_value(const String &p_key, const String &p
 }
 
 static String _justamcp_redact_debug_body(const String &p_body) {
-	bool oauth_enabled = false;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/oauth_enabled")) {
-		oauth_enabled = GLOBAL_GET("blazium/justamcp/oauth_enabled");
-	}
+	const bool oauth_enabled = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/oauth_enabled", false);
 	if (oauth_enabled) {
 		return "[body redacted: oauth enabled]";
 	}
@@ -98,31 +84,9 @@ void JustAMCPServer::_handle_cors_preflight(Ref<HTTPRequestContext> p_context, R
 
 bool JustAMCPServer::_validate_mcp_oauth(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
 #ifdef TOOLS_ENABLED
-	bool oauth_enabled = false;
-	String required_client_id = "";
-	String required_client_secret = "";
-
-	bool use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-
-	if (_is_headless()) {
-		use_project_override = true;
-	}
-
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		oauth_enabled = GLOBAL_GET("blazium/justamcp/oauth_enabled");
-		required_client_id = String(GLOBAL_GET("blazium/justamcp/client_id"));
-		required_client_secret = String(GLOBAL_GET("blazium/justamcp/client_secret"));
-	} else if (EditorSettings::get_singleton()) {
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/oauth_enabled")) {
-			oauth_enabled = EditorSettings::get_singleton()->get_setting("blazium/justamcp/oauth_enabled");
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/client_id")) {
-			required_client_id = String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/client_id"));
-		}
-		if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/client_secret")) {
-			required_client_secret = String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/client_secret"));
-		}
-	}
+	const bool oauth_enabled = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/oauth_enabled", false);
+	const String required_client_id = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/client_id");
+	const String required_client_secret = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/client_secret");
 
 	if (oauth_enabled) {
 		if (required_client_id.is_empty() || required_client_secret.is_empty()) {
@@ -197,7 +161,7 @@ bool JustAMCPServer::_validate_mcp_oauth(Ref<HTTPRequestContext> p_context, Ref<
 }
 
 void JustAMCPServer::_handle_legacy_sse_connect(Ref<HTTPRequestContext> p_context, Ref<HTTPResponse> p_response) {
-	if (GLOBAL_GET("blazium/justamcp/enable_debug_logging")) {
+	if (JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false)) {
 		_mcp_debug_log("Incoming " + p_context->get_method() + " /sse connection attempt...");
 	}
 	if (!_validate_mcp_oauth(p_context, p_response)) {
@@ -254,7 +218,7 @@ void JustAMCPServer::_on_sse_connection_opened(int p_connection_id, const String
 		return;
 	}
 	if (p_path == "/sse") {
-		if (GLOBAL_GET("blazium/justamcp/enable_debug_logging")) {
+		if (JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false)) {
 			_mcp_debug_log("New SSE connection opened on " + p_path + " (ID: " + itos(p_connection_id) + ")");
 		}
 		current_sse_connection_id = p_connection_id;
@@ -262,27 +226,8 @@ void JustAMCPServer::_on_sse_connection_opened(int p_connection_id, const String
 			session_manager->track_legacy_broadcast_connection(p_connection_id);
 		}
 
-		int port = 6506;
-		bool use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-		bool bind_to_localhost = true;
-
-		if (_is_headless()) {
-			use_project_override = true;
-		}
-
-		if (use_project_override || !EditorSettings::get_singleton()) {
-			port = GLOBAL_GET("blazium/justamcp/server_port");
-			if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/bind_to_localhost_only")) {
-				bind_to_localhost = GLOBAL_GET("blazium/justamcp/bind_to_localhost_only");
-			}
-		} else if (EditorSettings::get_singleton()) {
-			if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_port")) {
-				port = EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_port");
-			}
-			if (EditorSettings::get_singleton()->has_setting("blazium/justamcp/bind_to_localhost_only")) {
-				bind_to_localhost = EditorSettings::get_singleton()->get_setting("blazium/justamcp/bind_to_localhost_only");
-			}
-		}
+		int port = get_listening_port() > 0 ? get_listening_port() : JustAMCPSettingsResolver::resolve_server_port();
+		const bool bind_to_localhost = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/bind_to_localhost_only", true);
 
 		String host_authority;
 		if (bind_to_localhost) {
@@ -404,7 +349,7 @@ void JustAMCPServer::_handle_message_post(Ref<HTTPRequestContext> p_context, Ref
 		return;
 	}
 
-	if (GLOBAL_GET("blazium/justamcp/enable_debug_logging")) {
+	if (JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false)) {
 		Array keys = p_context->get_headers().keys();
 		String header_dump;
 		for (int i = 0; i < keys.size(); i++) {
@@ -437,7 +382,7 @@ void JustAMCPServer::_handle_mcp_stateless_post(Ref<HTTPRequestContext> p_contex
 		return;
 	}
 
-	const bool debug_logging = GLOBAL_GET("blazium/justamcp/enable_debug_logging");
+	const bool debug_logging = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false);
 	if (debug_logging) {
 		Array keys = p_context->get_headers().keys();
 		String header_dump;

--- a/modules/justamcp/justamcp_server_notifications.cpp
+++ b/modules/justamcp/justamcp_server_notifications.cpp
@@ -33,10 +33,10 @@
 #include "justamcp_notification_bus.h"
 #include "justamcp_pagination.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "core/os/time.h"
 #include "modules/httpserver/http_server.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 
 void JustAMCPServer::broadcast_prompts_list_changed() {
@@ -106,7 +106,7 @@ Dictionary JustAMCPServer::get_mcp_notification_log_page(const String &p_cursor)
 }
 
 void JustAMCPServer::_mcp_debug_log(const String &p_message) {
-	if (!GLOBAL_GET("blazium/justamcp/enable_debug_logging")) {
+	if (!JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_debug_logging", false)) {
 		return;
 	}
 	Dictionary log_data;

--- a/modules/justamcp/justamcp_server_tool_lifecycle.cpp
+++ b/modules/justamcp/justamcp_server_tool_lifecycle.cpp
@@ -29,7 +29,6 @@
 
 #include "justamcp_server.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "core/os/time.h"
 #include "justamcp_server_request_lookup.h"
@@ -37,6 +36,7 @@
 #include "justamcp_tool_queue_state.h"
 #include "scene/main/scene_tree.h"
 #include "tools/justamcp_json_rpc_helpers.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
@@ -185,10 +185,7 @@ void JustAMCPServer::_on_request_cancelled(const Variant &p_request_id, const St
 	}
 
 	if (is_in_flight) {
-		int deadline_ms = 5000;
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/in_flight_cancel_deadline_ms")) {
-			deadline_ms = int(GLOBAL_GET("blazium/justamcp/in_flight_cancel_deadline_ms"));
-		}
+		int deadline_ms = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/in_flight_cancel_deadline_ms", 5000);
 		if (deadline_ms <= 0) {
 			Dictionary cancelled;
 			cancelled["ok"] = false;
@@ -206,10 +203,7 @@ void JustAMCPServer::_on_request_cancelled(const Variant &p_request_id, const St
 }
 
 void JustAMCPServer::_enforce_in_flight_cancel_deadline(const Variant &p_request_id) {
-	int deadline_ms = 5000;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/in_flight_cancel_deadline_ms")) {
-		deadline_ms = int(GLOBAL_GET("blazium/justamcp/in_flight_cancel_deadline_ms"));
-	}
+	int deadline_ms = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/in_flight_cancel_deadline_ms", 5000);
 
 	MCPToolQueueEntry *target = nullptr;
 	uint64_t cancel_usec = 0;

--- a/modules/justamcp/justamcp_server_tool_queue.cpp
+++ b/modules/justamcp/justamcp_server_tool_queue.cpp
@@ -42,21 +42,19 @@
 #include "scene/main/scene_tree.h"
 #include "tools/justamcp_json_rpc_helpers.h"
 #include "tools/justamcp_readonly_tools.h"
+#include "tools/justamcp_settings_resolver.h"
 #include "tools/justamcp_task_manager.h"
 #include "tools/justamcp_tool_executor.h"
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 
 static int _justamcp_readonly_worker_concurrency() {
-	int concurrency = 2;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/readonly_worker_concurrency")) {
-		concurrency = int(GLOBAL_GET("blazium/justamcp/readonly_worker_concurrency"));
-	}
+	int concurrency = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/readonly_worker_concurrency", 2);
 	if (concurrency < 0) {
 		concurrency = 0;
 	}
 
-	if (concurrency == 0 && ProjectSettings::get_singleton() && bool(GLOBAL_GET("blazium/justamcp/parallel_readonly_lane"))) {
+	if (concurrency == 0 && JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/parallel_readonly_lane", false)) {
 		concurrency = 1;
 	}
 	return concurrency;
@@ -133,10 +131,7 @@ MCPToolQueueEntry *JustAMCPServer::_enqueue_tool_request(const Variant &p_reques
 			entry->sse_connection_id = route_connection_id;
 		}
 	}
-	int max_per_session = 8;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/max_pending_per_session")) {
-		max_per_session = int(GLOBAL_GET("blazium/justamcp/max_pending_per_session"));
-	}
+	const int max_per_session = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/max_pending_per_session", 8);
 	if (max_per_session > 0 && !entry->session_id.is_empty() && mcp_tool_queue.count_pending_for_session(entry->session_id) >= max_per_session) {
 		memdelete(entry);
 		r_queue_full_error["jsonrpc"] = "2.0";
@@ -147,10 +142,7 @@ MCPToolQueueEntry *JustAMCPServer::_enqueue_tool_request(const Variant &p_reques
 		r_queue_full_error["error"] = error_dict;
 		return nullptr;
 	}
-	int max_enqueue_per_sec = 10;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/max_enqueue_per_sec_per_session")) {
-		max_enqueue_per_sec = int(GLOBAL_GET("blazium/justamcp/max_enqueue_per_sec_per_session"));
-	}
+	const int max_enqueue_per_sec = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/max_enqueue_per_sec_per_session", 10);
 	if (max_enqueue_per_sec > 0) {
 		const String rate_key = entry->session_id.is_empty() ? String("__anonymous__") : entry->session_id;
 		MutexLock rate_lock(session_enqueue_rate_mutex);

--- a/modules/justamcp/justamcp_session_manager.cpp
+++ b/modules/justamcp/justamcp_session_manager.cpp
@@ -30,6 +30,7 @@
 #include "justamcp_session_manager.h"
 
 #include "justamcp_server.h"
+#include "tools/justamcp_settings_resolver.h"
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
@@ -38,10 +39,6 @@
 #include "core/templates/list.h"
 
 #include "modules/modules_enabled.gen.h"
-
-#ifdef TOOLS_ENABLED
-#include "editor/editor_settings.h"
-#endif
 
 MCPSessionManager::MCPSessionManager(JustAMCPServer *p_owner) {
 	owner = p_owner;
@@ -90,19 +87,7 @@ bool MCPSessionManager::is_legacy_protocol_version(const String &p_version) {
 }
 
 static String _configured_accepted_protocol_versions() {
-#ifdef TOOLS_ENABLED
-	bool use_project = true;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
-		use_project = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-	}
-	if (!use_project && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/accepted_protocol_versions")) {
-		return String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/accepted_protocol_versions"));
-	}
-#endif
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/accepted_protocol_versions")) {
-		return String(GLOBAL_GET("blazium/justamcp/accepted_protocol_versions"));
-	}
-	return String();
+	return JustAMCPSettingsResolver::resolve_string("blazium/justamcp/accepted_protocol_versions");
 }
 
 Vector<String> MCPSessionManager::supported_protocol_versions() {
@@ -298,19 +283,7 @@ void MCPSessionManager::clear_cli_protocol_version_override() {
 }
 
 static String _configured_protocol_version() {
-#ifdef TOOLS_ENABLED
-	bool use_project = true;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
-		use_project = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-	}
-	if (!use_project && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/protocol_version")) {
-		return String(EditorSettings::get_singleton()->get_setting("blazium/justamcp/protocol_version"));
-	}
-#endif
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/protocol_version")) {
-		return String(GLOBAL_GET("blazium/justamcp/protocol_version"));
-	}
-	return String();
+	return JustAMCPSettingsResolver::resolve_string("blazium/justamcp/protocol_version");
 }
 
 String MCPSessionManager::latest_protocol_version() {
@@ -389,7 +362,7 @@ bool MCPSessionManager::is_allowed_origin_string(const String &p_origin) {
 	if (p_origin.is_empty()) {
 		return false;
 	}
-	const String allowed = GLOBAL_GET("blazium/justamcp/streamable_http_allowed_origin");
+	const String allowed = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/streamable_http_allowed_origin");
 	if (!allowed.is_empty()) {
 		return p_origin == allowed;
 	}
@@ -450,7 +423,7 @@ bool MCPSessionManager::is_allowed_origin_string(const String &p_origin) {
 }
 
 bool MCPSessionManager::validate_origin(const Ref<HTTPRequestContext> &p_context) {
-	const bool strict = GLOBAL_GET("blazium/justamcp/streamable_http_strict_origin");
+	const bool strict = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/streamable_http_strict_origin", false);
 	if (!strict) {
 		return true;
 	}

--- a/modules/justamcp/justamcp_session_manager_core.cpp
+++ b/modules/justamcp/justamcp_session_manager_core.cpp
@@ -33,10 +33,10 @@
 #include "modules/modules_enabled.gen.h"
 #include "tools/justamcp_json_rpc_helpers.h"
 
-#include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/json.h"
 #include "core/os/time.h"
+#include "tools/justamcp_settings_resolver.h"
 
 #if defined(MODULE_HTTPSERVER_ENABLED)
 #include "modules/httpserver/http_server.h"
@@ -98,10 +98,7 @@ void MCPSessionManager::_touch_session(MCPSession &p_session) {
 }
 
 void MCPSessionManager::_prune_expired_pending_post_sse() {
-	int timeout_sec = 120;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/pending_post_sse_timeout_sec")) {
-		timeout_sec = int(GLOBAL_GET("blazium/justamcp/pending_post_sse_timeout_sec"));
-	}
+	int timeout_sec = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/pending_post_sse_timeout_sec", 120);
 
 	if (timeout_sec < 1) {
 		timeout_sec = 1;
@@ -122,7 +119,7 @@ void MCPSessionManager::_prune_expired_pending_post_sse() {
 
 void MCPSessionManager::_expire_sessions() {
 	_prune_expired_pending_post_sse();
-	const int ttl_seconds = GLOBAL_GET("blazium/justamcp/session_ttl_seconds");
+	const int ttl_seconds = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/session_ttl_seconds", 3600);
 	if (ttl_seconds <= 0) {
 		prune_request_routes();
 		return;
@@ -441,10 +438,7 @@ void MCPSessionManager::untrack_legacy_broadcast_connection(int p_connection_id)
 }
 
 void MCPSessionManager::prune_request_routes() {
-	int ttl_sec = 3600;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/request_route_ttl_sec")) {
-		ttl_sec = int(GLOBAL_GET("blazium/justamcp/request_route_ttl_sec"));
-	}
+	int ttl_sec = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/request_route_ttl_sec", 3600);
 	if (ttl_sec <= 0) {
 		return;
 	}

--- a/modules/justamcp/justamcp_session_manager_http_delete.cpp
+++ b/modules/justamcp/justamcp_session_manager_http_delete.cpp
@@ -27,12 +27,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "core/config/project_settings.h"
 #include "core/io/json.h"
 #include "core/os/time.h"
 #include "justamcp_server.h"
 #include "justamcp_session_manager.h"
 #include "modules/modules_enabled.gen.h"
+#include "tools/justamcp_settings_resolver.h"
 #if defined(MODULE_HTTPSERVER_ENABLED)
 #include "modules/httpserver/http_request_context.h"
 #include "modules/httpserver/http_response.h"
@@ -42,7 +42,7 @@
 #if defined(MODULE_HTTPSERVER_ENABLED)
 
 bool MCPSessionManager::handle_mcp_delete(const Ref<HTTPRequestContext> &p_context, Ref<HTTPResponse> p_response) {
-	const bool allow_delete = GLOBAL_GET("blazium/justamcp/session_allow_client_delete");
+	const bool allow_delete = JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/session_allow_client_delete", true);
 	if (!allow_delete) {
 		p_response->set_status(405);
 		p_response->set_body("Session DELETE not enabled");

--- a/modules/justamcp/register_types.cpp
+++ b/modules/justamcp/register_types.cpp
@@ -32,7 +32,11 @@
 
 #include "modules/modules_enabled.gen.h"
 
+#include "justamcp_cli_args.h"
 #include "justamcp_runtime.h"
+#include "tools/justamcp_settings_resolver.h"
+
+#include "core/config/engine.h"
 
 #ifdef TOOLS_ENABLED
 #include "core/config/project_settings.h"
@@ -147,47 +151,18 @@
 #include "core/os/os.h"
 #endif
 
-#include "servers/display_server.h"
-
-static bool _is_headless() {
-	if (DisplayServer::get_singleton() != nullptr) {
-		return DisplayServer::get_singleton()->get_name() == "headless";
-	}
-	if (OS::get_singleton() && OS::get_singleton()->get_cmdline_args().find("--headless")) {
-		return true;
-	}
-	return false;
+static bool _is_justamcp_editor_enabled() {
+	return JustAMCPSettingsResolver::resolve_server_enabled();
 }
 
-static bool _is_justamcp_enabled() {
-	if (OS::get_singleton()->get_cmdline_args().find("--enable-mcp")) {
+static bool _is_justamcp_game_control_requested() {
+	if (JustAMCPCliArgs::disable_game_mcp() || JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/disable_game_mcp", false)) {
+		return false;
+	}
+	if (JustAMCPCliArgs::enable_mcp_game_control()) {
 		return true;
 	}
-
-	bool use_project_override = false;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
-		use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-	}
-
-	if (_is_headless()) {
-		use_project_override = true;
-	}
-
-#ifdef TOOLS_ENABLED
-	if (use_project_override || !EditorSettings::get_singleton()) {
-#else
-	{
-#endif
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/server_enabled")) {
-			return GLOBAL_GET("blazium/justamcp/server_enabled");
-		}
-#ifdef TOOLS_ENABLED
-	} else if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/server_enabled")) {
-		return EditorSettings::get_singleton()->get_setting("blazium/justamcp/server_enabled");
-#endif
-	}
-
-	return false;
+	return JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/game_control_enabled", false);
 }
 
 #ifdef TOOLS_ENABLED
@@ -229,14 +204,17 @@ static void _register_all_toolsets() {
 void initialize_justamcp_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(JustAMCPRuntime);
-		if (_is_justamcp_enabled()) {
-			JustAMCPRuntime *runtime = memnew(JustAMCPRuntime);
-			Engine::get_singleton()->add_singleton(Engine::Singleton("JustAMCPRuntime", runtime));
-		}
-#ifdef TOOLS_ENABLED
 		GLOBAL_DEF_BASIC("blazium/justamcp/game_control_enabled", false);
 		GLOBAL_DEF_BASIC("blazium/justamcp/disable_game_mcp", false);
-#endif
+		const bool editor_enabled = _is_justamcp_editor_enabled();
+		const bool game_control = _is_justamcp_game_control_requested();
+		if (editor_enabled || game_control) {
+			JustAMCPRuntime *runtime = memnew(JustAMCPRuntime);
+			Engine::get_singleton()->add_singleton(Engine::Singleton("JustAMCPRuntime", runtime));
+			if (game_control) {
+				runtime->set_enabled(true);
+			}
+		}
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/justamcp/tests/test_justamcp_http_integration.cpp
+++ b/modules/justamcp/tests/test_justamcp_http_integration.cpp
@@ -38,6 +38,7 @@
 #include "../justamcp_session_manager.h"
 
 #ifdef TOOLS_ENABLED
+#include "../justamcp_cli_args.h"
 #include "../justamcp_editor_plugin.h"
 #endif
 
@@ -388,6 +389,19 @@ void test_justamcp_mcp_config_client_field_shapes() {
 #endif
 }
 
+void test_justamcp_mcp_config_json_uses_cli_port() {
+#ifdef TOOLS_ENABLED
+	JustAMCPCliArgs::set_test_mcp_port(16526);
+	const String cursor_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_CURSOR);
+	const String ag_cfg = JustAMCPEditorPlugin::get_mcp_config_json(JustAMCPEditorPlugin::MCP_CONFIG_ANTIGRAVITY);
+	JustAMCPCliArgs::clear_test_overrides();
+	CHECK(cursor_cfg.contains("http://127.0.0.1:16526/mcp"));
+	CHECK(ag_cfg.contains("http://127.0.0.1:16526/mcp"));
+#else
+	SUCCEED();
+#endif
+}
+
 #else
 void test_justamcp_http_initialize_creates_session() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
@@ -426,6 +440,9 @@ void test_justamcp_http_catalogs_after_initialize() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
 }
 void test_justamcp_mcp_config_client_field_shapes() {
+	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
+}
+void test_justamcp_mcp_config_json_uses_cli_port() {
 	TEST_FAIL_COND(true, "MODULE_HTTPSERVER_ENABLED is required for HTTP integration tests");
 }
 #endif

--- a/modules/justamcp/tests/test_justamcp_http_integration.h
+++ b/modules/justamcp/tests/test_justamcp_http_integration.h
@@ -46,6 +46,7 @@ void test_justamcp_http_catalogs_after_initialize();
 void test_justamcp_http_dual_accept_tools_list_returns_json();
 void test_justamcp_http_dual_accept_tools_call_uses_sse();
 void test_justamcp_mcp_config_client_field_shapes();
+void test_justamcp_mcp_config_json_uses_cli_port();
 
 TEST_CASE("[Modules][JustAMCP] http initialize creates session") {
 	test_justamcp_http_initialize_creates_session();
@@ -105,4 +106,8 @@ TEST_CASE("[Modules][JustAMCP] http dual-Accept tools/call uses SSE") {
 
 TEST_CASE("[Modules][JustAMCP] mcp config client field shapes") {
 	test_justamcp_mcp_config_client_field_shapes();
+}
+
+TEST_CASE("[Modules][JustAMCP] mcp config json uses CLI port") {
+	test_justamcp_mcp_config_json_uses_cli_port();
 }

--- a/modules/justamcp/tests/test_justamcp_server_listen.cpp
+++ b/modules/justamcp/tests/test_justamcp_server_listen.cpp
@@ -31,6 +31,7 @@
 
 #ifdef TESTS_ENABLED
 
+#include "../justamcp_cli_args.h"
 #include "../justamcp_server.h"
 #include "core/config/project_settings.h"
 #include "modules/modules_enabled.gen.h"
@@ -128,6 +129,29 @@ void test_justamcp_server_failed_listen_does_not_activate() {
 	CHECK(!server.is_server_started());
 	CHECK(server.get_listening_port() == -1);
 	CHECK(!HTTPServer::get_singleton()->is_listening());
+#endif
+}
+
+void test_justamcp_server_cli_port_wins_over_settings() {
+#if !defined(MODULE_HTTPSERVER_ENABLED)
+	return;
+#else
+	REQUIRE(HTTPServer::get_singleton());
+	_stop_httpserver_if_listening();
+
+	JustAMCPListenSettingsGuard settings;
+	settings.apply(true, 16506);
+	JustAMCPCliArgs::set_test_mcp_port(16516);
+
+	JustAMCPServer server;
+	server.test_start_server();
+	CHECK(server.is_server_started());
+	CHECK(server.get_listening_port() == 16516);
+	CHECK(HTTPServer::get_singleton()->is_listening());
+
+	server.test_stop_server();
+	JustAMCPCliArgs::clear_test_overrides();
+	_stop_httpserver_if_listening();
 #endif
 }
 

--- a/modules/justamcp/tests/test_justamcp_server_listen.h
+++ b/modules/justamcp/tests/test_justamcp_server_listen.h
@@ -33,6 +33,7 @@
 
 void test_justamcp_server_start_listens();
 void test_justamcp_server_failed_listen_does_not_activate();
+void test_justamcp_server_cli_port_wins_over_settings();
 
 TEST_CASE("[Modules][JustAMCP] server start listens") {
 	test_justamcp_server_start_listens();
@@ -40,4 +41,8 @@ TEST_CASE("[Modules][JustAMCP] server start listens") {
 
 TEST_CASE("[Modules][JustAMCP] failed listen does not claim Activated") {
 	test_justamcp_server_failed_listen_does_not_activate();
+}
+
+TEST_CASE("[Modules][JustAMCP] CLI --mcp-port wins over settings") {
+	test_justamcp_server_cli_port_wins_over_settings();
 }

--- a/modules/justamcp/tests/test_justamcp_settings_resolver.cpp
+++ b/modules/justamcp/tests/test_justamcp_settings_resolver.cpp
@@ -30,6 +30,7 @@
 #ifdef TESTS_ENABLED
 
 #include "test_justamcp_settings_resolver.h"
+#include "../justamcp_cli_args.h"
 #include "../tools/justamcp_json_rpc_helpers.h"
 #include "../tools/justamcp_prompt_executor.h"
 #include "../tools/justamcp_resource_manifest.h"
@@ -42,12 +43,52 @@
 #include "tests/test_macros.h"
 
 void test_justamcp_settings_resolver() {
+	// macOS editor CI runs `--test` without `--headless`; fixtures write Project Settings.
+	CHECK(JustAMCPSettingsResolver::uses_project_override());
 	bool cat_enabled = false;
 	bool tool_enabled = false;
 	CHECK(JustAMCPSettingsResolver::resolve_tool_enabled("asset_tags_tools", "blazium_tags_list", true, false, cat_enabled, tool_enabled));
 	CHECK(cat_enabled);
 	CHECK(tool_enabled);
 	CHECK(JustAMCPSettingsResolver::resolve_category_enabled("asset_tags_tools", true));
+}
+
+void test_justamcp_settings_resolver_typed_values() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	CHECK(ps);
+
+	const int prev_port = int(ps->get_setting("blazium/justamcp/server_port", 6506));
+	const String prev_origin = String(ps->get_setting("blazium/justamcp/streamable_http_allowed_origin", ""));
+	const bool prev_override = bool(ps->get_setting("blazium/justamcp/override_editor_settings", false));
+	const bool had_hosts = ps->has_setting("blazium/justamcp/bridge_url_allow_hosts");
+	const Variant prev_hosts = had_hosts ? ps->get_setting("blazium/justamcp/bridge_url_allow_hosts") : Variant();
+
+	ps->set_setting("blazium/justamcp/override_editor_settings", true);
+	ps->set_setting("blazium/justamcp/server_port", 6511);
+	ps->set_setting("blazium/justamcp/streamable_http_allowed_origin", "https://example.test");
+	Array hosts;
+	hosts.push_back("example.test");
+	ps->set_setting("blazium/justamcp/bridge_url_allow_hosts", hosts);
+
+	CHECK(JustAMCPSettingsResolver::resolve_int("blazium/justamcp/server_port", 6506) == 6511);
+	CHECK(JustAMCPSettingsResolver::resolve_string("blazium/justamcp/streamable_http_allowed_origin") == "https://example.test");
+	const Array resolved = JustAMCPSettingsResolver::resolve_array("blazium/justamcp/bridge_url_allow_hosts");
+	CHECK(resolved.size() == 1);
+	CHECK(String(resolved[0]) == "example.test");
+
+	JustAMCPCliArgs::set_test_mcp_port(6512);
+	CHECK(JustAMCPSettingsResolver::resolve_server_port() == 6512);
+	JustAMCPCliArgs::clear_test_overrides();
+	CHECK(JustAMCPSettingsResolver::resolve_server_port() == 6511);
+
+	ps->set_setting("blazium/justamcp/server_port", prev_port);
+	ps->set_setting("blazium/justamcp/streamable_http_allowed_origin", prev_origin);
+	ps->set_setting("blazium/justamcp/override_editor_settings", prev_override);
+	if (had_hosts) {
+		ps->set_setting("blazium/justamcp/bridge_url_allow_hosts", prev_hosts);
+	} else {
+		ps->clear("blazium/justamcp/bridge_url_allow_hosts");
+	}
 }
 
 void test_justamcp_resource_manifest() {

--- a/modules/justamcp/tests/test_justamcp_settings_resolver.h
+++ b/modules/justamcp/tests/test_justamcp_settings_resolver.h
@@ -32,11 +32,16 @@
 #include "tests/test_macros.h"
 
 void test_justamcp_settings_resolver();
+void test_justamcp_settings_resolver_typed_values();
 void test_justamcp_resource_manifest();
 void test_justamcp_list_vs_execute_and_active_count();
 
 TEST_CASE("[Modules][JustAMCP] settings resolver") {
 	test_justamcp_settings_resolver();
+}
+
+TEST_CASE("[Modules][JustAMCP] settings resolver typed values") {
+	test_justamcp_settings_resolver_typed_values();
 }
 
 TEST_CASE("[Modules][JustAMCP] section list budget vs execute") {

--- a/modules/justamcp/tools/justamcp_asset_tags_tools.cpp
+++ b/modules/justamcp/tools/justamcp_asset_tags_tools.cpp
@@ -51,6 +51,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "editor/editor_settings.h"
+#include "justamcp_settings_resolver.h"
 
 #ifdef MODULE_ASSETTAGS_ENABLED
 static void _invalidate_tags_dictionary_cache() {
@@ -115,10 +116,7 @@ Dictionary JustAMCPAssetTagsTools::_require_elicitation(const String &p_action, 
 	const Dictionary schema = justamcp_confirm_enum_schema();
 	const String request_id = p_args.get("request_id", String::num_uint64(OS::get_singleton()->get_ticks_usec()));
 	if (JustAMCPServer *server = JustAMCPServer::get_singleton()) {
-		String demo_url;
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/url_elicitation_demo_url")) {
-			demo_url = String(GLOBAL_GET("blazium/justamcp/url_elicitation_demo_url"));
-		}
+		const String demo_url = JustAMCPSettingsResolver::resolve_string("blazium/justamcp/url_elicitation_demo_url");
 		if (!demo_url.is_empty() && bool(p_args.get("url_elicit", false)) && justamcp_protocol_supports(server->get_negotiated_protocol_version(), JUSTAMCP_FEATURE_ELICITATION_URL)) {
 			server->send_url_elicitation_error(request_id, "elicitation_" + request_id, demo_url, "URL elicitation required for " + p_action);
 		} else {

--- a/modules/justamcp/tools/justamcp_mcp_client_bridge.cpp
+++ b/modules/justamcp/tools/justamcp_mcp_client_bridge.cpp
@@ -42,6 +42,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "editor/editor_settings.h"
+#include "justamcp_settings_resolver.h"
 
 JustAMCPMCPClientBridge *JustAMCPMCPClientBridge::singleton = nullptr;
 static uint64_t g_mcp_client_rpc_id = 1;
@@ -51,10 +52,10 @@ static bool _justamcp_bridge_host_allowed(const String &p_host) {
 	if (host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]") {
 		return true;
 	}
-	if (!ProjectSettings::get_singleton() || !ProjectSettings::get_singleton()->has_setting("blazium/justamcp/bridge_url_allow_hosts")) {
+	const Array allow = JustAMCPSettingsResolver::resolve_array("blazium/justamcp/bridge_url_allow_hosts");
+	if (allow.is_empty()) {
 		return false;
 	}
-	const Array allow = GLOBAL_GET("blazium/justamcp/bridge_url_allow_hosts");
 	for (int i = 0; i < allow.size(); i++) {
 		if (String(allow[i]).strip_edges().to_lower() == host) {
 			return true;
@@ -103,15 +104,11 @@ JustAMCPMCPClientBridge *JustAMCPMCPClientBridge::get_singleton() {
 }
 
 Array JustAMCPMCPClientBridge::_load_bridges() const {
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/mcp_clients")) {
-		return GLOBAL_GET("blazium/justamcp/mcp_clients");
-	}
-	return Array();
+	return JustAMCPSettingsResolver::resolve_array("blazium/justamcp/mcp_clients");
 }
 
 void JustAMCPMCPClientBridge::_save_bridges(const Array &p_bridges) const {
-	ProjectSettings::get_singleton()->set_setting("blazium/justamcp/mcp_clients", p_bridges);
-	ProjectSettings::get_singleton()->save();
+	JustAMCPSettingsResolver::set_array("blazium/justamcp/mcp_clients", p_bridges);
 }
 
 Dictionary JustAMCPMCPClientBridge::_get_bridge_config(const String &p_bridge_name) const {

--- a/modules/justamcp/tools/justamcp_settings_resolver.cpp
+++ b/modules/justamcp/tools/justamcp_settings_resolver.cpp
@@ -27,18 +27,22 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifdef TOOLS_ENABLED
-
 #include "justamcp_settings_resolver.h"
 
+#include "../justamcp_cli_args.h"
 #include "core/config/project_settings.h"
+
+#ifdef TOOLS_ENABLED
 #include "core/templates/hash_map.h"
 #include "editor/editor_settings.h"
+#endif
 
+#ifdef TOOLS_ENABLED
 static HashMap<String, bool> &justamcp_category_defaults() {
 	static HashMap<String, bool> defaults;
 	return defaults;
 }
+#endif
 
 static bool _justamcp_variant_as_bool(const Variant &p_value, bool p_default) {
 	if (p_value.get_type() == Variant::BOOL) {
@@ -53,26 +57,104 @@ static bool _justamcp_variant_as_bool(const Variant &p_value, bool p_default) {
 	return p_value.booleanize();
 }
 
+static Variant _justamcp_read_setting(const String &p_path, bool *r_found) {
+	*r_found = false;
+#ifdef TOOLS_ENABLED
+	if (!JustAMCPSettingsResolver::uses_project_override() && EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting(p_path)) {
+		*r_found = true;
+		return EditorSettings::get_singleton()->get_setting(p_path);
+	}
+#endif
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_path)) {
+		*r_found = true;
+		return ProjectSettings::get_singleton()->get_setting(p_path);
+	}
+	return Variant();
+}
+
 bool JustAMCPSettingsResolver::uses_project_override() {
+	if (JustAMCPCliArgs::is_headless() || JustAMCPCliArgs::is_unit_test()) {
+		return true;
+	}
+#ifdef TOOLS_ENABLED
+	if (!EditorSettings::get_singleton()) {
+		return true;
+	}
+#endif
 	if (!ProjectSettings::get_singleton() || !ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
+#ifndef TOOLS_ENABLED
+		return true;
+#else
 		return false;
+#endif
 	}
 	return GLOBAL_GET("blazium/justamcp/override_editor_settings");
 }
 
 bool JustAMCPSettingsResolver::resolve_bool(const String &p_path, bool p_default) {
-	if (uses_project_override() || !EditorSettings::get_singleton()) {
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting(p_path)) {
-			return _justamcp_variant_as_bool(ProjectSettings::get_singleton()->get_setting(p_path), p_default);
-		}
+	bool found = false;
+	const Variant value = _justamcp_read_setting(p_path, &found);
+	if (!found) {
 		return p_default;
 	}
-	if (EditorSettings::get_singleton()->has_setting(p_path)) {
-		return _justamcp_variant_as_bool(EditorSettings::get_singleton()->get_setting(p_path), p_default);
-	}
-	return p_default;
+	return _justamcp_variant_as_bool(value, p_default);
 }
 
+int JustAMCPSettingsResolver::resolve_int(const String &p_path, int p_default) {
+	bool found = false;
+	const Variant value = _justamcp_read_setting(p_path, &found);
+	if (!found) {
+		return p_default;
+	}
+	return int(value);
+}
+
+String JustAMCPSettingsResolver::resolve_string(const String &p_path, const String &p_default) {
+	bool found = false;
+	const Variant value = _justamcp_read_setting(p_path, &found);
+	if (!found) {
+		return p_default;
+	}
+	return String(value);
+}
+
+Array JustAMCPSettingsResolver::resolve_array(const String &p_path, const Array &p_default) {
+	bool found = false;
+	const Variant value = _justamcp_read_setting(p_path, &found);
+	if (!found || value.get_type() != Variant::ARRAY) {
+		return p_default;
+	}
+	return value;
+}
+
+void JustAMCPSettingsResolver::set_array(const String &p_path, const Array &p_value) {
+#ifdef TOOLS_ENABLED
+	if (!uses_project_override() && EditorSettings::get_singleton()) {
+		EditorSettings::get_singleton()->set_setting(p_path, p_value);
+		return;
+	}
+#endif
+	ERR_FAIL_NULL(ProjectSettings::get_singleton());
+	ProjectSettings::get_singleton()->set_setting(p_path, p_value);
+	ProjectSettings::get_singleton()->save();
+}
+
+int JustAMCPSettingsResolver::resolve_server_port() {
+	const int cli_port = JustAMCPCliArgs::mcp_port();
+	if (cli_port > 0) {
+		return cli_port;
+	}
+	return resolve_int("blazium/justamcp/server_port", 6506);
+}
+
+bool JustAMCPSettingsResolver::resolve_server_enabled() {
+	if (JustAMCPCliArgs::enable_mcp() || JustAMCPCliArgs::enable_mcp_game_control()) {
+		return true;
+	}
+	return resolve_bool("blazium/justamcp/server_enabled", false);
+}
+
+#ifdef TOOLS_ENABLED
 void JustAMCPSettingsResolver::set_category_default(const String &p_category, bool p_is_core) {
 	if (p_category.is_empty()) {
 		return;
@@ -144,5 +226,4 @@ bool JustAMCPSettingsResolver::is_resource_listed(const String &p_name) {
 bool JustAMCPSettingsResolver::resolve_allow_execute_tool_bypass() {
 	return resolve_bool("blazium/justamcp/allow_execute_tool_bypass", false);
 }
-
 #endif

--- a/modules/justamcp/tools/justamcp_settings_resolver.h
+++ b/modules/justamcp/tools/justamcp_settings_resolver.h
@@ -29,14 +29,22 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
-
 #include "core/string/ustring.h"
+#include "core/variant/array.h"
 
 class JustAMCPSettingsResolver {
 public:
 	static bool uses_project_override();
 	static bool resolve_bool(const String &p_path, bool p_default);
+	static int resolve_int(const String &p_path, int p_default);
+	static String resolve_string(const String &p_path, const String &p_default = String());
+	static Array resolve_array(const String &p_path, const Array &p_default = Array());
+	static void set_array(const String &p_path, const Array &p_value);
+
+	static int resolve_server_port();
+	static bool resolve_server_enabled();
+
+#ifdef TOOLS_ENABLED
 	static void set_category_default(const String &p_category, bool p_is_core);
 	static bool resolve_category_enabled(const String &p_category, bool p_default = true);
 	static bool resolve_tool_enabled(const String &p_category, const String &p_full_name, bool p_default = true);
@@ -47,6 +55,5 @@ public:
 	static bool is_prompt_listed(const String &p_name);
 	static bool is_resource_listed(const String &p_name);
 	static bool resolve_allow_execute_tool_bypass();
-};
-
 #endif
+};

--- a/modules/justamcp/tools/justamcp_task_manager.cpp
+++ b/modules/justamcp/tools/justamcp_task_manager.cpp
@@ -37,12 +37,10 @@
 #include "core/os/os.h"
 #include "core/os/thread.h"
 #include "core/os/time.h"
+#include "justamcp_settings_resolver.h"
 
 static int _justamcp_task_result_max_wait_ms() {
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_result_max_wait_ms")) {
-		return int(GLOBAL_GET("blazium/justamcp/task_result_max_wait_ms"));
-	}
-	return 120000;
+	return JustAMCPSettingsResolver::resolve_int("blazium/justamcp/task_result_max_wait_ms", 120000);
 }
 
 void JustAMCPTaskManager::_bind_methods() {
@@ -131,10 +129,7 @@ String JustAMCPTaskManager::create_task(int p_ttl_ms, int p_poll_interval_ms, co
 	MutexLock lock(tasks_mutex);
 	_purge_expired_tasks();
 
-	int max_tasks = 16;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/task_max_concurrent")) {
-		max_tasks = int(GLOBAL_GET("blazium/justamcp/task_max_concurrent"));
-	}
+	const int max_tasks = JustAMCPSettingsResolver::resolve_int("blazium/justamcp/task_max_concurrent", 16);
 	if (tasks.size() >= (uint32_t)max_tasks) {
 		return String();
 	}

--- a/modules/justamcp/tools/justamcp_toolset_registry.cpp
+++ b/modules/justamcp/tools/justamcp_toolset_registry.cpp
@@ -109,18 +109,7 @@ void JustAMCPToolsetRegistry::unregister_toolset(const String &p_name) {
 }
 
 bool JustAMCPToolsetRegistry::is_discovery_enabled() const {
-	bool use_project_override = false;
-	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/override_editor_settings")) {
-		use_project_override = GLOBAL_GET("blazium/justamcp/override_editor_settings");
-	}
-	if (use_project_override || !EditorSettings::get_singleton()) {
-		if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/justamcp/enable_toolset_discovery")) {
-			return GLOBAL_GET("blazium/justamcp/enable_toolset_discovery");
-		}
-	} else if (EditorSettings::get_singleton() && EditorSettings::get_singleton()->has_setting("blazium/justamcp/enable_toolset_discovery")) {
-		return EditorSettings::get_singleton()->get_setting("blazium/justamcp/enable_toolset_discovery");
-	}
-	return false;
+	return JustAMCPSettingsResolver::resolve_bool("blazium/justamcp/enable_toolset_discovery", false);
 }
 
 Array JustAMCPToolsetRegistry::list_toolset_names() const {


### PR DESCRIPTION
## Summary
- Route JustAMCP port, enable flags, and remaining settings through a shared resolver plus CLI helpers so `--mcp-port` / `--enable-mcp` stay applied after settings-changed restarts.
- Advertise the live or CLI port in generated Cursor/AntiGravity/OpenCode MCP JSON, honor `--mcp-port` on the runtime TCP bridge (default 6506), and start that bridge when `game_control_enabled` or `--enable-mcp-game-control` is set.
- Read Editor Settings for list size, logging, task/session/queue limits, OAuth, and MCP client bridges unless project override or headless is active.

## Test plan
- [ ] Run JustAMCP unit tests (`--test-case="*[JustAMCP]*"`) and confirm listen + config JSON cases keep the CLI port over settings.
- [ ] Start the editor with `--mcp-port` and confirm HTTP bind, settings-changed restart, and generated MCP JSON all use that port.
- [ ] Toggle Editor Settings (not Project Settings) for `list_page_size` / `enable_debug_logging` and confirm the process uses those values when override is off.
- [ ] Enable `game_control_enabled` or `--enable-mcp-game-control` and confirm the runtime TCP server starts on 6506 (or `--mcp-port`); `--disable-game-mcp` keeps it off.
