### PR TITLE
Add InterDVD authoring module

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -648,6 +648,39 @@
 		<member name="blazium/gif/max_frames" type="int" setter="" getter="" default="4096">
 			Maximum number of frames accepted when decoding or capturing a GIF.
 		</member>
+		<member name="blazium/inter_dvd/ac3_bitrate_k" type="int" setter="" getter="" default="192">
+			Target AC-3 bitrate in kbps used when muxing Interactive DVD audio.
+		</member>
+		<member name="blazium/inter_dvd/ac3_channels" type="int" setter="" getter="" default="2">
+			Number of AC-3 channels used when muxing Interactive DVD audio.
+		</member>
+		<member name="blazium/inter_dvd/bake_warmup_frames" type="int" setter="" getter="" default="2">
+			Number of warmup frames rendered before baking an Interactive DVD cell.
+		</member>
+		<member name="blazium/inter_dvd/cache_path" type="String" setter="" getter="" default="&quot;res://.inter_dvd_cache&quot;">
+			Directory used to cache Interactive DVD bake and mux artifacts.
+		</member>
+		<member name="blazium/inter_dvd/default_parental_level" type="int" setter="" getter="" default="1">
+			Default parental level written into a new [InterDVDProject] template.
+		</member>
+		<member name="blazium/inter_dvd/default_region_mask" type="int" setter="" getter="" default="1">
+			Default region mask written into a new [InterDVDProject] template.
+		</member>
+		<member name="blazium/inter_dvd/gop_size" type="int" setter="" getter="" default="15">
+			MPEG GOP size used when encoding Interactive DVD video.
+		</member>
+		<member name="blazium/inter_dvd/pip_blackdetect_pix_th" type="float" setter="" getter="" default="0.12">
+			Pixel brightness threshold used when detecting black frames around picture-in-picture cells.
+		</member>
+		<member name="blazium/inter_dvd/pip_blackdetect_sec" type="float" setter="" getter="" default="2.5">
+			Seconds of black-frame detection used around picture-in-picture cells.
+		</member>
+		<member name="blazium/inter_dvd/project" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the [InterDVDProject] resource used by the Windows Interactive DVD exporter.
+		</member>
+		<member name="blazium/inter_dvd/title_safe_bottom" type="int" setter="" getter="" default="432">
+			Lowest safe scanline for Interactive DVD button and overlay placement.
+		</member>
 		<member name="blazium/justamcp/accepted_protocol_versions" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional comma-separated allowlist of MCP protocol versions this process will serve. Empty accepts every implemented version ([code]2026-07-28[/code] through [code]2024-11-05[/code]).
 		</member>

--- a/modules/inter_dvd/SCsub
+++ b/modules/inter_dvd/SCsub
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_inter_dvd = env_modules.Clone()
+
+env_inter_dvd.add_source_files(env.modules_sources, "*.cpp")
+env_inter_dvd.add_source_files(env.modules_sources, "machine/*.cpp")
+env_inter_dvd.add_source_files(env.modules_sources, "author/*.cpp")
+env_inter_dvd.add_source_files(env.modules_sources, "editor/*.cpp")
+env_inter_dvd.add_source_files(env.modules_sources, "editor/export/*.cpp")
+
+if env["tests"]:
+    env_inter_dvd.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_inter_dvd.add_source_files(env.modules_sources, "tests/*.cpp")
+    if env["disable_exceptions"]:
+        env_inter_dvd.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/inter_dvd/author/inter_dvd_ifo_writer.cpp
+++ b/modules/inter_dvd/author/inter_dvd_ifo_writer.cpp
@@ -1,0 +1,1322 @@
+/**************************************************************************/
+/*  inter_dvd_ifo_writer.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "inter_dvd_ifo_writer.h"
+
+#include "inter_dvd_vob_mux.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
+#include "modules/inter_dvd/editor/inter_dvd_scene_baker.h"
+#endif
+
+#include "modules/inter_dvd/machine/inter_dvd_instruction.h"
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/math/math_funcs.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "core/string/print_string.h"
+#include "scene/main/node.h"
+
+void InterDVDExportProgress::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("begin", "total"), &InterDVDExportProgress::begin);
+	ClassDB::bind_method(D_METHOD("report", "label"), &InterDVDExportProgress::report);
+	ClassDB::bind_method(D_METHOD("set_notify", "callable"), &InterDVDExportProgress::set_notify);
+	ClassDB::bind_method(D_METHOD("get_notify"), &InterDVDExportProgress::get_notify);
+	ClassDB::bind_method(D_METHOD("get_step"), &InterDVDExportProgress::get_step);
+	ClassDB::bind_method(D_METHOD("get_total"), &InterDVDExportProgress::get_total);
+	ClassDB::bind_method(D_METHOD("get_label"), &InterDVDExportProgress::get_label);
+	ClassDB::bind_method(D_METHOD("get_started_usec"), &InterDVDExportProgress::get_started_usec);
+	ClassDB::bind_method(D_METHOD("format_line"), &InterDVDExportProgress::format_line);
+	ClassDB::bind_static_method("InterDVDExportProgress", D_METHOD("format_clock", "usec"), &InterDVDExportProgress::format_clock);
+	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "notify"), "set_notify", "get_notify");
+}
+
+String InterDVDExportProgress::format_clock(int64_t p_usec) {
+	const int64_t sec = MAX(p_usec, 0) / 1000000;
+	const int hours = int(sec / 3600);
+	const int minutes = int((sec % 3600) / 60);
+	const int seconds = int(sec % 60);
+	if (hours > 0) {
+		return vformat("%02d:%02d:%02d", hours, minutes, seconds);
+	}
+	return vformat("%02d:%02d", minutes, seconds);
+}
+
+void InterDVDExportProgress::begin(int p_total) {
+	if (started_usec == 0) {
+		started_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
+	}
+	if (total <= 0) {
+		total = MAX(p_total, 1);
+	}
+	step = 0;
+}
+
+String InterDVDExportProgress::format_line() const {
+	const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : started_usec;
+	const int64_t elapsed = int64_t(now - started_usec);
+	String eta = "--:--";
+	if (step > 0 && total > step) {
+		eta = format_clock(int64_t(double(elapsed) * (double(total) / double(step) - 1.0)));
+	} else if (step >= total && total > 0) {
+		eta = "00:00";
+	}
+	return vformat("[%d/%d] %s  elapsed %s  eta %s", step, total, label, format_clock(elapsed), eta);
+}
+
+void InterDVDExportProgress::report(const String &p_label) {
+	if (started_usec == 0) {
+		started_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
+	}
+	if (total <= 0) {
+		total = 1;
+	}
+	step++;
+	label = p_label;
+	const String line = format_line();
+	print_line(vformat("export_dvd: %s", line));
+#ifdef TOOLS_ENABLED
+	if (EditorNode::get_singleton()) {
+		EditorNode::progress_task_step("inter_dvd", line, MAX(step - 1, 0));
+	}
+#endif
+	if (notify.is_valid()) {
+		notify.call(step, total, label, line);
+	}
+}
+
+void InterDVDIfoWriter::_bind_methods() {
+	ClassDB::bind_static_method("InterDVDIfoWriter", D_METHOD("write_video_ts", "root", "project", "allow_dummy_vob", "ffmpeg", "auto_find_ffmpeg", "progress"), &InterDVDIfoWriter::write_video_ts_bind, DEFVAL(false), DEFVAL(String()), DEFVAL(true), DEFVAL(Ref<InterDVDExportProgress>()));
+	ClassDB::bind_static_method("InterDVDIfoWriter", D_METHOD("iso_tool_args", "tool", "volume_id", "work_dir", "out_path"), &InterDVDIfoWriter::iso_tool_args);
+}
+
+Vector<String> InterDVDIfoWriter::iso_tool_args(const String &p_tool, const String &p_volume_id, const String &p_work_dir, const String &p_out) {
+	Vector<String> args;
+	const String volume = InterDVDProject::sanitize_volume_id(p_volume_id);
+	const String tool_name = p_tool.get_file().to_lower();
+	if (tool_name.contains("mkisofs") || tool_name.contains("genisoimage")) {
+		args.push_back("-dvd-video");
+		args.push_back("-V");
+		args.push_back(volume);
+		args.push_back("-o");
+		args.push_back(p_out);
+		args.push_back(p_work_dir);
+	} else {
+		args.push_back("-u2");
+		args.push_back("-l" + volume);
+		args.push_back(p_work_dir);
+		args.push_back(p_out);
+	}
+	return args;
+}
+
+Error InterDVDIfoWriter::write_video_ts_bind(const String &p_root, const Ref<InterDVDProject> &p_project, bool p_allow_dummy_vob, const String &p_ffmpeg, bool p_auto_find_ffmpeg, const Ref<InterDVDExportProgress> &p_progress) {
+	String err;
+	const Error code = write_video_ts(p_root, p_project, p_allow_dummy_vob, p_ffmpeg, &err, p_auto_find_ffmpeg, p_progress);
+	if (code != OK && !err.is_empty()) {
+		ERR_PRINT(err);
+	}
+	return code;
+}
+
+namespace {
+
+constexpr int SECTOR = InterDVDIfoWriter::SECTOR_SIZE;
+constexpr int IFO_SECTORS = 16;
+
+void write_be16(Vector<uint8_t> &p_buf, int p_off, uint16_t p_value) {
+	p_buf.write[p_off] = uint8_t((p_value >> 8) & 0xFF);
+	p_buf.write[p_off + 1] = uint8_t(p_value & 0xFF);
+}
+
+void write_be32(Vector<uint8_t> &p_buf, int p_off, uint32_t p_value) {
+	p_buf.write[p_off] = uint8_t((p_value >> 24) & 0xFF);
+	p_buf.write[p_off + 1] = uint8_t((p_value >> 16) & 0xFF);
+	p_buf.write[p_off + 2] = uint8_t((p_value >> 8) & 0xFF);
+	p_buf.write[p_off + 3] = uint8_t(p_value & 0xFF);
+}
+
+void write_ident(Vector<uint8_t> &p_buf, const char *p_id) {
+	for (int i = 0; p_id[i] && i < 12; i++) {
+		p_buf.write[i] = uint8_t(p_id[i]);
+	}
+}
+
+Error write_file(const String &p_path, const Vector<uint8_t> &p_data) {
+	Error err = OK;
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	if (err != OK || f.is_null()) {
+		return err == OK ? ERR_CANT_CREATE : err;
+	}
+	f->store_buffer(p_data.ptr(), p_data.size());
+	return OK;
+}
+
+void append_commands(Vector<uint8_t> &p_cmds, const TypedArray<PackedByteArray> &p_list) {
+	for (int i = 0; i < p_list.size(); i++) {
+		const PackedByteArray cmd = p_list[i];
+		if (cmd.size() != 8) {
+			continue;
+		}
+		const int off = p_cmds.size();
+		p_cmds.resize(off + 8);
+		for (int b = 0; b < 8; b++) {
+			p_cmds.write[off + b] = cmd[b];
+		}
+	}
+}
+
+void append_cmd8(Vector<uint8_t> &p_pre, const uint8_t p_bytes[8]) {
+	const int off = p_pre.size();
+	p_pre.resize(off + 8);
+	for (int i = 0; i < 8; i++) {
+		p_pre.write[off + i] = p_bytes[i];
+	}
+}
+
+void append_default_jump_tt(Vector<uint8_t> &p_pre) {
+	const uint8_t jump_tt[8] = { 0x30, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00 };
+	append_cmd8(p_pre, jump_tt);
+}
+
+void append_default_jump_ss_title_menu(Vector<uint8_t> &p_pre) {
+	const uint8_t jump_ss[8] = { 0x30, 0x06, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00 };
+	append_cmd8(p_pre, jump_ss);
+}
+
+void write_ascii(Vector<uint8_t> &p_buf, int p_off, const String &p_text, int p_max) {
+	const CharString utf = p_text.utf8();
+	const char *ptr = utf.get_data();
+	for (int i = 0; ptr && ptr[i] && i < p_max; i++) {
+		p_buf.write[p_off + i] = uint8_t(ptr[i]);
+	}
+}
+
+void write_yuv_clut_entry(Vector<uint8_t> &p_buf, int p_off, const Color &p_color) {
+	const int y = CLAMP(int(16.0 + 65.481 * p_color.r + 128.553 * p_color.g + 24.966 * p_color.b), 16, 235);
+	const int cb = CLAMP(int(128.0 - 37.797 * p_color.r - 74.203 * p_color.g + 112.0 * p_color.b), 16, 240);
+	const int cr = CLAMP(int(128.0 + 112.0 * p_color.r - 93.786 * p_color.g - 18.214 * p_color.b), 16, 240);
+	p_buf.write[p_off] = 0;
+	p_buf.write[p_off + 1] = uint8_t(y);
+	p_buf.write[p_off + 2] = uint8_t(cr);
+	p_buf.write[p_off + 3] = uint8_t(cb);
+}
+
+void write_pgc_clut(Vector<uint8_t> &p_pgc, const PackedColorArray &p_clut) {
+	const uint8_t fallback[4][4] = {
+		{ 0, 16, 128, 128 },
+		{ 0, 210, 146, 16 },
+		{ 0, 90, 240, 110 },
+		{ 0, 235, 128, 128 },
+	};
+	for (int i = 0; i < 16; i++) {
+		if (i < p_clut.size()) {
+			write_yuv_clut_entry(p_pgc, 0xA4 + i * 4, p_clut[i]);
+		} else {
+			const int src = MIN(i, 3);
+			p_pgc.write[0xA4 + i * 4] = fallback[src][0];
+			p_pgc.write[0xA4 + i * 4 + 1] = fallback[src][1];
+			p_pgc.write[0xA4 + i * 4 + 2] = fallback[src][2];
+			p_pgc.write[0xA4 + i * 4 + 3] = fallback[src][3];
+		}
+	}
+}
+
+void write_audio_attr(Vector<uint8_t> &p_buf, int p_off, uint16_t p_lang) {
+	p_buf.write[p_off] = 0x00;
+	p_buf.write[p_off + 1] = 0x01;
+	write_be16(p_buf, p_off + 2, p_lang);
+	p_buf.write[p_off + 4] = 0;
+	p_buf.write[p_off + 5] = 1;
+}
+
+void write_subp_attr(Vector<uint8_t> &p_buf, int p_off, uint16_t p_lang) {
+	p_buf.write[p_off] = 0x01;
+	p_buf.write[p_off] = 0x40;
+	p_buf.write[p_off + 1] = 0;
+	write_be16(p_buf, p_off + 2, p_lang);
+	p_buf.write[p_off + 4] = 0;
+	p_buf.write[p_off + 5] = 1;
+}
+
+Vector<uint8_t> make_txtdt_mgi(const String &p_disc_title, const String &p_serial, uint16_t p_lang, const Vector<String> &p_titles) {
+	Vector<uint8_t> buf;
+	buf.resize(28);
+	buf.fill(0);
+	const String name = p_disc_title.is_empty() ? p_serial : p_disc_title;
+	write_ascii(buf, 0, InterDVDProject::sanitize_volume_id(name.is_empty() ? String("BLAZIUM_DVD") : name), 12);
+	write_be16(buf, 14, 1);
+	write_be32(buf, 16, 27);
+	write_be16(buf, 20, p_lang);
+	buf.write[23] = 0x01;
+	write_be32(buf, 24, 28);
+	(void)p_titles;
+	return buf;
+}
+
+uint8_t to_bcd(int p_value) {
+	const int v = CLAMP(p_value, 0, 99);
+	return uint8_t(((v / 10) << 4) | (v % 10));
+}
+
+void write_ntsc_playback(Vector<uint8_t> &p_buf, int p_off, double p_seconds) {
+	const int total = MAX(int(Math::round(MAX(p_seconds, 0.0) * 30.0)), 1);
+	const int hh = total / (30 * 3600);
+	const int mm = (total / (30 * 60)) % 60;
+	const int ss = (total / 30) % 60;
+	const int ff = total % 30;
+	p_buf.write[p_off] = to_bcd(hh);
+	p_buf.write[p_off + 1] = to_bcd(mm);
+	p_buf.write[p_off + 2] = to_bcd(ss);
+	p_buf.write[p_off + 3] = uint8_t(0xC0 | to_bcd(ff));
+}
+
+double resolve_playback_sec(const Ref<InterDVDCell> &p_cell, const String &p_vob, const String &p_ffmpeg = String()) {
+	const double authored = (p_cell.is_valid() && p_cell->get_duration_sec() > 0.0) ? p_cell->get_duration_sec() : 0.0;
+	const double probed = FileAccess::exists(p_vob) ? InterDVDVobMux::estimate_duration_sec(p_vob) : 0.0;
+	double pip = 0.0;
+	double src = 0.0;
+	if (p_cell.is_valid()) {
+		const String pip_path = p_cell->get_pip_source_path();
+		if (!pip_path.is_empty() && FileAccess::exists(pip_path)) {
+			pip = InterDVDVobMux::probe_media_sec(pip_path, p_ffmpeg) + MAX(p_cell->get_loop_pad_sec(), 0.0);
+		}
+		const String src_path = p_cell->get_source_path();
+		if (!src_path.is_empty() && FileAccess::exists(src_path)) {
+			src = InterDVDVobMux::probe_media_sec(src_path, p_ffmpeg);
+		}
+		const String enc = p_cell->get_encoded_path();
+		if (src <= 0.0 && !enc.is_empty() && enc != p_vob && FileAccess::exists(enc)) {
+			src = InterDVDVobMux::estimate_duration_sec(enc);
+		}
+	}
+	double sec = MAX(authored, MAX(probed, MAX(pip, src)));
+	const uint32_t sectors = FileAccess::exists(p_vob) ? InterDVDVobMux::sector_count(p_vob) : 0;
+	if (sec <= 2.25 && sectors > 400) {
+		sec = MAX(sec, (double(sectors) * 2048.0 * 8.0) / 5500000.0);
+	}
+	if (sec <= 0.0) {
+		sec = 2.0;
+	}
+	if (p_cell.is_valid() && sec > p_cell->get_duration_sec() + 0.05) {
+		p_cell->set_duration_sec(sec);
+	}
+
+
+	return sec;
+}
+
+struct CellPlayback {
+	uint32_t first_sector = 0;
+	uint32_t last_vobu = 0;
+	uint32_t last_sector = 0;
+	uint8_t still_time = 0;
+	uint8_t cell_cmd = 0;
+	uint8_t cell_id = 1;
+	double playback_sec = 2.0;
+};
+
+Vector<uint8_t> build_pgc(const Vector<uint8_t> &p_pre, const Vector<uint8_t> &p_post, const Vector<uint8_t> &p_cell_cmds, const Vector<CellPlayback> &p_cells, uint16_t p_next_pgc = 0, uint16_t p_prev_pgc = 0, double p_playback_sec = 2.0, bool p_has_audio = true, const PackedColorArray &p_clut = PackedColorArray(), int p_audio_streams = -1, int p_subp_streams = 0) {
+	const int programs = p_cells.size();
+	const int cells = p_cells.size();
+	const int pre_n = p_pre.size() / 8;
+	const int post_n = p_post.size() / 8;
+	const int cell_n = p_cell_cmds.size() / 8;
+	const int cmd_tbl = 0xEC;
+	const int cmd_bytes = 8 + p_pre.size() + p_post.size() + p_cell_cmds.size();
+	const int prog_off = (programs > 0) ? (cmd_tbl + cmd_bytes) : 0;
+	const int cell_pb_off = (cells > 0) ? (prog_off + programs) : 0;
+	const int cell_pos_off = (cells > 0) ? (cell_pb_off + cells * 24) : 0;
+	const int total = (cells > 0) ? (cell_pos_off + cells * 4) : (cmd_tbl + cmd_bytes);
+
+	Vector<uint8_t> pgc;
+	pgc.resize(total);
+	pgc.fill(0);
+	pgc.write[2] = uint8_t(programs);
+	pgc.write[3] = uint8_t(cells);
+	write_ntsc_playback(pgc, 4, p_playback_sec);
+	if (programs > 0 || cells > 0 || pre_n + post_n + cell_n > 0) {
+		write_be16(pgc, 0xE4, uint16_t(cmd_tbl));
+	}
+	if (prog_off > 0) {
+		write_be16(pgc, 0xE6, uint16_t(prog_off));
+	}
+	if (cell_pb_off > 0) {
+		write_be16(pgc, 0xE8, uint16_t(cell_pb_off));
+		write_be16(pgc, 0xEA, uint16_t(cell_pos_off));
+	}
+
+	pgc.write[cmd_tbl] = uint8_t((pre_n >> 8) & 0xFF);
+	pgc.write[cmd_tbl + 1] = uint8_t(pre_n & 0xFF);
+	pgc.write[cmd_tbl + 2] = uint8_t((post_n >> 8) & 0xFF);
+	pgc.write[cmd_tbl + 3] = uint8_t(post_n & 0xFF);
+	pgc.write[cmd_tbl + 4] = uint8_t((cell_n >> 8) & 0xFF);
+	pgc.write[cmd_tbl + 5] = uint8_t(cell_n & 0xFF);
+
+	write_be16(pgc, cmd_tbl + 6, uint16_t(cmd_bytes - 1));
+	int c = cmd_tbl + 8;
+	for (int i = 0; i < p_pre.size(); i++) {
+		pgc.write[c++] = p_pre[i];
+	}
+	for (int i = 0; i < p_post.size(); i++) {
+		pgc.write[c++] = p_post[i];
+	}
+	for (int i = 0; i < p_cell_cmds.size(); i++) {
+		pgc.write[c++] = p_cell_cmds[i];
+	}
+	if (programs > 0) {
+		for (int i = 0; i < programs; i++) {
+			pgc.write[prog_off + i] = uint8_t(i + 1);
+		}
+	}
+	if (p_next_pgc != 0) {
+		write_be16(pgc, 0x9C, p_next_pgc);
+	}
+	if (p_prev_pgc != 0) {
+		write_be16(pgc, 0x9E, p_prev_pgc);
+	} else if (p_next_pgc != 0) {
+		write_be16(pgc, 0x9E, p_next_pgc);
+	}
+	const int audio_n = p_audio_streams >= 0 ? CLAMP(p_audio_streams, 0, 8) : (p_has_audio ? 1 : 0);
+	if (cells > 0) {
+		for (int i = 0; i < audio_n; i++) {
+			pgc.write[0x0C + i] = 0x80;
+		}
+		const int subp_n = CLAMP(p_subp_streams, 0, 32);
+		for (int i = 0; i < subp_n; i++) {
+			pgc.write[0x1C + i * 4] = 0x80;
+		}
+		write_pgc_clut(pgc, p_clut);
+		for (int i = 0; i < cells; i++) {
+			const CellPlayback &cell = p_cells[i];
+			const int off = cell_pb_off + i * 24;
+
+			pgc.write[off] = 0x02;
+			pgc.write[off + 2] = cell.still_time;
+			pgc.write[off + 3] = cell.cell_cmd;
+			write_ntsc_playback(pgc, off + 4, cell.playback_sec);
+			write_be32(pgc, off + 8, cell.first_sector);
+			write_be32(pgc, off + 16, cell.last_vobu);
+			write_be32(pgc, off + 20, cell.last_sector);
+			write_be16(pgc, cell_pos_off + i * 4, 1);
+			pgc.write[cell_pos_off + i * 4 + 3] = cell.cell_id;
+		}
+	}
+	return pgc;
+}
+
+int table_sectors(int p_bytes) {
+	return MAX((p_bytes + SECTOR - 1) / SECTOR, 1);
+}
+
+void copy_table(Vector<uint8_t> &p_buf, int p_off, const Vector<uint8_t> &p_src) {
+	for (int i = 0; i < p_src.size(); i++) {
+		const int dest = p_off + i;
+		if (dest >= 0 && dest < p_buf.size()) {
+			p_buf.write[dest] = p_src[i];
+		}
+	}
+}
+
+struct DiscIdent {
+	String provider = "BLAZIUM INTER-DVD";
+	String disc_title;
+	String serial;
+	uint16_t menu_lang = 0x656E;
+	uint16_t audio_lang = 0x656E;
+	uint16_t subp_lang = 0x656E;
+};
+
+struct MenuPgcSpec {
+	uint8_t menu_id = 2;
+	uint8_t still_time = 0;
+	uint16_t next_pgc = 1;
+	uint16_t prev_pgc = 1;
+	double playback_sec = 2.0;
+	bool has_audio = false;
+	int audio_streams = 0;
+	int subp_streams = 0;
+	PackedColorArray clut;
+	Vector<CellPlayback> cells;
+};
+
+Vector<uint8_t> build_menu_pgc(const MenuPgcSpec &p_spec, const Vector<uint8_t> &p_fallback_pre) {
+	if (!p_spec.cells.is_empty()) {
+		return build_pgc(Vector<uint8_t>(), Vector<uint8_t>(), Vector<uint8_t>(), p_spec.cells, p_spec.next_pgc, p_spec.prev_pgc, p_spec.playback_sec, p_spec.has_audio, p_spec.clut, p_spec.audio_streams, p_spec.subp_streams);
+	}
+	return build_pgc(p_fallback_pre, Vector<uint8_t>(), Vector<uint8_t>(), Vector<CellPlayback>());
+}
+
+Vector<uint8_t> make_pgci_ut(const Vector<MenuPgcSpec> &p_menus, uint16_t p_lang, const Vector<uint8_t> &p_fallback_pre) {
+	Vector<MenuPgcSpec> menus = p_menus;
+	if (menus.is_empty()) {
+		MenuPgcSpec dummy;
+		dummy.menu_id = 2;
+		menus.push_back(dummy);
+	}
+	Vector<Vector<uint8_t>> pgcs;
+	for (int i = 0; i < menus.size(); i++) {
+		pgcs.push_back(build_menu_pgc(menus[i], p_fallback_pre));
+	}
+	const int n = pgcs.size();
+	const int srp_bytes = 8 + 8 * n;
+	int pgc_bytes = 0;
+	for (int i = 0; i < n; i++) {
+		pgc_bytes += pgcs[i].size();
+	}
+	Vector<uint8_t> buf;
+	buf.resize(16 + srp_bytes + pgc_bytes);
+	buf.fill(0);
+	write_be16(buf, 0, 1);
+	write_be32(buf, 4, uint32_t(buf.size() - 1));
+	write_be16(buf, 8, p_lang);
+	uint8_t exists = 0x80;
+	for (int i = 0; i < menus.size(); i++) {
+		const uint8_t menu_id = uint8_t(CLAMP(int(menus[i].menu_id), 2, 7));
+		if (menu_id != 2) {
+			exists = uint8_t(0x80 | menu_id);
+		}
+	}
+	buf.write[11] = exists;
+	write_be32(buf, 12, 16);
+	write_be16(buf, 16, uint16_t(n));
+	write_be32(buf, 20, uint32_t(srp_bytes + pgc_bytes - 1));
+	int cursor = srp_bytes;
+	for (int i = 0; i < n; i++) {
+		const uint8_t menu_id = uint8_t(CLAMP(int(menus[i].menu_id), 2, 7));
+		buf.write[24 + i * 8] = uint8_t(0x80 | menu_id);
+		write_be32(buf, 28 + i * 8, uint32_t(cursor));
+		for (int b = 0; b < pgcs[i].size(); b++) {
+			buf.write[16 + cursor + b] = pgcs[i][b];
+		}
+		cursor += pgcs[i].size();
+	}
+	return buf;
+}
+
+Vector<uint8_t> make_vmg_ifo(int p_title_count, int p_region_mask, uint32_t p_vts_start_sector, const Vector<uint8_t> &p_fp_pre, const Vector<int> &p_chapters, const Vector<MenuPgcSpec> &p_title_menus, const DiscIdent &p_ident, const Vector<String> &p_title_names = Vector<String>()) {
+	Vector<uint8_t> buf;
+	buf.resize(IFO_SECTORS * SECTOR);
+	buf.fill(0);
+	write_ident(buf, "DVDVIDEO-VMG");
+	write_be32(buf, 0x0C, uint32_t(IFO_SECTORS * 2));
+	write_be32(buf, 0x1C, uint32_t(IFO_SECTORS - 1));
+	write_be16(buf, 0x20, 0x0011);
+	write_be16(buf, 0x26, 1);
+	write_be16(buf, 0x28, 1);
+	buf.write[0x2A] = 1;
+	write_be16(buf, 0x3E, 1);
+	write_ascii(buf, 0x40, p_ident.provider.is_empty() ? String("BLAZIUM INTER-DVD") : p_ident.provider, 32);
+	const uint32_t fp_off = 0x0400;
+	write_be32(buf, 0x84, fp_off);
+	write_be32(buf, 0xC0, uint32_t(IFO_SECTORS));
+	write_be32(buf, 0xC4, 1);
+	write_be32(buf, 0xC8, 3);
+	write_be32(buf, 0xD0, 2);
+
+	buf.write[0x22] = uint8_t((~uint8_t(p_region_mask)) & 0xFF);
+	int menu_audio = 0;
+	int menu_subp = 0;
+	for (int i = 0; i < p_title_menus.size(); i++) {
+		menu_audio = MAX(menu_audio, p_title_menus[i].audio_streams);
+		if (p_title_menus[i].has_audio) {
+			menu_audio = MAX(menu_audio, 1);
+		}
+		menu_subp = MAX(menu_subp, p_title_menus[i].subp_streams);
+	}
+	write_be16(buf, 0x100, 0x4000);
+	write_be16(buf, 0x102, uint16_t(CLAMP(menu_audio, 0, 8)));
+	for (int i = 0; i < menu_audio && i < 8; i++) {
+		write_audio_attr(buf, 0x104 + i * 8, p_ident.audio_lang);
+	}
+	write_be16(buf, 0x254, uint16_t(CLAMP(menu_subp, 0, 32)));
+	for (int i = 0; i < menu_subp && i < 32; i++) {
+		write_subp_attr(buf, 0x256 + i * 6, p_ident.subp_lang);
+	}
+
+	const Vector<uint8_t> fp = build_pgc(p_fp_pre, Vector<uint8_t>(), Vector<uint8_t>(), Vector<CellPlayback>());
+	for (int i = 0; i < fp.size() && (int(fp_off) + i) < buf.size(); i++) {
+		buf.write[int(fp_off) + i] = fp[i];
+	}
+
+	write_be32(buf, 0x80, uint32_t(fp_off + MAX(fp.size(), 1) - 1));
+
+	const int tt = SECTOR;
+	const int title_n = MAX(p_title_count, 1);
+	write_be16(buf, tt, uint16_t(title_n));
+	write_be32(buf, tt + 4, uint32_t(8 + 12 * title_n - 1));
+	for (int i = 0; i < title_n; i++) {
+		const int off = tt + 8 + i * 12;
+		buf.write[off] = 0x3C;
+		buf.write[off + 1] = 1;
+		const int chapters = (i < p_chapters.size() && p_chapters[i] > 0) ? p_chapters[i] : 1;
+		write_be16(buf, off + 2, uint16_t(chapters));
+		write_be16(buf, off + 4, 1);
+		buf.write[off + 6] = 1;
+		buf.write[off + 7] = uint8_t(i + 1);
+		write_be32(buf, off + 8, p_vts_start_sector);
+	}
+
+	const int atrt = SECTOR * 2;
+	write_be16(buf, atrt, 1);
+	write_be32(buf, atrt + 4, 8 + 4 + 0x300 - 1);
+	write_be32(buf, atrt + 8, 12);
+	write_be32(buf, atrt + 12, 0x300);
+
+	const int ut = SECTOR * 3;
+	const Vector<uint8_t> ut_buf = make_pgci_ut(p_title_menus, p_ident.menu_lang, p_fp_pre);
+	copy_table(buf, ut, ut_buf);
+
+	if (!p_ident.disc_title.is_empty()) {
+		write_be32(buf, 0xD4, 4);
+		copy_table(buf, SECTOR * 4, make_txtdt_mgi(p_ident.disc_title, p_ident.serial, p_ident.menu_lang, p_title_names));
+	}
+	return buf;
+}
+
+struct TitlePart {
+	uint8_t still_time = 0;
+	uint16_t next_pgc = 0;
+	uint16_t prev_pgc = 0;
+	double playback_sec = 2.0;
+	bool has_audio = true;
+	int audio_streams = 0;
+	int subp_streams = 0;
+	PackedColorArray clut;
+	Vector<uint16_t> audio_langs;
+	Vector<uint8_t> pre;
+	Vector<uint8_t> post;
+	Vector<uint8_t> cell_cmds;
+	Vector<CellPlayback> cells;
+};
+
+Vector<uint8_t> make_vts_ifo(uint32_t p_title_sectors, const Vector<uint32_t> &p_vobus, const Vector<TitlePart> &p_parts, const DiscIdent &p_ident, const Vector<MenuPgcSpec> &p_vtsm, uint32_t p_vtsm_sectors, const Vector<uint32_t> &p_vtsm_vobus) {
+	const int part_n = MAX(p_parts.size(), 1);
+
+	int total_ptt = 0;
+	int total_cells = 0;
+	for (int i = 0; i < part_n; i++) {
+		const int chapters = (i < p_parts.size() && p_parts[i].cells.size() > 0) ? p_parts[i].cells.size() : 1;
+		total_ptt += chapters;
+		total_cells += chapters;
+	}
+
+	Vector<uint8_t> ptt_buf;
+	ptt_buf.resize(8 + 4 * part_n + 4 * total_ptt);
+	ptt_buf.fill(0);
+	write_be16(ptt_buf, 0, uint16_t(part_n));
+	write_be32(ptt_buf, 4, uint32_t(ptt_buf.size() - 1));
+	int ptt_cursor = 8 + 4 * part_n;
+	for (int i = 0; i < part_n; i++) {
+		write_be32(ptt_buf, 8 + i * 4, uint32_t(ptt_cursor));
+		const int chapters = (i < p_parts.size() && p_parts[i].cells.size() > 0) ? p_parts[i].cells.size() : 1;
+		for (int c = 0; c < chapters; c++) {
+			write_be16(ptt_buf, ptt_cursor, uint16_t(i + 1));
+			write_be16(ptt_buf, ptt_cursor + 2, uint16_t(c + 1));
+			ptt_cursor += 4;
+		}
+	}
+
+	Vector<Vector<uint8_t>> pgcs;
+	for (int i = 0; i < part_n; i++) {
+		if (i < p_parts.size() && !p_parts[i].cells.is_empty()) {
+			const TitlePart &p = p_parts[i];
+			pgcs.push_back(build_pgc(p.pre, p.post, p.cell_cmds, p.cells, p.next_pgc, p.prev_pgc, p.playback_sec, p.has_audio, p.clut, p.audio_streams, p.subp_streams));
+		} else {
+			Vector<CellPlayback> dummy;
+			CellPlayback cell;
+			cell.last_sector = p_title_sectors ? (p_title_sectors - 1) : 0;
+			dummy.push_back(cell);
+			pgcs.push_back(build_pgc(Vector<uint8_t>(), Vector<uint8_t>(), Vector<uint8_t>(), dummy));
+		}
+	}
+	int pgc_rel = 8 + 8 * part_n;
+	int pgc_bytes = 0;
+	for (int i = 0; i < pgcs.size(); i++) {
+		pgc_bytes += pgcs[i].size();
+	}
+	Vector<uint8_t> pgcit_buf;
+	pgcit_buf.resize(pgc_rel + pgc_bytes);
+	pgcit_buf.fill(0);
+	write_be16(pgcit_buf, 0, uint16_t(part_n));
+	write_be32(pgcit_buf, 4, uint32_t(pgcit_buf.size() - 1));
+	int cursor = pgc_rel;
+	for (int i = 0; i < pgcs.size(); i++) {
+		pgcit_buf.write[8 + i * 8] = uint8_t(0x80 | (i + 1));
+		write_be32(pgcit_buf, 12 + i * 8, uint32_t(cursor));
+		for (int b = 0; b < pgcs[i].size(); b++) {
+			pgcit_buf.write[cursor + b] = pgcs[i][b];
+		}
+		cursor += pgcs[i].size();
+	}
+
+	Vector<uint8_t> cadt_buf;
+	cadt_buf.resize(8 + 12 * total_cells);
+	cadt_buf.fill(0);
+	write_be16(cadt_buf, 0, uint16_t(total_cells));
+	write_be32(cadt_buf, 4, uint32_t(cadt_buf.size() - 1));
+	int cadt_i = 0;
+	for (int i = 0; i < part_n; i++) {
+		if (i < p_parts.size() && !p_parts[i].cells.is_empty()) {
+			for (int c = 0; c < p_parts[i].cells.size(); c++) {
+				const int off = 8 + cadt_i * 12;
+				write_be16(cadt_buf, off, 1);
+				cadt_buf.write[off + 2] = p_parts[i].cells[c].cell_id;
+				cadt_buf.write[off + 3] = 0;
+				write_be32(cadt_buf, off + 4, p_parts[i].cells[c].first_sector);
+				write_be32(cadt_buf, off + 8, p_parts[i].cells[c].last_sector);
+				cadt_i++;
+			}
+		} else {
+			const int off = 8 + cadt_i * 12;
+			write_be16(cadt_buf, off, 1);
+			cadt_buf.write[off + 2] = uint8_t(cadt_i + 1);
+			write_be32(cadt_buf, off + 4, 0);
+			write_be32(cadt_buf, off + 8, p_title_sectors ? (p_title_sectors - 1) : 0);
+			cadt_i++;
+		}
+	}
+
+	const int map_bytes = 4 + MAX(p_vobus.size(), 1) * 4;
+	Vector<uint8_t> admap_buf;
+	admap_buf.resize(map_bytes);
+	admap_buf.fill(0);
+	write_be32(admap_buf, 0, uint32_t(MAX(map_bytes - 1, 3)));
+	if (p_vobus.is_empty()) {
+		write_be32(admap_buf, 4, 0);
+	} else {
+		for (int i = 0; i < p_vobus.size(); i++) {
+			write_be32(admap_buf, 4 + i * 4, p_vobus[i]);
+		}
+	}
+
+	const Vector<uint8_t> vtsm_buf = make_pgci_ut(p_vtsm, p_ident.menu_lang, Vector<uint8_t>());
+
+	int vtsm_cells = 0;
+	for (int i = 0; i < p_vtsm.size(); i++) {
+		vtsm_cells += p_vtsm[i].cells.size();
+	}
+	Vector<uint8_t> vtsm_cadt;
+	if (vtsm_cells > 0) {
+		vtsm_cadt.resize(8 + 12 * vtsm_cells);
+		vtsm_cadt.fill(0);
+		write_be16(vtsm_cadt, 0, uint16_t(vtsm_cells));
+		write_be32(vtsm_cadt, 4, uint32_t(vtsm_cadt.size() - 1));
+		int vi = 0;
+		for (int i = 0; i < p_vtsm.size(); i++) {
+			for (int c = 0; c < p_vtsm[i].cells.size(); c++) {
+				const int off = 8 + vi * 12;
+				write_be16(vtsm_cadt, off, 1);
+				vtsm_cadt.write[off + 2] = p_vtsm[i].cells[c].cell_id;
+				write_be32(vtsm_cadt, off + 4, p_vtsm[i].cells[c].first_sector);
+				write_be32(vtsm_cadt, off + 8, p_vtsm[i].cells[c].last_sector);
+				vi++;
+			}
+		}
+	}
+	Vector<uint8_t> vtsm_admap;
+	if (!p_vtsm_vobus.is_empty() && vtsm_cells > 0) {
+		const int vtsm_map = 4 + p_vtsm_vobus.size() * 4;
+		vtsm_admap.resize(vtsm_map);
+		vtsm_admap.fill(0);
+		write_be32(vtsm_admap, 0, uint32_t(MAX(vtsm_map - 1, 3)));
+		for (int i = 0; i < p_vtsm_vobus.size(); i++) {
+			write_be32(vtsm_admap, 4 + i * 4, p_vtsm_vobus[i]);
+		}
+	}
+
+	int sec = 1;
+	const int ptt_sec = sec;
+	sec += table_sectors(ptt_buf.size());
+	const int pgcit_sec = sec;
+	sec += table_sectors(pgcit_buf.size());
+	const int cadt_sec = sec;
+	sec += table_sectors(cadt_buf.size());
+	const int admap_sec = sec;
+	sec += table_sectors(admap_buf.size());
+	const int vtsm_sec = sec;
+	sec += table_sectors(vtsm_buf.size());
+	int vtsm_cadt_sec = 0;
+	int vtsm_admap_sec = 0;
+	if (!vtsm_cadt.is_empty()) {
+		vtsm_cadt_sec = sec;
+		sec += table_sectors(vtsm_cadt.size());
+	}
+	if (!vtsm_admap.is_empty()) {
+		vtsm_admap_sec = sec;
+		sec += table_sectors(vtsm_admap.size());
+	}
+	const int ifo_secs = MAX(IFO_SECTORS, sec);
+
+	Vector<uint8_t> buf;
+	buf.resize(ifo_secs * SECTOR);
+	buf.fill(0);
+	write_ident(buf, "DVDVIDEO-VTS");
+	const uint32_t menu_secs = MAX(p_vtsm_sectors, uint32_t(1));
+	const uint32_t last = uint32_t(ifo_secs) + menu_secs + p_title_sectors + uint32_t(ifo_secs) - 1;
+	write_be32(buf, 0x0C, last);
+	write_be32(buf, 0x1C, uint32_t(ifo_secs - 1));
+	write_be16(buf, 0x20, 0x0011);
+	write_be32(buf, 0x80, 0x03FF);
+	write_be16(buf, 0x100, 0x4000);
+	int titles_audio = 0;
+	int titles_subp = 0;
+	Vector<uint16_t> audio_langs;
+	for (int i = 0; i < p_parts.size(); i++) {
+		int n = p_parts[i].audio_streams;
+		if (n <= 0 && p_parts[i].has_audio) {
+			n = 1;
+		}
+		titles_audio = MAX(titles_audio, n);
+		titles_subp = MAX(titles_subp, p_parts[i].subp_streams);
+		for (int a = 0; a < p_parts[i].audio_langs.size(); a++) {
+			if (audio_langs.size() < 8) {
+				audio_langs.push_back(p_parts[i].audio_langs[a]);
+			}
+		}
+	}
+	write_be16(buf, 0x102, uint16_t(CLAMP(titles_audio, 0, 8)));
+	for (int i = 0; i < titles_audio && i < 8; i++) {
+		const uint16_t lang = i < audio_langs.size() ? audio_langs[i] : p_ident.audio_lang;
+		write_audio_attr(buf, 0x104 + i * 8, lang);
+	}
+	write_be16(buf, 0x254, uint16_t(CLAMP(titles_subp, 0, 32)));
+	for (int i = 0; i < titles_subp && i < 32; i++) {
+		write_subp_attr(buf, 0x256 + i * 6, p_ident.subp_lang);
+	}
+	write_be32(buf, 0xC0, uint32_t(ifo_secs));
+	write_be32(buf, 0xC4, uint32_t(ifo_secs + menu_secs));
+	write_be32(buf, 0xC8, uint32_t(ptt_sec));
+	write_be32(buf, 0xCC, uint32_t(pgcit_sec));
+	write_be32(buf, 0xD0, uint32_t(vtsm_sec));
+	if (vtsm_cadt_sec > 0) {
+		write_be32(buf, 0xD8, uint32_t(vtsm_cadt_sec));
+	}
+	if (vtsm_admap_sec > 0) {
+		write_be32(buf, 0xDC, uint32_t(vtsm_admap_sec));
+	}
+	write_be32(buf, 0xE0, uint32_t(cadt_sec));
+	write_be32(buf, 0xE4, uint32_t(admap_sec));
+
+	copy_table(buf, ptt_sec * SECTOR, ptt_buf);
+	copy_table(buf, pgcit_sec * SECTOR, pgcit_buf);
+	copy_table(buf, cadt_sec * SECTOR, cadt_buf);
+	copy_table(buf, admap_sec * SECTOR, admap_buf);
+	copy_table(buf, vtsm_sec * SECTOR, vtsm_buf);
+	if (vtsm_cadt_sec > 0) {
+		copy_table(buf, vtsm_cadt_sec * SECTOR, vtsm_cadt);
+	}
+	if (vtsm_admap_sec > 0) {
+		copy_table(buf, vtsm_admap_sec * SECTOR, vtsm_admap);
+	}
+	return buf;
+}
+
+Error mux_menu_chain(const Vector<Ref<InterDVDMenu>> &p_menus, const String &p_out_vob, bool p_title_domain, const String &p_ffmpeg, bool p_allow_dummy, bool p_auto_find, String *r_error, Vector<MenuPgcSpec> &r_specs, const Ref<InterDVDProject> &p_project, const Ref<InterDVDExportProgress> &p_progress) {
+	r_specs.clear();
+	if (p_menus.is_empty()) {
+		return InterDVDVobMux::write_dummy_vob(p_out_vob);
+	}
+	uint8_t next_cell_id = 1;
+	int part_n = 0;
+	for (int i = 0; i < p_menus.size(); i++) {
+		const Ref<InterDVDMenu> menu = p_menus[i];
+		if (menu.is_null()) {
+			continue;
+		}
+		const bool first_file = r_specs.is_empty();
+		const String part_path = first_file ? p_out_vob : p_out_vob + vformat(".part%d", part_n++);
+#ifdef TOOLS_ENABLED
+		if (menu->get_cell().is_valid() && menu->get_cell()->get_packed_scene().is_valid()) {
+			if (p_progress.is_valid()) {
+				String name = menu->get_name();
+				if (name.is_empty() && menu->get_cell().is_valid()) {
+					name = menu->get_cell()->get_display_name();
+				}
+				if (name.is_empty()) {
+					name = "menu";
+				}
+				p_progress->report(vformat("Baking %s", name));
+			}
+			const Error bake = InterDVDSceneBaker::bake_cell(menu->get_cell(), p_ffmpeg, p_auto_find, r_error);
+			if (bake != OK) {
+				return bake;
+			}
+		} else if (p_progress.is_valid()) {
+			String name = menu->get_name();
+			if (name.is_empty()) {
+				name = "menu";
+			}
+			p_progress->report(vformat("Muxing %s", name));
+		}
+#endif
+		Error err = OK;
+		if (menu->get_cell().is_valid()) {
+			err = InterDVDVobMux::mux_cell(menu->get_cell(), part_path, p_ffmpeg, p_allow_dummy, r_error, p_auto_find);
+		} else {
+			err = InterDVDVobMux::write_dummy_vob(part_path);
+		}
+		if (err != OK) {
+			return err;
+		}
+		if (menu->get_buttons().size() > 0) {
+#ifdef TOOLS_ENABLED
+			if (menu->get_cell().is_valid() && menu->get_cell()->get_packed_scene().is_valid()) {
+				Node *inst = menu->get_cell()->get_packed_scene()->instantiate();
+				if (inst) {
+					TypedArray<InterDVDButton> btns = menu->get_buttons();
+					for (int b = 0; b < btns.size(); b++) {
+						Ref<InterDVDButton> btn = btns[b];
+						if (btn.is_valid()) {
+							const Rect2 fallback = menu->get_cell().is_valid() ? menu->get_cell()->get_default_highlight() : Rect2();
+							btn->sync_highlight_from_scene(inst, fallback, InterDVDSettings::title_safe_bottom(p_project));
+						}
+					}
+					inst->queue_free();
+				}
+			}
+#endif
+			int fosl = menu->get_forced_selected_button();
+			if (fosl <= 0) {
+				fosl = menu->get_default_button();
+			}
+			const double dur = resolve_playback_sec(menu->get_cell(), part_path, p_ffmpeg);
+			const uint32_t hli_e = (menu->get_still_time() == 255) ? 0x3FFFFFFFu : (dur >= 2.0 ? uint32_t(MIN(dur * 90000.0, 1073741822.0)) : 0);
+			err = InterDVDVobMux::apply_menu_buttons(part_path, menu->get_buttons(), p_title_domain, fosl, menu->get_forced_activated_button(), uint16_t(menu->get_button_group_mask()), hli_e, InterDVDSettings::title_safe_bottom(p_project));
+			if (err != OK) {
+				if (r_error) {
+					*r_error = "Could not write menu highlight buttons.";
+				}
+				return err;
+			}
+		}
+		const uint32_t offset = first_file ? 0 : InterDVDVobMux::sector_count(p_out_vob);
+		const uint32_t secs = InterDVDVobMux::sector_count(part_path);
+		Vector<uint32_t> local_vobus = InterDVDVobMux::scan_vobu_sectors(part_path);
+		if (local_vobus.is_empty()) {
+			local_vobus.push_back(0);
+		}
+		const int part_ac3 = InterDVDVobMux::count_ac3_streams(part_path);
+		const int part_spu = InterDVDVobMux::count_spu_streams(part_path);
+		const bool part_has_audio = InterDVDVobMux::contains_ac3(part_path);
+		const double part_sec = resolve_playback_sec(menu->get_cell(), part_path, p_ffmpeg);
+		if (!first_file) {
+			err = InterDVDVobMux::append_vob(p_out_vob, part_path);
+			if (err != OK) {
+				return err;
+			}
+			err = InterDVDVobMux::reindex_nav_lbns(p_out_vob, offset, next_cell_id);
+			if (err != OK) {
+				return err;
+			}
+			Ref<DirAccess> rm = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			if (rm.is_valid()) {
+				rm->remove(part_path);
+			}
+		}
+		MenuPgcSpec spec;
+		spec.menu_id = uint8_t(menu->get_menu_type());
+		spec.still_time = uint8_t(CLAMP(menu->get_still_time(), 0, 255));
+		spec.next_pgc = uint16_t(menu->get_next_pgc() > 0 ? menu->get_next_pgc() : 1);
+		spec.prev_pgc = uint16_t(menu->get_prev_pgc() > 0 ? menu->get_prev_pgc() : spec.next_pgc);
+		spec.playback_sec = part_sec;
+		spec.has_audio = part_has_audio;
+		spec.audio_streams = part_ac3;
+		spec.subp_streams = part_spu;
+		spec.clut = menu->get_clut();
+		CellPlayback playback;
+		playback.first_sector = offset;
+		playback.last_sector = offset + (secs ? secs - 1 : 0);
+		playback.last_vobu = offset + local_vobus[local_vobus.size() - 1];
+		playback.cell_id = next_cell_id;
+		playback.still_time = spec.still_time;
+		playback.playback_sec = spec.playback_sec;
+		spec.cells.push_back(playback);
+		r_specs.push_back(spec);
+		next_cell_id++;
+	}
+	if (r_specs.is_empty()) {
+		return InterDVDVobMux::write_dummy_vob(p_out_vob);
+	}
+	return OK;
+}
+
+void patch_vmg_last_sector(Vector<uint8_t> &p_vmg, uint32_t p_vmg_last) {
+	write_be32(p_vmg, 0x0C, p_vmg_last);
+}
+
+} //namespace
+
+Error InterDVDIfoWriter::write_video_ts(const String &p_root, const Ref<InterDVDProject> &p_project, bool p_allow_dummy_vob, const String &p_ffmpeg, String *r_error, bool p_auto_find_ffmpeg, const Ref<InterDVDExportProgress> &p_progress) {
+	Ref<InterDVDExportProgress> progress = p_progress;
+	if (progress.is_null()) {
+		progress.instantiate();
+	}
+	int step_total = 2;
+	if (p_project.is_valid()) {
+		const TypedArray<InterDVDMenu> menus = p_project->get_menus();
+		for (int i = 0; i < menus.size(); i++) {
+			if (Ref<InterDVDMenu>(menus[i]).is_valid()) {
+				step_total++;
+			}
+		}
+		const TypedArray<InterDVDPGC> titles = p_project->get_titles();
+		for (int i = 0; i < titles.size(); i++) {
+			const Ref<InterDVDPGC> title = titles[i];
+			if (title.is_null()) {
+				step_total++;
+				continue;
+			}
+			const int cells = title->get_cells().size();
+			step_total += cells > 0 ? cells : 1;
+		}
+	} else {
+		step_total++;
+	}
+	step_total++;
+	progress->begin(step_total);
+	progress->report("Loading project");
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (da.is_null()) {
+		return ERR_CANT_OPEN;
+	}
+	Error err = da->make_dir_recursive(p_root.path_join("VIDEO_TS"));
+	if (err != OK && err != ERR_ALREADY_EXISTS) {
+		if (r_error) {
+			*r_error = "Could not create VIDEO_TS.";
+		}
+		return err;
+	}
+	err = da->make_dir_recursive(p_root.path_join("AUDIO_TS"));
+	if (err != OK && err != ERR_ALREADY_EXISTS) {
+		if (r_error) {
+			*r_error = "Could not create AUDIO_TS.";
+		}
+		return err;
+	}
+
+	const String video_ts = p_root.path_join("VIDEO_TS");
+	const String title_vob = video_ts.path_join("VTS_01_1.VOB");
+	TypedArray<InterDVDPGC> title_pgcs;
+	if (p_project.is_valid()) {
+		title_pgcs = p_project->get_titles();
+	}
+	if (title_pgcs.is_empty()) {
+		title_pgcs.push_back(Ref<InterDVDPGC>());
+	}
+
+	Vector<TitlePart> parts;
+	int part_file_n = 0;
+	uint8_t next_cell_id = 1;
+	for (int i = 0; i < title_pgcs.size(); i++) {
+		const Ref<InterDVDPGC> title_pgc = title_pgcs[i];
+		TypedArray<InterDVDCell> title_cells;
+		if (title_pgc.is_valid() && title_pgc->get_cells().size() > 0) {
+			title_cells = title_pgc->get_cells();
+		} else {
+			title_cells.push_back(Ref<InterDVDCell>());
+		}
+		TitlePart part;
+		part.has_audio = false;
+		if (title_pgc.is_valid()) {
+			append_commands(part.pre, title_pgc->get_pre_commands());
+			append_commands(part.post, title_pgc->get_post_commands());
+			part.still_time = uint8_t(CLAMP(title_pgc->get_still_time(), 0, 255));
+			part.next_pgc = uint16_t(title_pgc->get_next_pgc());
+			part.prev_pgc = uint16_t(title_pgc->get_prev_pgc());
+			part.clut = title_pgc->get_clut();
+		}
+		if (title_pgc.is_valid() && title_pgc->get_buttons().size() > 0 && part.next_pgc == 0) {
+			part.next_pgc = uint16_t(i + 1);
+			if (part.prev_pgc == 0) {
+				part.prev_pgc = uint16_t(i + 1);
+			}
+		} else if (part.post.is_empty() && !(title_pgc.is_valid() && title_pgc->get_buttons().size() > 0)) {
+			const PackedByteArray call = InterDVDInstruction::encode_link(InterDVDInstruction::CALL_SS, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VMG, 2, nullptr);
+			if (call.size() == 8) {
+				const uint8_t bytes[8] = { call[0], call[1], call[2], call[3], call[4], call[5], call[6], call[7] };
+				append_cmd8(part.post, bytes);
+			}
+		}
+
+		{
+		}
+
+		int cell_cmd_index = 1;
+		for (int c = 0; c < title_cells.size(); c++) {
+			Ref<InterDVDCell> cell = title_cells[c];
+			const bool first_file = parts.is_empty() && part.cells.is_empty();
+			const String part_path = first_file ? title_vob : video_ts.path_join(vformat("VTS_01_1.part%d.vob", part_file_n++));
+#ifdef TOOLS_ENABLED
+			if (cell.is_valid() && cell->get_packed_scene().is_valid()) {
+				if (progress.is_valid()) {
+					String name = cell->get_display_name();
+					if (name.is_empty() && title_pgc.is_valid()) {
+						name = title_pgc->get_name();
+					}
+					if (name.is_empty()) {
+						name = "title";
+					}
+					progress->report(vformat("Baking %s", name));
+				}
+				err = InterDVDSceneBaker::bake_cell(cell, p_ffmpeg, p_auto_find_ffmpeg, r_error);
+				if (err != OK) {
+					return err;
+				}
+			} else if (progress.is_valid()) {
+				String name = cell.is_valid() ? cell->get_display_name() : String();
+				if (name.is_empty() && title_pgc.is_valid()) {
+					name = title_pgc->get_name();
+				}
+				if (name.is_empty()) {
+					name = "title";
+				}
+				progress->report(vformat("Muxing %s", name));
+			}
+#endif
+			err = InterDVDVobMux::mux_cell(cell, part_path, p_ffmpeg, p_allow_dummy_vob, r_error, p_auto_find_ffmpeg);
+			if (err != OK) {
+				return err;
+			}
+			const int ac3_n = InterDVDVobMux::count_ac3_streams(part_path);
+			const int spu_n = InterDVDVobMux::count_spu_streams(part_path);
+			if (ac3_n > 0) {
+				part.has_audio = true;
+				part.audio_streams = MAX(part.audio_streams, ac3_n);
+			}
+			part.subp_streams = MAX(part.subp_streams, spu_n);
+			if (cell.is_valid()) {
+				const uint16_t def_lang = p_project.is_valid() ? InterDVDProject::language_be16(p_project->get_audio_language()) : uint16_t(0x656E);
+				if (part.audio_langs.is_empty() && (cell->get_include_audio() || !cell->get_audio_path().is_empty())) {
+					part.audio_langs.push_back(def_lang);
+				}
+				const TypedArray<InterDVDStream> extra = cell->get_streams();
+				for (int s = 0; s < extra.size(); s++) {
+					const Ref<InterDVDStream> stream = extra[s];
+					if (stream.is_valid() && stream->is_enabled() && stream->get_kind() == InterDVDStream::KIND_AUDIO) {
+						part.audio_langs.push_back(InterDVDProject::language_be16(stream->get_language()));
+					}
+				}
+			}
+
+#ifdef TOOLS_ENABLED
+			if (cell.is_valid() && cell->get_packed_scene().is_valid() && title_pgc.is_valid() && c == 0) {
+				Node *inst = cell->get_packed_scene()->instantiate();
+				if (inst) {
+					TypedArray<InterDVDButton> btns = title_pgc->get_buttons();
+					for (int b = 0; b < btns.size(); b++) {
+						Ref<InterDVDButton> btn = btns[b];
+						if (btn.is_valid()) {
+							const Rect2 fallback = cell.is_valid() ? cell->get_default_highlight() : Rect2();
+							btn->sync_highlight_from_scene(inst, fallback, InterDVDSettings::title_safe_bottom(p_project));
+						}
+					}
+					inst->queue_free();
+				}
+			}
+#endif
+			if (title_pgc.is_valid() && title_pgc->get_buttons().size() > 0 && c == 0) {
+				const double dur = resolve_playback_sec(cell, part_path, p_ffmpeg);
+				const uint32_t hli_e = part.still_time == 255 ? 0x3FFFFFFFu : (dur >= 2.0 ? uint32_t(MIN(dur * 90000.0, 1073741822.0)) : 0);
+				err = InterDVDVobMux::apply_menu_buttons(part_path, title_pgc->get_buttons(), true, title_pgc->get_default_button(), 0, 0x1000, hli_e, InterDVDSettings::title_safe_bottom(p_project));
+				if (err != OK) {
+					if (r_error) {
+						*r_error = "Could not write title highlight buttons into the title VOB.";
+					}
+					return err;
+				}
+			}
+
+			const uint32_t offset = first_file ? 0 : InterDVDVobMux::sector_count(title_vob);
+			const uint32_t secs = InterDVDVobMux::sector_count(part_path);
+			Vector<uint32_t> local_vobus = InterDVDVobMux::scan_vobu_sectors(part_path);
+			if (local_vobus.is_empty()) {
+				local_vobus.push_back(0);
+			}
+			const double cell_sec = resolve_playback_sec(cell, part_path, p_ffmpeg);
+			if (!first_file) {
+				err = InterDVDVobMux::append_vob(title_vob, part_path);
+				if (err != OK) {
+					return err;
+				}
+				err = InterDVDVobMux::reindex_nav_lbns(title_vob, offset, next_cell_id);
+				if (err != OK) {
+					return err;
+				}
+				Ref<DirAccess> rm = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+				if (rm.is_valid()) {
+					rm->remove(part_path);
+				}
+			}
+			CellPlayback playback;
+			playback.first_sector = offset;
+			playback.last_sector = offset + (secs ? secs - 1 : 0);
+			playback.last_vobu = offset + local_vobus[local_vobus.size() - 1];
+			playback.cell_id = next_cell_id;
+
+			const bool has_menu_buttons = title_pgc.is_valid() && title_pgc->get_buttons().size() > 0;
+			if (has_menu_buttons) {
+				playback.still_time = (c == 0) ? part.still_time : 0;
+			} else {
+				playback.still_time = (c == title_cells.size() - 1) ? part.still_time : 0;
+			}
+			playback.playback_sec = cell_sec;
+			if (cell.is_valid() && cell->get_post_commands().size() > 0) {
+				append_commands(part.cell_cmds, cell->get_post_commands());
+				playback.cell_cmd = uint8_t(cell_cmd_index);
+				cell_cmd_index += cell->get_post_commands().size();
+			} else if (c + 1 < title_cells.size()) {
+				const PackedByteArray link = InterDVDInstruction::encode_link(InterDVDInstruction::LINK_PGN, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, c + 2, nullptr);
+				if (link.size() == 8) {
+					const uint8_t bytes[8] = { link[0], link[1], link[2], link[3], link[4], link[5], link[6], link[7] };
+					append_cmd8(part.cell_cmds, bytes);
+					playback.cell_cmd = uint8_t(cell_cmd_index);
+					cell_cmd_index++;
+				}
+			}
+			if (c == 0) {
+				part.playback_sec = playback.playback_sec;
+			} else {
+				part.playback_sec += playback.playback_sec;
+			}
+			part.cells.push_back(playback);
+			next_cell_id++;
+		}
+		parts.push_back(part);
+	}
+
+
+	Vector<Ref<InterDVDMenu>> title_menus;
+	Vector<Ref<InterDVDMenu>> vtsm_menus;
+	if (p_project.is_valid()) {
+		const TypedArray<InterDVDMenu> menus = p_project->get_menus();
+		for (int i = 0; i < menus.size(); i++) {
+			const Ref<InterDVDMenu> one = menus[i];
+			if (one.is_null()) {
+				continue;
+			}
+			if (one->get_menu_type() == InterDVDMenu::MENU_TITLE) {
+				title_menus.push_back(one);
+			} else {
+				vtsm_menus.push_back(one);
+			}
+		}
+	}
+	bool has_buttons = false;
+	for (int i = 0; i < title_menus.size(); i++) {
+		if (title_menus[i].is_valid() && title_menus[i]->get_buttons().size() > 0) {
+			has_buttons = true;
+			break;
+		}
+	}
+	const String menu_vob = video_ts.path_join("VIDEO_TS.VOB");
+	Vector<MenuPgcSpec> title_menu_specs;
+	err = mux_menu_chain(title_menus, menu_vob, false, p_ffmpeg, p_allow_dummy_vob, p_auto_find_ffmpeg, r_error, title_menu_specs, p_project, progress);
+	if (err != OK) {
+		return err;
+	}
+	const String vtsm_vob = video_ts.path_join("VTS_01_0.VOB");
+	Vector<MenuPgcSpec> vtsm_specs;
+	err = mux_menu_chain(vtsm_menus, vtsm_vob, true, p_ffmpeg, p_allow_dummy_vob, p_auto_find_ffmpeg, r_error, vtsm_specs, p_project, progress);
+	if (err != OK) {
+		return err;
+	}
+
+	const uint32_t title_secs = InterDVDVobMux::sector_count(video_ts.path_join("VTS_01_1.VOB"));
+	Vector<uint32_t> vobus = InterDVDVobMux::scan_vobu_sectors(video_ts.path_join("VTS_01_1.VOB"));
+	if (vobus.is_empty()) {
+		vobus.push_back(0);
+	}
+
+	Vector<uint8_t> fp_pre;
+	if (p_project.is_valid() && p_project->get_first_play().is_valid()) {
+		append_commands(fp_pre, p_project->get_first_play()->get_pre_commands());
+	}
+	if (fp_pre.is_empty()) {
+		if (has_buttons) {
+			append_default_jump_ss_title_menu(fp_pre);
+		} else {
+			append_default_jump_tt(fp_pre);
+		}
+	}
+
+	DiscIdent ident;
+	Vector<String> title_names;
+	if (p_project.is_valid()) {
+		ident.provider = p_project->get_provider_id();
+		ident.disc_title = p_project->get_disc_title();
+		ident.serial = p_project->get_serial().substr(0, 15);
+		ident.menu_lang = InterDVDProject::language_be16(p_project->get_menu_language());
+		ident.audio_lang = InterDVDProject::language_be16(p_project->get_audio_language());
+		ident.subp_lang = InterDVDProject::language_be16(p_project->get_subtitle_language());
+		for (int i = 0; i < title_pgcs.size(); i++) {
+			const Ref<InterDVDPGC> named = title_pgcs[i];
+			title_names.push_back(named.is_valid() ? named->get_name() : String());
+		}
+	}
+
+	const int titles = MAX(parts.size(), 1);
+	const int region = p_project.is_valid() ? p_project->get_region_mask() : 1;
+	const uint32_t vmg_ifo = uint32_t(IFO_SECTORS);
+	const uint32_t vmg_menu = MAX(InterDVDVobMux::sector_count(menu_vob), uint32_t(1));
+	const uint32_t vts_start = vmg_ifo + vmg_menu + vmg_ifo;
+	Vector<int> chapter_counts;
+	for (int i = 0; i < parts.size(); i++) {
+		chapter_counts.push_back(MAX(parts[i].cells.size(), 1));
+	}
+	const uint32_t vtsm_secs = MAX(InterDVDVobMux::sector_count(vtsm_vob), uint32_t(1));
+	Vector<uint32_t> vtsm_vobus = InterDVDVobMux::scan_vobu_sectors(vtsm_vob);
+	Vector<uint8_t> vmg = make_vmg_ifo(titles, region, vts_start, fp_pre, chapter_counts, title_menu_specs, ident, title_names);
+	patch_vmg_last_sector(vmg, vmg_ifo + vmg_menu + vmg_ifo - 1);
+	const Vector<uint8_t> vts = make_vts_ifo(title_secs, vobus, parts, ident, vtsm_specs, vtsm_secs, vtsm_vobus);
+
+	progress->report("Writing IFO");
+	err = write_file(video_ts.path_join("VIDEO_TS.IFO"), vmg);
+	if (err != OK) {
+		return err;
+	}
+	err = write_file(video_ts.path_join("VIDEO_TS.BUP"), vmg);
+	if (err != OK) {
+		return err;
+	}
+	err = write_file(video_ts.path_join("VTS_01_0.IFO"), vts);
+	if (err != OK) {
+		return err;
+	}
+	err = write_file(video_ts.path_join("VTS_01_0.BUP"), vts);
+	if (err != OK) {
+		return err;
+	}
+	progress->report("Finalizing VOB");
+	return InterDVDVobMux::split_vts_vob(video_ts.path_join("VTS_01_1.VOB"));
+}

--- a/modules/inter_dvd/author/inter_dvd_ifo_writer.h
+++ b/modules/inter_dvd/author/inter_dvd_ifo_writer.h
@@ -1,0 +1,78 @@
+/**************************************************************************/
+/*  inter_dvd_ifo_writer.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_list.h"
+#include "core/io/resource.h"
+#include "core/object/object.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+#include "core/variant/callable.h"
+#include "inter_dvd_project.h"
+
+class InterDVDExportProgress : public RefCounted {
+	GDCLASS(InterDVDExportProgress, RefCounted);
+
+	int step = 0;
+	int total = 0;
+	String label;
+	uint64_t started_usec = 0;
+	Callable notify;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void begin(int p_total);
+	void report(const String &p_label);
+	void set_notify(const Callable &p_notify) { notify = p_notify; }
+	Callable get_notify() const { return notify; }
+	int get_step() const { return step; }
+	int get_total() const { return total; }
+	String get_label() const { return label; }
+	uint64_t get_started_usec() const { return started_usec; }
+	static String format_clock(int64_t p_usec);
+	String format_line() const;
+};
+
+class InterDVDIfoWriter : public Object {
+	GDCLASS(InterDVDIfoWriter, Object);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static constexpr int SECTOR_SIZE = 2048;
+
+	static Error write_video_ts(const String &p_root, const Ref<InterDVDProject> &p_project, bool p_allow_dummy_vob, const String &p_ffmpeg, String *r_error = nullptr, bool p_auto_find_ffmpeg = true, const Ref<InterDVDExportProgress> &p_progress = Ref<InterDVDExportProgress>());
+	static Error write_video_ts_bind(const String &p_root, const Ref<InterDVDProject> &p_project, bool p_allow_dummy_vob = false, const String &p_ffmpeg = String(), bool p_auto_find_ffmpeg = true, const Ref<InterDVDExportProgress> &p_progress = Ref<InterDVDExportProgress>());
+	static Vector<String> iso_tool_args(const String &p_tool, const String &p_volume_id, const String &p_work_dir, const String &p_out);
+};

--- a/modules/inter_dvd/author/inter_dvd_project.cpp
+++ b/modules/inter_dvd/author/inter_dvd_project.cpp
@@ -1,0 +1,650 @@
+/**************************************************************************/
+/*  inter_dvd_project.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "inter_dvd_project.h"
+
+#include "modules/inter_dvd/machine/inter_dvd_instruction.h"
+
+#include "core/config/project_settings.h"
+#include "core/math/math_funcs.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "scene/2d/node_2d.h"
+#include "scene/gui/control.h"
+#include "scene/main/canvas_item.h"
+#include "scene/main/node.h"
+
+void InterDVDStream::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_kind", "kind"), &InterDVDStream::set_kind);
+	ClassDB::bind_method(D_METHOD("get_kind"), &InterDVDStream::get_kind);
+	ClassDB::bind_method(D_METHOD("set_source_path", "path"), &InterDVDStream::set_source_path);
+	ClassDB::bind_method(D_METHOD("get_source_path"), &InterDVDStream::get_source_path);
+	ClassDB::bind_method(D_METHOD("set_language", "language"), &InterDVDStream::set_language);
+	ClassDB::bind_method(D_METHOD("get_language"), &InterDVDStream::get_language);
+	ClassDB::bind_method(D_METHOD("set_code_extension", "extension"), &InterDVDStream::set_code_extension);
+	ClassDB::bind_method(D_METHOD("get_code_extension"), &InterDVDStream::get_code_extension);
+	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &InterDVDStream::set_enabled);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &InterDVDStream::is_enabled);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "kind", PROPERTY_HINT_ENUM, "Audio,Subtitle"), "set_kind", "get_kind");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_path", PROPERTY_HINT_FILE, "*.wav,*.mp3,*.ogg,*.flac,*.m4a,*.aac,*.ac3,*.srt,*.sup,*.sub,*.idx"), "set_source_path", "get_source_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "language"), "set_language", "get_language");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "code_extension", PROPERTY_HINT_RANGE, "0,15,1"), "set_code_extension", "get_code_extension");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
+	BIND_ENUM_CONSTANT(KIND_AUDIO);
+	BIND_ENUM_CONSTANT(KIND_SUBTITLE);
+}
+
+void InterDVDCell::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_encoded_path", "path"), &InterDVDCell::set_encoded_path);
+	ClassDB::bind_method(D_METHOD("get_encoded_path"), &InterDVDCell::get_encoded_path);
+	ClassDB::bind_method(D_METHOD("set_source_path", "path"), &InterDVDCell::set_source_path);
+	ClassDB::bind_method(D_METHOD("get_source_path"), &InterDVDCell::get_source_path);
+	ClassDB::bind_method(D_METHOD("set_pip_source_path", "path"), &InterDVDCell::set_pip_source_path);
+	ClassDB::bind_method(D_METHOD("get_pip_source_path"), &InterDVDCell::get_pip_source_path);
+	ClassDB::bind_method(D_METHOD("set_audio_path", "path"), &InterDVDCell::set_audio_path);
+	ClassDB::bind_method(D_METHOD("get_audio_path"), &InterDVDCell::get_audio_path);
+	ClassDB::bind_method(D_METHOD("set_pip_slot_path", "path"), &InterDVDCell::set_pip_slot_path);
+	ClassDB::bind_method(D_METHOD("get_pip_slot_path"), &InterDVDCell::get_pip_slot_path);
+	ClassDB::bind_method(D_METHOD("set_pip_rect", "rect"), &InterDVDCell::set_pip_rect);
+	ClassDB::bind_method(D_METHOD("get_pip_rect"), &InterDVDCell::get_pip_rect);
+	ClassDB::bind_method(D_METHOD("set_pip_lead_sec", "seconds"), &InterDVDCell::set_pip_lead_sec);
+	ClassDB::bind_method(D_METHOD("get_pip_lead_sec"), &InterDVDCell::get_pip_lead_sec);
+	ClassDB::bind_method(D_METHOD("set_bake_hold_sec", "seconds"), &InterDVDCell::set_bake_hold_sec);
+	ClassDB::bind_method(D_METHOD("get_bake_hold_sec"), &InterDVDCell::get_bake_hold_sec);
+	ClassDB::bind_method(D_METHOD("set_bake_camera_path", "path"), &InterDVDCell::set_bake_camera_path);
+	ClassDB::bind_method(D_METHOD("get_bake_camera_path"), &InterDVDCell::get_bake_camera_path);
+	ClassDB::bind_method(D_METHOD("set_default_highlight", "rect"), &InterDVDCell::set_default_highlight);
+	ClassDB::bind_method(D_METHOD("get_default_highlight"), &InterDVDCell::get_default_highlight);
+	ClassDB::bind_method(D_METHOD("set_packed_scene", "scene"), &InterDVDCell::set_packed_scene);
+	ClassDB::bind_method(D_METHOD("get_packed_scene"), &InterDVDCell::get_packed_scene);
+	ClassDB::bind_method(D_METHOD("set_duration_sec", "seconds"), &InterDVDCell::set_duration_sec);
+	ClassDB::bind_method(D_METHOD("get_duration_sec"), &InterDVDCell::get_duration_sec);
+	ClassDB::bind_method(D_METHOD("set_loop_pad_sec", "seconds"), &InterDVDCell::set_loop_pad_sec);
+	ClassDB::bind_method(D_METHOD("get_loop_pad_sec"), &InterDVDCell::get_loop_pad_sec);
+	ClassDB::bind_method(D_METHOD("set_include_audio", "include"), &InterDVDCell::set_include_audio);
+	ClassDB::bind_method(D_METHOD("get_include_audio"), &InterDVDCell::get_include_audio);
+	ClassDB::bind_method(D_METHOD("set_streams", "streams"), &InterDVDCell::set_streams);
+	ClassDB::bind_method(D_METHOD("get_streams"), &InterDVDCell::get_streams);
+	ClassDB::bind_method(D_METHOD("set_post_commands", "commands"), &InterDVDCell::set_post_commands);
+	ClassDB::bind_method(D_METHOD("get_post_commands"), &InterDVDCell::get_post_commands);
+	ClassDB::bind_method(D_METHOD("get_display_name"), &InterDVDCell::get_display_name);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "encoded_path", PROPERTY_HINT_FILE, "*.vob,*.m2v,*.mpg,*.mpeg"), "set_encoded_path", "get_encoded_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_path", PROPERTY_HINT_FILE, "*.mp4,*.mkv,*.mov,*.avi,*.webm,*.mpg,*.mpeg,*.vob,*.m2v"), "set_source_path", "get_source_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "pip_source_path", PROPERTY_HINT_FILE, "*.mp4,*.mkv,*.mov,*.avi,*.webm,*.mpg,*.mpeg,*.vob"), "set_pip_source_path", "get_pip_source_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "audio_path", PROPERTY_HINT_FILE, "*.wav,*.mp3,*.ogg,*.flac,*.m4a,*.aac,*.ac3,*.aif,*.aiff"), "set_audio_path", "get_audio_path");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "pip_slot_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Control,Node2D"), "set_pip_slot_path", "get_pip_slot_path");
+	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "pip_rect"), "set_pip_rect", "get_pip_rect");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pip_lead_sec", PROPERTY_HINT_RANGE, "0,5,0.01"), "set_pip_lead_sec", "get_pip_lead_sec");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_hold_sec", PROPERTY_HINT_RANGE, "0,60,0.1"), "set_bake_hold_sec", "get_bake_hold_sec");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "bake_camera_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Camera2D,Camera3D"), "set_bake_camera_path", "get_bake_camera_path");
+	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "default_highlight"), "set_default_highlight", "get_default_highlight");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "packed_scene", PROPERTY_HINT_RESOURCE_TYPE, "PackedScene"), "set_packed_scene", "get_packed_scene");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "duration_sec", PROPERTY_HINT_RANGE, "0,3600,0.1"), "set_duration_sec", "get_duration_sec");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "loop_pad_sec", PROPERTY_HINT_RANGE, "0,600,0.1"), "set_loop_pad_sec", "get_loop_pad_sec");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_audio"), "set_include_audio", "get_include_audio");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "streams", PROPERTY_HINT_ARRAY_TYPE, "InterDVDStream"), "set_streams", "get_streams");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "post_commands", PROPERTY_HINT_ARRAY_TYPE, "PackedByteArray"), "set_post_commands", "get_post_commands");
+}
+
+String InterDVDCell::get_display_name() const {
+	if (!get_name().is_empty()) {
+		return get_name();
+	}
+	if (!source_path.is_empty()) {
+		return source_path.get_file();
+	}
+	if (!encoded_path.is_empty()) {
+		return encoded_path.get_file();
+	}
+	return String();
+}
+
+void InterDVDButton::set_action(Action p_action) {
+	if (action == p_action) {
+		return;
+	}
+	action = p_action;
+	notify_property_list_changed();
+}
+
+void InterDVDButton::_validate_property(PropertyInfo &p_property) const {
+	const bool uses_target = action == ACTION_JUMP_TITLE || action == ACTION_JUMP_MENU || action == ACTION_JUMP_PGC || action == ACTION_JUMP_CHAPTER || action == ACTION_JUMP_PROGRAM || action == ACTION_JUMP_CELL || action == ACTION_HIGHLIGHT_BUTTON;
+	const bool uses_stream = action == ACTION_SET_AUDIO || action == ACTION_SET_SUBTITLE || action == ACTION_SET_ANGLE;
+	if (p_property.name == StringName("command")) {
+		if (action != ACTION_CUSTOM) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
+		return;
+	}
+	if (p_property.name == StringName("target")) {
+		if (!uses_target) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+			return;
+		}
+		if (action == ACTION_JUMP_MENU) {
+			p_property.hint = PROPERTY_HINT_ENUM;
+			p_property.hint_string = "Title Menu:2,Root Menu:3,Subpicture Menu:4,Audio Menu:5,Angle Menu:6,Chapter Menu:7";
+		} else if (action == ACTION_HIGHLIGHT_BUTTON) {
+			p_property.hint = PROPERTY_HINT_RANGE;
+			p_property.hint_string = "1,36,1";
+		} else {
+			p_property.hint = PROPERTY_HINT_RANGE;
+			p_property.hint_string = "1,99,1";
+		}
+		return;
+	}
+	if (p_property.name == StringName("title_n")) {
+		if (action != ACTION_JUMP_CHAPTER) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
+		return;
+	}
+	if (p_property.name == StringName("stream")) {
+		if (!uses_stream) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
+		return;
+	}
+	if (p_property.name == StringName("subtitle_on") && action != ACTION_SET_SUBTITLE) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+}
+
+PackedByteArray InterDVDButton::resolve_command(CommandDomain p_domain) const {
+	if (action == ACTION_CUSTOM && command.size() == 8) {
+		return command;
+	}
+	const InterDVDInstruction::Domain from = (p_domain == DOMAIN_VTST) ? InterDVDInstruction::DOMAIN_VTST : InterDVDInstruction::DOMAIN_VMG;
+	const int dest = target > 0 ? target : 1;
+	switch (action) {
+		case ACTION_JUMP_PGC:
+			return InterDVDInstruction::encode_link(InterDVDInstruction::LINK_PGCN, from, from, dest, nullptr);
+		case ACTION_JUMP_TITLE:
+			if (p_domain == DOMAIN_VTST) {
+				return InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_VTS_TT, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, dest, nullptr);
+			}
+			return InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_TT, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VTST, dest, nullptr);
+		case ACTION_JUMP_MENU:
+			if (p_domain == DOMAIN_VTST) {
+				return InterDVDInstruction::encode_link(InterDVDInstruction::CALL_SS, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VMG, dest, nullptr);
+			}
+			return InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_SS, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VMG, dest, nullptr);
+		case ACTION_JUMP_CHAPTER:
+
+			return InterDVDInstruction::encode_jump_vts_ptt(
+					p_domain == DOMAIN_VTST ? InterDVDInstruction::DOMAIN_VTST : InterDVDInstruction::DOMAIN_VMG,
+					title_n > 0 ? title_n : dest,
+					dest,
+					nullptr);
+		case ACTION_JUMP_PROGRAM:
+			return InterDVDInstruction::encode_link(InterDVDInstruction::LINK_PGN, from, from, dest, nullptr);
+		case ACTION_JUMP_CELL:
+			return InterDVDInstruction::encode_link(InterDVDInstruction::LINK_CN, from, from, dest, nullptr);
+		case ACTION_RESUME: {
+			const PackedByteArray rsm = InterDVDInstruction::encode_rsm(from, nullptr);
+			return rsm.size() == 8 ? rsm : InterDVDInstruction::encode_nop();
+		}
+		case ACTION_SET_AUDIO:
+			return InterDVDInstruction::encode_set_stn(stream, -1, false, -1, nullptr);
+		case ACTION_SET_SUBTITLE:
+			return InterDVDInstruction::encode_set_stn(-1, stream, subtitle_on, -1, nullptr);
+		case ACTION_SET_ANGLE:
+			return InterDVDInstruction::encode_set_stn(-1, -1, false, stream > 0 ? stream : dest, nullptr);
+		case ACTION_HIGHLIGHT_BUTTON:
+			return InterDVDInstruction::encode_set_hl_btnn(dest, nullptr);
+		case ACTION_EXIT:
+			return InterDVDInstruction::encode_exit();
+		default:
+			break;
+	}
+	return InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_TT, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VTST, dest, nullptr);
+}
+
+static Rect2 clamp_hli_rect(const Rect2 &p_rect, int p_title_safe_bottom) {
+	if (p_rect.size.x <= 0 || p_rect.size.y <= 0) {
+		return Rect2();
+	}
+	const int safe_y = CLAMP(p_title_safe_bottom > 0 ? p_title_safe_bottom : 432, 2, 480);
+	int x0 = CLAMP(int(p_rect.position.x), 0, 719);
+	int y0 = CLAMP(int(p_rect.position.y), 0, 479);
+	int x1 = CLAMP(int(p_rect.position.x + p_rect.size.x), x0, 719);
+	int y1 = CLAMP(int(p_rect.position.y + p_rect.size.y), y0, 479);
+	if (y1 > safe_y) {
+		const int bh = MAX(y1 - y0, 2);
+		y1 = safe_y;
+		y0 = MAX(0, y1 - bh);
+	}
+	x0 &= ~1;
+	y0 &= ~1;
+	x1 &= ~1;
+	y1 &= ~1;
+	if (x1 <= x0) {
+		x1 = MIN(x0 + 2, 718);
+	}
+	if (y1 <= y0) {
+		y1 = MIN(y0 + 2, 478);
+	}
+	return Rect2(x0, y0, x1 - x0, y1 - y0);
+}
+
+void InterDVDButton::sync_highlight_from_scene(Node *p_root, const Rect2 &p_default_highlight, int p_title_safe_bottom) {
+	Rect2 found_rect;
+	Node *found = nullptr;
+	if (p_root && !control_path.is_empty()) {
+		found = p_root->get_node_or_null(control_path);
+	}
+	if (!found && p_root && !get_name().is_empty()) {
+		found = p_root->find_child(get_name(), true, false);
+		if (found && !Object::cast_to<CanvasItem>(found)) {
+			found = nullptr;
+		}
+	}
+	if (Control *ctrl = Object::cast_to<Control>(found)) {
+		found_rect = ctrl->is_inside_tree() ? ctrl->get_global_rect() : Rect2(ctrl->get_position(), ctrl->get_size());
+	} else if (Node2D *n2 = Object::cast_to<Node2D>(found)) {
+		if (n2->has_method("get_rect")) {
+			const Rect2 local = n2->call("get_rect");
+			found_rect = n2->get_global_transform().xform(local);
+		}
+	} else if (CanvasItem *ci = Object::cast_to<CanvasItem>(found)) {
+		if (ci->has_method("get_rect")) {
+			const Rect2 local = ci->call("get_rect");
+			found_rect = ci->get_global_transform().xform(local);
+		}
+	}
+	if (found_rect.size.x <= 0 || found_rect.size.y <= 0) {
+		if (p_default_highlight.size.x <= 0 || p_default_highlight.size.y <= 0) {
+			return;
+		}
+		found_rect = p_default_highlight;
+	}
+	const int safe = p_title_safe_bottom > 0 ? p_title_safe_bottom : InterDVDSettings::title_safe_bottom();
+	highlight = clamp_hli_rect(found_rect, safe);
+}
+
+void InterDVDButton::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_highlight", "rect"), &InterDVDButton::set_highlight);
+	ClassDB::bind_method(D_METHOD("get_highlight"), &InterDVDButton::get_highlight);
+	ClassDB::bind_method(D_METHOD("set_command", "command"), &InterDVDButton::set_command);
+	ClassDB::bind_method(D_METHOD("get_command"), &InterDVDButton::get_command);
+	ClassDB::bind_method(D_METHOD("set_action", "action"), &InterDVDButton::set_action);
+	ClassDB::bind_method(D_METHOD("get_action"), &InterDVDButton::get_action);
+	ClassDB::bind_method(D_METHOD("set_target", "target"), &InterDVDButton::set_target);
+	ClassDB::bind_method(D_METHOD("get_target"), &InterDVDButton::get_target);
+	ClassDB::bind_method(D_METHOD("set_title_n", "title"), &InterDVDButton::set_title_n);
+	ClassDB::bind_method(D_METHOD("get_title_n"), &InterDVDButton::get_title_n);
+	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &InterDVDButton::set_stream);
+	ClassDB::bind_method(D_METHOD("get_stream"), &InterDVDButton::get_stream);
+	ClassDB::bind_method(D_METHOD("set_subtitle_on", "on"), &InterDVDButton::set_subtitle_on);
+	ClassDB::bind_method(D_METHOD("get_subtitle_on"), &InterDVDButton::get_subtitle_on);
+	ClassDB::bind_method(D_METHOD("set_auto_action", "enabled"), &InterDVDButton::set_auto_action);
+	ClassDB::bind_method(D_METHOD("get_auto_action"), &InterDVDButton::get_auto_action);
+	ClassDB::bind_method(D_METHOD("set_hidden", "hidden"), &InterDVDButton::set_hidden);
+	ClassDB::bind_method(D_METHOD("is_hidden"), &InterDVDButton::is_hidden);
+	ClassDB::bind_method(D_METHOD("set_forced_selected", "forced"), &InterDVDButton::set_forced_selected);
+	ClassDB::bind_method(D_METHOD("is_forced_selected"), &InterDVDButton::is_forced_selected);
+	ClassDB::bind_method(D_METHOD("set_forced_activated", "forced"), &InterDVDButton::set_forced_activated);
+	ClassDB::bind_method(D_METHOD("is_forced_activated"), &InterDVDButton::is_forced_activated);
+	ClassDB::bind_method(D_METHOD("set_numeric_select", "enabled"), &InterDVDButton::set_numeric_select);
+	ClassDB::bind_method(D_METHOD("get_numeric_select"), &InterDVDButton::get_numeric_select);
+	ClassDB::bind_method(D_METHOD("set_adjacent_up", "button"), &InterDVDButton::set_adjacent_up);
+	ClassDB::bind_method(D_METHOD("get_adjacent_up"), &InterDVDButton::get_adjacent_up);
+	ClassDB::bind_method(D_METHOD("set_adjacent_down", "button"), &InterDVDButton::set_adjacent_down);
+	ClassDB::bind_method(D_METHOD("get_adjacent_down"), &InterDVDButton::get_adjacent_down);
+	ClassDB::bind_method(D_METHOD("set_adjacent_left", "button"), &InterDVDButton::set_adjacent_left);
+	ClassDB::bind_method(D_METHOD("get_adjacent_left"), &InterDVDButton::get_adjacent_left);
+	ClassDB::bind_method(D_METHOD("set_adjacent_right", "button"), &InterDVDButton::set_adjacent_right);
+	ClassDB::bind_method(D_METHOD("get_adjacent_right"), &InterDVDButton::get_adjacent_right);
+	ClassDB::bind_method(D_METHOD("set_button_number", "number"), &InterDVDButton::set_button_number);
+	ClassDB::bind_method(D_METHOD("get_button_number"), &InterDVDButton::get_button_number);
+	ClassDB::bind_method(D_METHOD("set_color_group", "group"), &InterDVDButton::set_color_group);
+	ClassDB::bind_method(D_METHOD("get_color_group"), &InterDVDButton::get_color_group);
+	ClassDB::bind_method(D_METHOD("set_control_path", "path"), &InterDVDButton::set_control_path);
+	ClassDB::bind_method(D_METHOD("get_control_path"), &InterDVDButton::get_control_path);
+	ClassDB::bind_method(D_METHOD("set_select_color", "color"), &InterDVDButton::set_select_color);
+	ClassDB::bind_method(D_METHOD("get_select_color"), &InterDVDButton::get_select_color);
+	ClassDB::bind_method(D_METHOD("set_action_color", "color"), &InterDVDButton::set_action_color);
+	ClassDB::bind_method(D_METHOD("get_action_color"), &InterDVDButton::get_action_color);
+	ClassDB::bind_method(D_METHOD("resolve_command", "domain"), &InterDVDButton::resolve_command, DEFVAL(DOMAIN_VMGM));
+	ClassDB::bind_method(D_METHOD("sync_highlight_from_scene", "root", "default_highlight", "title_safe_bottom"), &InterDVDButton::sync_highlight_from_scene, DEFVAL(Rect2()), DEFVAL(-1));
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "action", PROPERTY_HINT_ENUM, "Jump Title,Jump Menu,Jump PGC,Custom,Jump Chapter,Jump Program,Jump Cell,Resume,Set Audio,Set Subtitle,Set Angle,Highlight Button,Exit"), "set_action", "get_action");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "target", PROPERTY_HINT_RANGE, "1,99,1"), "set_target", "get_target");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "title_n", PROPERTY_HINT_RANGE, "1,99,1"), "set_title_n", "get_title_n");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stream", PROPERTY_HINT_RANGE, "0,31,1"), "set_stream", "get_stream");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "subtitle_on"), "set_subtitle_on", "get_subtitle_on");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_action"), "set_auto_action", "get_auto_action");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hidden"), "set_hidden", "is_hidden");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "forced_selected"), "set_forced_selected", "is_forced_selected");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "forced_activated"), "set_forced_activated", "is_forced_activated");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "numeric_select"), "set_numeric_select", "get_numeric_select");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "adjacent_up", PROPERTY_HINT_RANGE, "0,36,1"), "set_adjacent_up", "get_adjacent_up");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "adjacent_down", PROPERTY_HINT_RANGE, "0,36,1"), "set_adjacent_down", "get_adjacent_down");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "adjacent_left", PROPERTY_HINT_RANGE, "0,36,1"), "set_adjacent_left", "get_adjacent_left");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "adjacent_right", PROPERTY_HINT_RANGE, "0,36,1"), "set_adjacent_right", "get_adjacent_right");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_number", PROPERTY_HINT_RANGE, "0,36,1"), "set_button_number", "get_button_number");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "color_group", PROPERTY_HINT_RANGE, "1,3,1"), "set_color_group", "get_color_group");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "control_path"), "set_control_path", "get_control_path");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "select_color"), "set_select_color", "get_select_color");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "action_color"), "set_action_color", "get_action_color");
+	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "highlight"), "set_highlight", "get_highlight");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "command"), "set_command", "get_command");
+	BIND_ENUM_CONSTANT(ACTION_JUMP_TITLE);
+	BIND_ENUM_CONSTANT(ACTION_JUMP_MENU);
+	BIND_ENUM_CONSTANT(ACTION_JUMP_PGC);
+	BIND_ENUM_CONSTANT(ACTION_CUSTOM);
+	BIND_ENUM_CONSTANT(ACTION_JUMP_CHAPTER);
+	BIND_ENUM_CONSTANT(ACTION_JUMP_PROGRAM);
+	BIND_ENUM_CONSTANT(ACTION_JUMP_CELL);
+	BIND_ENUM_CONSTANT(ACTION_RESUME);
+	BIND_ENUM_CONSTANT(ACTION_SET_AUDIO);
+	BIND_ENUM_CONSTANT(ACTION_SET_SUBTITLE);
+	BIND_ENUM_CONSTANT(ACTION_SET_ANGLE);
+	BIND_ENUM_CONSTANT(ACTION_HIGHLIGHT_BUTTON);
+	BIND_ENUM_CONSTANT(ACTION_EXIT);
+	BIND_ENUM_CONSTANT(DOMAIN_VMGM);
+	BIND_ENUM_CONSTANT(DOMAIN_VTST);
+}
+
+void InterDVDMenu::set_buttons(const TypedArray<InterDVDButton> &p_buttons) {
+	buttons = p_buttons;
+	if (buttons.size() > 36) {
+		buttons.resize(36);
+	}
+}
+
+void InterDVDMenu::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_motion", "motion"), &InterDVDMenu::set_motion);
+	ClassDB::bind_method(D_METHOD("is_motion"), &InterDVDMenu::is_motion);
+	ClassDB::bind_method(D_METHOD("set_buttons", "buttons"), &InterDVDMenu::set_buttons);
+	ClassDB::bind_method(D_METHOD("get_buttons"), &InterDVDMenu::get_buttons);
+	ClassDB::bind_method(D_METHOD("set_cell", "cell"), &InterDVDMenu::set_cell);
+	ClassDB::bind_method(D_METHOD("get_cell"), &InterDVDMenu::get_cell);
+	ClassDB::bind_method(D_METHOD("set_still_time", "seconds"), &InterDVDMenu::set_still_time);
+	ClassDB::bind_method(D_METHOD("get_still_time"), &InterDVDMenu::get_still_time);
+	ClassDB::bind_method(D_METHOD("set_next_pgc", "pgc"), &InterDVDMenu::set_next_pgc);
+	ClassDB::bind_method(D_METHOD("get_next_pgc"), &InterDVDMenu::get_next_pgc);
+	ClassDB::bind_method(D_METHOD("set_prev_pgc", "pgc"), &InterDVDMenu::set_prev_pgc);
+	ClassDB::bind_method(D_METHOD("get_prev_pgc"), &InterDVDMenu::get_prev_pgc);
+	ClassDB::bind_method(D_METHOD("set_default_button", "button"), &InterDVDMenu::set_default_button);
+	ClassDB::bind_method(D_METHOD("get_default_button"), &InterDVDMenu::get_default_button);
+	ClassDB::bind_method(D_METHOD("set_forced_selected_button", "button"), &InterDVDMenu::set_forced_selected_button);
+	ClassDB::bind_method(D_METHOD("get_forced_selected_button"), &InterDVDMenu::get_forced_selected_button);
+	ClassDB::bind_method(D_METHOD("set_forced_activated_button", "button"), &InterDVDMenu::set_forced_activated_button);
+	ClassDB::bind_method(D_METHOD("get_forced_activated_button"), &InterDVDMenu::get_forced_activated_button);
+	ClassDB::bind_method(D_METHOD("set_menu_type", "type"), &InterDVDMenu::set_menu_type);
+	ClassDB::bind_method(D_METHOD("get_menu_type"), &InterDVDMenu::get_menu_type);
+	ClassDB::bind_method(D_METHOD("set_button_group_mask", "mask"), &InterDVDMenu::set_button_group_mask);
+	ClassDB::bind_method(D_METHOD("get_button_group_mask"), &InterDVDMenu::get_button_group_mask);
+	ClassDB::bind_method(D_METHOD("set_clut", "clut"), &InterDVDMenu::set_clut);
+	ClassDB::bind_method(D_METHOD("get_clut"), &InterDVDMenu::get_clut);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "motion"), "set_motion", "is_motion");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "menu_type", PROPERTY_HINT_ENUM, "Title Menu:2,Root Menu:3,Subpicture Menu:4,Audio Menu:5,Angle Menu:6,Chapter Menu:7"), "set_menu_type", "get_menu_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "still_time", PROPERTY_HINT_RANGE, "0,255,1"), "set_still_time", "get_still_time");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "next_pgc", PROPERTY_HINT_RANGE, "0,99,1"), "set_next_pgc", "get_next_pgc");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "prev_pgc", PROPERTY_HINT_RANGE, "0,99,1"), "set_prev_pgc", "get_prev_pgc");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_button", PROPERTY_HINT_RANGE, "1,36,1"), "set_default_button", "get_default_button");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "forced_selected_button", PROPERTY_HINT_RANGE, "0,36,1"), "set_forced_selected_button", "get_forced_selected_button");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "forced_activated_button", PROPERTY_HINT_RANGE, "0,36,1"), "set_forced_activated_button", "get_forced_activated_button");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_group_mask"), "set_button_group_mask", "get_button_group_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "clut"), "set_clut", "get_clut");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "buttons", PROPERTY_HINT_ARRAY_TYPE, "InterDVDButton"), "set_buttons", "get_buttons");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "cell", PROPERTY_HINT_RESOURCE_TYPE, "InterDVDCell"), "set_cell", "get_cell");
+	BIND_ENUM_CONSTANT(MENU_TITLE);
+	BIND_ENUM_CONSTANT(MENU_ROOT);
+	BIND_ENUM_CONSTANT(MENU_SUBPICTURE);
+	BIND_ENUM_CONSTANT(MENU_AUDIO);
+	BIND_ENUM_CONSTANT(MENU_ANGLE);
+	BIND_ENUM_CONSTANT(MENU_CHAPTER);
+}
+
+void InterDVDPGC::set_buttons(const TypedArray<InterDVDButton> &p_buttons) {
+	buttons = p_buttons;
+	if (buttons.size() > 36) {
+		buttons.resize(36);
+	}
+}
+
+void InterDVDPGC::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_cells", "cells"), &InterDVDPGC::set_cells);
+	ClassDB::bind_method(D_METHOD("get_cells"), &InterDVDPGC::get_cells);
+	ClassDB::bind_method(D_METHOD("set_buttons", "buttons"), &InterDVDPGC::set_buttons);
+	ClassDB::bind_method(D_METHOD("get_buttons"), &InterDVDPGC::get_buttons);
+	ClassDB::bind_method(D_METHOD("set_pre_commands", "commands"), &InterDVDPGC::set_pre_commands);
+	ClassDB::bind_method(D_METHOD("get_pre_commands"), &InterDVDPGC::get_pre_commands);
+	ClassDB::bind_method(D_METHOD("set_post_commands", "commands"), &InterDVDPGC::set_post_commands);
+	ClassDB::bind_method(D_METHOD("get_post_commands"), &InterDVDPGC::get_post_commands);
+	ClassDB::bind_method(D_METHOD("set_still_time", "seconds"), &InterDVDPGC::set_still_time);
+	ClassDB::bind_method(D_METHOD("get_still_time"), &InterDVDPGC::get_still_time);
+	ClassDB::bind_method(D_METHOD("set_next_pgc", "pgc"), &InterDVDPGC::set_next_pgc);
+	ClassDB::bind_method(D_METHOD("get_next_pgc"), &InterDVDPGC::get_next_pgc);
+	ClassDB::bind_method(D_METHOD("set_prev_pgc", "pgc"), &InterDVDPGC::set_prev_pgc);
+	ClassDB::bind_method(D_METHOD("get_prev_pgc"), &InterDVDPGC::get_prev_pgc);
+	ClassDB::bind_method(D_METHOD("set_default_button", "button"), &InterDVDPGC::set_default_button);
+	ClassDB::bind_method(D_METHOD("get_default_button"), &InterDVDPGC::get_default_button);
+	ClassDB::bind_method(D_METHOD("set_clut", "clut"), &InterDVDPGC::set_clut);
+	ClassDB::bind_method(D_METHOD("get_clut"), &InterDVDPGC::get_clut);
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "cells", PROPERTY_HINT_ARRAY_TYPE, "InterDVDCell"), "set_cells", "get_cells");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "buttons", PROPERTY_HINT_ARRAY_TYPE, "InterDVDButton"), "set_buttons", "get_buttons");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "pre_commands", PROPERTY_HINT_ARRAY_TYPE, "PackedByteArray"), "set_pre_commands", "get_pre_commands");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "post_commands", PROPERTY_HINT_ARRAY_TYPE, "PackedByteArray"), "set_post_commands", "get_post_commands");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "still_time", PROPERTY_HINT_RANGE, "0,255,1"), "set_still_time", "get_still_time");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "next_pgc", PROPERTY_HINT_RANGE, "0,99,1"), "set_next_pgc", "get_next_pgc");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "prev_pgc", PROPERTY_HINT_RANGE, "0,99,1"), "set_prev_pgc", "get_prev_pgc");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_button", PROPERTY_HINT_RANGE, "1,36,1"), "set_default_button", "get_default_button");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "clut"), "set_clut", "get_clut");
+}
+
+void InterDVDProject::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_region_mask", "mask"), &InterDVDProject::set_region_mask);
+	ClassDB::bind_method(D_METHOD("get_region_mask"), &InterDVDProject::get_region_mask);
+	ClassDB::bind_method(D_METHOD("set_parental_level", "level"), &InterDVDProject::set_parental_level);
+	ClassDB::bind_method(D_METHOD("get_parental_level"), &InterDVDProject::get_parental_level);
+	ClassDB::bind_method(D_METHOD("set_volume_id", "id"), &InterDVDProject::set_volume_id);
+	ClassDB::bind_method(D_METHOD("get_volume_id"), &InterDVDProject::get_volume_id);
+	ClassDB::bind_method(D_METHOD("set_serial", "serial"), &InterDVDProject::set_serial);
+	ClassDB::bind_method(D_METHOD("get_serial"), &InterDVDProject::get_serial);
+	ClassDB::bind_method(D_METHOD("set_provider_id", "id"), &InterDVDProject::set_provider_id);
+	ClassDB::bind_method(D_METHOD("get_provider_id"), &InterDVDProject::get_provider_id);
+	ClassDB::bind_method(D_METHOD("set_disc_title", "title"), &InterDVDProject::set_disc_title);
+	ClassDB::bind_method(D_METHOD("get_disc_title"), &InterDVDProject::get_disc_title);
+	ClassDB::bind_method(D_METHOD("set_menu_language", "language"), &InterDVDProject::set_menu_language);
+	ClassDB::bind_method(D_METHOD("get_menu_language"), &InterDVDProject::get_menu_language);
+	ClassDB::bind_method(D_METHOD("set_audio_language", "language"), &InterDVDProject::set_audio_language);
+	ClassDB::bind_method(D_METHOD("get_audio_language"), &InterDVDProject::get_audio_language);
+	ClassDB::bind_method(D_METHOD("set_subtitle_language", "language"), &InterDVDProject::set_subtitle_language);
+	ClassDB::bind_method(D_METHOD("get_subtitle_language"), &InterDVDProject::get_subtitle_language);
+	ClassDB::bind_method(D_METHOD("set_ac3_bitrate_k", "kbps"), &InterDVDProject::set_ac3_bitrate_k);
+	ClassDB::bind_method(D_METHOD("get_ac3_bitrate_k"), &InterDVDProject::get_ac3_bitrate_k);
+	ClassDB::bind_method(D_METHOD("set_gop_size", "frames"), &InterDVDProject::set_gop_size);
+	ClassDB::bind_method(D_METHOD("get_gop_size"), &InterDVDProject::get_gop_size);
+	ClassDB::bind_method(D_METHOD("set_title_safe_bottom", "y"), &InterDVDProject::set_title_safe_bottom);
+	ClassDB::bind_method(D_METHOD("get_title_safe_bottom"), &InterDVDProject::get_title_safe_bottom);
+	ClassDB::bind_method(D_METHOD("set_bake_warmup_frames", "frames"), &InterDVDProject::set_bake_warmup_frames);
+	ClassDB::bind_method(D_METHOD("get_bake_warmup_frames"), &InterDVDProject::get_bake_warmup_frames);
+	ClassDB::bind_method(D_METHOD("seed_from_project_settings"), &InterDVDProject::seed_from_project_settings);
+	ClassDB::bind_static_method("InterDVDProject", D_METHOD("sanitize_volume_id", "id"), &InterDVDProject::sanitize_volume_id);
+	ClassDB::bind_static_method("InterDVDProject", D_METHOD("language_be16", "language"), &InterDVDProject::language_be16);
+	ClassDB::bind_method(D_METHOD("set_first_play", "pgc"), &InterDVDProject::set_first_play);
+	ClassDB::bind_method(D_METHOD("get_first_play"), &InterDVDProject::get_first_play);
+	ClassDB::bind_method(D_METHOD("set_titles", "titles"), &InterDVDProject::set_titles);
+	ClassDB::bind_method(D_METHOD("get_titles"), &InterDVDProject::get_titles);
+	ClassDB::bind_method(D_METHOD("set_menus", "menus"), &InterDVDProject::set_menus);
+	ClassDB::bind_method(D_METHOD("get_menus"), &InterDVDProject::get_menus);
+	ClassDB::bind_method(D_METHOD("add_title_from_video", "path"), &InterDVDProject::add_title_from_video);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_mask"), "set_region_mask", "get_region_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "parental_level"), "set_parental_level", "get_parental_level");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "volume_id"), "set_volume_id", "get_volume_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "serial"), "set_serial", "get_serial");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "provider_id"), "set_provider_id", "get_provider_id");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "disc_title"), "set_disc_title", "get_disc_title");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "menu_language"), "set_menu_language", "get_menu_language");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "audio_language"), "set_audio_language", "get_audio_language");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "subtitle_language"), "set_subtitle_language", "get_subtitle_language");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ac3_bitrate_k", PROPERTY_HINT_RANGE, "64,448,32"), "set_ac3_bitrate_k", "get_ac3_bitrate_k");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "gop_size", PROPERTY_HINT_RANGE, "1,30,1"), "set_gop_size", "get_gop_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "title_safe_bottom", PROPERTY_HINT_RANGE, "2,480,2"), "set_title_safe_bottom", "get_title_safe_bottom");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bake_warmup_frames", PROPERTY_HINT_RANGE, "0,30,1"), "set_bake_warmup_frames", "get_bake_warmup_frames");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "first_play", PROPERTY_HINT_RESOURCE_TYPE, "InterDVDPGC"), "set_first_play", "get_first_play");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "titles", PROPERTY_HINT_ARRAY_TYPE, "InterDVDPGC"), "set_titles", "get_titles");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "menus", PROPERTY_HINT_ARRAY_TYPE, "InterDVDMenu"), "set_menus", "get_menus");
+}
+
+Ref<InterDVDPGC> InterDVDProject::add_title_from_video(const String &p_path) {
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	cell->set_source_path(p_path);
+	const String clip_name = p_path.get_file().get_basename();
+	if (!clip_name.is_empty()) {
+		cell->set_name(clip_name);
+	}
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	if (!clip_name.is_empty()) {
+		title->set_name(clip_name);
+	}
+	TypedArray<InterDVDCell> cells;
+	cells.push_back(cell);
+	title->set_cells(cells);
+	titles.push_back(title);
+	return title;
+}
+
+String InterDVDProject::sanitize_volume_id(const String &p_id) {
+	String out;
+	const String src = p_id.strip_edges().to_upper();
+	for (int i = 0; i < src.length() && out.length() < 32; i++) {
+		const char32_t c = src[i];
+		if ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+			out += c;
+		} else if (c == '_' || c == '-' || c == ' ') {
+			out += '_';
+		}
+	}
+	while (out.contains("__")) {
+		out = out.replace("__", "_");
+	}
+	out = out.trim_prefix("_").trim_suffix("_");
+	return out.is_empty() ? String("BLAZIUM_DVD") : out;
+}
+
+uint16_t InterDVDProject::language_be16(const String &p_lang) {
+	String lang = p_lang.strip_edges().to_lower();
+	if (lang.length() < 2) {
+		lang = "en";
+	}
+	return uint16_t((uint16_t(lang.unicode_at(0) & 0x7F) << 8) | uint16_t(lang.unicode_at(1) & 0x7F));
+}
+
+InterDVDProject::InterDVDProject() {
+	seed_from_project_settings();
+}
+
+void InterDVDProject::seed_from_project_settings() {
+	region_mask = InterDVDSettings::setting_int("blazium/inter_dvd/default_region_mask", 1);
+	parental_level = InterDVDSettings::setting_int("blazium/inter_dvd/default_parental_level", 1);
+	ac3_bitrate_k = InterDVDSettings::ac3_bitrate_k();
+	gop_size = InterDVDSettings::gop_size();
+	title_safe_bottom = InterDVDSettings::title_safe_bottom();
+	bake_warmup_frames = InterDVDSettings::bake_warmup_frames();
+}
+
+namespace InterDVDSettings {
+
+int setting_int(const char *p_name, int p_fallback) {
+	if (!ProjectSettings::get_singleton() || !ProjectSettings::get_singleton()->has_setting(p_name)) {
+		return p_fallback;
+	}
+	return int(ProjectSettings::get_singleton()->get_setting(p_name));
+}
+
+double setting_float(const char *p_name, double p_fallback) {
+	if (!ProjectSettings::get_singleton() || !ProjectSettings::get_singleton()->has_setting(p_name)) {
+		return p_fallback;
+	}
+	return double(ProjectSettings::get_singleton()->get_setting(p_name));
+}
+
+int ac3_bitrate_k(const Ref<InterDVDProject> &p_project) {
+	if (p_project.is_valid() && p_project->get_ac3_bitrate_k() > 0) {
+		return p_project->get_ac3_bitrate_k();
+	}
+	return setting_int("blazium/inter_dvd/ac3_bitrate_k", 192);
+}
+
+int ac3_channels() {
+	return CLAMP(setting_int("blazium/inter_dvd/ac3_channels", 2), 1, 6);
+}
+
+int gop_size(const Ref<InterDVDProject> &p_project) {
+	if (p_project.is_valid() && p_project->get_gop_size() > 0) {
+		return p_project->get_gop_size();
+	}
+	return setting_int("blazium/inter_dvd/gop_size", 15);
+}
+
+int title_safe_bottom(const Ref<InterDVDProject> &p_project) {
+	if (p_project.is_valid() && p_project->get_title_safe_bottom() > 0) {
+		return p_project->get_title_safe_bottom();
+	}
+	return setting_int("blazium/inter_dvd/title_safe_bottom", 432);
+}
+
+int bake_warmup_frames(const Ref<InterDVDProject> &p_project) {
+	if (p_project.is_valid()) {
+		return MAX(p_project->get_bake_warmup_frames(), 0);
+	}
+	return MAX(setting_int("blazium/inter_dvd/bake_warmup_frames", 2), 0);
+}
+
+double pip_blackdetect_sec() {
+	return setting_float("blazium/inter_dvd/pip_blackdetect_sec", 2.5);
+}
+
+double pip_blackdetect_pix_th() {
+	return setting_float("blazium/inter_dvd/pip_blackdetect_pix_th", 0.12);
+}
+
+String cache_path() {
+	String path = "res://.inter_dvd_cache";
+	if (ProjectSettings::get_singleton() && ProjectSettings::get_singleton()->has_setting("blazium/inter_dvd/cache_path")) {
+		const String set = ProjectSettings::get_singleton()->get_setting("blazium/inter_dvd/cache_path");
+		if (!set.is_empty()) {
+			path = set;
+		}
+	}
+	if (path.begins_with("res://") && ProjectSettings::get_singleton() && !ProjectSettings::get_singleton()->get_resource_path().is_empty()) {
+		return ProjectSettings::get_singleton()->globalize_path(path);
+	}
+	if (path.is_empty() && OS::get_singleton()) {
+		return OS::get_singleton()->get_cache_path().path_join("inter_dvd_cache");
+	}
+	return path;
+}
+
+} //namespace InterDVDSettings

--- a/modules/inter_dvd/author/inter_dvd_project.h
+++ b/modules/inter_dvd/author/inter_dvd_project.h
@@ -1,0 +1,405 @@
+/**************************************************************************/
+/*  inter_dvd_project.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource.h"
+#include "core/math/color.h"
+#include "core/math/rect2.h"
+#include "core/string/node_path.h"
+#include "core/variant/typed_array.h"
+#include "scene/resources/packed_scene.h"
+
+class Node;
+
+class InterDVDStream : public Resource {
+	GDCLASS(InterDVDStream, Resource);
+
+public:
+	enum Kind {
+		KIND_AUDIO = 0,
+		KIND_SUBTITLE = 1,
+	};
+
+private:
+	Kind kind = KIND_AUDIO;
+	String source_path;
+	String language = "en";
+	int code_extension = 1;
+	bool enabled = true;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_kind(Kind p_kind) { kind = p_kind; }
+	Kind get_kind() const { return kind; }
+	void set_source_path(const String &p_path) { source_path = p_path; }
+	String get_source_path() const { return source_path; }
+	void set_language(const String &p_lang) { language = p_lang; }
+	String get_language() const { return language; }
+	void set_code_extension(int p_ext) { code_extension = p_ext; }
+	int get_code_extension() const { return code_extension; }
+	void set_enabled(bool p_enabled) { enabled = p_enabled; }
+	bool is_enabled() const { return enabled; }
+};
+
+VARIANT_ENUM_CAST(InterDVDStream::Kind);
+
+class InterDVDCell : public Resource {
+	GDCLASS(InterDVDCell, Resource);
+
+	String encoded_path;
+	String source_path;
+	String pip_source_path;
+	String audio_path;
+	NodePath pip_slot_path;
+	Rect2 pip_rect;
+	double pip_lead_sec = 0.40;
+	double bake_hold_sec = 0.0;
+	NodePath bake_camera_path;
+	Rect2 default_highlight;
+	Ref<PackedScene> packed_scene;
+	double duration_sec = 0.0;
+	double loop_pad_sec = 0.0;
+	bool include_audio = true;
+	TypedArray<InterDVDStream> streams;
+	TypedArray<PackedByteArray> post_commands;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_encoded_path(const String &p_path) { encoded_path = p_path; }
+	String get_encoded_path() const { return encoded_path; }
+	void set_source_path(const String &p_path) { source_path = p_path; }
+	String get_source_path() const { return source_path; }
+	void set_pip_source_path(const String &p_path) { pip_source_path = p_path; }
+	String get_pip_source_path() const { return pip_source_path; }
+	void set_audio_path(const String &p_path) { audio_path = p_path; }
+	String get_audio_path() const { return audio_path; }
+	void set_pip_slot_path(const NodePath &p_path) { pip_slot_path = p_path; }
+	NodePath get_pip_slot_path() const { return pip_slot_path; }
+	void set_pip_rect(const Rect2 &p_rect) { pip_rect = p_rect; }
+	Rect2 get_pip_rect() const { return pip_rect; }
+	void set_pip_lead_sec(double p_sec) { pip_lead_sec = p_sec; }
+	double get_pip_lead_sec() const { return pip_lead_sec; }
+	void set_bake_hold_sec(double p_sec) { bake_hold_sec = p_sec; }
+	double get_bake_hold_sec() const { return bake_hold_sec; }
+	void set_bake_camera_path(const NodePath &p_path) { bake_camera_path = p_path; }
+	NodePath get_bake_camera_path() const { return bake_camera_path; }
+	void set_default_highlight(const Rect2 &p_rect) { default_highlight = p_rect; }
+	Rect2 get_default_highlight() const { return default_highlight; }
+	void set_packed_scene(const Ref<PackedScene> &p_scene) { packed_scene = p_scene; }
+	Ref<PackedScene> get_packed_scene() const { return packed_scene; }
+	void set_duration_sec(double p_sec) { duration_sec = p_sec; }
+	double get_duration_sec() const { return duration_sec; }
+	void set_loop_pad_sec(double p_sec) { loop_pad_sec = p_sec; }
+	double get_loop_pad_sec() const { return loop_pad_sec; }
+	void set_include_audio(bool p_include) { include_audio = p_include; }
+	bool get_include_audio() const { return include_audio; }
+	void set_streams(const TypedArray<InterDVDStream> &p_streams) { streams = p_streams; }
+	TypedArray<InterDVDStream> get_streams() const { return streams; }
+	void set_post_commands(const TypedArray<PackedByteArray> &p_cmds) { post_commands = p_cmds; }
+	TypedArray<PackedByteArray> get_post_commands() const { return post_commands; }
+	String get_display_name() const;
+};
+
+class InterDVDButton : public Resource {
+	GDCLASS(InterDVDButton, Resource);
+
+public:
+	enum Action {
+		ACTION_JUMP_TITLE = 0,
+		ACTION_JUMP_MENU = 1,
+		ACTION_JUMP_PGC = 2,
+		ACTION_CUSTOM = 3,
+		ACTION_JUMP_CHAPTER = 4,
+		ACTION_JUMP_PROGRAM = 5,
+		ACTION_JUMP_CELL = 6,
+		ACTION_RESUME = 7,
+		ACTION_SET_AUDIO = 8,
+		ACTION_SET_SUBTITLE = 9,
+		ACTION_SET_ANGLE = 10,
+		ACTION_HIGHLIGHT_BUTTON = 11,
+		ACTION_EXIT = 12,
+	};
+
+	enum CommandDomain {
+		DOMAIN_VMGM = 0,
+		DOMAIN_VTST = 1,
+	};
+
+private:
+	Rect2 highlight;
+	PackedByteArray command;
+	Action action = ACTION_JUMP_TITLE;
+	int target = 1;
+	int title_n = 1;
+	int stream = 0;
+	bool subtitle_on = true;
+	bool auto_action = false;
+	bool hidden = false;
+	bool forced_selected = false;
+	bool forced_activated = false;
+	bool numeric_select = true;
+	int adjacent_up = 0;
+	int adjacent_down = 0;
+	int adjacent_left = 0;
+	int adjacent_right = 0;
+	int button_number = 0;
+	int color_group = 1;
+	NodePath control_path;
+	Color select_color = Color(1, 0.92, 0.2, 1);
+	Color action_color = Color(1, 0.35, 0.1, 1);
+
+protected:
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
+
+public:
+	void set_highlight(const Rect2 &p_rect) { highlight = p_rect; }
+	Rect2 get_highlight() const { return highlight; }
+	void set_command(const PackedByteArray &p_cmd) { command = p_cmd; }
+	PackedByteArray get_command() const { return command; }
+	void set_action(Action p_action);
+	Action get_action() const { return action; }
+	void set_target(int p_target) { target = p_target; }
+	int get_target() const { return target; }
+	void set_title_n(int p_title) { title_n = p_title; }
+	int get_title_n() const { return title_n; }
+	void set_stream(int p_stream) { stream = p_stream; }
+	int get_stream() const { return stream; }
+	void set_subtitle_on(bool p_on) { subtitle_on = p_on; }
+	bool get_subtitle_on() const { return subtitle_on; }
+	void set_auto_action(bool p_auto) { auto_action = p_auto; }
+	bool get_auto_action() const { return auto_action; }
+	void set_hidden(bool p_hidden) { hidden = p_hidden; }
+	bool is_hidden() const { return hidden; }
+	void set_forced_selected(bool p_forced) { forced_selected = p_forced; }
+	bool is_forced_selected() const { return forced_selected; }
+	void set_forced_activated(bool p_forced) { forced_activated = p_forced; }
+	bool is_forced_activated() const { return forced_activated; }
+	void set_numeric_select(bool p_numeric) { numeric_select = p_numeric; }
+	bool get_numeric_select() const { return numeric_select; }
+	void set_adjacent_up(int p_btn) { adjacent_up = p_btn; }
+	int get_adjacent_up() const { return adjacent_up; }
+	void set_adjacent_down(int p_btn) { adjacent_down = p_btn; }
+	int get_adjacent_down() const { return adjacent_down; }
+	void set_adjacent_left(int p_btn) { adjacent_left = p_btn; }
+	int get_adjacent_left() const { return adjacent_left; }
+	void set_adjacent_right(int p_btn) { adjacent_right = p_btn; }
+	int get_adjacent_right() const { return adjacent_right; }
+	void set_button_number(int p_n) { button_number = p_n; }
+	int get_button_number() const { return button_number; }
+	void set_color_group(int p_group) { color_group = p_group; }
+	int get_color_group() const { return color_group; }
+	void set_control_path(const NodePath &p_path) { control_path = p_path; }
+	NodePath get_control_path() const { return control_path; }
+	void set_select_color(const Color &p_color) { select_color = p_color; }
+	Color get_select_color() const { return select_color; }
+	void set_action_color(const Color &p_color) { action_color = p_color; }
+	Color get_action_color() const { return action_color; }
+	PackedByteArray resolve_command(CommandDomain p_domain = DOMAIN_VMGM) const;
+	void sync_highlight_from_scene(Node *p_root, const Rect2 &p_default_highlight = Rect2(), int p_title_safe_bottom = -1);
+};
+
+VARIANT_ENUM_CAST(InterDVDButton::Action);
+VARIANT_ENUM_CAST(InterDVDButton::CommandDomain);
+
+class InterDVDMenu : public Resource {
+	GDCLASS(InterDVDMenu, Resource);
+
+public:
+	enum MenuType {
+		MENU_TITLE = 2,
+		MENU_ROOT = 3,
+		MENU_SUBPICTURE = 4,
+		MENU_AUDIO = 5,
+		MENU_ANGLE = 6,
+		MENU_CHAPTER = 7,
+	};
+
+private:
+	bool motion = false;
+	TypedArray<InterDVDButton> buttons;
+	Ref<InterDVDCell> cell;
+	int still_time = 0;
+	int next_pgc = 1;
+	int prev_pgc = 1;
+	int default_button = 1;
+	int forced_selected_button = 0;
+	int forced_activated_button = 0;
+	MenuType menu_type = MENU_TITLE;
+	int button_group_mask = 0x1000;
+	PackedColorArray clut;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_motion(bool p_motion) { motion = p_motion; }
+	bool is_motion() const { return motion; }
+	void set_buttons(const TypedArray<InterDVDButton> &p_buttons);
+	TypedArray<InterDVDButton> get_buttons() const { return buttons; }
+	void set_cell(const Ref<InterDVDCell> &p_cell) { cell = p_cell; }
+	Ref<InterDVDCell> get_cell() const { return cell; }
+	void set_still_time(int p_sec) { still_time = p_sec; }
+	int get_still_time() const { return still_time; }
+	void set_next_pgc(int p_pgc) { next_pgc = p_pgc; }
+	int get_next_pgc() const { return next_pgc; }
+	void set_prev_pgc(int p_pgc) { prev_pgc = p_pgc; }
+	int get_prev_pgc() const { return prev_pgc; }
+	void set_default_button(int p_btn) { default_button = p_btn; }
+	int get_default_button() const { return default_button; }
+	void set_forced_selected_button(int p_btn) { forced_selected_button = p_btn; }
+	int get_forced_selected_button() const { return forced_selected_button; }
+	void set_forced_activated_button(int p_btn) { forced_activated_button = p_btn; }
+	int get_forced_activated_button() const { return forced_activated_button; }
+	void set_menu_type(MenuType p_type) { menu_type = p_type; }
+	MenuType get_menu_type() const { return menu_type; }
+	void set_button_group_mask(int p_mask) { button_group_mask = p_mask; }
+	int get_button_group_mask() const { return button_group_mask; }
+	void set_clut(const PackedColorArray &p_clut) { clut = p_clut; }
+	PackedColorArray get_clut() const { return clut; }
+};
+
+VARIANT_ENUM_CAST(InterDVDMenu::MenuType);
+
+class InterDVDPGC : public Resource {
+	GDCLASS(InterDVDPGC, Resource);
+
+	TypedArray<InterDVDCell> cells;
+	TypedArray<InterDVDButton> buttons;
+	TypedArray<PackedByteArray> pre_commands;
+	TypedArray<PackedByteArray> post_commands;
+	int still_time = 0;
+	int next_pgc = 0;
+	int prev_pgc = 0;
+	int default_button = 1;
+	PackedColorArray clut;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_cells(const TypedArray<InterDVDCell> &p_cells) { cells = p_cells; }
+	TypedArray<InterDVDCell> get_cells() const { return cells; }
+	void set_buttons(const TypedArray<InterDVDButton> &p_buttons);
+	TypedArray<InterDVDButton> get_buttons() const { return buttons; }
+	void set_pre_commands(const TypedArray<PackedByteArray> &p_cmds) { pre_commands = p_cmds; }
+	TypedArray<PackedByteArray> get_pre_commands() const { return pre_commands; }
+	void set_post_commands(const TypedArray<PackedByteArray> &p_cmds) { post_commands = p_cmds; }
+	TypedArray<PackedByteArray> get_post_commands() const { return post_commands; }
+	void set_still_time(int p_sec) { still_time = p_sec; }
+	int get_still_time() const { return still_time; }
+	void set_next_pgc(int p_pgc) { next_pgc = p_pgc; }
+	int get_next_pgc() const { return next_pgc; }
+	void set_prev_pgc(int p_pgc) { prev_pgc = p_pgc; }
+	int get_prev_pgc() const { return prev_pgc; }
+	void set_default_button(int p_btn) { default_button = p_btn; }
+	int get_default_button() const { return default_button; }
+	void set_clut(const PackedColorArray &p_clut) { clut = p_clut; }
+	PackedColorArray get_clut() const { return clut; }
+};
+
+class InterDVDProject : public Resource {
+	GDCLASS(InterDVDProject, Resource);
+
+	int region_mask = 0x01;
+	int parental_level = 1;
+	String volume_id = "BLAZIUM_DVD";
+	String serial;
+	String provider_id = "BLAZIUM INTER-DVD";
+	String disc_title;
+	String menu_language = "en";
+	String audio_language = "en";
+	String subtitle_language = "en";
+	int ac3_bitrate_k = 192;
+	int gop_size = 15;
+	int title_safe_bottom = 432;
+	int bake_warmup_frames = 2;
+	Ref<InterDVDPGC> first_play;
+	TypedArray<InterDVDPGC> titles;
+	TypedArray<InterDVDMenu> menus;
+
+protected:
+	static void _bind_methods();
+
+public:
+	InterDVDProject();
+	void seed_from_project_settings();
+	void set_region_mask(int p_mask) { region_mask = p_mask; }
+	int get_region_mask() const { return region_mask; }
+	void set_parental_level(int p_level) { parental_level = p_level; }
+	int get_parental_level() const { return parental_level; }
+	void set_volume_id(const String &p_id) { volume_id = p_id; }
+	String get_volume_id() const { return volume_id; }
+	void set_serial(const String &p_serial) { serial = p_serial; }
+	String get_serial() const { return serial; }
+	void set_provider_id(const String &p_id) { provider_id = p_id; }
+	String get_provider_id() const { return provider_id; }
+	void set_disc_title(const String &p_title) { disc_title = p_title; }
+	String get_disc_title() const { return disc_title; }
+	void set_menu_language(const String &p_lang) { menu_language = p_lang; }
+	String get_menu_language() const { return menu_language; }
+	void set_audio_language(const String &p_lang) { audio_language = p_lang; }
+	String get_audio_language() const { return audio_language; }
+	void set_subtitle_language(const String &p_lang) { subtitle_language = p_lang; }
+	String get_subtitle_language() const { return subtitle_language; }
+	void set_ac3_bitrate_k(int p_k) { ac3_bitrate_k = p_k; }
+	int get_ac3_bitrate_k() const { return ac3_bitrate_k; }
+	void set_gop_size(int p_gop) { gop_size = p_gop; }
+	int get_gop_size() const { return gop_size; }
+	void set_title_safe_bottom(int p_y) { title_safe_bottom = p_y; }
+	int get_title_safe_bottom() const { return title_safe_bottom; }
+	void set_bake_warmup_frames(int p_frames) { bake_warmup_frames = p_frames; }
+	int get_bake_warmup_frames() const { return bake_warmup_frames; }
+	static String sanitize_volume_id(const String &p_id);
+	static uint16_t language_be16(const String &p_lang);
+	void set_first_play(const Ref<InterDVDPGC> &p_pgc) { first_play = p_pgc; }
+	Ref<InterDVDPGC> get_first_play() const { return first_play; }
+	void set_titles(const TypedArray<InterDVDPGC> &p_titles) { titles = p_titles; }
+	TypedArray<InterDVDPGC> get_titles() const { return titles; }
+	void set_menus(const TypedArray<InterDVDMenu> &p_menus) { menus = p_menus; }
+	TypedArray<InterDVDMenu> get_menus() const { return menus; }
+	Ref<InterDVDPGC> add_title_from_video(const String &p_path);
+};
+
+namespace InterDVDSettings {
+int setting_int(const char *p_name, int p_fallback);
+int ac3_bitrate_k(const Ref<InterDVDProject> &p_project = Ref<InterDVDProject>());
+int ac3_channels();
+int gop_size(const Ref<InterDVDProject> &p_project = Ref<InterDVDProject>());
+int title_safe_bottom(const Ref<InterDVDProject> &p_project = Ref<InterDVDProject>());
+int bake_warmup_frames(const Ref<InterDVDProject> &p_project = Ref<InterDVDProject>());
+double pip_blackdetect_sec();
+double pip_blackdetect_pix_th();
+String cache_path();
+} //namespace InterDVDSettings

--- a/modules/inter_dvd/author/inter_dvd_vob_mux.cpp
+++ b/modules/inter_dvd/author/inter_dvd_vob_mux.cpp
@@ -1,0 +1,1378 @@
+/**************************************************************************/
+/*  inter_dvd_vob_mux.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "inter_dvd_vob_mux.h"
+
+#include "inter_dvd_project.h"
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/math/math_funcs.h"
+#include "core/os/os.h"
+
+namespace {
+
+void write_be16(Vector<uint8_t> &p_buf, int p_off, uint16_t p_value) {
+	p_buf.write[p_off] = uint8_t((p_value >> 8) & 0xFF);
+	p_buf.write[p_off + 1] = uint8_t(p_value & 0xFF);
+}
+
+void write_be32(Vector<uint8_t> &p_buf, int p_off, uint32_t p_value) {
+	p_buf.write[p_off] = uint8_t((p_value >> 24) & 0xFF);
+	p_buf.write[p_off + 1] = uint8_t((p_value >> 16) & 0xFF);
+	p_buf.write[p_off + 2] = uint8_t((p_value >> 8) & 0xFF);
+	p_buf.write[p_off + 3] = uint8_t(p_value & 0xFF);
+}
+
+uint8_t to_bcd(int p_value) {
+	const int v = CLAMP(p_value, 0, 99);
+	return uint8_t(((v / 10) << 4) | (v % 10));
+}
+
+void write_dvd_time(Vector<uint8_t> &p_buf, int p_off, double p_seconds) {
+	const int total = MAX(int(Math::round(MAX(p_seconds, 0.0) * 30.0)), 0);
+	const int hh = total / (30 * 3600);
+	const int mm = (total / (30 * 60)) % 60;
+	const int ss = (total / 30) % 60;
+	const int ff = total % 30;
+	p_buf.write[p_off] = to_bcd(hh);
+	p_buf.write[p_off + 1] = to_bcd(mm);
+	p_buf.write[p_off + 2] = to_bcd(ss);
+	p_buf.write[p_off + 3] = uint8_t(0xC0 | to_bcd(ff));
+}
+
+void write_pack_scr(uint8_t *p_d, uint64_t p_scr) {
+	p_d[0] = uint8_t(0x40 | ((p_scr >> 27) & 0x38) | 0x04 | ((p_scr >> 28) & 0x03));
+	p_d[1] = uint8_t((p_scr >> 20) & 0xFF);
+	p_d[2] = uint8_t(0x04 | ((p_scr >> 12) & 0xF8) | ((p_scr >> 13) & 0x03));
+	p_d[3] = uint8_t((p_scr >> 5) & 0xFF);
+	p_d[4] = uint8_t(((p_scr & 0x1F) << 3) | 0x04);
+	p_d[5] = 0x01;
+}
+
+bool is_pack_start(const uint8_t *p_sec) {
+	return p_sec[0] == 0x00 && p_sec[1] == 0x00 && p_sec[2] == 0x01 && p_sec[3] == 0xBA;
+}
+
+bool is_nav_sector(const uint8_t *p_sec) {
+	return is_pack_start(p_sec) && p_sec[38] == 0x00 && p_sec[39] == 0x00 && p_sec[40] == 0x01 && p_sec[41] == 0xBF;
+}
+
+bool is_ac3_sector(const uint8_t *p_sec) {
+	if (!is_pack_start(p_sec)) {
+		return false;
+	}
+	for (int i = 0; i <= InterDVDVobMux::SECTOR_SIZE - 10; i++) {
+		if (p_sec[i] != 0x00 || p_sec[i + 1] != 0x00 || p_sec[i + 2] != 0x01 || p_sec[i + 3] != 0xBD) {
+			continue;
+		}
+		const int sub = i + 9 + p_sec[i + 8];
+		if (sub < InterDVDVobMux::SECTOR_SIZE && (p_sec[sub] & 0xF8) == 0x80) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool is_spu_sector(const uint8_t *p_sec) {
+	if (!is_pack_start(p_sec)) {
+		return false;
+	}
+	for (int i = 0; i <= InterDVDVobMux::SECTOR_SIZE - 10; i++) {
+		if (p_sec[i] != 0x00 || p_sec[i + 1] != 0x00 || p_sec[i + 2] != 0x01 || p_sec[i + 3] != 0xBD) {
+			continue;
+		}
+		const int sub = i + 9 + p_sec[i + 8];
+		if (sub < InterDVDVobMux::SECTOR_SIZE && p_sec[sub] >= 0x20 && p_sec[sub] <= 0x3F) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void collect_private_ids(const uint8_t *p_sec, uint8_t p_min, uint8_t p_max, uint8_t *p_seen, int p_seen_n) {
+	if (!is_pack_start(p_sec)) {
+		return;
+	}
+	for (int i = 0; i <= InterDVDVobMux::SECTOR_SIZE - 10; i++) {
+		if (p_sec[i] != 0x00 || p_sec[i + 1] != 0x00 || p_sec[i + 2] != 0x01 || p_sec[i + 3] != 0xBD) {
+			continue;
+		}
+		const int sub = i + 9 + p_sec[i + 8];
+		if (sub >= InterDVDVobMux::SECTOR_SIZE) {
+			continue;
+		}
+		const uint8_t id = p_sec[sub];
+		if (id < p_min || id > p_max) {
+			continue;
+		}
+		const int idx = int(id - p_min);
+		if (idx >= 0 && idx < p_seen_n) {
+			p_seen[idx] = 1;
+		}
+	}
+}
+
+int count_private_range(const String &p_path, uint8_t p_min, uint8_t p_max) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return 0;
+	}
+	const int span = int(p_max) - int(p_min) + 1;
+	uint8_t seen[64];
+	for (int i = 0; i < 64; i++) {
+		seen[i] = 0;
+	}
+	uint8_t sec[InterDVDVobMux::SECTOR_SIZE];
+	int checked = 0;
+	while (f->get_position() < f->get_length() && checked < 512) {
+		const int n = int(f->get_buffer(sec, InterDVDVobMux::SECTOR_SIZE));
+		if (n < InterDVDVobMux::SECTOR_SIZE) {
+			break;
+		}
+		collect_private_ids(sec, p_min, p_max, seen, MIN(span, 64));
+		checked++;
+	}
+	int count = 0;
+	for (int i = 0; i < span && i < 64; i++) {
+		count += seen[i] ? 1 : 0;
+	}
+	return count;
+}
+
+bool is_mpeg_video_sector(const uint8_t *p_sec) {
+	if (!is_pack_start(p_sec)) {
+		return false;
+	}
+	for (int i = 0; i <= InterDVDVobMux::SECTOR_SIZE - 4; i++) {
+		if (p_sec[i] == 0x00 && p_sec[i + 1] == 0x00 && p_sec[i + 2] == 0x01 && p_sec[i + 3] >= 0xE0 && p_sec[i + 3] <= 0xEF) {
+			return true;
+		}
+	}
+	return false;
+}
+
+Error copy_file(const String &p_src, const String &p_dst);
+
+bool source_path_needs_safe_copy(const String &p_path) {
+	return p_path.contains("#") || p_path.contains("!") || p_path.contains("?") || p_path.contains(String::chr(0xFF1F)) || p_path.contains(" ");
+}
+
+String cached_ascii_source(const String &p_src, const String &p_out_vob, String *r_error) {
+	if (!source_path_needs_safe_copy(p_src)) {
+		return p_src;
+	}
+	String ext = p_src.get_extension().to_lower();
+	if (ext.is_empty()) {
+		ext = "mp4";
+	}
+	const String cache = p_out_vob.get_base_dir().path_join(p_src.md5_text() + "." + ext);
+	const Error err = copy_file(p_src, cache);
+	if (err != OK) {
+		if (r_error) {
+			*r_error = vformat("Could not cache source with special characters: %s", p_src);
+		}
+		return String();
+	}
+	return cache;
+}
+
+void collect_cell_sidecars(const Ref<InterDVDCell> &p_cell, Vector<String> &r_audio, Vector<String> &r_subs) {
+	if (p_cell.is_null()) {
+		return;
+	}
+	if (p_cell->get_include_audio() && !p_cell->get_audio_path().is_empty() && FileAccess::exists(p_cell->get_audio_path())) {
+		r_audio.push_back(p_cell->get_audio_path());
+	}
+	const TypedArray<InterDVDStream> streams = p_cell->get_streams();
+	for (int i = 0; i < streams.size(); i++) {
+		const Ref<InterDVDStream> stream = streams[i];
+		if (stream.is_null() || !stream->is_enabled() || stream->get_source_path().is_empty() || !FileAccess::exists(stream->get_source_path())) {
+			continue;
+		}
+		if (stream->get_kind() == InterDVDStream::KIND_SUBTITLE) {
+			r_subs.push_back(stream->get_source_path());
+		} else {
+			r_audio.push_back(stream->get_source_path());
+		}
+	}
+}
+
+Error run_dvd_ffmpeg(const String &p_ffmpeg, const String &p_video, const Vector<String> &p_audio, const Vector<String> &p_subs, bool p_include_audio, const String &p_out, String *r_error) {
+	List<String> args;
+	args.push_back("-y");
+	args.push_back("-i");
+	args.push_back(p_video);
+	for (int i = 0; i < p_audio.size(); i++) {
+		args.push_back("-i");
+		args.push_back(p_audio[i]);
+	}
+	for (int i = 0; i < p_subs.size(); i++) {
+		args.push_back("-i");
+		args.push_back(p_subs[i]);
+	}
+	args.push_back("-target");
+	args.push_back("ntsc-dvd");
+	const bool need_map = !p_audio.is_empty() || !p_subs.is_empty() || !p_include_audio;
+	if (need_map) {
+		args.push_back("-map");
+		args.push_back("0:v:0");
+		if (p_include_audio && p_audio.is_empty()) {
+			args.push_back("-map");
+			args.push_back("0:a:0?");
+		}
+		for (int i = 0; i < p_audio.size(); i++) {
+			args.push_back("-map");
+			args.push_back(vformat("%d:a:0?", i + 1));
+		}
+		const int sub_base = 1 + p_audio.size();
+		for (int i = 0; i < p_subs.size(); i++) {
+			args.push_back("-map");
+			args.push_back(vformat("%d:s:0?", sub_base + i));
+		}
+		if (!p_subs.is_empty()) {
+			args.push_back("-c:s");
+			args.push_back("dvdsub");
+		}
+	}
+	args.push_back(p_out);
+	String pipe;
+	const int code = OS::get_singleton()->execute(p_ffmpeg, args, &pipe);
+	if (code == 0 && FileAccess::exists(p_out)) {
+		return OK;
+	}
+	if (r_error) {
+		*r_error = vformat("ffmpeg failed (%d): %s", code, pipe);
+	}
+	return FAILED;
+}
+
+Error reject_unplayable_cell(const String &p_path, bool p_allow_dummy, String *r_error) {
+	if (p_allow_dummy) {
+		return OK;
+	}
+	const double dur = InterDVDVobMux::estimate_duration_sec(p_path);
+	if (dur < 2.0) {
+		if (r_error) {
+			*r_error = vformat("Muxed cell is %.2fs (need >= 2s): %s", dur, p_path);
+		}
+		return FAILED;
+	}
+	if (!InterDVDVobMux::contains_mpeg_video(p_path)) {
+		if (r_error) {
+			*r_error = vformat("Muxed cell has no MPEG video PES: %s", p_path);
+		}
+		return FAILED;
+	}
+	return OK;
+}
+
+uint16_t first_ac3_rel(const Vector<Vector<uint8_t>> &p_secs, int p_nav, int p_end) {
+	for (int i = p_nav + 1; i < p_end && i < p_secs.size(); i++) {
+		if (is_ac3_sector(p_secs[i].ptr())) {
+			return uint16_t(CLAMP(i - p_nav, 1, 0x3FFE));
+		}
+	}
+	return 0x3FFF;
+}
+
+bool read_pes_pts(const uint8_t *p_sec, uint8_t p_stream, uint32_t &r_pts) {
+	for (int i = 0; i <= InterDVDVobMux::SECTOR_SIZE - 14; i++) {
+		if (p_sec[i] != 0x00 || p_sec[i + 1] != 0x00 || p_sec[i + 2] != 0x01 || p_sec[i + 3] != p_stream) {
+			continue;
+		}
+		if ((p_sec[i + 7] & 0x80) == 0 || p_sec[i + 8] < 5) {
+			continue;
+		}
+		const uint8_t *b = p_sec + i + 9;
+		if ((b[0] & 0xC1) != 0x01 || ((b[0] & 0x30) != 0x20 && (b[0] & 0x30) != 0x30)) {
+			continue;
+		}
+		r_pts = (uint32_t((b[0] >> 1) & 0x07) << 30) | (uint32_t(b[1]) << 22) | (uint32_t((b[2] >> 1) & 0x7F) << 15) | (uint32_t(b[3]) << 7) | (uint32_t((b[4] >> 1) & 0x7F));
+		return true;
+	}
+	return false;
+}
+
+uint64_t read_pack_scr(const uint8_t *p_sec) {
+	const uint8_t b0 = p_sec[4];
+	const uint8_t b1 = p_sec[5];
+	const uint8_t b2 = p_sec[6];
+	const uint8_t b3 = p_sec[7];
+	const uint8_t b4 = p_sec[8];
+	return (uint64_t((b0 >> 3) & 0x07) << 30) | (uint64_t(b0 & 0x03) << 28) | (uint64_t(b1) << 20) | (uint64_t((b2 >> 3) & 0x1F) << 15) | (uint64_t(b2 & 0x03) << 13) | (uint64_t(b3) << 5) | (uint64_t((b4 >> 3) & 0x1F));
+}
+
+bool first_video_clock(const Vector<Vector<uint8_t>> &p_sectors, int p_from, int p_to, uint32_t &r_pts, uint64_t &r_scr) {
+	for (int i = p_from; i < p_to && i < p_sectors.size(); i++) {
+		if (p_sectors[i].size() < InterDVDVobMux::SECTOR_SIZE) {
+			continue;
+		}
+		const uint8_t *p = p_sectors[i].ptr();
+		uint32_t pts = 0;
+		if (!is_pack_start(p) || (p[4] & 0xC4) != 0x44 || !read_pes_pts(p, 0xE0, pts)) {
+			continue;
+		}
+		r_pts = pts;
+		r_scr = read_pack_scr(p);
+		return true;
+	}
+	return false;
+}
+
+bool sector_has_start_code(const uint8_t *p_sec, uint8_t p_id) {
+	for (int i = 0; i <= InterDVDVobMux::SECTOR_SIZE - 4; i++) {
+		if (p_sec[i] == 0x00 && p_sec[i + 1] == 0x00 && p_sec[i + 2] == 0x01 && p_sec[i + 3] == p_id) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool is_mpeg_program_stream(const String &p_path) {
+	const String ext = p_path.get_extension().to_lower();
+	if (ext == "vob" || ext == "mpg" || ext == "mpeg" || ext == "m2p") {
+		return true;
+	}
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null() || f->get_length() < 4) {
+		return false;
+	}
+	uint8_t h[4] = {};
+	f->get_buffer(h, 4);
+	return h[0] == 0x00 && h[1] == 0x00 && h[2] == 0x01 && h[3] == 0xBA;
+}
+
+Error copy_file(const String &p_src, const String &p_dst) {
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (da.is_null()) {
+		return ERR_CANT_OPEN;
+	}
+	return da->copy(p_src, p_dst);
+}
+
+Vector<uint8_t> make_nav_sector(uint32_t p_lbn, uint32_t p_vobu_ea, uint32_t p_next_vobu, uint32_t p_prev_vobu, uint32_t p_s_ptm, uint32_t p_e_ptm, uint64_t p_pack_scr, double p_eltm_sec) {
+	Vector<uint8_t> sec;
+	sec.resize(InterDVDVobMux::SECTOR_SIZE);
+	sec.fill(0);
+
+	sec.write[0] = 0x00;
+	sec.write[1] = 0x00;
+	sec.write[2] = 0x01;
+	sec.write[3] = 0xBA;
+	write_pack_scr(&sec.write[4], p_pack_scr);
+	sec.write[10] = 0x01;
+	sec.write[11] = 0x89;
+	sec.write[12] = 0xC3;
+	sec.write[13] = 0xF8;
+
+	const uint8_t sys[] = { 0x00, 0x00, 0x01, 0xBB, 0x00, 0x12, 0x80, 0x9F, 0xF3, 0x04, 0xE1, 0x7F, 0xFE, 0xE0, 0xE0, 0xC0, 0xC0, 0xBD, 0xE0, 0xBB, 0x00, 0x00, 0x00, 0x00 };
+	for (int i = 0; i < 24; i++) {
+		sec.write[14 + i] = sys[i];
+	}
+
+	sec.write[38] = 0x00;
+	sec.write[39] = 0x00;
+	sec.write[40] = 0x01;
+	sec.write[41] = 0xBF;
+	sec.write[42] = 0x03;
+	sec.write[43] = 0xD4;
+	sec.write[44] = 0x00;
+	write_be32(sec, 45, p_lbn);
+	write_be32(sec, 45 + 12, p_s_ptm);
+	write_be32(sec, 45 + 16, p_e_ptm);
+	write_be32(sec, 45 + 20, p_e_ptm);
+	write_dvd_time(sec, 45 + 24, p_eltm_sec);
+
+	sec.write[1024] = 0x00;
+	sec.write[1025] = 0x00;
+	sec.write[1026] = 0x01;
+	sec.write[1027] = 0xBF;
+	sec.write[1028] = 0x03;
+	sec.write[1029] = 0xFA;
+	sec.write[1030] = 0x01;
+	write_be32(sec, 1031, uint32_t(p_pack_scr));
+	write_be32(sec, 1031 + 4, p_lbn);
+	write_dvd_time(sec, 1031 + 28, p_eltm_sec);
+	write_be32(sec, 1031 + 8, p_vobu_ea);
+	if (p_vobu_ea > 0) {
+		write_be32(sec, 1031 + 12, p_vobu_ea);
+	}
+	write_be16(sec, 1031 + 24, 1);
+	sec.write[1031 + 27] = 1;
+
+	const int sri = 1031 + 0xEA;
+	write_be32(sec, sri, p_next_vobu);
+	write_be32(sec, sri + 80, p_next_vobu);
+	write_be32(sec, sri + 84, p_prev_vobu);
+	write_be32(sec, sri + 164, p_prev_vobu);
+	write_be16(sec, sri + 168, 0x3FFF);
+	return sec;
+}
+
+constexpr uint32_t SRI_NONE = 0x3FFFFFFF;
+constexpr uint32_t SRI_OK = 0x40000000;
+
+void put_bits(Vector<uint8_t> &p_buf, int &p_bit, int p_count, uint32_t p_value) {
+	for (int i = p_count - 1; i >= 0; i--) {
+		const int byte = p_bit / 8;
+		const int bit = 7 - (p_bit % 8);
+		if (byte < p_buf.size() && ((p_value >> i) & 1u)) {
+			p_buf.write[byte] = uint8_t(p_buf[byte] | (1u << bit));
+		}
+		p_bit++;
+	}
+}
+
+PackedByteArray hardware_button_command(const Ref<InterDVDButton> &p_btn, bool p_title_domain) {
+	if (p_btn.is_valid()) {
+		return p_btn->resolve_command(p_title_domain ? InterDVDButton::DOMAIN_VTST : InterDVDButton::DOMAIN_VMGM);
+	}
+	PackedByteArray jump;
+	jump.resize(8);
+	jump.fill(0);
+	if (p_title_domain) {
+		jump.write[0] = 0x20;
+		jump.write[1] = 0x04;
+		jump.write[7] = 1;
+	} else {
+		jump.write[0] = 0x30;
+		jump.write[1] = 0x02;
+		jump.write[5] = 1;
+	}
+	return jump;
+}
+
+Rect2 button_rect(const Ref<InterDVDButton> &p_btn) {
+	return p_btn.is_valid() ? p_btn->get_highlight() : Rect2();
+}
+
+uint8_t nearest_neighbor(const TypedArray<InterDVDButton> &p_buttons, int p_self, int p_axis, int p_dir) {
+	const int n = MIN(p_buttons.size(), 36);
+	const Vector2 self = button_rect(p_buttons[p_self]).get_center();
+	int best = p_self;
+	double best_score = 1e18;
+	for (int i = 0; i < n; i++) {
+		if (i == p_self) {
+			continue;
+		}
+		const Vector2 c = button_rect(p_buttons[i]).get_center();
+		const double along = p_axis == 0 ? (c.x - self.x) : (c.y - self.y);
+		const double across = p_axis == 0 ? Math::abs(c.y - self.y) : Math::abs(c.x - self.x);
+		if (along * p_dir <= 4.0) {
+			continue;
+		}
+		const double score = along * p_dir + across * 0.35;
+		if (score < best_score) {
+			best_score = score;
+			best = i;
+		}
+	}
+	return uint8_t(best + 1);
+}
+
+int nearest_clut_index(const Color &p_color) {
+	const Color slots[3] = { Color(1, 0.92, 0.2), Color(1, 0.35, 0.1), Color(1, 1, 1) };
+	int best = 1;
+	float best_d = 1e9f;
+	for (int i = 0; i < 3; i++) {
+		const float dr = p_color.r - slots[i].r;
+		const float dg = p_color.g - slots[i].g;
+		const float db = p_color.b - slots[i].b;
+		const float d = dr * dr + dg * dg + db * db;
+		if (d < best_d) {
+			best_d = d;
+			best = i + 1;
+		}
+	}
+	return best;
+}
+
+uint32_t pack_coli(int p_index) {
+	const uint32_t idx = uint32_t(CLAMP(p_index, 1, 15) & 0xF);
+	const uint16_t half = uint16_t((idx << 12) | 0x0F70);
+	return (uint32_t(half) << 16) | half;
+}
+
+void write_hli_buttons(Vector<uint8_t> &p_sec, const TypedArray<InterDVDButton> &p_buttons, uint32_t p_s_ptm, uint32_t p_e_ptm, bool p_title_domain, uint16_t p_hli_ss, int p_forced_select, int p_forced_activate, uint16_t p_btn_colnfo, int p_title_safe_bottom) {
+	const int n = MIN(p_buttons.size(), 36);
+	if (n <= 0) {
+		return;
+	}
+	int fosl = p_forced_select;
+	int foac = p_forced_activate;
+	int numeric_n = 0;
+	for (int i = 0; i < n; i++) {
+		const Ref<InterDVDButton> btn = p_buttons[i];
+		if (btn.is_null()) {
+			continue;
+		}
+		if (btn->get_numeric_select()) {
+			numeric_n++;
+		}
+		if (fosl <= 0 && btn->is_forced_selected()) {
+			fosl = i + 1;
+		}
+		if (foac <= 0 && btn->is_forced_activated()) {
+			foac = i + 1;
+		}
+	}
+	if (fosl <= 0 && p_hli_ss == 1) {
+		fosl = 1;
+	}
+	const int hli = 45 + 96;
+	write_be16(p_sec, hli, p_hli_ss);
+	write_be32(p_sec, hli + 2, p_s_ptm);
+	write_be32(p_sec, hli + 6, p_e_ptm);
+	write_be32(p_sec, hli + 10, p_e_ptm);
+
+	uint16_t colnfo = p_btn_colnfo;
+	if (colnfo == 0 || colnfo == 0x4000) {
+		colnfo = 0x1000;
+	}
+	write_be16(p_sec, hli + 14, colnfo);
+
+	p_sec.write[hli + 16] = uint8_t(n);
+	p_sec.write[hli + 17] = uint8_t(numeric_n > 0 ? numeric_n : n);
+	p_sec.write[hli + 18] = 0;
+	p_sec.write[hli + 19] = 0;
+	p_sec.write[hli + 20] = uint8_t(CLAMP(fosl, 0, 36));
+	p_sec.write[hli + 21] = uint8_t(CLAMP(foac, 0, 36));
+	const Ref<InterDVDButton> first = p_buttons[0];
+	const uint32_t sl0 = pack_coli(first.is_valid() ? nearest_clut_index(first->get_select_color()) : 1);
+	const uint32_t ac0 = pack_coli(first.is_valid() ? nearest_clut_index(first->get_action_color()) : 2);
+	uint32_t sl[3] = { sl0, sl0, sl0 };
+	uint32_t ac[3] = { ac0, ac0, ac0 };
+	bool have_group[3] = { false, false, false };
+	for (int i = 0; i < n; i++) {
+		const Ref<InterDVDButton> btn = p_buttons[i];
+		if (btn.is_null()) {
+			continue;
+		}
+		const int g = CLAMP(btn->get_color_group(), 1, 3) - 1;
+		if (have_group[g]) {
+			continue;
+		}
+		sl[g] = pack_coli(nearest_clut_index(btn->get_select_color()));
+		ac[g] = pack_coli(nearest_clut_index(btn->get_action_color()));
+		have_group[g] = true;
+	}
+	for (int g = 0; g < 3; g++) {
+		write_be32(p_sec, hli + 22 + g * 8, sl[g]);
+		write_be32(p_sec, hli + 26 + g * 8, ac[g]);
+	}
+	int bit = (hli + 46) * 8;
+	for (int i = 0; i < n; i++) {
+		const Ref<InterDVDButton> btn = p_buttons[i];
+		const bool hidden = btn.is_valid() && btn->is_hidden();
+		const Rect2 r = hidden ? Rect2() : button_rect(btn);
+		int x0 = hidden ? 0 : CLAMP(int(r.position.x), 0, 719);
+		int y0 = hidden ? 0 : CLAMP(int(r.position.y), 0, 479);
+		int x1 = hidden ? 0 : CLAMP(int(r.position.x + r.size.x), x0, 719);
+		int y1 = hidden ? 0 : CLAMP(int(r.position.y + r.size.y), y0, 479);
+		const int safe_y = CLAMP(p_title_safe_bottom > 0 ? p_title_safe_bottom : InterDVDSettings::title_safe_bottom(), 2, 480);
+		if (!hidden && y1 > safe_y) {
+			const int bh = MAX(y1 - y0, 2);
+			y1 = safe_y;
+			y0 = MAX(0, y1 - bh);
+		}
+
+		x0 &= ~1;
+		y0 &= ~1;
+		x1 &= ~1;
+		y1 &= ~1;
+		if (!hidden && x1 <= x0) {
+			x1 = MIN(x0 + 2, 718);
+		}
+		if (!hidden && y1 <= y0) {
+			y1 = MIN(y0 + 2, 478);
+		}
+		const int up = (btn.is_valid() && btn->get_adjacent_up() > 0) ? btn->get_adjacent_up() : nearest_neighbor(p_buttons, i, 1, -1);
+		const int down = (btn.is_valid() && btn->get_adjacent_down() > 0) ? btn->get_adjacent_down() : nearest_neighbor(p_buttons, i, 1, 1);
+		const int left = (btn.is_valid() && btn->get_adjacent_left() > 0) ? btn->get_adjacent_left() : nearest_neighbor(p_buttons, i, 0, -1);
+		const int right = (btn.is_valid() && btn->get_adjacent_right() > 0) ? btn->get_adjacent_right() : nearest_neighbor(p_buttons, i, 0, 1);
+		put_bits(p_sec, bit, 2, uint32_t(btn.is_valid() ? CLAMP(btn->get_color_group(), 1, 3) : 1));
+		put_bits(p_sec, bit, 10, uint32_t(x0));
+		put_bits(p_sec, bit, 2, 0);
+		put_bits(p_sec, bit, 10, uint32_t(x1));
+		put_bits(p_sec, bit, 2, (btn.is_valid() && btn->get_auto_action()) ? 1 : 0);
+		put_bits(p_sec, bit, 10, uint32_t(y0));
+		put_bits(p_sec, bit, 2, 0);
+		put_bits(p_sec, bit, 10, uint32_t(y1));
+		put_bits(p_sec, bit, 2, 0);
+		put_bits(p_sec, bit, 6, uint32_t(CLAMP(up, 1, 36)));
+		put_bits(p_sec, bit, 2, 0);
+		put_bits(p_sec, bit, 6, uint32_t(CLAMP(down, 1, 36)));
+		put_bits(p_sec, bit, 2, 0);
+		put_bits(p_sec, bit, 6, uint32_t(CLAMP(left, 1, 36)));
+		put_bits(p_sec, bit, 2, 0);
+		put_bits(p_sec, bit, 6, uint32_t(CLAMP(right, 1, 36)));
+		const PackedByteArray cmd = hardware_button_command(btn, p_title_domain);
+
+		{
+		}
+
+		for (int b = 0; b < 8; b++) {
+			put_bits(p_sec, bit, 8, cmd.size() > b ? cmd[b] : 0);
+		}
+	}
+}
+
+} //namespace
+
+String InterDVDVobMux::find_ffmpeg_on_path() {
+#ifdef WINDOWS_ENABLED
+	const String exe = "ffmpeg.exe";
+	const String sep = ";";
+#else
+	const String exe = "ffmpeg";
+	const String sep = ":";
+#endif
+	const Vector<String> parts = OS::get_singleton()->get_environment("PATH").split(sep, false);
+	for (int i = 0; i < parts.size(); i++) {
+		const String candidate = parts[i].strip_edges().path_join(exe);
+		if (FileAccess::exists(candidate)) {
+			return candidate;
+		}
+	}
+	const String env_ffmpeg = OS::get_singleton()->get_environment("FFMPEG_EXE");
+	if (!env_ffmpeg.is_empty() && FileAccess::exists(env_ffmpeg)) {
+		return env_ffmpeg;
+	}
+#ifdef WINDOWS_ENABLED
+	const String chocolatey = "C:/ProgramData/chocolatey/bin/ffmpeg.exe";
+	if (FileAccess::exists(chocolatey)) {
+		return chocolatey;
+	}
+#endif
+	return String();
+}
+
+String InterDVDVobMux::resolve_ffmpeg(const String &p_configured, bool p_auto_find) {
+	if (!p_configured.is_empty() && FileAccess::exists(p_configured)) {
+		return p_configured;
+	}
+	if (p_auto_find) {
+		return find_ffmpeg_on_path();
+	}
+	return String();
+}
+
+String InterDVDVobMux::find_ffmpeg(const String &p_configured) {
+	return resolve_ffmpeg(p_configured, true);
+}
+
+Error InterDVDVobMux::write_dummy_vob(const String &p_path) {
+	Error err = OK;
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	if (err != OK || f.is_null()) {
+		return err == OK ? ERR_CANT_CREATE : err;
+	}
+	const Vector<uint8_t> nav = make_nav_sector(0, 0, SRI_NONE, SRI_NONE, 0, 90000, 0, 0.0);
+	f->store_buffer(nav.ptr(), nav.size());
+	return OK;
+}
+
+uint32_t InterDVDVobMux::sector_count(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return 0;
+	}
+	return uint32_t((f->get_length() + SECTOR_SIZE - 1) / SECTOR_SIZE);
+}
+
+bool InterDVDVobMux::contains_ac3(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return false;
+	}
+	uint8_t sec[SECTOR_SIZE];
+	int checked = 0;
+	while (f->get_position() < f->get_length() && checked < 256) {
+		const int n = int(f->get_buffer(sec, SECTOR_SIZE));
+		if (n < SECTOR_SIZE) {
+			break;
+		}
+		if (is_ac3_sector(sec)) {
+			return true;
+		}
+		checked++;
+	}
+	return false;
+}
+
+bool InterDVDVobMux::contains_mpeg_video(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return false;
+	}
+	uint8_t sec[SECTOR_SIZE];
+	int checked = 0;
+	while (f->get_position() < f->get_length() && checked < 512) {
+		const int n = int(f->get_buffer(sec, SECTOR_SIZE));
+		if (n < SECTOR_SIZE) {
+			break;
+		}
+		if (is_mpeg_video_sector(sec)) {
+			return true;
+		}
+		checked++;
+	}
+	return false;
+}
+
+bool InterDVDVobMux::contains_spu(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return false;
+	}
+	uint8_t sec[SECTOR_SIZE];
+	int checked = 0;
+	while (f->get_position() < f->get_length() && checked < 512) {
+		const int n = int(f->get_buffer(sec, SECTOR_SIZE));
+		if (n < SECTOR_SIZE) {
+			break;
+		}
+		if (is_spu_sector(sec)) {
+			return true;
+		}
+		checked++;
+	}
+	return false;
+}
+
+int InterDVDVobMux::count_ac3_streams(const String &p_path) {
+	const int n = count_private_range(p_path, 0x80, 0x87);
+	return n > 0 ? n : (contains_ac3(p_path) ? 1 : 0);
+}
+
+int InterDVDVobMux::count_spu_streams(const String &p_path) {
+	return count_private_range(p_path, 0x20, 0x3F);
+}
+
+Vector<uint32_t> InterDVDVobMux::scan_vobu_sectors(const String &p_vob) {
+	Vector<uint32_t> starts;
+	Ref<FileAccess> f = FileAccess::open(p_vob, FileAccess::READ);
+	if (f.is_null()) {
+		return starts;
+	}
+	uint8_t sec[SECTOR_SIZE];
+	uint32_t idx = 0;
+	while (f->get_position() < f->get_length()) {
+		const int n = int(f->get_buffer(sec, SECTOR_SIZE));
+		if (n <= 0) {
+			break;
+		}
+		if (n < SECTOR_SIZE) {
+			for (int i = n; i < SECTOR_SIZE; i++) {
+				sec[i] = 0;
+			}
+		}
+		if (is_nav_sector(sec) || starts.is_empty()) {
+			starts.push_back(idx);
+		}
+		idx++;
+	}
+	if (starts.is_empty()) {
+		starts.push_back(0);
+	}
+	return starts;
+}
+
+Error InterDVDVobMux::finalize_title_vob(const String &p_path) {
+	Ref<FileAccess> in = FileAccess::open(p_path, FileAccess::READ);
+	if (in.is_null()) {
+		return ERR_FILE_CANT_OPEN;
+	}
+
+	Vector<Vector<uint8_t>> sectors;
+	while (in->get_position() < in->get_length()) {
+		Vector<uint8_t> sec;
+		sec.resize(SECTOR_SIZE);
+		sec.fill(0);
+		const int n = int(in->get_buffer(sec.ptrw(), SECTOR_SIZE));
+		if (n <= 0) {
+			break;
+		}
+		sectors.push_back(sec);
+	}
+	in.unref();
+
+	if (sectors.is_empty()) {
+		return write_dummy_vob(p_path);
+	}
+
+	const bool already_nav = is_nav_sector(sectors[0].ptr());
+	Vector<int> vobu_first;
+	if (already_nav) {
+		for (int i = 0; i < sectors.size(); i++) {
+			if (is_nav_sector(sectors[i].ptr())) {
+				vobu_first.push_back(i);
+			}
+		}
+	} else {
+		vobu_first.push_back(0);
+		int since = 0;
+		for (int i = 1; i < sectors.size(); i++) {
+			since++;
+			const uint8_t *p = sectors[i].ptr();
+			if (since >= 15 || sector_has_start_code(p, 0xB8) || sector_has_start_code(p, 0xB3)) {
+				vobu_first.push_back(i);
+				since = 0;
+			}
+		}
+	}
+
+	Vector<Vector<uint8_t>> out_sectors;
+	Vector<int> nav_index;
+	if (already_nav) {
+		out_sectors = sectors;
+		nav_index = vobu_first;
+	} else {
+		for (int v = 0; v < vobu_first.size(); v++) {
+			const int start = vobu_first[v];
+			const int end = (v + 1 < vobu_first.size()) ? vobu_first[v + 1] : sectors.size();
+			nav_index.push_back(out_sectors.size());
+			out_sectors.push_back(Vector<uint8_t>());
+			for (int i = start; i < end; i++) {
+				out_sectors.push_back(sectors[i]);
+			}
+		}
+	}
+
+	const int nout = out_sectors.size();
+	Vector<uint32_t> vo_pts;
+	vo_pts.resize(nav_index.size());
+	vo_pts.fill(0);
+	for (int v = 0; v < nav_index.size(); v++) {
+		const int nav_at = nav_index[v];
+		const int next_nav = (v + 1 < nav_index.size()) ? nav_index[v + 1] : nout;
+		const int vid_from = (already_nav && next_nav > nav_at + 1) ? (nav_at + 1) : nav_at;
+		uint32_t pts = 0;
+		uint64_t scr = 0;
+		if (first_video_clock(out_sectors, vid_from, next_nav, pts, scr)) {
+			vo_pts.write[v] = pts;
+		}
+	}
+	for (int v = 0; v < nav_index.size(); v++) {
+		const int nav_at = nav_index[v];
+		const int next_nav = (v + 1 < nav_index.size()) ? nav_index[v + 1] : nout;
+		const uint32_t ea = uint32_t(MAX(next_nav - nav_at - 1, 0));
+		const uint32_t next = (v + 1 < nav_index.size()) ? (SRI_OK | uint32_t(nav_index[v + 1] - nav_at)) : SRI_NONE;
+		const uint32_t prev = (v > 0) ? (SRI_OK | uint32_t(nav_at - nav_index[v - 1])) : SRI_NONE;
+		uint32_t s_ptm = uint32_t(v) * 45045;
+		uint32_t e_ptm = uint32_t(v + 1) * 45045;
+		if (already_nav) {
+			const uint8_t *p = out_sectors[nav_at].ptr();
+			const uint32_t src_s = (uint32_t(p[57]) << 24) | (uint32_t(p[58]) << 16) | (uint32_t(p[59]) << 8) | uint32_t(p[60]);
+			const uint32_t src_e = (uint32_t(p[61]) << 24) | (uint32_t(p[62]) << 16) | (uint32_t(p[63]) << 8) | uint32_t(p[64]);
+			if (src_e > src_s) {
+				s_ptm = src_s;
+				e_ptm = src_e;
+			} else if (vo_pts[v] > 0) {
+				s_ptm = vo_pts[v];
+				if (v + 1 < vo_pts.size() && vo_pts[v + 1] > vo_pts[v]) {
+					e_ptm = vo_pts[v + 1];
+				} else {
+					e_ptm = s_ptm + 45045;
+				}
+			}
+
+			Vector<uint8_t> nav = out_sectors[nav_at];
+			write_be32(nav, 45, uint32_t(nav_at));
+			if (src_e <= src_s) {
+				write_be32(nav, 45 + 12, s_ptm);
+				write_be32(nav, 45 + 16, e_ptm);
+				write_be32(nav, 45 + 20, e_ptm);
+				write_dvd_time(nav, 45 + 24, double(s_ptm) / 90000.0);
+				write_dvd_time(nav, 1031 + 28, double(s_ptm) / 90000.0);
+			}
+			if ((nav[4] & 0xC4) != 0x44) {
+				write_pack_scr(&nav.write[4], uint64_t(s_ptm));
+				write_dvd_time(nav, 45 + 24, double(s_ptm) / 90000.0);
+				write_dvd_time(nav, 1031 + 28, double(s_ptm) / 90000.0);
+			}
+			write_be32(nav, 1031 + 4, uint32_t(nav_at));
+			write_be32(nav, 1031 + 8, ea);
+			if (ea > 0) {
+				write_be32(nav, 1031 + 12, ea);
+			}
+			write_be16(nav, 1031 + 24, 1);
+			nav.write[1031 + 27] = 1;
+			const int sri = 1031 + 0xEA;
+			write_be32(nav, sri, next);
+			write_be32(nav, sri + 80, next);
+			write_be32(nav, sri + 84, prev);
+			write_be32(nav, sri + 164, prev);
+			write_be16(nav, sri + 168, first_ac3_rel(out_sectors, nav_at, next_nav));
+			out_sectors.write[nav_at] = nav;
+
+		} else {
+			out_sectors.write[nav_at] = make_nav_sector(uint32_t(nav_at), ea, next, prev, s_ptm, e_ptm, uint64_t(s_ptm), double(s_ptm) / 90000.0);
+			write_be16(out_sectors.write[nav_at], 1031 + 0xEA + 168, first_ac3_rel(out_sectors, nav_at, next_nav));
+		}
+	}
+
+	Error err = OK;
+	Ref<FileAccess> out = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	if (err != OK || out.is_null()) {
+		return err == OK ? ERR_CANT_CREATE : err;
+	}
+	for (int i = 0; i < out_sectors.size(); i++) {
+		out->store_buffer(out_sectors[i].ptr(), SECTOR_SIZE);
+	}
+	return OK;
+}
+
+Error InterDVDVobMux::apply_menu_buttons(const String &p_vob, const TypedArray<InterDVDButton> &p_buttons, bool p_title_domain, int p_forced_select, int p_forced_activate, uint16_t p_btn_colnfo, uint32_t p_hli_e_ptm, int p_title_safe_bottom) {
+	if (p_buttons.is_empty()) {
+		return OK;
+	}
+	Ref<FileAccess> in = FileAccess::open(p_vob, FileAccess::READ);
+	if (in.is_null()) {
+		return ERR_FILE_CANT_OPEN;
+	}
+	Vector<Vector<uint8_t>> sectors;
+	while (in->get_position() < in->get_length()) {
+		Vector<uint8_t> sec;
+		sec.resize(SECTOR_SIZE);
+		sec.fill(0);
+		const int n = int(in->get_buffer(sec.ptrw(), SECTOR_SIZE));
+		if (n <= 0) {
+			break;
+		}
+		sectors.push_back(sec);
+	}
+	in.unref();
+	if (sectors.is_empty()) {
+		return ERR_FILE_CANT_OPEN;
+	}
+	Vector<int> navs;
+	uint32_t first_s_ptm = 0;
+	uint32_t last_e_ptm = 0;
+	for (int i = 0; i < sectors.size(); i++) {
+		if (!is_nav_sector(sectors[i].ptr())) {
+			continue;
+		}
+		navs.push_back(i);
+		const uint32_t s_ptm = (uint32_t(sectors[i][57]) << 24) | (uint32_t(sectors[i][58]) << 16) | (uint32_t(sectors[i][59]) << 8) | uint32_t(sectors[i][60]);
+		const uint32_t e_ptm = (uint32_t(sectors[i][61]) << 24) | (uint32_t(sectors[i][62]) << 16) | (uint32_t(sectors[i][63]) << 8) | uint32_t(sectors[i][64]);
+		if (navs.size() == 1) {
+			first_s_ptm = s_ptm;
+		}
+		if (e_ptm) {
+			last_e_ptm = e_ptm;
+		}
+	}
+
+	const uint32_t hl_e_ptm = p_hli_e_ptm ? p_hli_e_ptm : (last_e_ptm ? last_e_ptm : 90000);
+
+	if (!navs.is_empty()) {
+		write_hli_buttons(sectors.write[navs[0]], p_buttons, first_s_ptm, hl_e_ptm, p_title_domain, 1, p_forced_select, p_forced_activate, p_btn_colnfo, p_title_safe_bottom);
+		for (int i = 1; i < navs.size(); i++) {
+			write_hli_buttons(sectors.write[navs[i]], p_buttons, first_s_ptm, hl_e_ptm, p_title_domain, 2, 0, 0, p_btn_colnfo, p_title_safe_bottom);
+		}
+	}
+	Error err = OK;
+	Ref<FileAccess> out = FileAccess::open(p_vob, FileAccess::WRITE, &err);
+	if (err != OK || out.is_null()) {
+		return err == OK ? ERR_CANT_CREATE : err;
+	}
+	for (int i = 0; i < sectors.size(); i++) {
+		out->store_buffer(sectors[i].ptr(), SECTOR_SIZE);
+	}
+	return OK;
+}
+
+Error InterDVDVobMux::append_vob(const String &p_dst, const String &p_src) {
+	Ref<FileAccess> src = FileAccess::open(p_src, FileAccess::READ);
+	if (src.is_null()) {
+		return ERR_FILE_CANT_OPEN;
+	}
+	Error err = OK;
+	Ref<FileAccess> dst = FileAccess::open(p_dst, FileAccess::READ_WRITE, &err);
+	if (err != OK || dst.is_null()) {
+		return err == OK ? ERR_CANT_OPEN : err;
+	}
+	dst->seek_end();
+	uint8_t sec[SECTOR_SIZE];
+	while (src->get_position() < src->get_length()) {
+		const int n = int(src->get_buffer(sec, SECTOR_SIZE));
+		if (n <= 0) {
+			break;
+		}
+		if (n < SECTOR_SIZE) {
+			for (int i = n; i < SECTOR_SIZE; i++) {
+				sec[i] = 0;
+			}
+		}
+		dst->store_buffer(sec, SECTOR_SIZE);
+	}
+	return OK;
+}
+
+Error InterDVDVobMux::split_vts_vob(const String &p_vob_1) {
+	constexpr uint32_t CAP = 524288;
+	const uint32_t secs = sector_count(p_vob_1);
+	int files = 1;
+	if (secs > CAP) {
+		Ref<FileAccess> in = FileAccess::open(p_vob_1, FileAccess::READ);
+		if (in.is_null()) {
+			return ERR_FILE_CANT_OPEN;
+		}
+		Vector<String> tmps;
+		int part = 1;
+		uint8_t buf[SECTOR_SIZE];
+		while (in->get_position() < in->get_length()) {
+			const String dest = p_vob_1.get_base_dir().path_join(vformat("VTS_01_%d.VOB", part));
+			const String tmp = dest + ".split";
+			Error err = OK;
+			Ref<FileAccess> out = FileAccess::open(tmp, FileAccess::WRITE, &err);
+			if (err != OK || out.is_null()) {
+				return err == OK ? ERR_CANT_CREATE : err;
+			}
+			uint32_t n = 0;
+			while (n < CAP && in->get_position() < in->get_length()) {
+				const int got = int(in->get_buffer(buf, SECTOR_SIZE));
+				if (got <= 0) {
+					break;
+				}
+				if (got < SECTOR_SIZE) {
+					for (int i = got; i < SECTOR_SIZE; i++) {
+						buf[i] = 0;
+					}
+				}
+				out->store_buffer(buf, SECTOR_SIZE);
+				n++;
+			}
+			tmps.push_back(tmp);
+			part++;
+		}
+		in.unref();
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (da.is_null()) {
+			return FAILED;
+		}
+		da->remove(p_vob_1);
+		for (int i = 0; i < tmps.size(); i++) {
+			const String dest = p_vob_1.get_base_dir().path_join(vformat("VTS_01_%d.VOB", i + 1));
+			da->remove(dest);
+			const Error copied = copy_file(tmps[i], dest);
+			da->remove(tmps[i]);
+			if (copied != OK) {
+				return copied;
+			}
+		}
+		files = tmps.size();
+	}
+
+
+	return OK;
+}
+
+Error InterDVDVobMux::reindex_nav_lbns(const String &p_vob, uint32_t p_from_sector, uint8_t p_cell_id) {
+	Ref<FileAccess> in = FileAccess::open(p_vob, FileAccess::READ);
+	if (in.is_null()) {
+		return ERR_FILE_CANT_OPEN;
+	}
+	Vector<Vector<uint8_t>> sectors;
+	while (in->get_position() < in->get_length()) {
+		Vector<uint8_t> sec;
+		sec.resize(SECTOR_SIZE);
+		sec.fill(0);
+		const int n = int(in->get_buffer(sec.ptrw(), SECTOR_SIZE));
+		if (n <= 0) {
+			break;
+		}
+		sectors.push_back(sec);
+	}
+	in.unref();
+	for (int i = int(p_from_sector); i < sectors.size(); i++) {
+		if (!is_nav_sector(sectors[i].ptr())) {
+			continue;
+		}
+		write_be32(sectors.write[i], 45, uint32_t(i));
+		write_be32(sectors.write[i], 1031 + 4, uint32_t(i));
+		sectors.write[i].write[1031 + 27] = p_cell_id;
+	}
+	Error err = OK;
+	Ref<FileAccess> out = FileAccess::open(p_vob, FileAccess::WRITE, &err);
+	if (err != OK || out.is_null()) {
+		return err == OK ? ERR_CANT_CREATE : err;
+	}
+	for (int i = 0; i < sectors.size(); i++) {
+		out->store_buffer(sectors[i].ptr(), SECTOR_SIZE);
+	}
+	return OK;
+}
+
+double InterDVDVobMux::probe_media_sec(const String &p_path, const String &p_ffmpeg) {
+	if (p_path.is_empty() || !FileAccess::exists(p_path)) {
+		return 0.0;
+	}
+	String ffmpeg = p_ffmpeg;
+	if (ffmpeg.is_empty()) {
+		ffmpeg = resolve_ffmpeg(String(), true);
+	}
+	if (ffmpeg.is_empty()) {
+		return 0.0;
+	}
+	const String dir = ffmpeg.get_base_dir();
+	const String ff_name = ffmpeg.get_file();
+	String probe = dir.path_join(ff_name.replacen("ffmpeg", "ffprobe"));
+	if (!FileAccess::exists(probe)) {
+		probe = dir.path_join(OS::get_singleton()->get_name() == "Windows" ? "ffprobe.exe" : "ffprobe");
+	}
+	String pipe;
+	if (FileAccess::exists(probe)) {
+		List<String> args;
+		args.push_back("-v");
+		args.push_back("error");
+		args.push_back("-show_entries");
+		args.push_back("format=duration");
+		args.push_back("-of");
+		args.push_back("default=nokey=1:noprint_wrappers=1");
+		args.push_back(p_path);
+		OS::get_singleton()->execute(probe, args, &pipe);
+		return pipe.strip_edges().to_float();
+	}
+	List<String> args;
+	args.push_back("-i");
+	args.push_back(p_path);
+	OS::get_singleton()->execute(ffmpeg, args, &pipe);
+	const int idx = pipe.find("Duration:");
+	if (idx < 0) {
+		return 0.0;
+	}
+	const String token = pipe.substr(idx + 9).get_slice(",", 0).strip_edges();
+	const PackedStringArray parts = token.split(":");
+	if (parts.size() < 3) {
+		return token.to_float();
+	}
+	return parts[0].to_float() * 3600.0 + parts[1].to_float() * 60.0 + parts[2].to_float();
+}
+
+double InterDVDVobMux::estimate_duration_sec(const String &p_vob) {
+	Ref<FileAccess> f = FileAccess::open(p_vob, FileAccess::READ);
+	if (f.is_null() || f->get_length() < 65) {
+		return 0.0;
+	}
+	uint32_t last_e_ptm = 0;
+	uint32_t first_pts = 0;
+	uint32_t last_pts = 0;
+	uint8_t sec[SECTOR_SIZE];
+	while (f->get_position() < f->get_length()) {
+		const int n = int(f->get_buffer(sec, SECTOR_SIZE));
+		if (n < 65) {
+			break;
+		}
+		if (is_nav_sector(sec)) {
+			last_e_ptm = (uint32_t(sec[61]) << 24) | (uint32_t(sec[62]) << 16) | (uint32_t(sec[63]) << 8) | uint32_t(sec[64]);
+		}
+		uint32_t pts = 0;
+		if (is_pack_start(sec) && read_pes_pts(sec, 0xE0, pts)) {
+			if (first_pts == 0) {
+				first_pts = pts;
+			}
+			last_pts = pts;
+		}
+	}
+	double used = 0.0;
+	const char *src = "none";
+	if (last_e_ptm > 0) {
+		used = double(last_e_ptm) / 90000.0;
+		src = "pci";
+	} else if (last_pts > first_pts) {
+		used = double(last_pts - first_pts) / 90000.0;
+		src = "pts";
+	}
+
+
+	return used;
+}
+
+Error InterDVDVobMux::mux_cell(const Ref<InterDVDCell> &p_cell, const String &p_out_vob, const String &p_ffmpeg, bool p_allow_dummy, String *r_error, bool p_auto_find_ffmpeg) {
+	Vector<String> extra_audio;
+	Vector<String> extra_subs;
+	collect_cell_sidecars(p_cell, extra_audio, extra_subs);
+	const bool include_audio = p_cell.is_null() || p_cell->get_include_audio();
+	const bool has_sidecars = !extra_audio.is_empty() || !extra_subs.is_empty();
+
+	if (p_cell.is_valid() && !p_cell->get_encoded_path().is_empty()) {
+		const String src = p_cell->get_encoded_path();
+		if (!FileAccess::exists(src)) {
+			if (r_error) {
+				*r_error = vformat("Pre-encoded cell not found: %s", src);
+			}
+			return ERR_FILE_NOT_FOUND;
+		}
+		if (!has_sidecars) {
+			const Error copy_err = copy_file(src, p_out_vob);
+			if (copy_err != OK) {
+				return copy_err;
+			}
+			const Error fin = finalize_title_vob(p_out_vob);
+			if (fin != OK) {
+				return fin;
+			}
+			return reject_unplayable_cell(p_out_vob, p_allow_dummy, r_error);
+		}
+	}
+
+	if (p_cell.is_valid() && (!p_cell->get_source_path().is_empty() || !p_cell->get_encoded_path().is_empty())) {
+		const String src = !p_cell->get_encoded_path().is_empty() && has_sidecars ? p_cell->get_encoded_path() : p_cell->get_source_path();
+		if (src.is_empty() || !FileAccess::exists(src)) {
+			if (r_error) {
+				*r_error = vformat("Source media not found: %s", src);
+			}
+			return ERR_FILE_NOT_FOUND;
+		}
+		if (is_mpeg_program_stream(src) && !has_sidecars) {
+			const Error copy_err = copy_file(src, p_out_vob);
+			if (copy_err != OK) {
+				return copy_err;
+			}
+			const Error fin = finalize_title_vob(p_out_vob);
+			if (fin != OK) {
+				return fin;
+			}
+			return reject_unplayable_cell(p_out_vob, p_allow_dummy, r_error);
+		}
+
+		const String ffmpeg = resolve_ffmpeg(p_ffmpeg, p_auto_find_ffmpeg);
+		if (ffmpeg.is_empty()) {
+			if (p_allow_dummy) {
+				return write_dummy_vob(p_out_vob);
+			}
+			if (r_error) {
+				*r_error = "Cannot transcode cell: ffmpeg was not found on PATH and no ffmpeg path is set. Install ffmpeg, enable Auto-find ffmpeg, or set export/inter_dvd/ffmpeg in Editor Settings (that path is not stored in the project).";
+			}
+			return ERR_UNCONFIGURED;
+		}
+		const String safe_src = cached_ascii_source(src, p_out_vob, r_error);
+		if (safe_src.is_empty()) {
+			if (p_allow_dummy) {
+				return write_dummy_vob(p_out_vob);
+			}
+			return FAILED;
+		}
+		Vector<String> safe_audio;
+		Vector<String> safe_subs;
+		for (int i = 0; i < extra_audio.size(); i++) {
+			const String safe = cached_ascii_source(extra_audio[i], p_out_vob + vformat(".a%d", i), r_error);
+			if (!safe.is_empty()) {
+				safe_audio.push_back(safe);
+			}
+		}
+		for (int i = 0; i < extra_subs.size(); i++) {
+			const String safe = cached_ascii_source(extra_subs[i], p_out_vob + vformat(".s%d", i), r_error);
+			if (!safe.is_empty()) {
+				safe_subs.push_back(safe);
+			}
+		}
+		const Error mux_err = run_dvd_ffmpeg(ffmpeg, safe_src, safe_audio, safe_subs, include_audio, p_out_vob, r_error);
+		if (mux_err == OK) {
+			const Error fin = finalize_title_vob(p_out_vob);
+			if (fin != OK) {
+				return fin;
+			}
+			return reject_unplayable_cell(p_out_vob, p_allow_dummy, r_error);
+		}
+		if (p_allow_dummy) {
+			return write_dummy_vob(p_out_vob);
+		}
+		return mux_err;
+	}
+
+	if (p_allow_dummy) {
+		return write_dummy_vob(p_out_vob);
+	}
+	if (r_error) {
+		*r_error = "Cell has no pre-encoded MPEG-2/VOB and no source to transcode.";
+	}
+	return ERR_UNCONFIGURED;
+}
+
+Error InterDVDVobMux::loop_extend_vob(const String &p_vob, double p_seconds, const String &p_ffmpeg, String *r_error, bool p_auto_find_ffmpeg) {
+	const double have = estimate_duration_sec(p_vob);
+	if (have < 2.0 || have + 0.25 >= p_seconds) {
+		return OK;
+	}
+	const String ffmpeg = resolve_ffmpeg(p_ffmpeg, p_auto_find_ffmpeg);
+	if (ffmpeg.is_empty()) {
+		return OK;
+	}
+	const String tmp = p_vob + ".loop.tmp.vob";
+	List<String> args;
+	args.push_back("-y");
+	args.push_back("-fflags");
+	args.push_back("+genpts");
+	args.push_back("-stream_loop");
+	args.push_back("-1");
+	args.push_back("-i");
+	args.push_back(p_vob);
+	args.push_back("-t");
+	args.push_back(String::num(p_seconds, 1));
+	args.push_back("-target");
+	args.push_back("ntsc-dvd");
+	args.push_back("-bf");
+	args.push_back("0");
+	args.push_back("-g");
+	args.push_back(itos(InterDVDSettings::gop_size()));
+	args.push_back(tmp);
+	String pipe;
+	const int code = OS::get_singleton()->execute(ffmpeg, args, &pipe);
+
+
+	if (code != 0 || !FileAccess::exists(tmp)) {
+		Ref<DirAccess> rm = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (rm.is_valid()) {
+			rm->remove(tmp);
+		}
+		return OK;
+	}
+	if (finalize_title_vob(tmp) != OK) {
+		Ref<DirAccess> rm = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (rm.is_valid()) {
+			rm->remove(tmp);
+		}
+		return OK;
+	}
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (da.is_valid()) {
+		da->remove(p_vob);
+	}
+	const Error copied = copy_file(tmp, p_vob);
+	if (da.is_valid()) {
+		da->remove(tmp);
+	}
+
+
+	return copied;
+}

--- a/modules/inter_dvd/author/inter_dvd_vob_mux.h
+++ b/modules/inter_dvd/author/inter_dvd_vob_mux.h
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  inter_dvd_vob_mux.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/error/error_list.h"
+#include "core/io/resource.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+#include "core/variant/typed_array.h"
+
+class InterDVDButton;
+class InterDVDCell;
+
+class InterDVDVobMux {
+public:
+	static constexpr int SECTOR_SIZE = 2048;
+
+	static String find_ffmpeg_on_path();
+	static String resolve_ffmpeg(const String &p_configured, bool p_auto_find);
+	static String find_ffmpeg(const String &p_configured);
+	static Error write_dummy_vob(const String &p_path);
+	static Error mux_cell(const Ref<InterDVDCell> &p_cell, const String &p_out_vob, const String &p_ffmpeg, bool p_allow_dummy, String *r_error = nullptr, bool p_auto_find_ffmpeg = true);
+	static Error loop_extend_vob(const String &p_vob, double p_seconds, const String &p_ffmpeg, String *r_error = nullptr, bool p_auto_find_ffmpeg = true);
+	static Error finalize_title_vob(const String &p_path);
+	static Error apply_menu_buttons(const String &p_vob, const TypedArray<InterDVDButton> &p_buttons, bool p_title_domain = false, int p_forced_select = 0, int p_forced_activate = 0, uint16_t p_btn_colnfo = 0x1000, uint32_t p_hli_e_ptm = 0, int p_title_safe_bottom = -1);
+	static Error append_vob(const String &p_dst, const String &p_src);
+	static Error split_vts_vob(const String &p_vob_1);
+	static Error reindex_nav_lbns(const String &p_vob, uint32_t p_from_sector, uint8_t p_cell_id);
+	static Vector<uint32_t> scan_vobu_sectors(const String &p_vob);
+	static uint32_t sector_count(const String &p_path);
+	static bool contains_ac3(const String &p_path);
+	static bool contains_mpeg_video(const String &p_path);
+	static bool contains_spu(const String &p_path);
+	static int count_ac3_streams(const String &p_path);
+	static int count_spu_streams(const String &p_path);
+	static double estimate_duration_sec(const String &p_vob);
+	static double probe_media_sec(const String &p_path, const String &p_ffmpeg = String());
+};

--- a/modules/inter_dvd/config.py
+++ b/modules/inter_dvd/config.py
@@ -1,0 +1,28 @@
+def can_build(env, platform):
+    return env.editor_build
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "InterDVDInstruction",
+        "InterDVDMachine",
+        "InterDVDCell",
+        "InterDVDButton",
+        "InterDVDMenu",
+        "InterDVDPGC",
+        "InterDVDProject",
+        "InterDVDIfoWriter",
+        "InterDVDSceneBaker",
+        "InterDVDEditorPlugin",
+        "InterDVDExportProgress",
+        "InterDVDStream",
+        "EditorExportPlatformWindowsInterDVD",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/inter_dvd/doc_classes/EditorExportPlatformWindowsInterDVD.xml
+++ b/modules/inter_dvd/doc_classes/EditorExportPlatformWindowsInterDVD.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformWindowsInterDVD" inherits="EditorExportPlatform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Exports a burnable VIDEO_TS / AUDIO_TS folder, ZIP, or ISO.
+	</brief_description>
+	<description>
+		Does not copy an engine executable and does not use a [code].inter_dvd[/code] template flavor. Missing ffmpeg is a configuration warning, not a missing engine template. ISO output needs [code]oscdimg[/code] or [code]mkisofs[/code] (Editor Setting [code]export/inter_dvd/iso_tool[/code]). Test the result on a burnt disc or a standalone DVD player, not inside Blazium.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="inter_dvd/allow_dummy_vob" type="bool" setter="" getter="">
+			When [code]true[/code], export writes a dummy title VOB if no MPEG-2 cell is configured. Keep [code]false[/code] for production discs.
+		</member>
+		<member name="inter_dvd/audio_language" type="String" setter="" getter="">
+			Preset override for [member InterDVDProject.audio_language].
+		</member>
+		<member name="inter_dvd/auto_find_ffmpeg" type="bool" setter="" getter="">
+			When [code]true[/code], export searches [code]PATH[/code] (and [code]FFMPEG_EXE[/code]) for ffmpeg. The discovered path is never written into the project or preset.
+		</member>
+		<member name="inter_dvd/ffmpeg" type="String" setter="" getter="">
+			Optional ffmpeg override. Leave empty and use [member inter_dvd/auto_find_ffmpeg] so no machine-specific path is stored in the project.
+		</member>
+		<member name="inter_dvd/iso_tool" type="String" setter="" getter="">
+		</member>
+		<member name="inter_dvd/menu_language" type="String" setter="" getter="">
+			Preset override for [member InterDVDProject.menu_language].
+		</member>
+		<member name="inter_dvd/output_kind" type="int" setter="" getter="">
+		</member>
+		<member name="inter_dvd/parental_level" type="int" setter="" getter="">
+			Seeded from [code]blazium/inter_dvd/default_parental_level[/code].
+		</member>
+		<member name="inter_dvd/provider_id" type="String" setter="" getter="">
+			Preset override for [member InterDVDProject.provider_id].
+		</member>
+		<member name="inter_dvd/region_mask" type="int" setter="" getter="">
+			Seeded from [code]blazium/inter_dvd/default_region_mask[/code].
+		</member>
+		<member name="inter_dvd/subtitle_language" type="String" setter="" getter="">
+			Preset override for [member InterDVDProject.subtitle_language].
+		</member>
+		<member name="inter_dvd/volume_id" type="String" setter="" getter="">
+			Preset override for [member InterDVDProject.volume_id] (ISO [code]-V[/code] / [code]-l[/code]).
+		</member>
+	</members>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDButton.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDButton.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDButton" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A PCI HLI highlight plus a domain-validated 8-byte DVD-Video command.
+	</brief_description>
+	<description>
+		Menus and titles may have up to 36 buttons. Set [member action] to a hardware destination and [member target], [member title_n], or [member stream] as needed. The inspector lists named titles and video cells from [code]blazium/inter_dvd/project[/code]. [method resolve_command] encodes through [InterDVDInstruction]: Jump Title is JumpTT from the VMGM and LinkPGCN from a title; Jump Chapter is LinkPTT or JumpVTS_PTT; Jump Menu ids 2-7 are JumpSS or CallSS. JumpSS from the title domain is illegal. There is no URL, file, or app launch — a video file on disc is a muxed VOB cell reached by JumpTT / LinkPTT.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="resolve_command" qualifiers="const">
+			<return type="PackedByteArray" />
+			<param index="0" name="domain" type="int" enum="InterDVDButton.CommandDomain" default="0" />
+			<description>
+				Returns the 8-byte hardware command for [param domain] ([constant DOMAIN_VMGM] or [constant DOMAIN_VTST]).
+			</description>
+		</method>
+		<method name="sync_highlight_from_scene">
+			<return type="void" />
+			<param index="0" name="root" type="Node" />
+			<param index="1" name="default_highlight" type="Rect2" default="Rect2(0, 0, 0, 0)" />
+			<param index="2" name="title_safe_bottom" type="int" default="-1" />
+			<description>
+				Copies [member highlight] from the [CanvasItem] at [member control_path] (Control rect or Node2D [code]get_rect()[/code]). If the node is missing, uses [param default_highlight] only when that rect has area. Clamps to 720×480 even HLI edges and [param title_safe_bottom] (or ProjectSettings when [code]-1[/code]).
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="action" type="int" setter="set_action" getter="get_action" enum="InterDVDButton.Action" default="0">
+			Hardware navigation: play title/chapter, jump menu/PGC/program/cell, set stream, highlight, resume, exit, or [member command].
+		</member>
+		<member name="action_color" type="Color" setter="set_action_color" getter="get_action_color" default="Color(1, 0.35, 0.1, 1)">
+			Preferred pressed highlight. Authoring maps this to a PGC palette action slot.
+		</member>
+		<member name="adjacent_down" type="int" setter="set_adjacent_down" getter="get_adjacent_down" default="0">
+			Manual down neighbor (1-36). [code]0[/code] uses nearest-neighbor.
+		</member>
+		<member name="adjacent_left" type="int" setter="set_adjacent_left" getter="get_adjacent_left" default="0">
+			Manual left neighbor (1-36). [code]0[/code] uses nearest-neighbor.
+		</member>
+		<member name="adjacent_right" type="int" setter="set_adjacent_right" getter="get_adjacent_right" default="0">
+			Manual right neighbor (1-36). [code]0[/code] uses nearest-neighbor.
+		</member>
+		<member name="adjacent_up" type="int" setter="set_adjacent_up" getter="get_adjacent_up" default="0">
+			Manual up neighbor (1-36). [code]0[/code] uses nearest-neighbor.
+		</member>
+		<member name="auto_action" type="bool" setter="set_auto_action" getter="get_auto_action" default="false">
+			If [code]true[/code], highlighting this button also activates it.
+		</member>
+		<member name="button_number" type="int" setter="set_button_number" getter="get_button_number" default="0">
+			Optional numeric-select number (1-36). [code]0[/code] uses the array index.
+		</member>
+		<member name="color_group" type="int" setter="set_color_group" getter="get_color_group" default="1">
+			HLI color-group index (1-3). Select/action colors for this group are packed into that group's [code]btn_coli[/code] slot.
+		</member>
+		<member name="command" type="PackedByteArray" setter="set_command" getter="get_command" default="PackedByteArray()">
+			Raw 8-byte command used when [member action] is [constant ACTION_CUSTOM].
+		</member>
+		<member name="control_path" type="NodePath" setter="set_control_path" getter="get_control_path" default="NodePath(&quot;&quot;)">
+			Optional [CanvasItem] in the cell packed scene whose rectangle becomes [member highlight] at export.
+		</member>
+		<member name="forced_activated" type="bool" setter="set_forced_activated" getter="is_forced_activated" default="false">
+			If [code]true[/code], this button is the HLI forced-activated button (PGC still-time auto-fire).
+		</member>
+		<member name="forced_selected" type="bool" setter="set_forced_selected" getter="is_forced_selected" default="false">
+			If [code]true[/code], this button is the HLI forced-selected button.
+		</member>
+		<member name="hidden" type="bool" setter="set_hidden" getter="is_hidden" default="false">
+			If [code]true[/code], no highlight rectangle is written; the button remains numerically selectable.
+		</member>
+		<member name="highlight" type="Rect2" setter="set_highlight" getter="get_highlight" default="Rect2(0, 0, 0, 0)">
+			Highlight rectangle in 720×480 pixel space.
+		</member>
+		<member name="numeric_select" type="bool" setter="set_numeric_select" getter="get_numeric_select" default="true">
+			If [code]true[/code], the remote number keys can select this button.
+		</member>
+		<member name="select_color" type="Color" setter="set_select_color" getter="get_select_color" default="Color(1, 0.92, 0.2, 1)">
+			Preferred hover highlight. Authoring maps this to a PGC palette select slot.
+		</member>
+		<member name="stream" type="int" setter="set_stream" getter="get_stream" default="0">
+			Audio, subtitle, or angle stream index for SetSTN actions.
+		</member>
+		<member name="subtitle_on" type="bool" setter="set_subtitle_on" getter="get_subtitle_on" default="true">
+			Subtitle visibility flag for [constant ACTION_SET_SUBTITLE].
+		</member>
+		<member name="target" type="int" setter="set_target" getter="get_target" default="1">
+			Destination: 1-based title, chapter, program, cell, PGC, highlight button, or menu id (2-7).
+		</member>
+		<member name="title_n" type="int" setter="set_title_n" getter="get_title_n" default="1">
+			Title number used with [constant ACTION_JUMP_CHAPTER] from the VMGM (JumpVTS_PTT).
+		</member>
+	</members>
+	<constants>
+		<constant name="ACTION_JUMP_TITLE" value="0" enum="Action">
+			Play Title: JumpTT ([code]30 02[/code]) from the menu domain, or LinkPGCN ([code]20 04[/code]) from a title.
+		</constant>
+		<constant name="ACTION_JUMP_MENU" value="1" enum="Action">
+			JumpSS ([code]30 06[/code]) from the menu domain, or CallSS ([code]30 08[/code]) from a title. Menu ids: Title 2, Root 3, Subpicture 4, Audio 5, Angle 6, Chapter 7.
+		</constant>
+		<constant name="ACTION_JUMP_PGC" value="2" enum="Action">
+			LinkPGCN ([code]20 04[/code]) to [member target] in the current domain.
+		</constant>
+		<constant name="ACTION_CUSTOM" value="3" enum="Action">
+			Use [member command] as-is.
+		</constant>
+		<constant name="ACTION_JUMP_CHAPTER" value="4" enum="Action">
+			Play Chapter: LinkPTT from a title, or JumpVTS_PTT from the VMGM using [member title_n] and [member target].
+		</constant>
+		<constant name="ACTION_JUMP_PROGRAM" value="5" enum="Action">
+			LinkPGN to [member target].
+		</constant>
+		<constant name="ACTION_JUMP_CELL" value="6" enum="Action">
+			LinkCN to [member target].
+		</constant>
+		<constant name="ACTION_RESUME" value="7" enum="Action">
+			RSM. Legal only from a menu domain.
+		</constant>
+		<constant name="ACTION_SET_AUDIO" value="8" enum="Action">
+			SetSTN audio stream [member stream].
+		</constant>
+		<constant name="ACTION_SET_SUBTITLE" value="9" enum="Action">
+			SetSTN subtitle stream [member stream] and [member subtitle_on].
+		</constant>
+		<constant name="ACTION_SET_ANGLE" value="10" enum="Action">
+			SetSTN angle [member stream].
+		</constant>
+		<constant name="ACTION_HIGHLIGHT_BUTTON" value="11" enum="Action">
+			SetHL_BTNN to [member target] (1-36).
+		</constant>
+		<constant name="ACTION_EXIT" value="12" enum="Action">
+			Exit the disc.
+		</constant>
+		<constant name="DOMAIN_VMGM" value="0" enum="CommandDomain">
+			Title-menu (VMGM) highlight stream.
+		</constant>
+		<constant name="DOMAIN_VTST" value="1" enum="CommandDomain">
+			Title-domain (VTST) highlight stream.
+		</constant>
+	</constants>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDCell.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDCell.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDCell" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		One DVD-Video cell: a Godot scene to bake, pre-encoded MPEG-2/VOB, or a source file to transcode.
+	</brief_description>
+	<description>
+		One muxed VOB cell. Export resolution order: [member encoded_path] if it exists; otherwise bake [member packed_scene] for [member duration_sec]; otherwise copy or transcode [member source_path]. A title PGC muxes every cell (cell N is chapter N / program N). A scene bake records 720×480 video plus a 48 kHz stereo AC3 track. Missing encoder plus no encoded cell is an export error unless dummy VOB is allowed. No CSS is applied.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_display_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the resource name, or the source/encoded file name, for inspector chapter lists.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="audio_path" type="String" setter="set_audio_path" getter="get_audio_path" default="&quot;&quot;">
+			Optional menu music file. Used when [member include_audio] is on and the cell has no picture-in-picture audio. A [member pip_source_path] soundtrack replaces this file.
+		</member>
+		<member name="bake_camera_path" type="NodePath" setter="set_bake_camera_path" getter="get_bake_camera_path" default="NodePath(&quot;&quot;)">
+			Optional [Camera2D] or [Camera3D] used for GPU bake. Empty uses the scene's current camera. A 3D scene with no camera is an authoring error (no camera is invented).
+		</member>
+		<member name="bake_hold_sec" type="float" setter="set_bake_hold_sec" getter="get_bake_hold_sec" default="0.0">
+			Seconds each unique bake frame is held. [code]0[/code] uses 30 fps, or a root [code]inter_dvd_bake_hold_sec()[/code] script hook if present.
+		</member>
+		<member name="default_highlight" type="Rect2" setter="set_default_highlight" getter="get_default_highlight" default="Rect2(0, 0, 0, 0)">
+			Fallback HLI rectangle when [method InterDVDButton.sync_highlight_from_scene] cannot resolve [member InterDVDButton.control_path]. Empty leaves the highlight unset.
+		</member>
+		<member name="duration_sec" type="float" setter="set_duration_sec" getter="get_duration_sec" default="0.0">
+			How long to play and bake this cell, in seconds. Required when [member packed_scene] is set. Also written as the PGC playback time.
+		</member>
+		<member name="encoded_path" type="String" setter="set_encoded_path" getter="get_encoded_path" default="&quot;&quot;">
+			Pre-encoded MPEG-2 or VOB path, or a bake cache produced from [member packed_scene].
+		</member>
+		<member name="include_audio" type="bool" setter="set_include_audio" getter="get_include_audio" default="true">
+			Mux AC3 when a soundtrack exists: PiP video audio first, then [member audio_path], then a scene [AudioStreamPlayer]. No dummy silent track.
+		</member>
+		<member name="loop_pad_sec" type="float" setter="set_loop_pad_sec" getter="get_loop_pad_sec" default="0.0">
+			Extra seconds appended after the picture-in-picture clip before the baked menu cycle repeats. Bake length becomes probed PiP duration plus this pad.
+		</member>
+		<member name="packed_scene" type="PackedScene" setter="set_packed_scene" getter="get_packed_scene">
+			Optional Godot scene recorded to NTSC DVD MPEG-2 at export time.
+		</member>
+		<member name="pip_lead_sec" type="float" setter="set_pip_lead_sec" getter="get_pip_lead_sec" default="0.4">
+			Seconds trimmed from the start of a picture-in-picture overlay after black-detect.
+		</member>
+		<member name="pip_rect" type="Rect2" setter="set_pip_rect" getter="get_pip_rect" default="Rect2(0, 0, 0, 0)">
+			PiP overlay rectangle used only when [member pip_slot_path] does not resolve. Empty means no default geometry.
+		</member>
+		<member name="pip_slot_path" type="NodePath" setter="set_pip_slot_path" getter="get_pip_slot_path" default="NodePath(&quot;&quot;)">
+			Control or Node2D that receives the scaled PiP video during a scene bake. Empty means no slot unless [member pip_rect] is set.
+		</member>
+		<member name="pip_source_path" type="String" setter="set_pip_source_path" getter="get_pip_source_path" default="&quot;&quot;">
+			Optional video composited into [member pip_slot_path] for the probed clip length, then the slot shows the baked still for [member loop_pad_sec] before the menu loops. If this file has audio, that soundtrack replaces [member audio_path] and scene music.
+		</member>
+		<member name="post_commands" type="PackedByteArray[]" setter="set_post_commands" getter="get_post_commands" default="[]">
+			Cell-post instruction stream (one 8-byte command typical). Empty non-last cells get a LinkPGN to the next chapter so the title plays through.
+		</member>
+		<member name="source_path" type="String" setter="set_source_path" getter="get_source_path" default="&quot;&quot;">
+			Source media. ffmpeg-readable files ([code].mp4[/code], [code].mkv[/code], [code].mov[/code], [code].avi[/code], [code].webm[/code]) are transcoded to NTSC DVD. MPEG-2/VOB ([code].mpg[/code], [code].mpeg[/code], [code].vob[/code], [code].m2v[/code]) is copied when already a program stream.
+		</member>
+		<member name="streams" type="InterDVDStream[]" setter="set_streams" getter="get_streams" default="[]">
+			Extra audio ([code]0x81+[/code]) and subtitle ([code]0x20+[/code]) streams. [member audio_path] remains stream 0.
+		</member>
+	</members>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDEditorPlugin.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDEditorPlugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDEditorPlugin" inherits="EditorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Registers the Interactive DVD export platform.
+	</brief_description>
+	<description>
+		Adds [EditorExportPlatformWindowsInterDVD]. There is no play-in-editor disc player. Starter [InterDVDProject] resources live in the inter_dvd_module_tests project.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDExportProgress.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDExportProgress.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDExportProgress" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Step, elapsed, and ETA reporting for Interactive DVD export.
+	</brief_description>
+	<description>
+		[method InterDVDIfoWriter.write_video_ts] and editor export call [method report] for each bake/mux/IFO/finalize step. Headless prints [code]export_dvd: [n/N] label  elapsed mm:ss  eta mm:ss[/code]. Optional [member notify] receives [code](step, total, label, line)[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="begin">
+			<return type="void" />
+			<param index="0" name="total" type="int" />
+			<description>
+				Sets the step total when it is still zero and records the start timestamp.
+			</description>
+		</method>
+		<method name="format_clock" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="usec" type="int" />
+			<description>
+				Formats a microsecond duration as [code]mm:ss[/code] or [code]hh:mm:ss[/code].
+			</description>
+		</method>
+		<method name="format_line" qualifiers="const">
+			<return type="String" />
+			<description>
+				Current [code][step/total] label  elapsed …  eta …[/code] line.
+			</description>
+		</method>
+		<method name="get_label" qualifiers="const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="get_started_usec" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_step" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_total" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="report">
+			<return type="void" />
+			<param index="0" name="label" type="String" />
+			<description>
+				Increments the current step, prints elapsed/ETA, and calls [member notify] if set.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="notify" type="Callable" setter="set_notify" getter="get_notify" default="Callable()">
+			Optional callback [code](step, total, label, line)[/code].
+		</member>
+	</members>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDIfoWriter.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDIfoWriter.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDIfoWriter" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Writes a VIDEO_TS / AUDIO_TS DVD-Video volume from an [InterDVDProject].
+	</brief_description>
+	<description>
+		Creates unencrypted IFO/BUP/VOB files for burning. There is no in-engine disc player. Dummy title VOBs are for tests only when no MPEG-2 cell is available.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="iso_tool_args" qualifiers="static">
+			<return type="PackedStringArray" />
+			<param index="0" name="tool" type="String" />
+			<param index="1" name="volume_id" type="String" />
+			<param index="2" name="work_dir" type="String" />
+			<param index="3" name="out_path" type="String" />
+			<description>
+				Argument list for mkisofs/genisoimage ([code]-V[/code]) or oscdimg ([code]-l[/code]) using a sanitized [param volume_id].
+			</description>
+		</method>
+		<method name="write_video_ts" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="root" type="String" />
+			<param index="1" name="project" type="InterDVDProject" />
+			<param index="2" name="allow_dummy_vob" type="bool" default="false" />
+			<param index="3" name="ffmpeg" type="String" default="&quot;&quot;" />
+			<param index="4" name="auto_find_ffmpeg" type="bool" default="true" />
+			<param index="5" name="progress" type="InterDVDExportProgress" default="null" />
+			<description>
+				Writes [code]VIDEO_TS[/code] and [code]AUDIO_TS[/code] under [param root]. Returns [constant OK] on success. Every [InterDVDCell] on a title is muxed into [code]VTS_01_1.VOB[/code] (append + reindex). Cell N is chapter N (PGN N / PTT N). A cell can use [member InterDVDCell.encoded_path], bake [member InterDVDCell.packed_scene] for [member InterDVDCell.duration_sec], copy an already-encoded MPEG-2/VOB [member InterDVDCell.source_path], or transcode other sources with [param ffmpeg] / PATH (when [param auto_find_ffmpeg] is [code]true[/code]). PGC playback time is the sum of cell durations. Discovered ffmpeg paths are not stored. When [param allow_dummy_vob] is [code]true[/code], a dummy title VOB is written if no cell or encoder is available. [param progress] receives step/total/label updates and prints elapsed plus ETA.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDInstruction.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDInstruction.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDInstruction" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Encodes 8-byte DVD-Video Interaction Machine commands for IFO authoring.
+	</brief_description>
+	<description>
+		Compiles on-disc VM instructions (groups 0-6, GPRM/SPRM, Link/Jump/Call/RSM). The DVD player executes them after burn. There is no in-engine interpreter or disc player.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="encode" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="group" type="int" />
+			<param index="1" name="op" type="int" />
+			<param index="2" name="cmp" type="int" />
+			<param index="3" name="dest_reg" type="int" />
+			<param index="4" name="dest_sprm" type="bool" />
+			<param index="5" name="src" type="int" />
+			<param index="6" name="src_reg" type="bool" />
+			<param index="7" name="src_sprm" type="bool" />
+			<param index="8" name="link" type="int" />
+			<param index="9" name="from_domain" type="int" />
+			<param index="10" name="to_domain" type="int" />
+			<param index="11" name="link_target" type="int" />
+			<description>
+				Encodes one 8-byte instruction. Returns an empty array when the domain transfer is illegal.
+			</description>
+		</method>
+		<method name="encode_break" qualifiers="static">
+			<return type="PackedByteArray" />
+			<description>
+				Encodes Break ([code]00 02[/code]).
+			</description>
+		</method>
+		<method name="encode_exit" qualifiers="static">
+			<return type="PackedByteArray" />
+			<description>
+				Encodes Exit ([code]30 01[/code]).
+			</description>
+		</method>
+		<method name="encode_goto" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="line" type="int" />
+			<description>
+				Encodes Goto to instruction line [param line] (1-128).
+			</description>
+		</method>
+		<method name="encode_jump_vts_ptt" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="from_domain" type="int" />
+			<param index="1" name="title" type="int" />
+			<param index="2" name="ptt" type="int" />
+			<description>
+				Encodes JumpVTS_PTT to [param title] / [param ptt] after validating the domain matrix.
+			</description>
+		</method>
+		<method name="encode_link" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="kind" type="int" />
+			<param index="1" name="from_domain" type="int" />
+			<param index="2" name="to_domain" type="int" />
+			<param index="3" name="target" type="int" />
+			<description>
+				Encodes a Link, Jump, Call, or RSM command after validating the domain matrix.
+			</description>
+		</method>
+		<method name="encode_nop" qualifiers="static">
+			<return type="PackedByteArray" />
+			<description>
+				Returns eight zero bytes (NOP).
+			</description>
+		</method>
+		<method name="encode_rsm" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="from_domain" type="int" />
+			<description>
+				Encodes Resume. Legal only from VMG or VTSM.
+			</description>
+		</method>
+		<method name="encode_set" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="op" type="int" />
+			<param index="1" name="gprm" type="int" />
+			<param index="2" name="src" type="int" />
+			<param index="3" name="src_reg" type="bool" />
+			<param index="4" name="src_sprm" type="bool" />
+			<description>
+				Encodes a set-op targeting a GPRM (assign, swap, add, [constant SET_RANDOM] in the range 1 through [param src], and, or, xor, and similar ops).
+			</description>
+		</method>
+		<method name="encode_set_gprmmd" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="gprm" type="int" />
+			<param index="1" name="value" type="int" />
+			<param index="2" name="counter" type="bool" />
+			<description>
+				Encodes SetGPRMMD for GPRM [param gprm].
+			</description>
+		</method>
+		<method name="encode_set_hl_btnn" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="button" type="int" />
+			<description>
+				Encodes SetHL_BTNN for button 1-36.
+			</description>
+		</method>
+		<method name="encode_set_nvtmr" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="seconds" type="int" />
+			<param index="1" name="pgc" type="int" />
+			<description>
+				Encodes SetNVTMR.
+			</description>
+		</method>
+		<method name="encode_set_stn" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="audio" type="int" />
+			<param index="1" name="subtitle" type="int" />
+			<param index="2" name="subtitle_on" type="bool" />
+			<param index="3" name="angle" type="int" />
+			<description>
+				Encodes SetSTN. Pass [code]-1[/code] for a stream that should not change.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="GROUP_SPECIAL" value="0" enum="Group">
+		</constant>
+		<constant name="GROUP_LINK" value="1" enum="Group">
+		</constant>
+		<constant name="GROUP_SET_SYSTEM" value="2" enum="Group">
+		</constant>
+		<constant name="GROUP_SET" value="3" enum="Group">
+		</constant>
+		<constant name="GROUP_SET_LINK" value="4" enum="Group">
+		</constant>
+		<constant name="GROUP_CMP_SET_SYSTEM" value="5" enum="Group">
+		</constant>
+		<constant name="GROUP_CMP_SET_LINK" value="6" enum="Group">
+		</constant>
+		<constant name="CMP_ALWAYS" value="0" enum="Compare">
+		</constant>
+		<constant name="CMP_AND" value="1" enum="Compare">
+		</constant>
+		<constant name="CMP_EQ" value="2" enum="Compare">
+		</constant>
+		<constant name="CMP_NE" value="3" enum="Compare">
+		</constant>
+		<constant name="CMP_GE" value="4" enum="Compare">
+		</constant>
+		<constant name="CMP_GT" value="5" enum="Compare">
+		</constant>
+		<constant name="CMP_LE" value="6" enum="Compare">
+		</constant>
+		<constant name="CMP_LT" value="7" enum="Compare">
+		</constant>
+		<constant name="SET_NOP" value="0" enum="SetOp">
+		</constant>
+		<constant name="SET_ASSIGN" value="1" enum="SetOp">
+		</constant>
+		<constant name="SET_SWAP" value="2" enum="SetOp">
+		</constant>
+		<constant name="SET_ADD" value="3" enum="SetOp">
+		</constant>
+		<constant name="SET_SUB" value="4" enum="SetOp">
+		</constant>
+		<constant name="SET_MUL" value="5" enum="SetOp">
+		</constant>
+		<constant name="SET_DIV" value="6" enum="SetOp">
+		</constant>
+		<constant name="SET_MOD" value="7" enum="SetOp">
+		</constant>
+		<constant name="SET_RANDOM" value="8" enum="SetOp">
+		</constant>
+		<constant name="SET_AND" value="9" enum="SetOp">
+		</constant>
+		<constant name="SET_OR" value="10" enum="SetOp">
+		</constant>
+		<constant name="SET_XOR" value="11" enum="SetOp">
+		</constant>
+		<constant name="LINK_NONE" value="0" enum="LinkKind">
+		</constant>
+		<constant name="LINK_PGCN" value="1" enum="LinkKind">
+		</constant>
+		<constant name="LINK_PGN" value="2" enum="LinkKind">
+		</constant>
+		<constant name="LINK_PTT" value="3" enum="LinkKind">
+		</constant>
+		<constant name="LINK_RSM" value="4" enum="LinkKind">
+		</constant>
+		<constant name="JUMP_TT" value="5" enum="LinkKind">
+		</constant>
+		<constant name="JUMP_VTS_TT" value="6" enum="LinkKind">
+		</constant>
+		<constant name="JUMP_VTS_PTT" value="7" enum="LinkKind">
+		</constant>
+		<constant name="CALL_SS" value="8" enum="LinkKind">
+		</constant>
+		<constant name="JUMP_SS" value="9" enum="LinkKind">
+		</constant>
+		<constant name="LINK_CN" value="10" enum="LinkKind">
+		</constant>
+		<constant name="DOMAIN_FPC" value="0" enum="Domain">
+		</constant>
+		<constant name="DOMAIN_VMG" value="1" enum="Domain">
+		</constant>
+		<constant name="DOMAIN_VTSM" value="2" enum="Domain">
+		</constant>
+		<constant name="DOMAIN_VTST" value="3" enum="Domain">
+		</constant>
+		<constant name="SPRM_M_ASN" value="0" enum="SPRM">
+		</constant>
+		<constant name="SPRM_ASTN" value="1" enum="SPRM">
+		</constant>
+		<constant name="SPRM_SPSTN" value="2" enum="SPRM">
+		</constant>
+		<constant name="SPRM_AGL_N" value="3" enum="SPRM">
+		</constant>
+		<constant name="SPRM_TT_N" value="4" enum="SPRM">
+		</constant>
+		<constant name="SPRM_VTS_TT_N" value="5" enum="SPRM">
+		</constant>
+		<constant name="SPRM_TT_VTS_N" value="6" enum="SPRM">
+		</constant>
+		<constant name="SPRM_PTT_N" value="7" enum="SPRM">
+		</constant>
+		<constant name="SPRM_HL_BTNN" value="8" enum="SPRM">
+		</constant>
+		<constant name="SPRM_NVTMR" value="9" enum="SPRM">
+		</constant>
+		<constant name="SPRM_NV_PGC" value="10" enum="SPRM">
+		</constant>
+		<constant name="SPRM_P_N" value="11" enum="SPRM">
+		</constant>
+		<constant name="SPRM_PTT_N2" value="12" enum="SPRM">
+		</constant>
+		<constant name="SPRM_CN" value="13" enum="SPRM">
+		</constant>
+		<constant name="SPRM_VIDEO_CFG" value="14" enum="SPRM">
+		</constant>
+		<constant name="SPRM_AUDIO_CFG" value="15" enum="SPRM">
+		</constant>
+		<constant name="SPRM_INI_AUD_LANG" value="16" enum="SPRM">
+		</constant>
+		<constant name="SPRM_INI_AUD_EXT" value="17" enum="SPRM">
+		</constant>
+		<constant name="SPRM_INI_SP_LANG" value="18" enum="SPRM">
+		</constant>
+		<constant name="SPRM_INI_SP_EXT" value="19" enum="SPRM">
+		</constant>
+		<constant name="SPRM_REGION" value="20" enum="SPRM">
+		</constant>
+		<constant name="SPRM_RESERVED_21" value="21" enum="SPRM">
+		</constant>
+		<constant name="SPRM_RESERVED_22" value="22" enum="SPRM">
+		</constant>
+		<constant name="SPRM_RESERVED_23" value="23" enum="SPRM">
+		</constant>
+	</constants>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDMachine.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDMachine.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDMachine" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Constants for the DVD-Video Interaction Machine register file.
+	</brief_description>
+	<description>
+		Documents the 16 GPRMs, 24 SPRMs, and 8-byte instruction size used when authoring IFO command streams. This class does not interpret or play discs.
+	</description>
+	<tutorials>
+	</tutorials>
+	<constants>
+		<constant name="GPRM_COUNT" value="16">
+			Number of 16-bit general parameter registers.
+		</constant>
+		<constant name="SPRM_COUNT" value="24">
+			Number of 16-bit system parameter registers.
+		</constant>
+		<constant name="INSTRUCTION_SIZE" value="8">
+			Size of one VM command in bytes.
+		</constant>
+	</constants>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDMenu.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDMenu.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDMenu" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Still or motion DVD menu with up to 36 buttons.
+	</brief_description>
+	<description>
+		Used when authoring VMG/VTSM menus. Playback happens on a burnt disc, not in the editor. Set [member Resource.resource_name] so button destination dropdowns can label this menu.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="button_group_mask" type="int" setter="set_button_group_mask" getter="get_button_group_mask" default="4096">
+			HLI BTN_MD word. Default [code]0x1000[/code] is one 4:3 group (libdvdread: reserved [code]zero1[/code]=0, [code]btngr_ns[/code]=1). Do not use [code]0x4000[/code]; that sets [code]zero1[/code] and leaves [code]btngr_ns[/code]=0.
+		</member>
+		<member name="buttons" type="InterDVDButton[]" setter="set_buttons" getter="get_buttons" default="[]">
+			Menu buttons (capped at 36).
+		</member>
+		<member name="cell" type="InterDVDCell" setter="set_cell" getter="get_cell">
+			Still or motion background cell. Uses the same mux path as a title video cell.
+		</member>
+		<member name="clut" type="PackedColorArray" setter="set_clut" getter="get_clut" default="PackedColorArray()">
+			Optional 16-entry PGC palette. Empty keeps the default gold highlight colors.
+		</member>
+		<member name="default_button" type="int" setter="set_default_button" getter="get_default_button" default="1">
+			Forced-selected button on the first NAV pack (1-36).
+		</member>
+		<member name="forced_activated_button" type="int" setter="set_forced_activated_button" getter="get_forced_activated_button" default="0">
+			HLI forced-activated button, or [code]0[/code] for none.
+		</member>
+		<member name="forced_selected_button" type="int" setter="set_forced_selected_button" getter="get_forced_selected_button" default="0">
+			HLI forced-selected button override, or [code]0[/code] to use [member default_button].
+		</member>
+		<member name="menu_type" type="int" setter="set_menu_type" getter="get_menu_type" enum="InterDVDMenu.MenuType" default="2">
+			PGCI_UT menu id: Title 2, Root 3, Subpicture 4, Audio 5, Angle 6, Chapter 7.
+		</member>
+		<member name="motion" type="bool" setter="set_motion" getter="is_motion" default="false">
+			If [code]true[/code], the menu uses a motion video cell.
+		</member>
+		<member name="next_pgc" type="int" setter="set_next_pgc" getter="get_next_pgc" default="1">
+			Next PGC number (default loops this menu).
+		</member>
+		<member name="prev_pgc" type="int" setter="set_prev_pgc" getter="get_prev_pgc" default="1">
+			Previous PGC number.
+		</member>
+		<member name="still_time" type="int" setter="set_still_time" getter="get_still_time" default="0">
+			PGC still time in seconds ([code]255[/code] = infinite).
+		</member>
+	</members>
+	<constants>
+		<constant name="MENU_TITLE" value="2" enum="MenuType">
+			Title menu.
+		</constant>
+		<constant name="MENU_ROOT" value="3" enum="MenuType">
+			Root menu.
+		</constant>
+		<constant name="MENU_SUBPICTURE" value="4" enum="MenuType">
+			Subpicture menu.
+		</constant>
+		<constant name="MENU_AUDIO" value="5" enum="MenuType">
+			Audio menu.
+		</constant>
+		<constant name="MENU_ANGLE" value="6" enum="MenuType">
+			Angle menu.
+		</constant>
+		<constant name="MENU_CHAPTER" value="7" enum="MenuType">
+			Chapter menu.
+		</constant>
+	</constants>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDPGC.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDPGC.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDPGC" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Program Chain: cells plus pre/post instruction arrays.
+	</brief_description>
+	<description>
+		PGC pre/post and cell-post sites are written into the IFO. First Play (FPC) is a PGC on [InterDVDProject]. Set [member Resource.resource_name] so button destination dropdowns can label this title.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="buttons" type="InterDVDButton[]" setter="set_buttons" getter="get_buttons" default="[]">
+			Optional highlight buttons overlaid on this title (for example a Next Scene control). Written as PCI HLI in the title VOB.
+		</member>
+		<member name="cells" type="InterDVDCell[]" setter="set_cells" getter="get_cells" default="[]">
+			Ordered cells in this PGC. Each cell is muxed into the title VOB; cell N is chapter N (PGN N / PTT N).
+		</member>
+		<member name="clut" type="PackedColorArray" setter="set_clut" getter="get_clut" default="PackedColorArray()">
+			Optional 16-entry PGC palette written at PGC offset [code]0xA4[/code]. Empty keeps the default golds.
+		</member>
+		<member name="default_button" type="int" setter="set_default_button" getter="get_default_button" default="1">
+			Forced-selected title-domain button when this PGC has highlight buttons.
+		</member>
+		<member name="next_pgc" type="int" setter="set_next_pgc" getter="get_next_pgc" default="0">
+			Next PGC number. Titles with highlight buttons default to looping this PGC when unset.
+		</member>
+		<member name="post_commands" type="PackedByteArray[]" setter="set_post_commands" getter="get_post_commands" default="[]">
+			PGC post commands (used after the last cell).
+		</member>
+		<member name="pre_commands" type="PackedByteArray[]" setter="set_pre_commands" getter="get_pre_commands" default="[]">
+			PGC pre commands.
+		</member>
+		<member name="prev_pgc" type="int" setter="set_prev_pgc" getter="get_prev_pgc" default="0">
+			Previous PGC number.
+		</member>
+		<member name="still_time" type="int" setter="set_still_time" getter="get_still_time" default="0">
+			Still time in seconds written on the last cell ([code]255[/code] = infinite).
+		</member>
+	</members>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDProject.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDProject.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDProject" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Authoring graph for a VIDEO_TS / AUDIO_TS disc.
+	</brief_description>
+	<description>
+		Describes VMG, titles, menus, region mask, and parental level. Export writes an unencrypted DVD-Video volume for burning. Point [code]blazium/inter_dvd/project[/code] at this resource.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_title_from_video">
+			<return type="InterDVDPGC" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Creates a title PGC with one cell whose [member InterDVDCell.source_path] is [param path], appends it to [member titles], and returns the title.
+			</description>
+		</method>
+		<method name="language_be16" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="language" type="String" />
+			<description>
+				Packs an ISO 639-1 code into the 16-bit IFO language field ([code]en[/code] is [code]0x656E[/code]).
+			</description>
+		</method>
+		<method name="sanitize_volume_id" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="id" type="String" />
+			<description>
+				Uppercase ISO9660 volume label: [code]A-Z0-9_[/code], max 32 characters. Empty input becomes [code]BLAZIUM_DVD[/code].
+			</description>
+		</method>
+		<method name="seed_from_project_settings">
+			<return type="void" />
+			<description>
+				Copies [code]blazium/inter_dvd[/code] ProjectSettings defaults onto this resource (region, parental, AC3, GOP, title-safe, warmup).
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="ac3_bitrate_k" type="int" setter="set_ac3_bitrate_k" getter="get_ac3_bitrate_k" default="192">
+			AC3 encode bitrate in kbps. Seeded from [code]blazium/inter_dvd/ac3_bitrate_k[/code].
+		</member>
+		<member name="audio_language" type="String" setter="set_audio_language" getter="get_audio_language" default="&quot;en&quot;">
+			Default ISO 639-1 code for title audio attributes.
+		</member>
+		<member name="bake_warmup_frames" type="int" setter="set_bake_warmup_frames" getter="get_bake_warmup_frames" default="2">
+			Viewport frames skipped before the first captured bake frame.
+		</member>
+		<member name="disc_title" type="String" setter="set_disc_title" getter="get_disc_title" default="&quot;&quot;">
+			Human title written into TXTDT_MGI (libdvdnav [code]get_title_string[/code]).
+		</member>
+		<member name="first_play" type="InterDVDPGC" setter="set_first_play" getter="get_first_play">
+			Optional First Play PGC (FPC).
+		</member>
+		<member name="gop_size" type="int" setter="set_gop_size" getter="get_gop_size" default="15">
+			MPEG GOP size passed to ffmpeg [code]-g[/code].
+		</member>
+		<member name="menu_language" type="String" setter="set_menu_language" getter="get_menu_language" default="&quot;en&quot;">
+			ISO 639-1 code written on VMGM/VTSM PGCI_UT language units.
+		</member>
+		<member name="menus" type="InterDVDMenu[]" setter="set_menus" getter="get_menus" default="[]">
+			[constant InterDVDMenu.MENU_TITLE] menus are concatenated into [code]VIDEO_TS.VOB[/code] (VMGM). Root, audio, subpicture, angle, and chapter menus are concatenated into [code]VTS_01_0.VOB[/code] (VTSM).
+		</member>
+		<member name="parental_level" type="int" setter="set_parental_level" getter="get_parental_level" default="1">
+			Default parental level.
+		</member>
+		<member name="provider_id" type="String" setter="set_provider_id" getter="get_provider_id" default="&quot;BLAZIUM INTER-DVD&quot;">
+			32-byte VMGI provider identifier.
+		</member>
+		<member name="region_mask" type="int" setter="set_region_mask" getter="get_region_mask" default="1">
+			Region mask written into the VMG.
+		</member>
+		<member name="serial" type="String" setter="set_serial" getter="get_serial" default="&quot;&quot;">
+			Optional disc serial string (max 15 characters) stored with TXTDT.
+		</member>
+		<member name="subtitle_language" type="String" setter="set_subtitle_language" getter="get_subtitle_language" default="&quot;en&quot;">
+			Default ISO 639-1 code for subtitle attributes when SPU PES is muxed.
+		</member>
+		<member name="title_safe_bottom" type="int" setter="set_title_safe_bottom" getter="get_title_safe_bottom" default="432">
+			NTSC title-safe bottom scanline for HLI clamp (buttons below this are lifted).
+		</member>
+		<member name="titles" type="InterDVDPGC[]" setter="set_titles" getter="get_titles" default="[]">
+			Title PGCs (one VTS). Every cell on each title is muxed; use [method add_title_from_video] to add a clip.
+		</member>
+		<member name="volume_id" type="String" setter="set_volume_id" getter="get_volume_id" default="&quot;BLAZIUM_DVD&quot;">
+			ISO9660 volume label passed to mkisofs [code]-V[/code] or oscdimg [code]-l[/code].
+		</member>
+	</members>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDSceneBaker.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDSceneBaker.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDSceneBaker" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Records an [InterDVDCell] packed scene to NTSC DVD MPEG-2 plus audio.
+	</brief_description>
+	<description>
+		Instantiates [member InterDVDCell.packed_scene] in a 720×480 viewport, captures [member InterDVDCell.duration_sec] at 30 fps, and encodes with ffmpeg [code]-target ntsc-dvd[/code]. GPU capture uses the scene (or [member InterDVDCell.bake_camera_path]) camera; dummy/headless CPU-rasters common Node2D and Control types. A packed [Node3D] on the dummy renderer returns [constant ERR_UNAVAILABLE]. [AnimationPlayer] / [AnimatedSprite2D] scenes bake looping motion frames. A root [code]inter_dvd_bake_time(seconds)[/code] method is called each captured frame. [member InterDVDCell.bake_hold_sec] or [code]inter_dvd_bake_hold_sec()[/code] holds each unique frame. Cache path, AC3, GOP, PiP lead, and warmup come from ProjectSettings / [InterDVDProject] / [InterDVDCell]. Fails if the probed MPEG is shorter than the requested duration. Editor-only.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="bake_cell" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="cell" type="InterDVDCell" />
+			<param index="1" name="ffmpeg" type="String" default="&quot;&quot;" />
+			<param index="2" name="auto_find_ffmpeg" type="bool" default="true" />
+			<description>
+				Bakes [param cell] when a packed scene is set and the cache is missing or dirty. Sets [member InterDVDCell.encoded_path] to the cached MPEG. Does not store machine ffmpeg paths.
+			</description>
+		</method>
+		<method name="raster_root" qualifiers="static">
+			<return type="Image" />
+			<param index="0" name="root" type="Node" />
+			<description>
+				CPU-raster [param root] and its visible children to a 720×480 [Image]. Used by headless bake and tests. Does not encode MPEG.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/inter_dvd/doc_classes/InterDVDStream.xml
+++ b/modules/inter_dvd/doc_classes/InterDVDStream.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InterDVDStream" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Extra audio or subtitle stream muxed into an [InterDVDCell].
+	</brief_description>
+	<description>
+		[member InterDVDCell.audio_path] is stream 0. Additional AC3 audio tracks use [constant KIND_AUDIO] (private stream [code]0x81+[/code]). Caption files ([code].srt[/code], [code].sup[/code]) use [constant KIND_SUBTITLE] and are muxed as [code]dvdsub[/code] (private stream [code]0x20+[/code]). IFO stream tables are written only when that PES exists in the muxed VOB.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="code_extension" type="int" setter="set_code_extension" getter="get_code_extension" default="1">
+			Language code extension (normal, visually impaired, director comments, and so on).
+		</member>
+		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
+			If [code]false[/code], export skips this stream.
+		</member>
+		<member name="kind" type="int" setter="set_kind" getter="get_kind" enum="InterDVDStream.Kind" default="0">
+			Audio or subtitle.
+		</member>
+		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;en&quot;">
+			ISO 639-1 language code written into the IFO audio or subpicture attribute table.
+		</member>
+		<member name="source_path" type="String" setter="set_source_path" getter="get_source_path" default="&quot;&quot;">
+			Audio file or subtitle file to mux.
+		</member>
+	</members>
+	<constants>
+		<constant name="KIND_AUDIO" value="0" enum="Kind">
+			Additional AC3 audio track.
+		</constant>
+		<constant name="KIND_SUBTITLE" value="1" enum="Kind">
+			SPU / [code]dvdsub[/code] caption track.
+		</constant>
+	</constants>
+</class>

--- a/modules/inter_dvd/editor/export/windows_inter_dvd_export_platform.cpp
+++ b/modules/inter_dvd/editor/export/windows_inter_dvd_export_platform.cpp
@@ -1,0 +1,254 @@
+/**************************************************************************/
+/*  windows_inter_dvd_export_platform.cpp                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "windows_inter_dvd_export_platform.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/io/image.h"
+#include "core/io/resource_loader.h"
+#include "core/io/zip_io.h"
+#include "core/os/os.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_string_names.h"
+#include "modules/inter_dvd/author/inter_dvd_ifo_writer.h"
+#include "modules/inter_dvd/author/inter_dvd_project.h"
+#include "modules/inter_dvd/author/inter_dvd_vob_mux.h"
+#include "scene/resources/image_texture.h"
+
+namespace {
+int count_export_steps(const Ref<InterDVDProject> &p_project, int p_kind) {
+	int n = 3;
+	if (p_project.is_valid()) {
+		n += p_project->get_menus().size();
+		const TypedArray<InterDVDPGC> titles = p_project->get_titles();
+		for (int i = 0; i < titles.size(); i++) {
+			const Ref<InterDVDPGC> title = titles[i];
+			const int cells = title.is_valid() ? title->get_cells().size() : 0;
+			n += cells > 0 ? cells : 1;
+		}
+	} else {
+		n++;
+	}
+	if (p_kind == 1 || p_kind == 2) {
+		n++;
+	}
+	return MAX(n, 1);
+}
+} //namespace
+
+EditorExportPlatformWindowsInterDVD::EditorExportPlatformWindowsInterDVD() {
+	if (EditorNode::get_singleton()) {
+		Ref<Image> img = Image::create_empty(16, 16, false, Image::FORMAT_RGBA8);
+		img->fill(Color(0.15, 0.2, 0.55));
+		logo = ImageTexture::create_from_image(img);
+	}
+}
+
+void EditorExportPlatformWindowsInterDVD::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+	(void)p_preset;
+	r_features->push_back("inter_dvd");
+}
+
+void EditorExportPlatformWindowsInterDVD::get_platform_features(List<String> *r_features) const {
+	r_features->push_back("windows");
+	r_features->push_back("inter_dvd");
+}
+
+void EditorExportPlatformWindowsInterDVD::get_export_options(List<ExportOption> *r_options) const {
+	const int region = InterDVDSettings::setting_int("blazium/inter_dvd/default_region_mask", 1);
+	const int parental = InterDVDSettings::setting_int("blazium/inter_dvd/default_parental_level", 1);
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "inter_dvd/output_kind", PROPERTY_HINT_ENUM, "Folder,Zip,ISO"), 0));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "inter_dvd/region_mask", PROPERTY_HINT_RANGE, "1,255,1"), region));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "inter_dvd/parental_level", PROPERTY_HINT_RANGE, "1,8,1"), parental));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "inter_dvd/auto_find_ffmpeg"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/ffmpeg", PROPERTY_HINT_GLOBAL_FILE), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/iso_tool", PROPERTY_HINT_GLOBAL_FILE), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "inter_dvd/allow_dummy_vob"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/volume_id"), "BLAZIUM_DVD"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/menu_language"), "en"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/audio_language"), "en"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/subtitle_language"), "en"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "inter_dvd/provider_id"), "BLAZIUM INTER-DVD"));
+}
+
+List<String> EditorExportPlatformWindowsInterDVD::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> list;
+	const int kind = p_preset.is_valid() ? int(p_preset->get("inter_dvd/output_kind")) : 0;
+	if (kind == 1) {
+		list.push_back("zip");
+	} else if (kind == 2) {
+		list.push_back("iso");
+	} else {
+		list.push_back("zip");
+		list.push_back("iso");
+	}
+	return list;
+}
+
+bool EditorExportPlatformWindowsInterDVD::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+	(void)p_debug;
+	r_missing_templates = false;
+	String err;
+	if (int(p_preset->get("inter_dvd/output_kind")) == 2) {
+		String tool = p_preset->get("inter_dvd/iso_tool");
+		if (tool.is_empty() && EditorSettings::get_singleton()) {
+			tool = EDITOR_GET("export/inter_dvd/iso_tool");
+		}
+		if (tool.is_empty() || !FileAccess::exists(tool)) {
+			err += TTR("ISO export needs oscdimg or mkisofs configured (export/inter_dvd/iso_tool).") + "\n";
+		}
+	}
+	if (!err.is_empty()) {
+		r_error = err;
+		return false;
+	}
+	return true;
+}
+
+bool EditorExportPlatformWindowsInterDVD::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
+	(void)p_preset;
+	const String path = GLOBAL_GET("blazium/inter_dvd/project");
+	if (path.is_empty()) {
+		r_error = TTR("Set blazium/inter_dvd/project to an InterDVDProject resource.");
+		return false;
+	}
+	return true;
+}
+
+Error EditorExportPlatformWindowsInterDVD::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
+	const String project_path = GLOBAL_GET("blazium/inter_dvd/project");
+	Ref<InterDVDProject> project;
+	if (!project_path.is_empty()) {
+		project = ResourceLoader::load(project_path);
+	}
+	if (project.is_null()) {
+		project.instantiate();
+	}
+	if (p_preset.is_valid()) {
+		project->set_region_mask(p_preset->get("inter_dvd/region_mask"));
+		project->set_parental_level(p_preset->get("inter_dvd/parental_level"));
+		const String volume = p_preset->get("inter_dvd/volume_id");
+		if (!volume.is_empty()) {
+			project->set_volume_id(volume);
+		}
+		const String menu_lang = p_preset->get("inter_dvd/menu_language");
+		if (!menu_lang.is_empty()) {
+			project->set_menu_language(menu_lang);
+		}
+		const String audio_lang = p_preset->get("inter_dvd/audio_language");
+		if (!audio_lang.is_empty()) {
+			project->set_audio_language(audio_lang);
+		}
+		const String sub_lang = p_preset->get("inter_dvd/subtitle_language");
+		if (!sub_lang.is_empty()) {
+			project->set_subtitle_language(sub_lang);
+		}
+		const String provider = p_preset->get("inter_dvd/provider_id");
+		if (!provider.is_empty()) {
+			project->set_provider_id(provider);
+		}
+	}
+
+	String ffmpeg = p_preset->get("inter_dvd/ffmpeg");
+	if (ffmpeg.is_empty() && EditorSettings::get_singleton()) {
+		ffmpeg = EDITOR_GET("export/inter_dvd/ffmpeg");
+	}
+	const bool auto_find = p_preset.is_valid() && bool(p_preset->get("inter_dvd/auto_find_ffmpeg"));
+	String iso_tool = p_preset->get("inter_dvd/iso_tool");
+	if (iso_tool.is_empty() && EditorSettings::get_singleton()) {
+		iso_tool = EDITOR_GET("export/inter_dvd/iso_tool");
+	}
+
+	const int kind = p_preset->get("inter_dvd/output_kind");
+	String work_dir = p_path;
+	if (kind != 0) {
+		work_dir = p_path.get_base_dir().path_join(p_path.get_file().get_basename() + "_disc");
+	} else if (p_path.get_extension() != "") {
+		work_dir = p_path.get_base_dir();
+	}
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(work_dir);
+
+	const bool allow_dummy = p_preset.is_valid() && bool(p_preset->get("inter_dvd/allow_dummy_vob"));
+	Ref<InterDVDExportProgress> progress;
+	progress.instantiate();
+	const int steps = count_export_steps(project, kind);
+	progress->begin(steps);
+	EditorProgress ep("inter_dvd", TTR("Interactive DVD"), steps);
+	String write_error;
+	Error err = InterDVDIfoWriter::write_video_ts(work_dir, project, allow_dummy, ffmpeg, &write_error, auto_find, progress);
+	if (err != OK) {
+		add_message(EXPORT_MESSAGE_ERROR, TTR("Interactive DVD"), write_error.is_empty() ? TTR("Failed to write VIDEO_TS.") : write_error);
+		return err;
+	}
+
+	if (kind == 1) {
+		progress->report("Creating ZIP");
+		if (FileAccess::exists(p_path)) {
+			OS::get_singleton()->move_to_trash(p_path);
+		}
+		Ref<FileAccess> io_fa;
+		zlib_filefunc_def io = zipio_create_io(&io_fa);
+		zipFile zip = zipOpen2(p_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io);
+		zip_folder_recursive(zip, work_dir, "", "VIDEO_TS");
+		zipClose(zip, nullptr);
+		if (da->change_dir(work_dir) == OK) {
+			da->erase_contents_recursive();
+		}
+	} else if (kind == 2) {
+		if (iso_tool.is_empty()) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Interactive DVD"), TTR("ISO tool (oscdimg or mkisofs) is not configured."));
+			return ERR_UNCONFIGURED;
+		}
+		progress->report("Creating ISO");
+		const Vector<String> iso_args = InterDVDIfoWriter::iso_tool_args(iso_tool, project->get_volume_id(), work_dir, p_path);
+		List<String> args;
+		for (int i = 0; i < iso_args.size(); i++) {
+			args.push_back(iso_args[i]);
+		}
+		String pipe;
+		const int code = OS::get_singleton()->execute(iso_tool, args, &pipe);
+		if (code != 0) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Interactive DVD"), vformat(TTR("ISO tool failed (%d): %s"), code, pipe));
+			return FAILED;
+		}
+	}
+
+	return OK;
+}
+
+#endif

--- a/modules/inter_dvd/editor/export/windows_inter_dvd_export_platform.h
+++ b/modules/inter_dvd/editor/export/windows_inter_dvd_export_platform.h
@@ -1,0 +1,59 @@
+/**************************************************************************/
+/*  windows_inter_dvd_export_platform.h                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/export/editor_export_platform.h"
+
+class EditorExportPlatformWindowsInterDVD : public EditorExportPlatform {
+	GDCLASS(EditorExportPlatformWindowsInterDVD, EditorExportPlatform);
+
+	Ref<ImageTexture> logo;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	EditorExportPlatformWindowsInterDVD();
+
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
+	virtual void get_export_options(List<ExportOption> *r_options) const override;
+	virtual String get_os_name() const override { return "Windows"; }
+	virtual String get_name() const override { return "Windows Interactive DVD"; }
+	virtual Ref<Texture2D> get_logo() const override { return logo; }
+	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
+	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0) override;
+	virtual void get_platform_features(List<String> *r_features) const override;
+};
+
+#endif

--- a/modules/inter_dvd/editor/inter_dvd_editor_plugin.cpp
+++ b/modules/inter_dvd/editor/inter_dvd_editor_plugin.cpp
@@ -1,0 +1,227 @@
+/**************************************************************************/
+/*  inter_dvd_editor_plugin.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "inter_dvd_editor_plugin.h"
+
+#include "export/windows_inter_dvd_export_platform.h"
+#include "inter_dvd_scene_baker.h"
+#include "modules/inter_dvd/author/inter_dvd_ifo_writer.h"
+#include "modules/inter_dvd/author/inter_dvd_project.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/resource_loader.h"
+#include "core/math/math_funcs.h"
+#include "core/object/object.h"
+#include "core/os/os.h"
+#include "editor/editor_node.h"
+#include "editor/editor_properties.h"
+#include "editor/editor_settings.h"
+#include "editor/export/editor_export.h"
+#include "scene/gui/button.h"
+
+bool EditorInspectorPluginInterDVDCell::can_handle(Object *p_object) {
+	return Object::cast_to<InterDVDCell>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginInterDVDCell::parse_begin(Object *p_object) {
+	InterDVDCell *cell = Object::cast_to<InterDVDCell>(p_object);
+	if (!cell) {
+		return;
+	}
+	Button *bake = memnew(Button);
+	bake->set_text(TTR("Bake Scene Now"));
+	bake->connect(SNAME("pressed"), callable_mp(this, &EditorInspectorPluginInterDVDCell::_bake_pressed).bind(cell->get_instance_id()));
+	add_custom_control(bake);
+}
+
+void EditorInspectorPluginInterDVDCell::_bake_pressed(ObjectID p_id) {
+	InterDVDCell *cell = Object::cast_to<InterDVDCell>(ObjectDB::get_instance(p_id));
+	if (!cell) {
+		return;
+	}
+	String ffmpeg;
+	bool auto_find = true;
+	if (EditorSettings::get_singleton()) {
+		ffmpeg = EDITOR_GET("export/inter_dvd/ffmpeg");
+		auto_find = EDITOR_GET("export/inter_dvd/auto_find_ffmpeg");
+	}
+	String err;
+	const uint64_t started = OS::get_singleton()->get_ticks_usec();
+	EditorProgress ep("inter_dvd_bake", TTR("Interactive DVD"), 1);
+	ep.step(vformat(TTR("Baking scene…  %s elapsed"), InterDVDExportProgress::format_clock(0)), 0, true);
+	const Error code = InterDVDSceneBaker::bake_cell(Ref<InterDVDCell>(cell), ffmpeg, auto_find, &err);
+	const String elapsed = InterDVDExportProgress::format_clock(int64_t(OS::get_singleton()->get_ticks_usec() - started));
+	ep.step(vformat(TTR("Bake finished  %s elapsed"), elapsed), 1, true);
+	ERR_FAIL_COND_MSG(code != OK, err.is_empty() ? String("InterDVD scene bake failed.") : err);
+}
+
+bool EditorInspectorPluginInterDVDButton::can_handle(Object *p_object) {
+	return Object::cast_to<InterDVDButton>(p_object) != nullptr;
+}
+
+bool EditorInspectorPluginInterDVDButton::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
+	(void)p_type;
+	(void)p_hint;
+	(void)p_hint_text;
+	(void)p_usage;
+	(void)p_wide;
+	if (p_path != "target" && p_path != "title_n") {
+		return false;
+	}
+	InterDVDButton *btn = Object::cast_to<InterDVDButton>(p_object);
+	if (!btn) {
+		return false;
+	}
+
+	Vector<String> options;
+	const InterDVDButton::Action action = btn->get_action();
+	Ref<InterDVDProject> project;
+	const String project_path = GLOBAL_GET("blazium/inter_dvd/project");
+	if (!project_path.is_empty()) {
+		project = ResourceLoader::load(project_path);
+	}
+	if (p_path == "title_n" && action == InterDVDButton::ACTION_JUMP_CHAPTER && project.is_valid()) {
+		const TypedArray<InterDVDPGC> titles = project->get_titles();
+		for (int i = 0; i < titles.size(); i++) {
+			const Ref<InterDVDPGC> title = titles[i];
+			String label = title.is_valid() ? title->get_name() : String();
+			if (label.is_empty() && title.is_valid() && title->get_cells().size() > 0) {
+				const Ref<InterDVDCell> cell = title->get_cells()[0];
+				if (cell.is_valid()) {
+					label = cell->get_display_name();
+				}
+			}
+			if (label.is_empty()) {
+				label = vformat("Title %d", i + 1);
+			}
+			options.push_back(vformat("%d — %s:%d", i + 1, label, i + 1));
+		}
+	} else if (action == InterDVDButton::ACTION_JUMP_MENU) {
+		options.push_back("Title Menu:2");
+		options.push_back("Root Menu:3");
+		options.push_back("Subpicture Menu:4");
+		options.push_back("Audio Menu:5");
+		options.push_back("Angle Menu:6");
+		options.push_back("Chapter Menu:7");
+	} else if (action == InterDVDButton::ACTION_JUMP_CHAPTER && p_path == "target") {
+		if (project.is_valid()) {
+			const TypedArray<InterDVDPGC> titles = project->get_titles();
+			const int title_idx = CLAMP(btn->get_title_n() - 1, 0, MAX(titles.size() - 1, 0));
+			if (title_idx < titles.size()) {
+				const Ref<InterDVDPGC> title = titles[title_idx];
+				if (title.is_valid()) {
+					const TypedArray<InterDVDCell> cells = title->get_cells();
+					for (int c = 0; c < cells.size(); c++) {
+						const Ref<InterDVDCell> cell = cells[c];
+						String label = cell.is_valid() ? cell->get_display_name() : String();
+						if (label.is_empty()) {
+							label = vformat("Chapter %d", c + 1);
+						}
+						options.push_back(vformat("%d — %s:%d", c + 1, label, c + 1));
+					}
+				}
+			}
+		}
+	} else if (action == InterDVDButton::ACTION_JUMP_TITLE || action == InterDVDButton::ACTION_JUMP_PGC) {
+		if (project.is_valid()) {
+			const TypedArray<InterDVDPGC> titles = project->get_titles();
+			for (int i = 0; i < titles.size(); i++) {
+				const Ref<InterDVDPGC> title = titles[i];
+				String label = title.is_valid() ? title->get_name() : String();
+				if (label.is_empty() && title.is_valid() && title->get_cells().size() > 0) {
+					const Ref<InterDVDCell> cell = title->get_cells()[0];
+					if (cell.is_valid()) {
+						label = cell->get_display_name();
+					}
+				}
+				if (label.is_empty()) {
+					label = vformat("Title %d", i + 1);
+				}
+				if (action == InterDVDButton::ACTION_JUMP_PGC) {
+					options.push_back(vformat("PGC %d — %s:%d", i + 1, label, i + 1));
+				} else {
+					options.push_back(vformat("%d — %s:%d", i + 1, label, i + 1));
+				}
+			}
+		}
+	}
+	if (options.is_empty()) {
+		return false;
+	}
+
+	EditorPropertyEnum *editor = memnew(EditorPropertyEnum);
+	editor->setup(options);
+	add_property_editor(p_path, editor);
+	return true;
+}
+
+void InterDVDEditorPlugin::_bind_methods() {
+}
+
+void InterDVDEditorPlugin::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		EDITOR_DEF_BASIC("export/inter_dvd/auto_find_ffmpeg", true);
+		EDITOR_DEF_BASIC("export/inter_dvd/ffmpeg", "");
+		EDITOR_DEF_BASIC("export/inter_dvd/iso_tool", "");
+		if (EditorSettings::get_singleton()) {
+			EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::BOOL, "export/inter_dvd/auto_find_ffmpeg"));
+			EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/inter_dvd/ffmpeg", PROPERTY_HINT_GLOBAL_FILE));
+			EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/inter_dvd/iso_tool", PROPERTY_HINT_GLOBAL_FILE));
+		}
+
+		if (EditorExport::get_singleton()) {
+			Ref<EditorExportPlatformWindowsInterDVD> platform;
+			platform.instantiate();
+			export_platform = platform;
+			EditorExport::get_singleton()->add_export_platform(export_platform);
+		}
+
+		inspector_plugin.instantiate();
+		add_inspector_plugin(inspector_plugin);
+		button_inspector_plugin.instantiate();
+		add_inspector_plugin(button_inspector_plugin);
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
+		if (button_inspector_plugin.is_valid()) {
+			remove_inspector_plugin(button_inspector_plugin);
+			button_inspector_plugin.unref();
+		}
+		if (inspector_plugin.is_valid()) {
+			remove_inspector_plugin(inspector_plugin);
+			inspector_plugin.unref();
+		}
+		if (export_platform.is_valid() && EditorExport::get_singleton()) {
+			EditorExport::get_singleton()->remove_export_platform(export_platform);
+			export_platform.unref();
+		}
+	}
+}
+
+#endif

--- a/modules/inter_dvd/editor/inter_dvd_editor_plugin.h
+++ b/modules/inter_dvd/editor/inter_dvd_editor_plugin.h
@@ -1,0 +1,74 @@
+/**************************************************************************/
+/*  inter_dvd_editor_plugin.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/editor_inspector.h"
+#include "editor/export/editor_export_platform.h"
+#include "editor/plugins/editor_plugin.h"
+
+class InterDVDCell;
+class InterDVDButton;
+
+class EditorInspectorPluginInterDVDCell : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginInterDVDCell, EditorInspectorPlugin);
+
+	void _bake_pressed(ObjectID p_id);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
+class EditorInspectorPluginInterDVDButton : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginInterDVDButton, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override;
+};
+
+class InterDVDEditorPlugin : public EditorPlugin {
+	GDCLASS(InterDVDEditorPlugin, EditorPlugin);
+
+	Ref<EditorExportPlatform> export_platform;
+	Ref<EditorInspectorPluginInterDVDCell> inspector_plugin;
+	Ref<EditorInspectorPluginInterDVDButton> button_inspector_plugin;
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	virtual String get_plugin_name() const override { return "InteractiveDVD"; }
+};
+
+#endif

--- a/modules/inter_dvd/editor/inter_dvd_scene_baker.cpp
+++ b/modules/inter_dvd/editor/inter_dvd_scene_baker.cpp
@@ -1,0 +1,1573 @@
+/**************************************************************************/
+/*  inter_dvd_scene_baker.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "inter_dvd_scene_baker.h"
+
+#include "modules/inter_dvd/author/inter_dvd_project.h"
+#include "modules/inter_dvd/author/inter_dvd_vob_mux.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/io/image.h"
+#include "core/math/math_funcs.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "scene/2d/animated_sprite_2d.h"
+#include "scene/2d/audio_stream_player_2d.h"
+#include "scene/2d/camera_2d.h"
+#include "scene/2d/line_2d.h"
+#include "scene/2d/mesh_instance_2d.h"
+#include "scene/2d/polygon_2d.h"
+#include "scene/2d/sprite_2d.h"
+#include "scene/2d/tile_map.h"
+#include "scene/2d/tile_map_layer.h"
+#ifndef _3D_DISABLED
+#include "scene/3d/audio_stream_player_3d.h"
+#include "scene/3d/camera_3d.h"
+#include "scene/3d/node_3d.h"
+#endif
+#include "scene/animation/animation_player.h"
+#include "scene/audio/audio_stream_player.h"
+#include "scene/gui/button.h"
+#include "scene/gui/color_rect.h"
+#include "scene/gui/control.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/link_button.h"
+#include "scene/gui/nine_patch_rect.h"
+#include "scene/gui/panel.h"
+#include "scene/gui/panel_container.h"
+#include "scene/gui/progress_bar.h"
+#include "scene/gui/range.h"
+#include "scene/gui/rich_text_label.h"
+#include "scene/gui/slider.h"
+#include "scene/gui/text_edit.h"
+#include "scene/gui/texture_button.h"
+#include "scene/gui/texture_rect.h"
+#include "scene/gui/video_stream_player.h"
+#include "scene/resources/2d/tile_set.h"
+#include "scene/resources/packed_scene.h"
+#include "scene/resources/sprite_frames.h"
+#include "scene/resources/style_box.h"
+#include "scene/resources/style_box_flat.h"
+#include "scene/resources/style_box_texture.h"
+
+#include "scene/main/scene_tree.h"
+#include "scene/main/viewport.h"
+#include "scene/main/window.h"
+#include "scene/resources/audio_stream_wav.h"
+#include "scene/resources/texture.h"
+#include "servers/rendering_server.h"
+#include "servers/text_server.h"
+namespace {
+
+constexpr int BAKE_WIDTH = 720;
+constexpr int BAKE_HEIGHT = 480;
+constexpr double BAKE_FPS = 30.0;
+constexpr double DURATION_SLACK_SEC = 0.25;
+
+String packed_visual_fingerprint(const Ref<PackedScene> &p_scene);
+
+String cache_root() {
+	return InterDVDSettings::cache_path();
+}
+
+String scene_key(const Ref<InterDVDCell> &p_cell) {
+	const Ref<PackedScene> scene = p_cell.is_valid() ? p_cell->get_packed_scene() : Ref<PackedScene>();
+	String path = scene.is_valid() ? scene->get_path() : String();
+	if (path.is_empty() && scene.is_valid()) {
+		path = vformat("embedded_%d", scene->get_instance_id());
+	}
+	uint64_t mtime = 0;
+	if (!path.is_empty() && !path.begins_with("embedded_")) {
+		String abs = path;
+		const int sub = path.find("::");
+		if (sub >= 0) {
+			abs = path.substr(0, sub);
+		}
+		if (ProjectSettings::get_singleton()) {
+			abs = ProjectSettings::get_singleton()->globalize_path(abs);
+		}
+		mtime = FileAccess::get_modified_time(abs);
+	}
+	const String pip = p_cell.is_valid() ? p_cell->get_pip_source_path() : String();
+	uint64_t pip_mtime = 0;
+	if (!pip.is_empty() && FileAccess::exists(pip)) {
+		pip_mtime = FileAccess::get_modified_time(pip);
+	}
+	const String menu_audio = p_cell.is_valid() ? p_cell->get_audio_path() : String();
+	uint64_t audio_mtime = 0;
+	if (!menu_audio.is_empty() && FileAccess::exists(menu_audio)) {
+		audio_mtime = FileAccess::get_modified_time(menu_audio);
+	}
+	const double duration = p_cell.is_valid() ? p_cell->get_duration_sec() : 0.0;
+	const double pad = p_cell.is_valid() ? p_cell->get_loop_pad_sec() : 0.0;
+	const bool audio = p_cell.is_valid() && p_cell->get_include_audio();
+	const double hold = p_cell.is_valid() ? p_cell->get_bake_hold_sec() : 0.0;
+	const double lead = p_cell.is_valid() ? p_cell->get_pip_lead_sec() : 0.0;
+	const Rect2 pip_rect = p_cell.is_valid() ? p_cell->get_pip_rect() : Rect2();
+	return vformat("%s|%s|%.3f|%d|%s|%s|%s|%s|%.3f|%s|%.3f|%.3f|%s|pipv12", path, uitos(mtime), duration, audio ? 1 : 0, pip, uitos(pip_mtime), menu_audio, uitos(audio_mtime), pad, packed_visual_fingerprint(scene), hold, lead, String(pip_rect));
+}
+
+String resource_mtime_token(const Variant &p_value) {
+	if (p_value.get_type() != Variant::OBJECT) {
+		return String(p_value);
+	}
+	const Ref<Resource> res = p_value;
+	if (res.is_null()) {
+		return String();
+	}
+	String res_path = res->get_path();
+	if (res_path.is_empty()) {
+		return vformat("res_%d", res->get_instance_id());
+	}
+	const int sub = res_path.find("::");
+	if (sub >= 0) {
+		res_path = res_path.substr(0, sub);
+	}
+	if (ProjectSettings::get_singleton()) {
+		res_path = ProjectSettings::get_singleton()->globalize_path(res_path);
+	}
+	return vformat("%s|%s", res_path, uitos(FileAccess::exists(res_path) ? FileAccess::get_modified_time(res_path) : 0));
+}
+
+String packed_visual_fingerprint(const Ref<PackedScene> &p_scene) {
+	if (p_scene.is_null()) {
+		return String();
+	}
+	const Ref<SceneState> st = p_scene->get_state();
+	if (st.is_null()) {
+		return String();
+	}
+	String acc;
+	for (int i = 0; i < st->get_node_count(); i++) {
+		acc += String(st->get_node_type(i));
+		acc += "/";
+		acc += String(st->get_node_name(i));
+		acc += ":";
+		for (int p = 0; p < st->get_node_property_count(i); p++) {
+			const String n = st->get_node_property_name(i, p);
+			if (n != "text" && n != "visible" && n != "modulate" && n != "self_modulate" && n != "texture" &&
+					n != "position" && n != "offset_left" && n != "offset_top" && n != "offset_right" &&
+					n != "offset_bottom" && n != "size" && n != "bbcode_enabled") {
+				continue;
+			}
+			acc += n;
+			acc += "=";
+			acc += resource_mtime_token(st->get_node_property_value(i, p));
+			acc += ";";
+		}
+	}
+	return acc.md5_text().substr(0, 16);
+}
+
+void play_animations(Node *p_node) {
+	if (AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node)) {
+		List<StringName> names;
+		ap->get_animation_list(&names);
+		if (!names.is_empty() && !ap->is_playing()) {
+			ap->play(names.front()->get());
+		}
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		play_animations(p_node->get_child(i));
+	}
+}
+
+void collect_audio_path(Node *p_node, String &r_path, const String &p_wav_out) {
+	if (!r_path.is_empty()) {
+		return;
+	}
+	Ref<AudioStream> stream;
+	if (AudioStreamPlayer *p = Object::cast_to<AudioStreamPlayer>(p_node)) {
+		stream = p->get_stream();
+		p->play();
+	} else if (AudioStreamPlayer2D *p = Object::cast_to<AudioStreamPlayer2D>(p_node)) {
+		stream = p->get_stream();
+		p->play();
+#ifndef _3D_DISABLED
+	} else if (AudioStreamPlayer3D *p = Object::cast_to<AudioStreamPlayer3D>(p_node)) {
+		stream = p->get_stream();
+		p->play();
+#endif
+	}
+	if (stream.is_valid()) {
+		const String res_path = stream->get_path();
+		if (!res_path.is_empty()) {
+			r_path = ProjectSettings::get_singleton() ? ProjectSettings::get_singleton()->globalize_path(res_path) : res_path;
+		} else if (AudioStreamWAV *wav = Object::cast_to<AudioStreamWAV>(stream.ptr())) {
+			if (wav->save_to_wav(p_wav_out) == OK && FileAccess::exists(p_wav_out)) {
+				r_path = p_wav_out;
+			}
+		}
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		collect_audio_path(p_node->get_child(i), r_path, p_wav_out);
+	}
+}
+
+uint8_t glyph5x7(char32_t p_ch, int p_col) {
+	char32_t ch = p_ch;
+	if (ch >= 'a' && ch <= 'z') {
+		ch = ch - 'a' + 'A';
+	}
+
+	static const uint8_t table[27][5] = {
+		{ 0x00, 0x00, 0x00, 0x00, 0x00 },
+		{ 0x1E, 0x05, 0x05, 0x05, 0x1E },
+		{ 0x1F, 0x15, 0x15, 0x15, 0x0A },
+		{ 0x0E, 0x11, 0x11, 0x11, 0x0A },
+		{ 0x1F, 0x11, 0x11, 0x11, 0x0E },
+		{ 0x1F, 0x15, 0x15, 0x11, 0x11 },
+		{ 0x1F, 0x05, 0x05, 0x01, 0x01 },
+		{ 0x0E, 0x11, 0x15, 0x15, 0x1C },
+		{ 0x1F, 0x04, 0x04, 0x04, 0x1F },
+		{ 0x11, 0x11, 0x1F, 0x11, 0x11 },
+		{ 0x08, 0x10, 0x11, 0x0F, 0x01 },
+		{ 0x1F, 0x04, 0x0A, 0x11, 0x11 },
+		{ 0x1F, 0x10, 0x10, 0x10, 0x10 },
+		{ 0x1F, 0x02, 0x04, 0x02, 0x1F },
+		{ 0x1F, 0x02, 0x04, 0x08, 0x1F },
+		{ 0x0E, 0x11, 0x11, 0x11, 0x0E },
+		{ 0x1F, 0x05, 0x05, 0x05, 0x02 },
+		{ 0x0E, 0x11, 0x19, 0x11, 0x1E },
+		{ 0x1F, 0x05, 0x0D, 0x15, 0x12 },
+		{ 0x12, 0x15, 0x15, 0x15, 0x09 },
+		{ 0x01, 0x01, 0x1F, 0x01, 0x01 },
+		{ 0x0F, 0x10, 0x10, 0x10, 0x0F },
+		{ 0x07, 0x08, 0x10, 0x08, 0x07 },
+		{ 0x0F, 0x10, 0x0C, 0x10, 0x0F },
+		{ 0x11, 0x0A, 0x04, 0x0A, 0x11 },
+		{ 0x01, 0x02, 0x1C, 0x02, 0x01 },
+		{ 0x11, 0x19, 0x15, 0x13, 0x11 },
+	};
+	int idx = 0;
+	if (ch >= 'A' && ch <= 'Z') {
+		idx = int(ch - 'A') + 1;
+	} else if (ch != ' ') {
+		idx = 0;
+	}
+	if (idx > 0 || ch == ' ') {
+		return table[idx][CLAMP(p_col, 0, 4)];
+	}
+	static const uint8_t extra[][5] = {
+		{ 0x0E, 0x13, 0x15, 0x19, 0x0E },
+		{ 0x00, 0x12, 0x1F, 0x10, 0x00 },
+		{ 0x12, 0x19, 0x15, 0x13, 0x12 },
+		{ 0x11, 0x15, 0x15, 0x15, 0x0A },
+		{ 0x07, 0x04, 0x04, 0x1F, 0x04 },
+		{ 0x17, 0x15, 0x15, 0x15, 0x09 },
+		{ 0x0E, 0x15, 0x15, 0x15, 0x08 },
+		{ 0x01, 0x01, 0x19, 0x05, 0x03 },
+		{ 0x0A, 0x15, 0x15, 0x15, 0x0A },
+		{ 0x02, 0x15, 0x15, 0x15, 0x0E },
+		{ 0x00, 0x10, 0x10, 0x00, 0x00 },
+		{ 0x00, 0x10, 0x18, 0x00, 0x00 },
+		{ 0x00, 0x0A, 0x0A, 0x00, 0x00 },
+		{ 0x00, 0x04, 0x04, 0x04, 0x00 },
+		{ 0x10, 0x08, 0x04, 0x02, 0x01 },
+		{ 0x00, 0x00, 0x17, 0x00, 0x00 },
+		{ 0x02, 0x01, 0x15, 0x05, 0x02 },
+		{ 0x0E, 0x11, 0x15, 0x15, 0x06 },
+		{ 0x10, 0x10, 0x10, 0x10, 0x10 },
+		{ 0x04, 0x04, 0x1F, 0x04, 0x04 },
+		{ 0x00, 0x0E, 0x11, 0x00, 0x00 },
+		{ 0x00, 0x11, 0x0E, 0x00, 0x00 },
+	};
+	int extra_idx = -1;
+	if (ch >= '0' && ch <= '9') {
+		extra_idx = int(ch - '0');
+	} else if (ch == '.') {
+		extra_idx = 10;
+	} else if (ch == ',') {
+		extra_idx = 11;
+	} else if (ch == ':') {
+		extra_idx = 12;
+	} else if (ch == '-') {
+		extra_idx = 13;
+	} else if (ch == '/') {
+		extra_idx = 14;
+	} else if (ch == '!') {
+		extra_idx = 15;
+	} else if (ch == '?') {
+		extra_idx = 16;
+	} else if (ch == '@') {
+		extra_idx = 17;
+	} else if (ch == '_') {
+		extra_idx = 18;
+	} else if (ch == '+') {
+		extra_idx = 19;
+	} else if (ch == '(') {
+		extra_idx = 20;
+	} else if (ch == ')') {
+		extra_idx = 21;
+	}
+	if (extra_idx >= 0) {
+		return extra[extra_idx][CLAMP(p_col, 0, 4)];
+	}
+	return 0x00;
+}
+
+Rect2i control_rect(const Control *p_ctrl) {
+	if (!p_ctrl) {
+		return Rect2i();
+	}
+	if (p_ctrl->is_inside_tree()) {
+		return Rect2i(p_ctrl->get_global_rect());
+	}
+	return Rect2i(p_ctrl->get_position(), p_ctrl->get_size());
+}
+
+void blit_clipped(Ref<Image> &p_img, const Rect2i &p_rect, const Color &p_color) {
+	const Rect2i clipped = p_rect.intersection(Rect2i(0, 0, BAKE_WIDTH, BAKE_HEIGHT));
+	if (clipped.has_area()) {
+		p_img->fill_rect(clipped, p_color);
+	}
+}
+
+void draw_text_line(Ref<Image> &p_img, const String &p_line, int p_x, int p_y, const Color &p_color, int p_scale) {
+	for (int i = 0; i < p_line.length(); i++) {
+		const char32_t ch = p_line[i];
+		for (int col = 0; col < 5; col++) {
+			const uint8_t bits = glyph5x7(ch, col);
+			for (int row = 0; row < 7; row++) {
+				if (bits & (1 << row)) {
+					blit_clipped(p_img, Rect2i(p_x + i * 6 * p_scale + col * p_scale, p_y + row * p_scale, p_scale, p_scale), p_color);
+				}
+			}
+		}
+	}
+}
+
+Vector<String> wrap_text_lines(const String &p_text, int p_max_chars) {
+	Vector<String> lines;
+	const Vector<String> raw = p_text.replace("\r", "").split("\n");
+	const int max_chars = MAX(p_max_chars, 1);
+	for (int r = 0; r < raw.size(); r++) {
+		String rest = raw[r];
+		if (rest.is_empty()) {
+			lines.push_back(String());
+			continue;
+		}
+		while (rest.length() > max_chars) {
+			int cut = rest.rfind(" ", max_chars);
+			if (cut <= 0) {
+				cut = max_chars;
+			}
+			lines.push_back(rest.substr(0, cut).strip_edges());
+			rest = rest.substr(cut).strip_edges();
+		}
+		if (!rest.is_empty() || lines.is_empty()) {
+			lines.push_back(rest);
+		}
+	}
+	return lines;
+}
+
+void draw_text_at(Ref<Image> &p_img, const String &p_text, const Rect2 &p_rect, const Color &p_color, int p_font_size, bool p_center, bool p_wrap = false) {
+	if (p_text.is_empty()) {
+		return;
+	}
+	const int scale = MAX(p_font_size / 8, 2);
+	const int cell = 6 * scale;
+	const int line_h = 8 * scale;
+	const int max_chars = p_wrap ? MAX(int(p_rect.size.x) / cell, 1) : p_text.length();
+	const Vector<String> lines = p_wrap ? wrap_text_lines(p_text, max_chars) : wrap_text_lines(p_text, 100000);
+	const int block_h = lines.size() * line_h;
+	int y = int(p_rect.position.y);
+	if (!p_wrap) {
+		y = int(p_rect.position.y + MAX((p_rect.size.y - block_h) * 0.5, 0.0));
+	} else {
+		y += 2;
+	}
+	for (int i = 0; i < lines.size(); i++) {
+		const String &line = lines[i];
+		int x = int(p_rect.position.x);
+		if (p_center) {
+			x = int(p_rect.position.x + (p_rect.size.x - line.length() * cell) * 0.5);
+		}
+		draw_text_line(p_img, line, x, y + i * line_h, p_color, scale);
+	}
+}
+
+void blit_image(Ref<Image> &p_dst, const Ref<Image> &p_src, const Rect2i &p_dest) {
+	if (p_src.is_null() || p_src->is_empty() || !p_dest.has_area()) {
+		return;
+	}
+	Ref<Image> copy = p_src->duplicate();
+	if (copy->get_format() != Image::FORMAT_RGBA8) {
+		copy->convert(Image::FORMAT_RGBA8);
+	}
+	if (p_dst->get_format() != Image::FORMAT_RGBA8) {
+		p_dst->convert(Image::FORMAT_RGBA8);
+	}
+	if (copy->get_size() != p_dest.size) {
+		copy->resize(MAX(p_dest.size.x, 1), MAX(p_dest.size.y, 1), Image::INTERPOLATE_BILINEAR);
+	}
+	const Rect2i clipped = p_dest.intersection(Rect2i(0, 0, BAKE_WIDTH, BAKE_HEIGHT));
+	if (!clipped.has_area()) {
+		return;
+	}
+	const Point2i src_ofs = clipped.position - p_dest.position;
+	p_dst->blend_rect(copy, Rect2i(src_ofs, clipped.size), clipped.position);
+}
+
+void blit_image_mod(Ref<Image> &p_dst, const Ref<Image> &p_src, const Rect2i &p_dest, const Color &p_mod) {
+	if (p_mod.r >= 0.999f && p_mod.g >= 0.999f && p_mod.b >= 0.999f && p_mod.a >= 0.999f) {
+		blit_image(p_dst, p_src, p_dest);
+		return;
+	}
+	if (p_src.is_null() || p_src->is_empty() || !p_dest.has_area()) {
+		return;
+	}
+	Ref<Image> tinted = p_src->duplicate();
+	if (tinted->get_format() != Image::FORMAT_RGBA8) {
+		tinted->convert(Image::FORMAT_RGBA8);
+	}
+	for (int y = 0; y < tinted->get_height(); y++) {
+		for (int x = 0; x < tinted->get_width(); x++) {
+			tinted->set_pixel(x, y, tinted->get_pixel(x, y) * p_mod);
+		}
+	}
+	blit_image(p_dst, tinted, p_dest);
+}
+
+Color canvas_modulate(const CanvasItem *p_ci, const Color &p_parent) {
+	if (!p_ci) {
+		return p_parent;
+	}
+	return p_parent * p_ci->get_modulate() * p_ci->get_self_modulate();
+}
+
+bool skip_software_node(const Node *p_node) {
+	if (!p_node) {
+		return true;
+	}
+	if (Object::cast_to<AudioStreamPlayer>(p_node) || Object::cast_to<AudioStreamPlayer2D>(p_node)) {
+		return true;
+	}
+#ifndef _3D_DISABLED
+	if (Object::cast_to<AudioStreamPlayer3D>(p_node)) {
+		return true;
+	}
+#endif
+	const String type = p_node->get_class();
+	return type == "Timer" || type == "CollisionShape2D" || type == "CollisionPolygon2D" || type == "CollisionShape3D" || type == "RayCast2D" || type == "RayCast3D" || type == "VisibleOnScreenNotifier2D" || type == "VisibleOnScreenNotifier3D";
+}
+
+bool node_or_packed_has_3d(const Node *p_node) {
+#ifndef _3D_DISABLED
+	if (Object::cast_to<Node3D>(p_node)) {
+		return true;
+	}
+#endif
+	if (!p_node) {
+		return false;
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		if (node_or_packed_has_3d(p_node->get_child(i))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool packed_has_node3d(const Ref<PackedScene> &p_scene) {
+	if (p_scene.is_null()) {
+		return false;
+	}
+	const Ref<SceneState> st = p_scene->get_state();
+	if (st.is_null()) {
+		return false;
+	}
+	for (int i = 0; i < st->get_node_count(); i++) {
+		if (ClassDB::is_parent_class(st->get_node_type(i), "Node3D")) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool dummy_renderer() {
+	return OS::get_singleton() && OS::get_singleton()->get_current_rendering_method() == "dummy";
+}
+
+Rect2i texture_dest_rect(const TextureRect *p_tr, const Size2i &p_src) {
+	const Rect2i gr = control_rect(p_tr);
+	if (p_src.x <= 0 || p_src.y <= 0) {
+		return gr;
+	}
+	const TextureRect::StretchMode mode = p_tr->get_stretch_mode();
+	if (mode == TextureRect::STRETCH_KEEP_ASPECT || mode == TextureRect::STRETCH_KEEP_ASPECT_CENTERED) {
+		const float scale = MIN(float(gr.size.x) / float(p_src.x), float(gr.size.y) / float(p_src.y));
+		const int w = MAX(int(Math::round(p_src.x * scale)), 1);
+		const int h = MAX(int(Math::round(p_src.y * scale)), 1);
+		int x = gr.position.x;
+		int y = gr.position.y;
+		if (mode == TextureRect::STRETCH_KEEP_ASPECT_CENTERED) {
+			x += (gr.size.x - w) / 2;
+			y += (gr.size.y - h) / 2;
+		}
+		return Rect2i(x, y, w, h);
+	}
+	if (mode == TextureRect::STRETCH_KEEP_ASPECT_COVERED) {
+		const float scale = MAX(float(gr.size.x) / float(p_src.x), float(gr.size.y) / float(p_src.y));
+		const int w = MAX(int(Math::round(p_src.x * scale)), 1);
+		const int h = MAX(int(Math::round(p_src.y * scale)), 1);
+		return Rect2i(gr.position.x + (gr.size.x - w) / 2, gr.position.y + (gr.size.y - h) / 2, w, h);
+	}
+	return gr;
+}
+
+Ref<Image> image_from_texture(const Ref<Texture2D> &p_tex) {
+	if (p_tex.is_null()) {
+		return Ref<Image>();
+	}
+	Ref<Image> src = p_tex->get_image();
+	if (src.is_valid() && !src->is_empty()) {
+		return src;
+	}
+	String path = p_tex->get_path();
+	if (path.is_empty()) {
+		return src;
+	}
+	if (ProjectSettings::get_singleton()) {
+		path = ProjectSettings::get_singleton()->globalize_path(path);
+	}
+	return Image::load_from_file(path);
+}
+
+void draw_texture_rect(Ref<Image> &p_img, const TextureRect *p_tr) {
+	const Ref<Image> src = image_from_texture(p_tr->get_texture());
+	if (src.is_null() || src->is_empty()) {
+		return;
+	}
+	blit_image(p_img, src, texture_dest_rect(p_tr, src->get_size()));
+}
+
+void draw_stylebox(Ref<Image> &p_img, const Ref<StyleBox> &p_sb, const Rect2 &p_rect) {
+	if (p_sb.is_null() || Object::cast_to<StyleBoxEmpty>(p_sb.ptr())) {
+		return;
+	}
+	if (const StyleBoxTexture *stex = Object::cast_to<StyleBoxTexture>(p_sb.ptr())) {
+		const Ref<Image> src = image_from_texture(stex->get_texture());
+		if (src.is_valid() && !src->is_empty()) {
+			blit_image(p_img, src, Rect2i(p_rect));
+		}
+		return;
+	}
+	if (const StyleBoxFlat *flat = Object::cast_to<StyleBoxFlat>(p_sb.ptr())) {
+		const Rect2i r(p_rect);
+		if (flat->is_draw_center_enabled() && flat->get_bg_color().a > 0.01f) {
+			blit_clipped(p_img, r, flat->get_bg_color());
+		}
+		const Color bc = flat->get_border_color();
+		if (bc.a > 0.01f) {
+			const int l = MAX(flat->get_border_width(SIDE_LEFT), 0);
+			const int t = MAX(flat->get_border_width(SIDE_TOP), 0);
+			const int ri = MAX(flat->get_border_width(SIDE_RIGHT), 0);
+			const int b = MAX(flat->get_border_width(SIDE_BOTTOM), 0);
+			if (l > 0) {
+				blit_clipped(p_img, Rect2i(r.position.x, r.position.y, l, r.size.y), bc);
+			}
+			if (ri > 0) {
+				blit_clipped(p_img, Rect2i(r.position.x + r.size.x - ri, r.position.y, ri, r.size.y), bc);
+			}
+			if (t > 0) {
+				blit_clipped(p_img, Rect2i(r.position.x, r.position.y, r.size.x, t), bc);
+			}
+			if (b > 0) {
+				blit_clipped(p_img, Rect2i(r.position.x, r.position.y + r.size.y - b, r.size.x, b), bc);
+			}
+		}
+	}
+}
+
+void draw_control_style(Ref<Image> &p_img, const Control *p_ctrl, const StringName &p_name) {
+	if (!p_ctrl) {
+		return;
+	}
+	if (!p_ctrl->has_theme_stylebox_override(p_name) && !p_ctrl->is_inside_tree()) {
+		return;
+	}
+	draw_stylebox(p_img, p_ctrl->get_theme_stylebox(p_name), control_rect(p_ctrl));
+}
+
+void draw_label_text(Ref<Image> &p_img, const Label *p_label) {
+	draw_control_style(p_img, p_label, SNAME("normal"));
+	Color color(1, 1, 1);
+	if (p_label->has_theme_color_override("font_color")) {
+		color = p_label->get_theme_color("font_color");
+	} else if (p_label->is_inside_tree()) {
+		color = p_label->get_theme_color("font_color");
+	}
+	int font_size = 0;
+	if (p_label->has_theme_font_size_override("font_size") || p_label->is_inside_tree()) {
+		font_size = p_label->get_theme_font_size(SNAME("font_size"));
+	}
+	if (font_size <= 0) {
+		return;
+	}
+	const bool wrap = p_label->get_autowrap_mode() != TextServer::AUTOWRAP_OFF;
+	draw_text_at(p_img, p_label->get_text(), control_rect(p_label), color, font_size, p_label->get_horizontal_alignment() == HORIZONTAL_ALIGNMENT_CENTER, wrap);
+}
+
+void draw_rich_text(Ref<Image> &p_img, const RichTextLabel *p_rtl) {
+	draw_control_style(p_img, p_rtl, SNAME("normal"));
+	Color color(1, 1, 1);
+	int font_size = 0;
+	if (p_rtl->has_theme_font_size_override("normal_font_size") || p_rtl->is_inside_tree()) {
+		if (p_rtl->has_theme_color("default_color", SNAME("RichTextLabel")) || p_rtl->has_theme_color_override("default_color")) {
+			color = p_rtl->get_theme_color("default_color", SNAME("RichTextLabel"));
+		}
+		font_size = p_rtl->get_theme_font_size(SNAME("normal_font_size"));
+	}
+	if (font_size <= 0) {
+		return;
+	}
+	const String text = p_rtl->get_parsed_text().is_empty() ? p_rtl->get_text() : p_rtl->get_parsed_text();
+	draw_text_at(p_img, text, control_rect(p_rtl), color, font_size, false, true);
+}
+
+void draw_sprite_tex(Ref<Image> &p_img, Node2D *p_node, const Ref<Texture2D> &p_tex, const Rect2 &p_local) {
+	const Ref<Image> src = image_from_texture(p_tex);
+	if (src.is_null() || src->is_empty()) {
+		return;
+	}
+	const Rect2 dest = p_node->get_global_transform().xform(p_local);
+	blit_image(p_img, src, Rect2i(dest));
+}
+
+void draw_button(Ref<Image> &p_img, const Button *p_button) {
+	const Rect2 gr = control_rect(p_button);
+	Ref<StyleBox> sb = p_button->get_theme_stylebox(SNAME("normal"));
+	if (Object::cast_to<StyleBoxEmpty>(sb.ptr())) {
+		return;
+	}
+	if (const StyleBoxTexture *stex = Object::cast_to<StyleBoxTexture>(sb.ptr())) {
+		const Ref<Texture2D> tex = stex->get_texture();
+		Ref<Image> src = image_from_texture(tex);
+
+		if (src.is_valid() && !src->is_empty()) {
+			blit_image(p_img, src, Rect2i(gr));
+			return;
+		}
+	}
+	Color bg;
+	if (const StyleBoxFlat *flat = Object::cast_to<StyleBoxFlat>(sb.ptr())) {
+		if (flat->get_bg_color().a < 0.01f && p_button->get_text().is_empty()) {
+			return;
+		}
+		bg = flat->get_bg_color();
+
+	} else {
+		return;
+	}
+	blit_clipped(p_img, Rect2i(gr), bg);
+	Color fg(0, 0, 0);
+	if (p_button->has_theme_color_override("font_color")) {
+		fg = p_button->get_theme_color("font_color");
+	}
+	int font_size = 0;
+	if (p_button->has_theme_font_size_override("font_size") || p_button->is_inside_tree()) {
+		font_size = p_button->get_theme_font_size(SNAME("font_size"));
+	}
+	if (font_size > 0) {
+		draw_text_at(p_img, p_button->get_text(), gr, fg, font_size, true);
+	}
+}
+
+bool scene_has_motion(Node *p_node) {
+	if (!p_node) {
+		return false;
+	}
+	if (p_node->has_method("inter_dvd_bake_time") || Object::cast_to<AnimationPlayer>(p_node) || Object::cast_to<AnimatedSprite2D>(p_node)) {
+		return true;
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		if (scene_has_motion(p_node->get_child(i))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void apply_bake_time(Node *p_node, double p_sec) {
+	if (!p_node) {
+		return;
+	}
+	if (p_node->has_method("inter_dvd_bake_time")) {
+		p_node->call("inter_dvd_bake_time", p_sec);
+	}
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		apply_bake_time(p_node->get_child(i), p_sec);
+	}
+}
+
+double bake_hold_sec(Node *p_node) {
+	if (!p_node || !p_node->has_method("inter_dvd_bake_hold_sec")) {
+		return 0.0;
+	}
+	return MAX(double(p_node->call("inter_dvd_bake_hold_sec")), 0.0);
+}
+
+void draw_polygon2d(Ref<Image> &p_img, Polygon2D *p_poly, const Color &p_mod) {
+	const PackedVector2Array pts = p_poly->get_polygon();
+	if (pts.is_empty()) {
+		return;
+	}
+	const Transform2D xf = p_poly->get_global_transform();
+	Rect2 bounds(xf.xform(pts[0]), Size2());
+	for (int i = 1; i < pts.size(); i++) {
+		bounds.expand_to(xf.xform(pts[i]));
+	}
+	const Ref<Image> tex = image_from_texture(p_poly->get_texture());
+	if (tex.is_valid() && !tex->is_empty()) {
+		blit_image_mod(p_img, tex, Rect2i(bounds), p_mod);
+	} else {
+		blit_clipped(p_img, Rect2i(bounds), p_poly->get_color() * p_mod);
+	}
+}
+
+void draw_line2d(Ref<Image> &p_img, const Line2D *p_line, const Color &p_mod) {
+	const PackedVector2Array pts = p_line->get_points();
+	if (pts.size() < 2) {
+		return;
+	}
+	const Transform2D xf = p_line->get_global_transform();
+	const int w = MAX(int(Math::ceil(p_line->get_width())), 1);
+	const Color col = p_line->get_default_color() * p_mod;
+	for (int i = 0; i + 1 < pts.size(); i++) {
+		const Vector2 a = xf.xform(pts[i]);
+		const Vector2 b = xf.xform(pts[i + 1]);
+		const Vector2 d = b - a;
+		const int steps = MAX(int(d.length()), 1);
+		for (int s = 0; s <= steps; s++) {
+			const Vector2 p = a.lerp(b, float(s) / float(steps));
+			blit_clipped(p_img, Rect2i(int(p.x) - w / 2, int(p.y) - w / 2, w, w), col);
+		}
+	}
+}
+
+void draw_mesh2d(Ref<Image> &p_img, MeshInstance2D *p_mesh, const Color &p_mod) {
+	const Ref<Image> src = image_from_texture(p_mesh->get_texture());
+	if (src.is_null() || src->is_empty()) {
+		return;
+	}
+	const Size2 sz = src->get_size();
+	const Rect2 dest = p_mesh->get_global_transform().xform(Rect2(-sz * 0.5, sz));
+	blit_image_mod(p_img, src, Rect2i(dest), p_mod);
+}
+
+void draw_tilemap_layer(Ref<Image> &p_img, const TileMapLayer *p_layer, const Color &p_mod) {
+	const Ref<TileSet> tileset = p_layer->get_tile_set();
+	if (tileset.is_null()) {
+		return;
+	}
+	const TypedArray<Vector2i> cells = p_layer->get_used_cells();
+	const Transform2D xf = p_layer->get_global_transform();
+	const Vector2i tile_size = tileset->get_tile_size();
+	for (int i = 0; i < cells.size(); i++) {
+		const Vector2i cell = cells[i];
+		const int src_id = p_layer->get_cell_source_id(cell);
+		if (!tileset->has_source(src_id)) {
+			continue;
+		}
+		const Ref<TileSetAtlasSource> atlas = tileset->get_source(src_id);
+		if (atlas.is_null()) {
+			continue;
+		}
+		const Vector2i atlas_coords = p_layer->get_cell_atlas_coords(cell);
+		const Ref<Image> atlas_img = image_from_texture(atlas->get_texture());
+		if (atlas_img.is_null() || atlas_img->is_empty()) {
+			continue;
+		}
+		const Rect2i region = atlas->get_tile_texture_region(atlas_coords);
+		if (!region.has_area()) {
+			continue;
+		}
+		Ref<Image> tile = atlas_img->get_region(region);
+		const Vector2 local = p_layer->map_to_local(cell) - Vector2(tile_size) * 0.5;
+		const Rect2 dest = xf.xform(Rect2(local, tile_size));
+		blit_image_mod(p_img, tile, Rect2i(dest), p_mod);
+	}
+}
+
+void draw_range_chrome(Ref<Image> &p_img, const Range *p_range, const Color &p_mod) {
+	const Control *ctrl = Object::cast_to<Control>(p_range);
+	if (!ctrl) {
+		return;
+	}
+	draw_control_style(p_img, ctrl, SNAME("background"));
+	const Rect2i gr = control_rect(ctrl);
+	const double span = p_range->get_max() - p_range->get_min();
+	const double ratio = span > 0.0 ? CLAMP((p_range->get_value() - p_range->get_min()) / span, 0.0, 1.0) : 0.0;
+	if (ratio > 0.0) {
+		blit_clipped(p_img, Rect2i(gr.position.x, gr.position.y, MAX(int(gr.size.x * ratio), 1), gr.size.y), Color(0.3, 0.7, 0.35) * p_mod);
+	}
+}
+
+void draw_text_control(Ref<Image> &p_img, const Control *p_ctrl, const String &p_text, const Color &p_mod) {
+	draw_control_style(p_img, p_ctrl, SNAME("normal"));
+	int font_size = 0;
+	if (p_ctrl->has_theme_font_size_override("font_size") || p_ctrl->is_inside_tree()) {
+		font_size = p_ctrl->get_theme_font_size(SNAME("font_size"));
+	}
+	if (font_size <= 0) {
+		return;
+	}
+	Color color(1, 1, 1);
+	if (p_ctrl->has_theme_color_override("font_color") || p_ctrl->is_inside_tree()) {
+		color = p_ctrl->get_theme_color(SNAME("font_color"));
+	}
+	draw_text_at(p_img, p_text, control_rect(p_ctrl), color * p_mod, font_size, false, true);
+}
+
+void software_draw_node(Node *p_node, Ref<Image> &p_img, const Color &p_mod) {
+	if (skip_software_node(p_node)) {
+		for (int i = 0; i < p_node->get_child_count(); i++) {
+			software_draw_node(p_node->get_child(i), p_img, p_mod);
+		}
+		return;
+	}
+	Color mod = p_mod;
+	if (CanvasItem *ci = Object::cast_to<CanvasItem>(p_node)) {
+		if (!ci->is_visible()) {
+			return;
+		}
+		mod = canvas_modulate(ci, p_mod);
+	}
+	if (const ColorRect *rect = Object::cast_to<ColorRect>(p_node)) {
+		blit_clipped(p_img, control_rect(rect), rect->get_color() * mod);
+	}
+	if (const Panel *panel = Object::cast_to<Panel>(p_node)) {
+		draw_control_style(p_img, panel, SNAME("panel"));
+	}
+	if (const PanelContainer *pc = Object::cast_to<PanelContainer>(p_node)) {
+		draw_control_style(p_img, pc, SNAME("panel"));
+	}
+	if (const NinePatchRect *np = Object::cast_to<NinePatchRect>(p_node)) {
+		const Ref<Image> src = image_from_texture(np->get_texture());
+		if (src.is_valid() && !src->is_empty()) {
+			blit_image_mod(p_img, src, control_rect(np), mod);
+		}
+	}
+	if (const TextureRect *tr = Object::cast_to<TextureRect>(p_node)) {
+		draw_texture_rect(p_img, tr);
+	}
+	if (const TextureButton *tb = Object::cast_to<TextureButton>(p_node)) {
+		const Ref<Image> src = image_from_texture(tb->get_texture_normal());
+		if (src.is_valid() && !src->is_empty()) {
+			blit_image_mod(p_img, src, control_rect(tb), mod);
+		}
+	}
+	if (Sprite2D *sprite = Object::cast_to<Sprite2D>(p_node)) {
+		draw_sprite_tex(p_img, sprite, sprite->get_texture(), sprite->get_rect());
+	}
+	if (AnimatedSprite2D *anim = Object::cast_to<AnimatedSprite2D>(p_node)) {
+		const Ref<SpriteFrames> frames = anim->get_sprite_frames();
+		if (frames.is_valid() && frames->has_animation(anim->get_animation())) {
+			const Ref<Texture2D> tex = frames->get_frame_texture(anim->get_animation(), anim->get_frame());
+			const Size2 sz = tex.is_valid() ? tex->get_size() : Size2();
+			const Point2 off = anim->is_centered() ? -sz * 0.5 : Point2();
+			draw_sprite_tex(p_img, anim, tex, Rect2(off + anim->get_offset(), sz));
+		}
+	}
+	if (Polygon2D *poly = Object::cast_to<Polygon2D>(p_node)) {
+		draw_polygon2d(p_img, poly, mod);
+	}
+	if (const Line2D *line = Object::cast_to<Line2D>(p_node)) {
+		draw_line2d(p_img, line, mod);
+	}
+	if (MeshInstance2D *mesh = Object::cast_to<MeshInstance2D>(p_node)) {
+		draw_mesh2d(p_img, mesh, mod);
+	}
+	if (const TileMapLayer *tml = Object::cast_to<TileMapLayer>(p_node)) {
+		draw_tilemap_layer(p_img, tml, mod);
+	}
+	if (const TileMap *tm = Object::cast_to<TileMap>(p_node)) {
+		const int layers = tm->get_layers_count();
+		for (int l = 0; l < layers; l++) {
+			if (TileMapLayer *layer = Object::cast_to<TileMapLayer>(tm->get_child(l))) {
+				draw_tilemap_layer(p_img, layer, mod);
+			}
+		}
+	}
+	if (const Label *label = Object::cast_to<Label>(p_node)) {
+		draw_label_text(p_img, label);
+	}
+	if (const RichTextLabel *rtl = Object::cast_to<RichTextLabel>(p_node)) {
+		draw_rich_text(p_img, rtl);
+	}
+	if (const Button *button = Object::cast_to<Button>(p_node)) {
+		if (!Object::cast_to<TextureButton>(p_node) && !Object::cast_to<LinkButton>(p_node)) {
+			draw_button(p_img, button);
+		}
+	}
+	if (const LinkButton *lb = Object::cast_to<LinkButton>(p_node)) {
+		draw_text_control(p_img, lb, lb->get_text(), mod);
+	}
+	if (const ProgressBar *bar = Object::cast_to<ProgressBar>(p_node)) {
+		draw_range_chrome(p_img, bar, mod);
+	}
+	if (const Slider *slider = Object::cast_to<Slider>(p_node)) {
+		draw_range_chrome(p_img, slider, mod);
+	}
+	if (const LineEdit *le = Object::cast_to<LineEdit>(p_node)) {
+		draw_text_control(p_img, le, le->get_text(), mod);
+	}
+	if (const TextEdit *te = Object::cast_to<TextEdit>(p_node)) {
+		draw_text_control(p_img, te, te->get_text(), mod);
+	}
+	if (const VideoStreamPlayer *vsp = Object::cast_to<VideoStreamPlayer>(p_node)) {
+		const Ref<Image> src = image_from_texture(vsp->get_video_texture());
+		if (src.is_valid() && !src->is_empty()) {
+			blit_image_mod(p_img, src, control_rect(vsp), mod);
+		}
+	}
+	struct DrawOrder {
+		bool operator()(const Node *a, const Node *b) const {
+			const CanvasItem *ca = Object::cast_to<CanvasItem>(a);
+			const CanvasItem *cb = Object::cast_to<CanvasItem>(b);
+			const bool ba = ca && ca->is_draw_behind_parent_enabled();
+			const bool bb = cb && cb->is_draw_behind_parent_enabled();
+			if (ba != bb) {
+				return ba;
+			}
+			const int za = ca ? ca->get_z_index() : 0;
+			const int zb = cb ? cb->get_z_index() : 0;
+			return za < zb;
+		}
+	};
+	Vector<Node *> kids;
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		kids.push_back(p_node->get_child(i));
+	}
+	kids.sort_custom<DrawOrder>();
+	for (int i = 0; i < kids.size(); i++) {
+		software_draw_node(kids[i], p_img, mod);
+	}
+}
+
+Ref<Image> software_raster(Node *p_root) {
+	Ref<Image> img = Image::create_empty(BAKE_WIDTH, BAKE_HEIGHT, false, Image::FORMAT_RGBA8);
+	img->fill(Color(0, 0, 0, 1));
+	software_draw_node(p_root, img, Color(1, 1, 1, 1));
+	return img;
+}
+
+void cleanup_frames(const String &p_dir, int p_count) {
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (da.is_null()) {
+		return;
+	}
+	for (int i = 0; i < p_count; i++) {
+		da->remove(p_dir.path_join(vformat("frame_%06d.png", i)));
+	}
+}
+
+double probe_black_lead_sec(const String &p_ffmpeg, const String &p_pip) {
+	List<String> args;
+	args.push_back("-hide_banner");
+	args.push_back("-t");
+	args.push_back(rtos(InterDVDSettings::pip_blackdetect_sec()));
+	args.push_back("-i");
+	args.push_back(p_pip);
+	args.push_back("-vf");
+	args.push_back(vformat("blackdetect=d=0.04:pix_th=%g", InterDVDSettings::pip_blackdetect_pix_th()));
+	args.push_back("-an");
+	args.push_back("-f");
+	args.push_back("null");
+	args.push_back("-");
+	String pipe;
+	OS::get_singleton()->execute(p_ffmpeg, args, &pipe);
+	double lead = 0.0;
+	int from = 0;
+	while (true) {
+		const int at = pipe.find("black_end:", from);
+		if (at < 0) {
+			break;
+		}
+		const int start_at = pipe.find("black_start:", MAX(from, at - 96));
+		const double st = start_at >= 0 ? pipe.substr(start_at + 12).to_float() : 0.0;
+		const double en = pipe.substr(at + 10).to_float();
+		if (st <= 0.08 && en > lead) {
+			lead = en;
+		}
+		from = at + 10;
+	}
+	return CLAMP(lead, 0.0, 1.5);
+}
+
+void log_first_frame_slot(const String &p_ffmpeg, const String &p_mpg, int p_x, int p_y, int p_w, int p_h, const char *p_tag) {
+	const String raw = p_mpg + ".ff0.rgb";
+	List<String> args;
+	args.push_back("-y");
+	args.push_back("-i");
+	args.push_back(p_mpg);
+	args.push_back("-frames:v");
+	args.push_back("1");
+	args.push_back("-f");
+	args.push_back("rawvideo");
+	args.push_back("-pix_fmt");
+	args.push_back("rgb24");
+	args.push_back(raw);
+	String pipe;
+	OS::get_singleton()->execute(p_ffmpeg, args, &pipe);
+	int avg_r = 0;
+	int avg_g = 0;
+	int avg_b = 0;
+	int n = 0;
+	int dark = 0;
+	Ref<FileAccess> f = FileAccess::open(raw, FileAccess::READ);
+	if (f.is_valid()) {
+		const PackedByteArray buf = f->get_buffer(720 * 480 * 3);
+		f.unref();
+		Ref<DirAccess> rm = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (rm.is_valid()) {
+			rm->remove(raw);
+		}
+		if (buf.size() >= 720 * 480 * 3) {
+			const int x0 = CLAMP(p_x, 0, 719);
+			const int y0 = CLAMP(p_y, 0, 479);
+			const int x1 = CLAMP(p_x + p_w, x0 + 1, 720);
+			const int y1 = CLAMP(p_y + p_h, y0 + 1, 480);
+			int64_t sr = 0;
+			int64_t sg = 0;
+			int64_t sb = 0;
+			for (int py = y0; py < y1; py += 2) {
+				for (int px = x0; px < x1; px += 2) {
+					const int i = (py * 720 + px) * 3;
+					const int r = buf[i];
+					const int g = buf[i + 1];
+					const int b = buf[i + 2];
+					sr += r;
+					sg += g;
+					sb += b;
+					n++;
+					if (r + g + b < 40) {
+						dark++;
+					}
+				}
+			}
+			if (n > 0) {
+				avg_r = int(sr / n);
+				avg_g = int(sg / n);
+				avg_b = int(sb / n);
+			}
+		}
+	}
+
+}
+
+void push_pip_inputs(List<String> &p_args, const String &p_bg, const String &p_pip, double p_lead, bool p_bg_sequence = false) {
+	p_args.push_back("-y");
+	p_args.push_back("-framerate");
+	p_args.push_back("30000/1001");
+	if (p_bg_sequence) {
+		p_args.push_back("-stream_loop");
+		p_args.push_back("-1");
+	} else {
+		p_args.push_back("-loop");
+		p_args.push_back("1");
+	}
+	p_args.push_back("-i");
+	p_args.push_back(p_bg);
+	if (p_lead > 0.001) {
+		p_args.push_back("-ss");
+		p_args.push_back(rtos(p_lead));
+	}
+	p_args.push_back("-i");
+	p_args.push_back(p_pip);
+}
+
+String ffprobe_next_to(const String &p_ffmpeg) {
+	if (p_ffmpeg.is_empty()) {
+		return String();
+	}
+	const String dir = p_ffmpeg.get_base_dir();
+	const String stem = p_ffmpeg.get_file().get_basename();
+	String probe = stem.to_lower().ends_with("ffmpeg") ? stem.substr(0, stem.length() - 6) + "ffprobe" : String("ffprobe");
+	if (p_ffmpeg.get_extension().to_lower() == "exe" && !probe.ends_with(".exe")) {
+		probe += ".exe";
+	}
+	const String sibling = dir.path_join(probe);
+	if (FileAccess::exists(sibling)) {
+		return sibling;
+	}
+	const String bare = dir.path_join(OS::get_singleton()->get_name() == "Windows" ? "ffprobe.exe" : "ffprobe");
+	return FileAccess::exists(bare) ? bare : String();
+}
+
+bool probe_has_audio(const String &p_ffmpeg, const String &p_path) {
+	if (p_ffmpeg.is_empty() || p_path.is_empty() || !FileAccess::exists(p_path)) {
+		return false;
+	}
+	const String ffprobe = ffprobe_next_to(p_ffmpeg);
+	if (!ffprobe.is_empty()) {
+		List<String> args;
+		args.push_back("-v");
+		args.push_back("error");
+		args.push_back("-select_streams");
+		args.push_back("a");
+		args.push_back("-show_entries");
+		args.push_back("stream=index");
+		args.push_back("-of");
+		args.push_back("csv=p=0");
+		args.push_back(p_path);
+		String pipe;
+		int exitcode = 1;
+		OS::get_singleton()->execute(ffprobe, args, &pipe, &exitcode, false);
+		if (!pipe.strip_edges().is_empty()) {
+			return true;
+		}
+	}
+	List<String> args;
+	args.push_back("-hide_banner");
+	args.push_back("-i");
+	args.push_back(p_path);
+	String pipe;
+	int exitcode = 0;
+
+	OS::get_singleton()->execute(p_ffmpeg, args, &pipe, &exitcode, true);
+	return pipe.findn("Audio:") >= 0;
+}
+
+void push_legal_ac3(List<String> &p_args) {
+	p_args.push_back("-c:a");
+	p_args.push_back("ac3");
+	p_args.push_back("-ac");
+	p_args.push_back(itos(InterDVDSettings::ac3_channels()));
+	p_args.push_back("-ar");
+	p_args.push_back("48000");
+	p_args.push_back("-b:a");
+	p_args.push_back(vformat("%dk", InterDVDSettings::ac3_bitrate_k()));
+}
+
+Error composite_pip_mpg(const String &p_ffmpeg, const String &p_bg_png, const String &p_pip, const Rect2i &p_slot, const String &p_audio, double p_pip_sec, double p_total, const String &p_mpg, String *r_error, bool p_bg_sequence = false, double p_trim_sec = 0.40) {
+	const String bg_check = p_bg_sequence ? p_bg_png.replace("%06d", "000000") : p_bg_png;
+	if (p_pip_sec <= 0.0 || p_total <= 0.0 || !FileAccess::exists(bg_check) || !FileAccess::exists(p_pip)) {
+		if (r_error) {
+			*r_error = "PiP bake is missing a background still or source video.";
+		}
+		return ERR_INVALID_PARAMETER;
+	}
+	const int x = p_slot.position.x & ~1;
+	const int y = p_slot.position.y & ~1;
+	const int w = MAX(p_slot.size.x & ~1, 2);
+	const int h = MAX(p_slot.size.y & ~1, 2);
+	const double lead = probe_black_lead_sec(p_ffmpeg, p_pip);
+	const bool pip_audio = probe_has_audio(p_ffmpeg, p_pip);
+	const bool menu_audio = !pip_audio && !p_audio.is_empty() && FileAccess::exists(p_audio);
+	const double trim = MAX(p_trim_sec, 0.0);
+	String filter = vformat("[1:v]setpts=PTS-STARTPTS,fps=30000/1001,scale=%d:%d:force_original_aspect_ratio=decrease,pad=%d:%d:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[pip];[0:v]fps=30000/1001,setpts=PTS-STARTPTS[bg];[bg][pip]overlay=%d:%d:eof_action=pass:repeatlast=0[ov];[ov]trim=start=%.3f,setpts=PTS-STARTPTS[v]", w, h, w, h, x, y, trim);
+	if (pip_audio) {
+		if (p_total > p_pip_sec + 0.01) {
+			filter += vformat(";[1:a]atrim=start=%.3f,asetpts=PTS-STARTPTS,aresample=48000,aformat=sample_fmts=fltp:channel_layouts=stereo,apad,atrim=duration=%.3f[a]", trim, p_total);
+		} else {
+			filter += vformat(";[1:a]atrim=start=%.3f,asetpts=PTS-STARTPTS,aresample=48000,aformat=sample_fmts=fltp:channel_layouts=stereo[a]", trim);
+		}
+	} else if (menu_audio) {
+		filter += vformat(";[2:a]aresample=48000,aformat=sample_fmts=fltp:channel_layouts=stereo,apad,atrim=duration=%.3f,asetpts=PTS-STARTPTS[a]", p_total);
+	}
+	List<String> args;
+	push_pip_inputs(args, p_bg_png, p_pip, lead, p_bg_sequence);
+	if (menu_audio) {
+		args.push_back("-i");
+		args.push_back(p_audio);
+	}
+	args.push_back("-filter_complex");
+	args.push_back(filter);
+	args.push_back("-map");
+	args.push_back("[v]");
+	if (pip_audio || menu_audio) {
+		args.push_back("-map");
+		args.push_back("[a]");
+	}
+	args.push_back("-t");
+	args.push_back(rtos(p_total));
+	args.push_back("-target");
+	args.push_back("ntsc-dvd");
+	if (pip_audio || menu_audio) {
+		push_legal_ac3(args);
+	} else {
+		args.push_back("-an");
+	}
+	args.push_back("-bf");
+	args.push_back("0");
+	args.push_back("-g");
+	args.push_back(itos(InterDVDSettings::gop_size()));
+	args.push_back(p_mpg);
+	String pipe;
+	int code = OS::get_singleton()->execute(p_ffmpeg, args, &pipe);
+	if (code != 0 || !FileAccess::exists(p_mpg)) {
+		if (r_error) {
+			*r_error = vformat("ffmpeg PiP overlay failed (%d): %s", code, pipe);
+		}
+		return FAILED;
+	}
+
+
+
+	log_first_frame_slot(p_ffmpeg, p_mpg, x, y, w, h, "post-bake");
+
+
+	return OK;
+}
+
+Error probe_or_fail(const String &p_mpg, double p_duration, String *r_error) {
+	const double probed = InterDVDVobMux::estimate_duration_sec(p_mpg);
+	if (probed + 0.001 < p_duration - DURATION_SLACK_SEC) {
+		if (r_error) {
+			*r_error = vformat("Scene bake was truncated: probed %.2fs but duration_sec is %.2fs.", probed, p_duration);
+		}
+		return FAILED;
+	}
+	return OK;
+}
+
+} //namespace
+
+void InterDVDSceneBaker::_bind_methods() {
+	ClassDB::bind_static_method("InterDVDSceneBaker", D_METHOD("raster_root", "root"), &InterDVDSceneBaker::raster_root);
+	ClassDB::bind_static_method("InterDVDSceneBaker", D_METHOD("bake_cell", "cell", "ffmpeg", "auto_find_ffmpeg"), &InterDVDSceneBaker::bake_cell_bind, DEFVAL(String()), DEFVAL(true));
+}
+
+Ref<Image> InterDVDSceneBaker::raster_root(Node *p_root) {
+	ERR_FAIL_NULL_V(p_root, Ref<Image>());
+	return software_raster(p_root);
+}
+
+Error InterDVDSceneBaker::bake_cell_bind(const Ref<InterDVDCell> &p_cell, const String &p_ffmpeg, bool p_auto_find_ffmpeg) {
+	String err;
+	const Error code = bake_cell(p_cell, p_ffmpeg, p_auto_find_ffmpeg, &err);
+	if (code != OK && !err.is_empty()) {
+		ERR_PRINT(err);
+	}
+	return code;
+}
+
+Error InterDVDSceneBaker::bake_cell(const Ref<InterDVDCell> &p_cell, const String &p_ffmpeg, bool p_auto_find_ffmpeg, String *r_error) {
+	if (p_cell.is_null() || p_cell->get_packed_scene().is_null()) {
+		return OK;
+	}
+	if (dummy_renderer() && packed_has_node3d(p_cell->get_packed_scene())) {
+		if (r_error) {
+			*r_error = "3D scenes need a GPU bake / non-dummy export. Headless dummy cannot raster Node3D.";
+		}
+		return ERR_UNAVAILABLE;
+	}
+
+	double duration = p_cell->get_duration_sec();
+	const double authored_sec = duration;
+	const String pip_path = p_cell->get_pip_source_path();
+	double pip_sec = 0.0;
+	String ffmpeg = InterDVDVobMux::resolve_ffmpeg(p_ffmpeg, p_auto_find_ffmpeg);
+	if (!pip_path.is_empty() && FileAccess::exists(pip_path)) {
+		if (ffmpeg.is_empty()) {
+			if (r_error) {
+				*r_error = "Cannot bake InterDVD scene: ffmpeg was not found. Install ffmpeg or enable Auto-find ffmpeg. Discovered paths are not stored in the project.";
+			}
+			return ERR_UNCONFIGURED;
+		}
+		pip_sec = InterDVDVobMux::probe_media_sec(pip_path, ffmpeg);
+		if (pip_sec > 0.0) {
+			duration = pip_sec + MAX(p_cell->get_loop_pad_sec(), 0.0);
+			p_cell->set_duration_sec(duration);
+		}
+	}
+
+
+	if (duration <= 0.0) {
+		if (r_error) {
+			*r_error = "InterDVDCell.duration_sec must be greater than 0 when packed_scene is set.";
+		}
+		return ERR_INVALID_PARAMETER;
+	}
+
+	const String key = scene_key(p_cell);
+	const String id = key.md5_text().substr(0, 16);
+	const String cache_dir = cache_root();
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(cache_dir);
+	const String mpg = cache_dir.path_join(id + ".mpg");
+	const String sidecar = cache_dir.path_join(id + ".meta");
+
+	const String existing = p_cell->get_encoded_path();
+	if (!existing.is_empty() && existing != mpg && FileAccess::exists(existing)) {
+		return OK;
+	}
+
+	if (FileAccess::exists(mpg) && FileAccess::exists(sidecar)) {
+		const String stored = FileAccess::get_file_as_string(sidecar).strip_edges();
+		if (stored == key && probe_or_fail(mpg, duration, nullptr) == OK) {
+			p_cell->set_encoded_path(mpg);
+			if (!ffmpeg.is_empty()) {
+				p_cell->set_include_audio(probe_has_audio(ffmpeg, mpg));
+			}
+			return OK;
+		}
+	}
+
+	if (ffmpeg.is_empty()) {
+		ffmpeg = InterDVDVobMux::resolve_ffmpeg(p_ffmpeg, p_auto_find_ffmpeg);
+	}
+	if (ffmpeg.is_empty()) {
+		if (r_error) {
+			*r_error = "Cannot bake InterDVD scene: ffmpeg was not found. Install ffmpeg or enable Auto-find ffmpeg. Discovered paths are not stored in the project.";
+		}
+		return ERR_UNCONFIGURED;
+	}
+
+	SceneTree *tree = SceneTree::get_singleton();
+	if (!tree || !tree->get_root()) {
+		if (r_error) {
+			*r_error = "Cannot bake InterDVD scene: no SceneTree is available.";
+		}
+		return ERR_UNAVAILABLE;
+	}
+
+	Node *inst = p_cell->get_packed_scene()->instantiate();
+	if (!inst) {
+		if (r_error) {
+			*r_error = "InterDVD packed_scene failed to instantiate.";
+		}
+		return ERR_CANT_CREATE;
+	}
+
+	const bool has_3d = node_or_packed_has_3d(inst);
+	if (dummy_renderer() && has_3d) {
+		inst->queue_free();
+		if (r_error) {
+			*r_error = "3D scenes need a GPU bake / non-dummy export. Headless dummy cannot raster Node3D.";
+		}
+		return ERR_UNAVAILABLE;
+	}
+
+	SubViewport *vp = memnew(SubViewport);
+	vp->set_size(Size2i(BAKE_WIDTH, BAKE_HEIGHT));
+	vp->set_update_mode(SubViewport::UPDATE_ALWAYS);
+	vp->set_disable_3d(!has_3d);
+	vp->set_transparent_background(false);
+	tree->get_root()->add_child(vp);
+	vp->add_child(inst);
+	const NodePath cam_path = p_cell->get_bake_camera_path();
+	if (!cam_path.is_empty()) {
+		if (Camera2D *cam2 = Object::cast_to<Camera2D>(inst->get_node_or_null(cam_path))) {
+			cam2->make_current();
+#ifndef _3D_DISABLED
+		} else if (Camera3D *cam3 = Object::cast_to<Camera3D>(inst->get_node_or_null(cam_path))) {
+			cam3->make_current();
+#endif
+		}
+#ifndef _3D_DISABLED
+	} else if (has_3d) {
+		Camera3D *current = vp->get_camera_3d();
+		if (!current) {
+			vp->remove_child(inst);
+			inst->queue_free();
+			tree->get_root()->remove_child(vp);
+			vp->queue_free();
+			if (r_error) {
+				*r_error = "3D bake needs bake_camera_path or a current Camera3D in the packed scene.";
+			}
+			return ERR_UNCONFIGURED;
+		}
+#endif
+	}
+	if (Control *ctrl = Object::cast_to<Control>(inst)) {
+		if (ctrl->get_size().x < 2 || ctrl->get_size().y < 2) {
+			ctrl->set_size(Size2(BAKE_WIDTH, BAKE_HEIGHT));
+		}
+	}
+
+	play_animations(inst);
+	String menu_audio = p_cell->get_audio_path();
+	if (!menu_audio.is_empty() && !FileAccess::exists(menu_audio) && ProjectSettings::get_singleton()) {
+		menu_audio = ProjectSettings::get_singleton()->globalize_path(menu_audio);
+	}
+	if (menu_audio.is_empty() || !FileAccess::exists(menu_audio)) {
+		menu_audio = String();
+		const String wav_tmp = cache_dir.path_join(id + ".wav");
+		if (p_cell->get_include_audio()) {
+			collect_audio_path(inst, menu_audio, wav_tmp);
+		}
+	}
+	const bool use_pip = pip_sec > 0.0;
+	const bool motion = scene_has_motion(inst);
+	const bool pip_has_audio = use_pip && probe_has_audio(ffmpeg, pip_path);
+	String mux_audio_path;
+	const char *audio_src = "none";
+	if (pip_has_audio) {
+		audio_src = "pip";
+	} else if (p_cell->get_include_audio() && !menu_audio.is_empty() && FileAccess::exists(menu_audio)) {
+		mux_audio_path = menu_audio;
+		audio_src = "menu";
+	}
+	double hold_sec = 0.0;
+	if (!use_pip) {
+		hold_sec = p_cell->get_bake_hold_sec() > 0.0 ? p_cell->get_bake_hold_sec() : bake_hold_sec(inst);
+	}
+	const double chrome_sec = (use_pip && motion) ? MIN(duration, authored_sec > 0.05 ? authored_sec : 4.0) : duration;
+	const int frames = (hold_sec > 0.05) ? MAX(int(Math::ceil(duration / hold_sec)), 1) : ((use_pip && !motion) ? 1 : MAX(int(Math::ceil(chrome_sec * BAKE_FPS)), 1));
+	const bool pip_sequence = use_pip && motion;
+	const double dt = (hold_sec > 0.05) ? hold_sec : (1.0 / BAKE_FPS);
+	const int warmup = InterDVDSettings::bake_warmup_frames();
+	Error capture_err = OK;
+	Rect2i pip_slot;
+	bool have_pip_slot = false;
+	if (p_cell->get_pip_rect().size.x > 0 && p_cell->get_pip_rect().size.y > 0) {
+		pip_slot = Rect2i(p_cell->get_pip_rect());
+		have_pip_slot = true;
+	}
+	const NodePath slot_path = p_cell->get_pip_slot_path();
+	for (int i = 0; i < frames + warmup; i++) {
+		const double bake_t = (hold_sec > 0.05) ? (MAX(i - warmup, 0) * hold_sec + hold_sec * 0.5) : (MAX(i - warmup, 0) * dt);
+		apply_bake_time(inst, bake_t);
+		tree->process(dt);
+		tree->physics_process(dt);
+		if (RenderingServer::get_singleton()) {
+			RenderingServer::get_singleton()->draw(false, dt);
+		}
+		if (i < warmup) {
+			continue;
+		}
+		if (!slot_path.is_empty()) {
+			if (Control *slot = Object::cast_to<Control>(inst->get_node_or_null(slot_path))) {
+				pip_slot = Rect2i(slot->get_global_rect());
+				have_pip_slot = true;
+			} else if (CanvasItem *ci = Object::cast_to<CanvasItem>(inst->get_node_or_null(slot_path))) {
+				if (ci->has_method("get_rect")) {
+					pip_slot = Rect2i(ci->get_global_transform().xform(Rect2(ci->call("get_rect"))));
+					have_pip_slot = true;
+				}
+			}
+		}
+		Ref<Image> img;
+		if (!dummy_renderer()) {
+			Ref<ViewportTexture> tex = vp->get_texture();
+			img = tex.is_valid() ? tex->get_image() : Ref<Image>();
+		}
+		if (img.is_null() || img->is_empty()) {
+			img = software_raster(inst);
+		}
+		if (img->get_size() != Size2i(BAKE_WIDTH, BAKE_HEIGHT)) {
+			img->resize(BAKE_WIDTH, BAKE_HEIGHT, Image::INTERPOLATE_BILINEAR);
+		}
+		if (img->get_format() != Image::FORMAT_RGB8 && img->get_format() != Image::FORMAT_RGBA8) {
+			img->convert(Image::FORMAT_RGB8);
+		}
+		const Error png_err = img->save_png(cache_dir.path_join((use_pip && !pip_sequence) ? "pip_bg.png" : vformat("frame_%06d.png", i - warmup)));
+		if (png_err != OK) {
+			capture_err = png_err;
+			if (r_error) {
+				*r_error = "Scene bake could not write a PNG frame.";
+			}
+			break;
+		}
+	}
+
+	vp->remove_child(inst);
+	inst->queue_free();
+	tree->get_root()->remove_child(vp);
+	vp->queue_free();
+
+	if (capture_err != OK) {
+		cleanup_frames(cache_dir, frames);
+		return capture_err;
+	}
+
+	if (use_pip && have_pip_slot) {
+		const String bg = pip_sequence ? cache_dir.path_join("frame_%06d.png") : cache_dir.path_join("pip_bg.png");
+		const Error pip_err = composite_pip_mpg(ffmpeg, bg, pip_path, pip_slot, mux_audio_path, pip_sec, duration, mpg, r_error, pip_sequence, p_cell->get_pip_lead_sec());
+		if (pip_sequence) {
+			cleanup_frames(cache_dir, frames);
+		}
+		if (pip_err != OK) {
+			return pip_err;
+		}
+	} else {
+		List<String> args;
+		args.push_back("-y");
+		args.push_back("-framerate");
+		args.push_back(hold_sec > 0.05 ? rtos(1.0 / hold_sec) : String("30"));
+		args.push_back("-i");
+		args.push_back(cache_dir.path_join("frame_%06d.png"));
+		const bool mux_audio = !mux_audio_path.is_empty() && FileAccess::exists(mux_audio_path);
+		if (mux_audio) {
+			args.push_back("-stream_loop");
+			args.push_back("-1");
+			args.push_back("-i");
+			args.push_back(mux_audio_path);
+		}
+		args.push_back("-t");
+		args.push_back(rtos(duration));
+		if (mux_audio) {
+			push_legal_ac3(args);
+		} else {
+			args.push_back("-an");
+		}
+		args.push_back("-target");
+		args.push_back("ntsc-dvd");
+		args.push_back("-g");
+		args.push_back(itos(InterDVDSettings::gop_size()));
+		args.push_back(mpg);
+
+		{
+		}
+
+		String pipe;
+		const int code = OS::get_singleton()->execute(ffmpeg, args, &pipe);
+		cleanup_frames(cache_dir, frames);
+		if (code != 0 || !FileAccess::exists(mpg)) {
+			if (r_error) {
+				*r_error = vformat("ffmpeg scene bake failed (%d): %s", code, pipe);
+			}
+			return FAILED;
+		}
+	}
+
+	const Error probe_err = probe_or_fail(mpg, duration, r_error);
+	if (probe_err != OK) {
+		return probe_err;
+	}
+
+	Ref<FileAccess> meta = FileAccess::open(sidecar, FileAccess::WRITE);
+	if (meta.is_valid()) {
+		meta->store_string(key);
+	}
+	p_cell->set_encoded_path(mpg);
+	p_cell->set_include_audio(String(audio_src) != "none");
+	return OK;
+}
+
+#endif

--- a/modules/inter_dvd/editor/inter_dvd_scene_baker.h
+++ b/modules/inter_dvd/editor/inter_dvd_scene_baker.h
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  inter_dvd_scene_baker.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "core/error/error_list.h"
+#include "core/io/image.h"
+#include "core/io/resource.h"
+#include "core/object/object.h"
+#include "core/string/ustring.h"
+
+class InterDVDCell;
+class Node;
+
+class InterDVDSceneBaker : public Object {
+	GDCLASS(InterDVDSceneBaker, Object);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static Ref<Image> raster_root(Node *p_root);
+	static Error bake_cell(const Ref<InterDVDCell> &p_cell, const String &p_ffmpeg, bool p_auto_find_ffmpeg, String *r_error = nullptr);
+	static Error bake_cell_bind(const Ref<InterDVDCell> &p_cell, const String &p_ffmpeg = String(), bool p_auto_find_ffmpeg = true);
+};
+
+#endif

--- a/modules/inter_dvd/machine/inter_dvd_instruction.cpp
+++ b/modules/inter_dvd/machine/inter_dvd_instruction.cpp
@@ -1,0 +1,474 @@
+/**************************************************************************/
+/*  inter_dvd_instruction.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "inter_dvd_instruction.h"
+
+#include "core/math/math_funcs.h"
+#include "core/object/class_db.h"
+
+bool InterDVDInstruction::validate_transfer(Domain p_from, Domain p_to, LinkKind p_kind, String *r_error) {
+	if (p_kind == LINK_NONE) {
+		return true;
+	}
+	if (p_kind == LINK_RSM) {
+		if (p_from != DOMAIN_VMG && p_from != DOMAIN_VTSM) {
+			if (r_error) {
+				*r_error = "RSM is only legal from VMG or VTSM menu domains.";
+			}
+			return false;
+		}
+		return true;
+	}
+
+	if (p_kind == JUMP_SS && p_from == DOMAIN_VTST) {
+		if (r_error) {
+			*r_error = "JumpSS is illegal from VTST; use CallSS so RSM can return.";
+		}
+		return false;
+	}
+
+	const bool is_link = p_kind == LINK_PGCN || p_kind == LINK_PGN || p_kind == LINK_PTT || p_kind == LINK_CN;
+	const bool is_jump = p_kind == JUMP_TT || p_kind == JUMP_VTS_TT || p_kind == JUMP_VTS_PTT || p_kind == JUMP_SS;
+	const bool is_call = p_kind == CALL_SS;
+
+	if (is_link && p_from != p_to) {
+		if (r_error) {
+			*r_error = "Link stays in the current domain.";
+		}
+		return false;
+	}
+	if (is_call && p_from != DOMAIN_VTST) {
+		if (r_error) {
+			*r_error = "Call is only legal from VTST (one-deep resume).";
+		}
+		return false;
+	}
+	if (is_call && p_to != DOMAIN_VMG && p_to != DOMAIN_VTSM) {
+		if (r_error) {
+			*r_error = "Call target must be VMG or VTSM.";
+		}
+		return false;
+	}
+	if (is_jump && p_from == DOMAIN_VTST && p_to == DOMAIN_VTST && p_kind == JUMP_TT) {
+		if (r_error) {
+			*r_error = "JumpTT is illegal from VTST; use JumpVTS_TT in the same title set.";
+		}
+		return false;
+	}
+	if (is_jump && p_from == DOMAIN_VTST && (p_to == DOMAIN_VMG || p_to == DOMAIN_VTSM)) {
+		if (r_error) {
+			*r_error = "VTST must Call (not Jump) into a menu domain so RSM can return.";
+		}
+		return false;
+	}
+	return true;
+}
+
+PackedByteArray InterDVDInstruction::encode(Group p_group, int p_op, Compare p_cmp, int p_dest_reg, bool p_dest_sprm, int p_src, bool p_src_reg, bool p_src_sprm, LinkKind p_link, Domain p_from, Domain p_to, int p_link_target, String *r_error) {
+	if (p_group < GROUP_SPECIAL || p_group > GROUP_CMP_SET_LINK) {
+		if (r_error) {
+			*r_error = "Instruction group must be 0-6.";
+		}
+		return PackedByteArray();
+	}
+	if (p_dest_sprm) {
+		if (p_dest_reg < 0 || p_dest_reg > 23) {
+			if (r_error) {
+				*r_error = "SPRM index must be 0-23.";
+			}
+			return PackedByteArray();
+		}
+	} else if (p_dest_reg < 0 || p_dest_reg > 15) {
+		if (r_error) {
+			*r_error = "GPRM index must be 0-15.";
+		}
+		return PackedByteArray();
+	}
+	if (!validate_transfer(p_from, p_to, p_link, r_error)) {
+		return PackedByteArray();
+	}
+
+	PackedByteArray bytes;
+	bytes.resize(8);
+	bytes.write[0] = uint8_t((int(p_group) << 5) | (p_op & 0x1F));
+	uint8_t flags = uint8_t((int(p_cmp) & 0x07) << 5);
+	if (p_dest_sprm) {
+		flags |= 0x10;
+	}
+	if (p_src_reg) {
+		flags |= 0x08;
+	}
+	if (p_src_sprm) {
+		flags |= 0x04;
+	}
+	bytes.write[1] = flags;
+	bytes.write[2] = uint8_t((p_dest_reg >> 8) & 0xFF);
+	bytes.write[3] = uint8_t(p_dest_reg & 0xFF);
+	bytes.write[4] = uint8_t((p_src >> 8) & 0xFF);
+	bytes.write[5] = uint8_t(p_src & 0xFF);
+	bytes.write[6] = uint8_t(((int(p_link) & 0x0F) << 4) | ((p_link_target >> 8) & 0x0F));
+	bytes.write[7] = uint8_t(p_link_target & 0xFF);
+	return bytes;
+}
+
+PackedByteArray InterDVDInstruction::encode_nop() {
+	PackedByteArray bytes;
+	bytes.resize(8);
+	bytes.fill(0);
+	return bytes;
+}
+
+static PackedByteArray _hw8() {
+	PackedByteArray bytes;
+	bytes.resize(8);
+	bytes.fill(0);
+	return bytes;
+}
+
+static uint8_t _menu_id(int p_target) {
+	if (p_target >= 2 && p_target <= 7) {
+		return uint8_t(p_target);
+	}
+	return 2;
+}
+
+PackedByteArray InterDVDInstruction::encode_link(LinkKind p_kind, Domain p_from, Domain p_to, int p_target, String *r_error) {
+	if (!validate_transfer(p_from, p_to, p_kind, r_error)) {
+		return PackedByteArray();
+	}
+	PackedByteArray out = _hw8();
+	const int t = p_target > 0 ? p_target : 1;
+	switch (p_kind) {
+		case LINK_PGCN: {
+			const uint16_t pgcn = uint16_t(CLAMP(t, 1, 999));
+			out.write[0] = 0x20;
+			out.write[1] = 0x04;
+			out.write[6] = uint8_t((pgcn >> 8) & 0xFF);
+			out.write[7] = uint8_t(pgcn & 0xFF);
+			return out;
+		}
+		case LINK_PTT: {
+			const uint16_t ptt = uint16_t(CLAMP(t, 1, 999));
+			out.write[0] = 0x20;
+			out.write[1] = 0x05;
+			out.write[6] = uint8_t((ptt >> 8) & 0xFF);
+			out.write[7] = uint8_t(ptt & 0xFF);
+			return out;
+		}
+		case LINK_PGN:
+			out.write[0] = 0x20;
+			out.write[1] = 0x06;
+			out.write[7] = uint8_t(CLAMP(t, 1, 99));
+			return out;
+		case LINK_CN:
+			out.write[0] = 0x20;
+			out.write[1] = 0x07;
+			out.write[7] = uint8_t(CLAMP(t, 1, 255));
+			return out;
+		case LINK_RSM:
+			out.write[0] = 0x20;
+			out.write[1] = 0x10;
+			return out;
+		case JUMP_TT:
+			out.write[0] = 0x30;
+			out.write[1] = 0x02;
+			out.write[5] = uint8_t(CLAMP(t, 1, 99));
+			return out;
+		case JUMP_VTS_TT:
+			out.write[0] = 0x30;
+			out.write[1] = 0x03;
+			out.write[5] = uint8_t(CLAMP(t, 1, 99));
+			return out;
+		case JUMP_VTS_PTT: {
+			const uint16_t ptt = uint16_t(CLAMP(t, 1, 999));
+			out.write[0] = 0x30;
+			out.write[1] = 0x05;
+			out.write[5] = 1;
+			out.write[6] = uint8_t((ptt >> 8) & 0xFF);
+			out.write[7] = uint8_t(ptt & 0xFF);
+			return out;
+		}
+		case JUMP_SS:
+			out.write[0] = 0x30;
+			out.write[1] = 0x06;
+			out.write[5] = uint8_t(0x40 | _menu_id(p_target));
+			return out;
+		case CALL_SS:
+			out.write[0] = 0x30;
+			out.write[1] = 0x08;
+			out.write[4] = 1;
+			out.write[5] = uint8_t(0x40 | _menu_id(p_target));
+			return out;
+		default:
+			return encode(GROUP_LINK, int(p_kind), CMP_ALWAYS, 0, false, 0, false, false, p_kind, p_from, p_to, p_target, r_error);
+	}
+}
+
+PackedByteArray InterDVDInstruction::encode_set(SetOp p_op, int p_gprm, int p_src, bool p_src_reg, bool p_src_sprm, String *r_error) {
+	return encode(GROUP_SET, int(p_op), CMP_ALWAYS, p_gprm, false, p_src, p_src_reg, p_src_sprm, LINK_NONE, DOMAIN_FPC, DOMAIN_FPC, 0, r_error);
+}
+
+PackedByteArray InterDVDInstruction::encode_rsm(Domain p_from, String *r_error) {
+	return encode_link(LINK_RSM, p_from, p_from, 0, r_error);
+}
+
+PackedByteArray InterDVDInstruction::encode_jump_vts_ptt(Domain p_from, int p_title, int p_ptt, String *r_error) {
+	if (!validate_transfer(p_from, DOMAIN_VTST, JUMP_VTS_PTT, r_error)) {
+		return PackedByteArray();
+	}
+	PackedByteArray out = _hw8();
+	const uint16_t ptt = uint16_t(CLAMP(p_ptt > 0 ? p_ptt : 1, 1, 999));
+	out.write[0] = 0x30;
+	out.write[1] = 0x05;
+	out.write[5] = uint8_t(CLAMP(p_title > 0 ? p_title : 1, 1, 99));
+	out.write[6] = uint8_t((ptt >> 8) & 0xFF);
+	out.write[7] = uint8_t(ptt & 0xFF);
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_set_stn(int p_audio, int p_subtitle, bool p_subtitle_on, int p_angle, String *r_error) {
+	(void)r_error;
+	PackedByteArray out = _hw8();
+	out.write[0] = 0x51;
+	if (p_audio >= 0) {
+		out.write[4] = uint8_t(0x80 | (CLAMP(p_audio, 0, 7) & 0x07));
+	}
+	if (p_subtitle >= 0) {
+		uint8_t sp = uint8_t(0x80 | (CLAMP(p_subtitle, 0, 31) & 0x1F));
+		if (p_subtitle_on) {
+			sp |= 0x40;
+		}
+		out.write[5] = sp;
+	}
+	if (p_angle >= 0) {
+		out.write[6] = uint8_t(0x80 | (CLAMP(p_angle, 1, 9) & 0x0F));
+	}
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_set_hl_btnn(int p_button, String *r_error) {
+	if (p_button < 1 || p_button > 36) {
+		if (r_error) {
+			*r_error = "Highlighted button must be 1-36.";
+		}
+		return PackedByteArray();
+	}
+	PackedByteArray out = _hw8();
+	out.write[0] = 0x46;
+	out.write[5] = uint8_t(p_button);
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_set_nvtmr(int p_seconds, int p_pgc, String *r_error) {
+	if (p_seconds < 0 || p_seconds > 0xFFFF) {
+		if (r_error) {
+			*r_error = "Navigation timer must be 0-65535 seconds.";
+		}
+		return PackedByteArray();
+	}
+	PackedByteArray out = _hw8();
+	out.write[0] = 0x42;
+	out.write[4] = uint8_t((p_seconds >> 8) & 0xFF);
+	out.write[5] = uint8_t(p_seconds & 0xFF);
+	const uint16_t pgc = uint16_t(CLAMP(p_pgc > 0 ? p_pgc : 1, 1, 999));
+	out.write[6] = uint8_t((pgc >> 8) & 0xFF);
+	out.write[7] = uint8_t(pgc & 0xFF);
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_set_gprmmd(int p_gprm, int p_value, bool p_counter, String *r_error) {
+	if (p_gprm < 0 || p_gprm > 15) {
+		if (r_error) {
+			*r_error = "GPRM index must be 0-15.";
+		}
+		return PackedByteArray();
+	}
+	PackedByteArray out = _hw8();
+	out.write[0] = 0x47;
+	out.write[4] = p_counter ? 1 : 0;
+	out.write[5] = uint8_t(p_gprm);
+	out.write[6] = uint8_t((p_value >> 8) & 0xFF);
+	out.write[7] = uint8_t(p_value & 0xFF);
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_exit() {
+	PackedByteArray out = _hw8();
+	out.write[0] = 0x30;
+	out.write[1] = 0x01;
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_goto(int p_line, String *r_error) {
+	if (p_line < 1 || p_line > 128) {
+		if (r_error) {
+			*r_error = "Goto line must be 1-128.";
+		}
+		return PackedByteArray();
+	}
+	PackedByteArray out = _hw8();
+	out.write[1] = 0x01;
+	out.write[6] = uint8_t((p_line >> 8) & 0xFF);
+	out.write[7] = uint8_t(p_line & 0xFF);
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::encode_break() {
+	PackedByteArray out = _hw8();
+	out.write[1] = 0x02;
+	return out;
+}
+
+PackedByteArray InterDVDInstruction::_encode_script(int p_group, int p_op, int p_cmp, int p_dest_reg, bool p_dest_sprm, int p_src, bool p_src_reg, bool p_src_sprm, int p_link, int p_from, int p_to, int p_link_target) {
+	return encode(Group(p_group), p_op, Compare(p_cmp), p_dest_reg, p_dest_sprm, p_src, p_src_reg, p_src_sprm, LinkKind(p_link), Domain(p_from), Domain(p_to), p_link_target, nullptr);
+}
+
+static PackedByteArray _encode_link_bind(int p_kind, int p_from, int p_to, int p_target) {
+	return InterDVDInstruction::encode_link(InterDVDInstruction::LinkKind(p_kind), InterDVDInstruction::Domain(p_from), InterDVDInstruction::Domain(p_to), p_target, nullptr);
+}
+
+static PackedByteArray _encode_set_bind(int p_op, int p_gprm, int p_src, bool p_src_reg, bool p_src_sprm) {
+	return InterDVDInstruction::encode_set(InterDVDInstruction::SetOp(p_op), p_gprm, p_src, p_src_reg, p_src_sprm, nullptr);
+}
+
+static PackedByteArray _encode_rsm_bind(int p_from) {
+	return InterDVDInstruction::encode_rsm(InterDVDInstruction::Domain(p_from), nullptr);
+}
+
+static PackedByteArray _encode_jump_vts_ptt_bind(int p_from, int p_title, int p_ptt) {
+	return InterDVDInstruction::encode_jump_vts_ptt(InterDVDInstruction::Domain(p_from), p_title, p_ptt, nullptr);
+}
+
+static PackedByteArray _encode_set_stn_bind(int p_audio, int p_subtitle, bool p_subtitle_on, int p_angle) {
+	return InterDVDInstruction::encode_set_stn(p_audio, p_subtitle, p_subtitle_on, p_angle, nullptr);
+}
+
+static PackedByteArray _encode_set_hl_btnn_bind(int p_button) {
+	return InterDVDInstruction::encode_set_hl_btnn(p_button, nullptr);
+}
+
+static PackedByteArray _encode_set_nvtmr_bind(int p_seconds, int p_pgc) {
+	return InterDVDInstruction::encode_set_nvtmr(p_seconds, p_pgc, nullptr);
+}
+
+static PackedByteArray _encode_set_gprmmd_bind(int p_gprm, int p_value, bool p_counter) {
+	return InterDVDInstruction::encode_set_gprmmd(p_gprm, p_value, p_counter, nullptr);
+}
+
+static PackedByteArray _encode_goto_bind(int p_line) {
+	return InterDVDInstruction::encode_goto(p_line, nullptr);
+}
+
+void InterDVDInstruction::_bind_methods() {
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode", "group", "op", "cmp", "dest_reg", "dest_sprm", "src", "src_reg", "src_sprm", "link", "from_domain", "to_domain", "link_target"), &InterDVDInstruction::_encode_script);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_nop"), &InterDVDInstruction::encode_nop);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_link", "kind", "from_domain", "to_domain", "target"), &_encode_link_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_set", "op", "gprm", "src", "src_reg", "src_sprm"), &_encode_set_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_rsm", "from_domain"), &_encode_rsm_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_jump_vts_ptt", "from_domain", "title", "ptt"), &_encode_jump_vts_ptt_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_set_stn", "audio", "subtitle", "subtitle_on", "angle"), &_encode_set_stn_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_set_hl_btnn", "button"), &_encode_set_hl_btnn_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_set_nvtmr", "seconds", "pgc"), &_encode_set_nvtmr_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_set_gprmmd", "gprm", "value", "counter"), &_encode_set_gprmmd_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_exit"), &InterDVDInstruction::encode_exit);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_goto", "line"), &_encode_goto_bind);
+	ClassDB::bind_static_method("InterDVDInstruction", D_METHOD("encode_break"), &InterDVDInstruction::encode_break);
+
+	BIND_ENUM_CONSTANT(GROUP_SPECIAL);
+	BIND_ENUM_CONSTANT(GROUP_LINK);
+	BIND_ENUM_CONSTANT(GROUP_SET_SYSTEM);
+	BIND_ENUM_CONSTANT(GROUP_SET);
+	BIND_ENUM_CONSTANT(GROUP_SET_LINK);
+	BIND_ENUM_CONSTANT(GROUP_CMP_SET_SYSTEM);
+	BIND_ENUM_CONSTANT(GROUP_CMP_SET_LINK);
+
+	BIND_ENUM_CONSTANT(CMP_ALWAYS);
+	BIND_ENUM_CONSTANT(CMP_AND);
+	BIND_ENUM_CONSTANT(CMP_EQ);
+	BIND_ENUM_CONSTANT(CMP_NE);
+	BIND_ENUM_CONSTANT(CMP_GE);
+	BIND_ENUM_CONSTANT(CMP_GT);
+	BIND_ENUM_CONSTANT(CMP_LE);
+	BIND_ENUM_CONSTANT(CMP_LT);
+
+	BIND_ENUM_CONSTANT(SET_NOP);
+	BIND_ENUM_CONSTANT(SET_ASSIGN);
+	BIND_ENUM_CONSTANT(SET_SWAP);
+	BIND_ENUM_CONSTANT(SET_ADD);
+	BIND_ENUM_CONSTANT(SET_SUB);
+	BIND_ENUM_CONSTANT(SET_MUL);
+	BIND_ENUM_CONSTANT(SET_DIV);
+	BIND_ENUM_CONSTANT(SET_MOD);
+	BIND_ENUM_CONSTANT(SET_RANDOM);
+	BIND_ENUM_CONSTANT(SET_AND);
+	BIND_ENUM_CONSTANT(SET_OR);
+	BIND_ENUM_CONSTANT(SET_XOR);
+
+	BIND_ENUM_CONSTANT(LINK_NONE);
+	BIND_ENUM_CONSTANT(LINK_PGCN);
+	BIND_ENUM_CONSTANT(LINK_PGN);
+	BIND_ENUM_CONSTANT(LINK_PTT);
+	BIND_ENUM_CONSTANT(LINK_RSM);
+	BIND_ENUM_CONSTANT(JUMP_TT);
+	BIND_ENUM_CONSTANT(JUMP_VTS_TT);
+	BIND_ENUM_CONSTANT(JUMP_VTS_PTT);
+	BIND_ENUM_CONSTANT(CALL_SS);
+	BIND_ENUM_CONSTANT(JUMP_SS);
+	BIND_ENUM_CONSTANT(LINK_CN);
+
+	BIND_ENUM_CONSTANT(DOMAIN_FPC);
+	BIND_ENUM_CONSTANT(DOMAIN_VMG);
+	BIND_ENUM_CONSTANT(DOMAIN_VTSM);
+	BIND_ENUM_CONSTANT(DOMAIN_VTST);
+
+	BIND_ENUM_CONSTANT(SPRM_M_ASN);
+	BIND_ENUM_CONSTANT(SPRM_ASTN);
+	BIND_ENUM_CONSTANT(SPRM_SPSTN);
+	BIND_ENUM_CONSTANT(SPRM_AGL_N);
+	BIND_ENUM_CONSTANT(SPRM_TT_N);
+	BIND_ENUM_CONSTANT(SPRM_VTS_TT_N);
+	BIND_ENUM_CONSTANT(SPRM_TT_VTS_N);
+	BIND_ENUM_CONSTANT(SPRM_PTT_N);
+	BIND_ENUM_CONSTANT(SPRM_HL_BTNN);
+	BIND_ENUM_CONSTANT(SPRM_NVTMR);
+	BIND_ENUM_CONSTANT(SPRM_NV_PGC);
+	BIND_ENUM_CONSTANT(SPRM_P_N);
+	BIND_ENUM_CONSTANT(SPRM_PTT_N2);
+	BIND_ENUM_CONSTANT(SPRM_CN);
+	BIND_ENUM_CONSTANT(SPRM_VIDEO_CFG);
+	BIND_ENUM_CONSTANT(SPRM_AUDIO_CFG);
+	BIND_ENUM_CONSTANT(SPRM_INI_AUD_LANG);
+	BIND_ENUM_CONSTANT(SPRM_INI_AUD_EXT);
+	BIND_ENUM_CONSTANT(SPRM_INI_SP_LANG);
+	BIND_ENUM_CONSTANT(SPRM_INI_SP_EXT);
+	BIND_ENUM_CONSTANT(SPRM_REGION);
+	BIND_ENUM_CONSTANT(SPRM_RESERVED_21);
+	BIND_ENUM_CONSTANT(SPRM_RESERVED_22);
+	BIND_ENUM_CONSTANT(SPRM_RESERVED_23);
+}

--- a/modules/inter_dvd/machine/inter_dvd_instruction.h
+++ b/modules/inter_dvd/machine/inter_dvd_instruction.h
@@ -1,0 +1,152 @@
+/**************************************************************************/
+/*  inter_dvd_instruction.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/variant/typed_array.h"
+
+class InterDVDInstruction : public Object {
+	GDCLASS(InterDVDInstruction, Object);
+
+public:
+	enum Group {
+		GROUP_SPECIAL = 0,
+		GROUP_LINK = 1,
+		GROUP_SET_SYSTEM = 2,
+		GROUP_SET = 3,
+		GROUP_SET_LINK = 4,
+		GROUP_CMP_SET_SYSTEM = 5,
+		GROUP_CMP_SET_LINK = 6,
+	};
+
+	enum Compare {
+		CMP_ALWAYS = 0,
+		CMP_AND = 1,
+		CMP_EQ = 2,
+		CMP_NE = 3,
+		CMP_GE = 4,
+		CMP_GT = 5,
+		CMP_LE = 6,
+		CMP_LT = 7,
+	};
+
+	enum SetOp {
+		SET_NOP = 0,
+		SET_ASSIGN = 1,
+		SET_SWAP = 2,
+		SET_ADD = 3,
+		SET_SUB = 4,
+		SET_MUL = 5,
+		SET_DIV = 6,
+		SET_MOD = 7,
+		SET_RANDOM = 8,
+		SET_AND = 9,
+		SET_OR = 10,
+		SET_XOR = 11,
+	};
+
+	enum LinkKind {
+		LINK_NONE = 0,
+		LINK_PGCN = 1,
+		LINK_PGN = 2,
+		LINK_PTT = 3,
+		LINK_RSM = 4,
+		JUMP_TT = 5,
+		JUMP_VTS_TT = 6,
+		JUMP_VTS_PTT = 7,
+		CALL_SS = 8,
+		JUMP_SS = 9,
+		LINK_CN = 10,
+	};
+
+	enum Domain {
+		DOMAIN_FPC = 0,
+		DOMAIN_VMG = 1,
+		DOMAIN_VTSM = 2,
+		DOMAIN_VTST = 3,
+	};
+
+	enum SPRM {
+		SPRM_M_ASN = 0,
+		SPRM_ASTN = 1,
+		SPRM_SPSTN = 2,
+		SPRM_AGL_N = 3,
+		SPRM_TT_N = 4,
+		SPRM_VTS_TT_N = 5,
+		SPRM_TT_VTS_N = 6,
+		SPRM_PTT_N = 7,
+		SPRM_HL_BTNN = 8,
+		SPRM_NVTMR = 9,
+		SPRM_NV_PGC = 10,
+		SPRM_P_N = 11,
+		SPRM_PTT_N2 = 12,
+		SPRM_CN = 13,
+		SPRM_VIDEO_CFG = 14,
+		SPRM_AUDIO_CFG = 15,
+		SPRM_INI_AUD_LANG = 16,
+		SPRM_INI_AUD_EXT = 17,
+		SPRM_INI_SP_LANG = 18,
+		SPRM_INI_SP_EXT = 19,
+		SPRM_REGION = 20,
+		SPRM_RESERVED_21 = 21,
+		SPRM_RESERVED_22 = 22,
+		SPRM_RESERVED_23 = 23,
+	};
+
+	static bool validate_transfer(Domain p_from, Domain p_to, LinkKind p_kind, String *r_error = nullptr);
+	static PackedByteArray encode(Group p_group, int p_op, Compare p_cmp, int p_dest_reg, bool p_dest_sprm, int p_src, bool p_src_reg, bool p_src_sprm, LinkKind p_link, Domain p_from, Domain p_to, int p_link_target, String *r_error = nullptr);
+
+	static PackedByteArray encode_nop();
+	static PackedByteArray encode_link(LinkKind p_kind, Domain p_from, Domain p_to, int p_target, String *r_error = nullptr);
+	static PackedByteArray encode_set(SetOp p_op, int p_gprm, int p_src, bool p_src_reg, bool p_src_sprm, String *r_error = nullptr);
+	static PackedByteArray encode_rsm(Domain p_from, String *r_error = nullptr);
+	static PackedByteArray encode_jump_vts_ptt(Domain p_from, int p_title, int p_ptt, String *r_error = nullptr);
+	static PackedByteArray encode_set_stn(int p_audio, int p_subtitle, bool p_subtitle_on, int p_angle, String *r_error = nullptr);
+	static PackedByteArray encode_set_hl_btnn(int p_button, String *r_error = nullptr);
+	static PackedByteArray encode_set_nvtmr(int p_seconds, int p_pgc, String *r_error = nullptr);
+	static PackedByteArray encode_set_gprmmd(int p_gprm, int p_value, bool p_counter, String *r_error = nullptr);
+	static PackedByteArray encode_exit();
+	static PackedByteArray encode_goto(int p_line, String *r_error = nullptr);
+	static PackedByteArray encode_break();
+
+protected:
+	static void _bind_methods();
+
+private:
+	static PackedByteArray _encode_script(int p_group, int p_op, int p_cmp, int p_dest_reg, bool p_dest_sprm, int p_src, bool p_src_reg, bool p_src_sprm, int p_link, int p_from, int p_to, int p_link_target);
+};
+
+VARIANT_ENUM_CAST(InterDVDInstruction::Group);
+VARIANT_ENUM_CAST(InterDVDInstruction::Compare);
+VARIANT_ENUM_CAST(InterDVDInstruction::SetOp);
+VARIANT_ENUM_CAST(InterDVDInstruction::LinkKind);
+VARIANT_ENUM_CAST(InterDVDInstruction::Domain);
+VARIANT_ENUM_CAST(InterDVDInstruction::SPRM);

--- a/modules/inter_dvd/machine/inter_dvd_machine.cpp
+++ b/modules/inter_dvd/machine/inter_dvd_machine.cpp
@@ -1,0 +1,38 @@
+/**************************************************************************/
+/*  inter_dvd_machine.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "inter_dvd_machine.h"
+
+#include "core/object/class_db.h"
+
+void InterDVDMachine::_bind_methods() {
+	BIND_CONSTANT(GPRM_COUNT);
+	BIND_CONSTANT(SPRM_COUNT);
+	BIND_CONSTANT(INSTRUCTION_SIZE);
+}

--- a/modules/inter_dvd/machine/inter_dvd_machine.h
+++ b/modules/inter_dvd/machine/inter_dvd_machine.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  inter_dvd_machine.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+
+class InterDVDMachine : public Object {
+	GDCLASS(InterDVDMachine, Object);
+
+public:
+	static constexpr int GPRM_COUNT = 16;
+	static constexpr int SPRM_COUNT = 24;
+	static constexpr int INSTRUCTION_SIZE = 8;
+
+protected:
+	static void _bind_methods();
+};

--- a/modules/inter_dvd/register_types.cpp
+++ b/modules/inter_dvd/register_types.cpp
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "author/inter_dvd_ifo_writer.h"
+#include "author/inter_dvd_project.h"
+#include "machine/inter_dvd_instruction.h"
+#include "machine/inter_dvd_machine.h"
+
+#include "core/config/project_settings.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/export/windows_inter_dvd_export_platform.h"
+#include "editor/inter_dvd_editor_plugin.h"
+#include "editor/inter_dvd_scene_baker.h"
+#include "editor/plugins/editor_plugin.h"
+#endif
+
+void initialize_inter_dvd_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "blazium/inter_dvd/project", PROPERTY_HINT_FILE, "*.tres,*.res"), String());
+		GLOBAL_DEF_BASIC("blazium/inter_dvd/default_region_mask", 1);
+		GLOBAL_DEF_BASIC("blazium/inter_dvd/default_parental_level", 1);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "blazium/inter_dvd/cache_path", PROPERTY_HINT_DIR), "res://.inter_dvd_cache");
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/inter_dvd/ac3_bitrate_k", PROPERTY_HINT_RANGE, "64,448,32"), 192);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/inter_dvd/ac3_channels", PROPERTY_HINT_RANGE, "1,6,1"), 2);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/inter_dvd/gop_size", PROPERTY_HINT_RANGE, "1,30,1"), 15);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/inter_dvd/title_safe_bottom", PROPERTY_HINT_RANGE, "2,480,2"), 432);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "blazium/inter_dvd/pip_blackdetect_sec", PROPERTY_HINT_RANGE, "0,10,0.1"), 2.5);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "blazium/inter_dvd/pip_blackdetect_pix_th", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.12);
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "blazium/inter_dvd/bake_warmup_frames", PROPERTY_HINT_RANGE, "0,30,1"), 2);
+		return;
+	}
+
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(InterDVDInstruction);
+		GDREGISTER_CLASS(InterDVDMachine);
+		GDREGISTER_CLASS(InterDVDStream);
+		GDREGISTER_CLASS(InterDVDCell);
+		GDREGISTER_CLASS(InterDVDButton);
+		GDREGISTER_CLASS(InterDVDMenu);
+		GDREGISTER_CLASS(InterDVDPGC);
+		GDREGISTER_CLASS(InterDVDProject);
+		GDREGISTER_CLASS(InterDVDExportProgress);
+		GDREGISTER_CLASS(InterDVDIfoWriter);
+		return;
+	}
+
+#ifdef TOOLS_ENABLED
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDREGISTER_VIRTUAL_CLASS(EditorExportPlatformWindowsInterDVD);
+		GDREGISTER_CLASS(InterDVDEditorPlugin);
+		GDREGISTER_CLASS(InterDVDSceneBaker);
+		EditorPlugins::add_by_type<InterDVDEditorPlugin>();
+	}
+#endif
+}
+
+void uninitialize_inter_dvd_module(ModuleInitializationLevel p_level) {
+	(void)p_level;
+}

--- a/modules/inter_dvd/register_types.h
+++ b/modules/inter_dvd/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_inter_dvd_module(ModuleInitializationLevel p_level);
+void uninitialize_inter_dvd_module(ModuleInitializationLevel p_level);

--- a/modules/inter_dvd/tests/test_inter_dvd.cpp
+++ b/modules/inter_dvd/tests/test_inter_dvd.cpp
@@ -1,0 +1,33 @@
+/**************************************************************************/
+/*  test_inter_dvd.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_inter_dvd_ifo_writer.h"
+#include "test_inter_dvd_instruction.h"
+#include "test_inter_dvd_settings.h"
+#include "test_inter_dvd_vob_mux.h"

--- a/modules/inter_dvd/tests/test_inter_dvd_ifo_writer.h
+++ b/modules/inter_dvd/tests/test_inter_dvd_ifo_writer.h
@@ -1,0 +1,770 @@
+/**************************************************************************/
+/*  test_inter_dvd_ifo_writer.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "modules/inter_dvd/author/inter_dvd_ifo_writer.h"
+#include "modules/inter_dvd/author/inter_dvd_project.h"
+#include "modules/inter_dvd/author/inter_dvd_vob_mux.h"
+#include "modules/inter_dvd/machine/inter_dvd_instruction.h"
+#include "tests/test_macros.h"
+#include "tests/test_utils.h"
+
+TEST_CASE("[Modules][InterDVD] IFO writer smoke test") {
+	const String root = TestUtils::get_temp_path("inter_dvd_video_ts");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	project->set_titles(titles);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	const String video = root.path_join("VIDEO_TS");
+	CHECK(FileAccess::exists(video.path_join("VIDEO_TS.IFO")));
+	CHECK(FileAccess::exists(video.path_join("VIDEO_TS.BUP")));
+	CHECK(FileAccess::exists(video.path_join("VTS_01_0.IFO")));
+	CHECK(FileAccess::exists(video.path_join("VTS_01_0.BUP")));
+	CHECK(FileAccess::exists(video.path_join("VTS_01_1.VOB")));
+	CHECK(DirAccess::exists(root.path_join("AUDIO_TS")));
+
+	Ref<FileAccess> ifo = FileAccess::open(video.path_join("VIDEO_TS.IFO"), FileAccess::READ);
+	REQUIRE(ifo.is_valid());
+	const Vector<uint8_t> vmg = ifo->get_buffer(int(ifo->get_length()));
+	REQUIRE(vmg.size() >= 0x500);
+	CHECK(String::utf8((const char *)vmg.ptr(), 12) == "DVDVIDEO-VMG");
+	const uint32_t vmgi_last = (uint32_t(vmg[0x80]) << 24) | (uint32_t(vmg[0x81]) << 16) | (uint32_t(vmg[0x82]) << 8) | uint32_t(vmg[0x83]);
+	const uint32_t first_play = (uint32_t(vmg[0x84]) << 24) | (uint32_t(vmg[0x85]) << 16) | (uint32_t(vmg[0x86]) << 8) | uint32_t(vmg[0x87]);
+	CHECK(first_play < vmgi_last);
+	CHECK(vmg[int(first_play) + 0xEC] == 0);
+	CHECK(vmg[int(first_play) + 0xED] == 1);
+	CHECK(vmg[int(first_play) + 0xF2] == 0);
+	CHECK(vmg[int(first_play) + 0xF3] == 15);
+	CHECK(vmg[int(first_play) + 0xF4] == 0x30);
+	CHECK(vmg[int(first_play) + 0xF5] == 0x02);
+	CHECK(vmg[int(first_play) + 0xF9] == 1);
+
+	Ref<FileAccess> vts = FileAccess::open(video.path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	REQUIRE(vtsi.size() >= 2048 + 16);
+	CHECK(String::utf8((const char *)vtsi.ptr(), 12) == "DVDVIDEO-VTS");
+	CHECK(vtsi[0x100] == 0x40);
+	CHECK(vtsi[0x101] == 0x00);
+	const uint32_t ptt_last = (uint32_t(vtsi[2048 + 4]) << 24) | (uint32_t(vtsi[2048 + 5]) << 16) | (uint32_t(vtsi[2048 + 6]) << 8) | uint32_t(vtsi[2048 + 7]);
+	CHECK(ptt_last == 15);
+	CHECK(((ptt_last + 1 - 12) % 4) == 0);
+}
+
+TEST_CASE("[Modules][InterDVD] IFO writer authors a PCI highlight button") {
+	const String root = TestUtils::get_temp_path("inter_dvd_button_menu");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+
+	Ref<InterDVDMenu> menu;
+	menu.instantiate();
+	menu->set_buttons(buttons);
+
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	TypedArray<InterDVDMenu> menus;
+	menus.push_back(menu);
+
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+	project->set_menus(menus);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	const String video = root.path_join("VIDEO_TS");
+	Ref<FileAccess> ifo = FileAccess::open(video.path_join("VIDEO_TS.IFO"), FileAccess::READ);
+	REQUIRE(ifo.is_valid());
+	const Vector<uint8_t> vmg = ifo->get_buffer(int(ifo->get_length()));
+	const uint32_t first_play = (uint32_t(vmg[0x84]) << 24) | (uint32_t(vmg[0x85]) << 16) | (uint32_t(vmg[0x86]) << 8) | uint32_t(vmg[0x87]);
+	CHECK(vmg[int(first_play) + 0xF4] == 0x30);
+	CHECK(vmg[int(first_play) + 0xF5] == 0x06);
+	CHECK(vmg[int(first_play) + 0xF9] == 0x42);
+
+	Ref<FileAccess> vob = FileAccess::open(video.path_join("VIDEO_TS.VOB"), FileAccess::READ);
+	REQUIRE(vob.is_valid());
+	const Vector<uint8_t> nav = vob->get_buffer(InterDVDIfoWriter::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 200);
+	CHECK(nav[141] == 0);
+	CHECK(nav[142] == 1);
+	CHECK(nav[157] == 1);
+	CHECK(nav[158] == 1);
+	CHECK(nav[159] == 0);
+	CHECK(nav[160] == 0);
+	CHECK(nav[197] == 0x30);
+	CHECK(nav[198] == 0x02);
+	CHECK(nav[202] == 1);
+	const int menu_pgc = 3 * 2048 + 32;
+	REQUIRE(vmg.size() > menu_pgc + 0xEA);
+	const uint16_t menu_cell_pb = (uint16_t(vmg[menu_pgc + 0xE8]) << 8) | uint16_t(vmg[menu_pgc + 0xE9]);
+	CHECK(vmg[menu_pgc + 0x9D] == 1);
+	CHECK(vmg[menu_pgc + menu_cell_pb + 2] == 0);
+}
+
+TEST_CASE("[Modules][InterDVD] IFO writer authors a second title and title-domain button") {
+	const String root = TestUtils::get_temp_path("inter_dvd_two_scenes");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDButton> next;
+	next.instantiate();
+	next->set_highlight(Rect2(400, 390, 280, 60));
+	next->set_action(InterDVDButton::ACTION_JUMP_TITLE);
+	next->set_target(2);
+	TypedArray<InterDVDButton> title_buttons;
+	title_buttons.push_back(next);
+
+	Ref<InterDVDPGC> scene1;
+	scene1.instantiate();
+	scene1->set_buttons(title_buttons);
+	Ref<InterDVDButton> back;
+	back.instantiate();
+	back->set_highlight(Rect2(80, 390, 200, 60));
+	back->set_action(InterDVDButton::ACTION_JUMP_TITLE);
+	back->set_target(1);
+	Ref<InterDVDButton> replay;
+	replay.instantiate();
+	replay->set_highlight(Rect2(400, 390, 240, 60));
+	replay->set_action(InterDVDButton::ACTION_JUMP_TITLE);
+	replay->set_target(1);
+	TypedArray<InterDVDButton> scene2_buttons;
+	scene2_buttons.push_back(back);
+	scene2_buttons.push_back(replay);
+	Ref<InterDVDPGC> scene2;
+	scene2.instantiate();
+	scene2->set_buttons(scene2_buttons);
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(scene1);
+	titles.push_back(scene2);
+
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> menu_buttons;
+	menu_buttons.push_back(play);
+	Ref<InterDVDMenu> menu;
+	menu.instantiate();
+	menu->set_buttons(menu_buttons);
+	TypedArray<InterDVDMenu> menus;
+	menus.push_back(menu);
+
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+	project->set_menus(menus);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	const String video = root.path_join("VIDEO_TS");
+	Ref<FileAccess> ifo = FileAccess::open(video.path_join("VIDEO_TS.IFO"), FileAccess::READ);
+	REQUIRE(ifo.is_valid());
+	const Vector<uint8_t> vmg = ifo->get_buffer(int(ifo->get_length()));
+	REQUIRE(vmg.size() >= 2048 + 4);
+	CHECK(vmg[2048] == 0);
+	CHECK(vmg[2049] == 2);
+
+	Ref<FileAccess> title = FileAccess::open(video.path_join("VTS_01_1.VOB"), FileAccess::READ);
+	REQUIRE(title.is_valid());
+	const Vector<uint8_t> nav = title->get_buffer(InterDVDIfoWriter::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 210);
+	CHECK(nav[142] == 1);
+	CHECK(nav[157] == 1);
+	CHECK(nav[158] == 1);
+	CHECK(nav[159] == 0);
+	CHECK(nav[160] == 0);
+	CHECK(nav[197] == 0x30);
+	CHECK(nav[198] == 0x03);
+	CHECK(nav[202] == 2);
+
+	title->seek(InterDVDIfoWriter::SECTOR_SIZE);
+	const Vector<uint8_t> nav2 = title->get_buffer(InterDVDIfoWriter::SECTOR_SIZE);
+	REQUIRE(nav2.size() >= 210);
+	CHECK(nav2[157] == 2);
+	CHECK(nav2[158] == 2);
+	CHECK(nav2[159] == 0);
+	CHECK(nav2[160] == 0);
+	CHECK(nav2[197] == 0x30);
+	CHECK(nav2[198] == 0x03);
+	CHECK(nav2[202] == 1);
+	CHECK(nav2[215] == 0x30);
+	CHECK(nav2[216] == 0x03);
+	CHECK(nav2[220] == 1);
+
+	Ref<FileAccess> vtsi = FileAccess::open(video.path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vtsi.is_valid());
+	const Vector<uint8_t> vts = vtsi->get_buffer(int(vtsi->get_length()));
+	REQUIRE(vts.size() >= 4096 + 32);
+	CHECK(vts[0x254] == 0);
+	CHECK(vts[0x255] == 0);
+	const int pgcit = 4096;
+	const uint32_t pgc_rel = (uint32_t(vts[pgcit + 12]) << 24) | (uint32_t(vts[pgcit + 13]) << 16) | (uint32_t(vts[pgcit + 14]) << 8) | uint32_t(vts[pgcit + 15]);
+	const int pgc_off = pgcit + int(pgc_rel);
+	REQUIRE(pgc_off + 0xEC + 16 < vts.size());
+	const uint16_t cmd_tbl = (uint16_t(vts[pgc_off + 0xE4]) << 8) | uint16_t(vts[pgc_off + 0xE5]);
+	const uint16_t cell_pb = (uint16_t(vts[pgc_off + 0xE8]) << 8) | uint16_t(vts[pgc_off + 0xE9]);
+	CHECK(vts[pgc_off + 0x1C] == 0);
+	CHECK(vts[pgc_off + 0x9C] == 0);
+	CHECK(vts[pgc_off + 0x9D] == 1);
+	CHECK(vts[pgc_off + cmd_tbl + 3] == 0);
+	CHECK(vts[pgc_off + cell_pb + 2] == 0);
+}
+
+TEST_CASE("[Modules][InterDVD] button action target authors JumpTT without raw command") {
+	Ref<InterDVDButton> btn;
+	btn.instantiate();
+	btn->set_action(InterDVDButton::ACTION_JUMP_TITLE);
+	btn->set_target(2);
+	const PackedByteArray menu_cmd = btn->resolve_command(InterDVDButton::DOMAIN_VMGM);
+	REQUIRE(menu_cmd.size() == 8);
+	CHECK(menu_cmd[0] == 0x30);
+	CHECK(menu_cmd[1] == 0x02);
+	CHECK(menu_cmd[5] == 2);
+	const PackedByteArray title_cmd = btn->resolve_command(InterDVDButton::DOMAIN_VTST);
+	REQUIRE(title_cmd.size() == 8);
+	CHECK(title_cmd[0] == 0x30);
+	CHECK(title_cmd[1] == 0x03);
+	CHECK(title_cmd[5] == 2);
+	Ref<InterDVDButton> menu;
+	menu.instantiate();
+	menu->set_action(InterDVDButton::ACTION_JUMP_MENU);
+	const PackedByteArray call = menu->resolve_command(InterDVDButton::DOMAIN_VTST);
+	CHECK(call[1] == 0x08);
+	CHECK(call[4] == 1);
+	CHECK(call[5] == 0x42);
+	Ref<InterDVDButton> pgc;
+	pgc.instantiate();
+	pgc->set_action(InterDVDButton::ACTION_JUMP_PGC);
+	pgc->set_target(2);
+	const PackedByteArray link = pgc->resolve_command(InterDVDButton::DOMAIN_VTST);
+	CHECK(link[0] == 0x20);
+	CHECK(link[1] == 0x04);
+	CHECK(link[7] == 2);
+	Ref<InterDVDButton> chapter;
+	chapter.instantiate();
+	chapter->set_action(InterDVDButton::ACTION_JUMP_CHAPTER);
+	chapter->set_target(2);
+	const PackedByteArray ptt = chapter->resolve_command(InterDVDButton::DOMAIN_VTST);
+	CHECK(ptt[0] == 0x30);
+	CHECK(ptt[1] == 0x05);
+	CHECK(ptt[5] == 1);
+	CHECK(ptt[7] == 2);
+	const PackedByteArray vts_ptt = chapter->resolve_command(InterDVDButton::DOMAIN_VMGM);
+	CHECK(vts_ptt[0] == 0x30);
+	CHECK(vts_ptt[1] == 0x05);
+	CHECK(vts_ptt[7] == 2);
+	Ref<InterDVDButton> audio;
+	audio.instantiate();
+	audio->set_action(InterDVDButton::ACTION_JUMP_MENU);
+	audio->set_target(5);
+	const PackedByteArray audio_menu = audio->resolve_command(InterDVDButton::DOMAIN_VMGM);
+	CHECK(audio_menu[0] == 0x30);
+	CHECK(audio_menu[1] == 0x06);
+	CHECK(audio_menu[5] == 0x45);
+	Ref<InterDVDButton> exit_btn;
+	exit_btn.instantiate();
+	exit_btn->set_action(InterDVDButton::ACTION_EXIT);
+	CHECK(exit_btn->resolve_command()[1] == 0x01);
+}
+
+TEST_CASE("[Modules][InterDVD] IFO writer uses cell duration as PGC playback time") {
+	const String root = TestUtils::get_temp_path("inter_dvd_pgc_duration");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	cell->set_duration_sec(8.0);
+	TypedArray<InterDVDCell> cells;
+	cells.push_back(cell);
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	title->set_cells(cells);
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	const int pgcit = 4096;
+	REQUIRE(vtsi.size() > pgcit + 16);
+	const uint32_t pgc_rel = (uint32_t(vtsi[pgcit + 12]) << 24) | (uint32_t(vtsi[pgcit + 13]) << 16) | (uint32_t(vtsi[pgcit + 14]) << 8) | uint32_t(vtsi[pgcit + 15]);
+	const int pgc_off = pgcit + int(pgc_rel);
+	REQUIRE(vtsi.size() > pgc_off + 8);
+	CHECK(vtsi[pgc_off + 4] == 0);
+	CHECK(vtsi[pgc_off + 5] == 0);
+	CHECK(vtsi[pgc_off + 6] != 2);
+	CHECK(vtsi[pgc_off + 6] == 0x08);
+	CHECK((vtsi[pgc_off + 7] & 0xC0) == 0xC0);
+	const int cell_pb = ((int(vtsi[pgc_off + 0xE8]) << 8) | int(vtsi[pgc_off + 0xE9]));
+	REQUIRE(vtsi.size() > pgc_off + cell_pb);
+	CHECK(vtsi[pgc_off + cell_pb] == 0x02);
+}
+
+TEST_CASE("[Modules][InterDVD] IFO writer muxes every cell as a chapter") {
+	const String root = TestUtils::get_temp_path("inter_dvd_two_cells");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	Ref<InterDVDCell> cell_a;
+	cell_a.instantiate();
+	cell_a->set_duration_sec(4.0);
+	Ref<InterDVDCell> cell_b;
+	cell_b.instantiate();
+	cell_b->set_duration_sec(6.0);
+	TypedArray<InterDVDCell> cells;
+	cells.push_back(cell_a);
+	cells.push_back(cell_b);
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	title->set_cells(cells);
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	project->set_titles(titles);
+
+	Ref<InterDVDButton> play_ch2;
+	play_ch2.instantiate();
+	play_ch2->set_action(InterDVDButton::ACTION_JUMP_CHAPTER);
+	play_ch2->set_target(2);
+	CHECK(play_ch2->resolve_command(InterDVDButton::DOMAIN_VTST)[1] == 0x05);
+	CHECK(play_ch2->resolve_command(InterDVDButton::DOMAIN_VTST)[7] == 2);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	REQUIRE(vtsi.size() >= 2048 + 24);
+	CHECK(vtsi[2048] == 0);
+	CHECK(vtsi[2049] == 1);
+	const uint32_t ptt_last = (uint32_t(vtsi[2048 + 4]) << 24) | (uint32_t(vtsi[2048 + 5]) << 16) | (uint32_t(vtsi[2048 + 6]) << 8) | uint32_t(vtsi[2048 + 7]);
+	CHECK(ptt_last == 19);
+	const uint32_t ptt0 = (uint32_t(vtsi[2048 + 8]) << 24) | (uint32_t(vtsi[2048 + 9]) << 16) | (uint32_t(vtsi[2048 + 10]) << 8) | uint32_t(vtsi[2048 + 11]);
+	CHECK(vtsi[2048 + int(ptt0) + 3] == 1);
+	CHECK(vtsi[2048 + int(ptt0) + 7] == 2);
+	const int pgcit = 4096;
+	const uint32_t pgc_rel = (uint32_t(vtsi[pgcit + 12]) << 24) | (uint32_t(vtsi[pgcit + 13]) << 16) | (uint32_t(vtsi[pgcit + 14]) << 8) | uint32_t(vtsi[pgcit + 15]);
+	const int pgc_off = pgcit + int(pgc_rel);
+	CHECK(vtsi[pgc_off + 2] == 2);
+	CHECK(vtsi[pgc_off + 3] == 2);
+}
+
+TEST_CASE("[Modules][InterDVD] IFO writer grows VTS tables so eight titles do not overlap") {
+	const String root = TestUtils::get_temp_path("inter_dvd_eight_titles");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	TypedArray<InterDVDPGC> titles;
+	for (int t = 0; t < 8; t++) {
+		TypedArray<InterDVDCell> cells;
+		const int n = (t == 0) ? 4 : ((t == 1) ? 6 : 1);
+		for (int c = 0; c < n; c++) {
+			Ref<InterDVDCell> cell;
+			cell.instantiate();
+			cell->set_duration_sec(2.0);
+			cells.push_back(cell);
+		}
+		Ref<InterDVDPGC> pgc;
+		pgc.instantiate();
+		pgc->set_cells(cells);
+		titles.push_back(pgc);
+	}
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	const uint32_t ptt_sec = (uint32_t(vtsi[0xC8]) << 24) | (uint32_t(vtsi[0xC9]) << 16) | (uint32_t(vtsi[0xCA]) << 8) | uint32_t(vtsi[0xCB]);
+	const uint32_t pgcit_sec = (uint32_t(vtsi[0xCC]) << 24) | (uint32_t(vtsi[0xCD]) << 16) | (uint32_t(vtsi[0xCE]) << 8) | uint32_t(vtsi[0xCF]);
+	const uint32_t cadt_sec = (uint32_t(vtsi[0xE0]) << 24) | (uint32_t(vtsi[0xE1]) << 16) | (uint32_t(vtsi[0xE2]) << 8) | uint32_t(vtsi[0xE3]);
+	const uint32_t admap_sec = (uint32_t(vtsi[0xE4]) << 24) | (uint32_t(vtsi[0xE5]) << 16) | (uint32_t(vtsi[0xE6]) << 8) | uint32_t(vtsi[0xE7]);
+	CHECK(ptt_sec == 1);
+	CHECK(pgcit_sec == 2);
+	CHECK(cadt_sec > pgcit_sec);
+	CHECK(admap_sec > cadt_sec);
+	const int pgcit = int(pgcit_sec) * 2048;
+	const uint32_t pgc_last = (uint32_t(vtsi[pgcit + 4]) << 24) | (uint32_t(vtsi[pgcit + 5]) << 16) | (uint32_t(vtsi[pgcit + 6]) << 8) | uint32_t(vtsi[pgcit + 7]);
+	CHECK(int(pgc_last) + 1 > 2048);
+	CHECK(pgcit + int(pgc_last) + 1 <= int(cadt_sec) * 2048);
+	CHECK(vtsi[pgcit] == 0);
+	CHECK(vtsi[pgcit + 1] == 8);
+	for (int i = 0; i < 8; i++) {
+		const uint32_t rel = (uint32_t(vtsi[pgcit + 12 + i * 8]) << 24) | (uint32_t(vtsi[pgcit + 13 + i * 8]) << 16) | (uint32_t(vtsi[pgcit + 14 + i * 8]) << 8) | uint32_t(vtsi[pgcit + 15 + i * 8]);
+		const int pgc_off = pgcit + int(rel);
+		REQUIRE(pgc_off + 4 < vtsi.size());
+		CHECK(vtsi[pgc_off + 3] >= 1);
+	}
+}
+
+TEST_CASE("[Modules][InterDVD] cell picture-in-picture and loop pad defaults") {
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	CHECK(cell->get_pip_source_path().is_empty());
+	CHECK(cell->get_pip_slot_path().is_empty());
+	CHECK(cell->get_loop_pad_sec() == 0.0);
+	cell->set_pip_source_path("D:/clips/preview.mp4");
+	cell->set_pip_slot_path(NodePath("VideoSlot"));
+	cell->set_loop_pad_sec(5.0);
+	cell->set_audio_path("D:/music/menu.wav");
+	CHECK(cell->get_pip_source_path() == "D:/clips/preview.mp4");
+	CHECK(cell->get_audio_path() == "D:/music/menu.wav");
+	CHECK(String(cell->get_pip_slot_path()) == "VideoSlot");
+	CHECK(cell->get_loop_pad_sec() == 5.0);
+}
+
+TEST_CASE("[Modules][InterDVD] add_title_from_video wires a cell source") {
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	const Ref<InterDVDPGC> title = project->add_title_from_video("D:/clips/intro.mkv");
+	REQUIRE(title.is_valid());
+	CHECK(project->get_titles().size() == 1);
+	REQUIRE(title->get_cells().size() == 1);
+	const Ref<InterDVDCell> cell = title->get_cells()[0];
+	CHECK(cell->get_source_path() == "D:/clips/intro.mkv");
+	CHECK(cell->get_display_name() == "intro");
+}
+
+TEST_CASE("[Modules][InterDVD] menu type 4-7 is written into VTSM PGCI_UT") {
+	const String root = TestUtils::get_temp_path("inter_dvd_audio_menu");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+	Ref<InterDVDMenu> menu;
+	menu.instantiate();
+	menu->set_buttons(buttons);
+	menu->set_menu_type(InterDVDMenu::MENU_AUDIO);
+	menu->set_still_time(10);
+	TypedArray<InterDVDMenu> menus;
+	menus.push_back(menu);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_menus(menus);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	const uint32_t vtsm_sec = (uint32_t(vtsi[0xD0]) << 24) | (uint32_t(vtsi[0xD1]) << 16) | (uint32_t(vtsi[0xD2]) << 8) | uint32_t(vtsi[0xD3]);
+	const int ut = int(vtsm_sec) * 2048;
+	REQUIRE(vtsi.size() > ut + 32);
+	CHECK(vtsi[ut + 24] == 0x85);
+	const int menu_pgc = ut + 32;
+	const uint16_t menu_cell_pb = (uint16_t(vtsi[menu_pgc + 0xE8]) << 8) | uint16_t(vtsi[menu_pgc + 0xE9]);
+	CHECK(vtsi[menu_pgc + menu_cell_pb + 2] == 10);
+}
+
+TEST_CASE("[Modules][InterDVD] menu still stays on the HLI cell when an exit cell follows") {
+	const String root = TestUtils::get_temp_path("inter_dvd_exit_cell_still");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+
+	Ref<InterDVDButton> back;
+	back.instantiate();
+	back->set_highlight(Rect2(40, 400, 180, 36));
+	back->set_action(InterDVDButton::ACTION_JUMP_CELL);
+	back->set_target(2);
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(back);
+
+	Ref<InterDVDCell> menu_cell;
+	menu_cell.instantiate();
+	menu_cell->set_duration_sec(4.0);
+	Ref<InterDVDCell> exit_cell;
+	exit_cell.instantiate();
+	exit_cell->set_duration_sec(0.4);
+	const PackedByteArray jump = InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_VTS_TT, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, 1, nullptr);
+	TypedArray<PackedByteArray> post;
+	post.push_back(jump);
+	exit_cell->set_post_commands(post);
+	TypedArray<InterDVDCell> cells;
+	cells.push_back(menu_cell);
+	cells.push_back(exit_cell);
+
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	title->set_cells(cells);
+	title->set_buttons(buttons);
+	title->set_still_time(255);
+	title->set_next_pgc(0);
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> buf = vts->get_buffer(int(vts->get_length()));
+	const int pgcit = 4096;
+	const uint32_t pgc_rel = (uint32_t(buf[pgcit + 12]) << 24) | (uint32_t(buf[pgcit + 13]) << 16) | (uint32_t(buf[pgcit + 14]) << 8) | uint32_t(buf[pgcit + 15]);
+	const int pgc_off = pgcit + int(pgc_rel);
+	const uint16_t cell_pb = (uint16_t(buf[pgc_off + 0xE8]) << 8) | uint16_t(buf[pgc_off + 0xE9]);
+	CHECK(buf[pgc_off + 3] == 2);
+	CHECK(buf[pgc_off + cell_pb + 2] == 255);
+	CHECK(buf[pgc_off + cell_pb + 24 + 2] == 0);
+	CHECK(back->resolve_command(InterDVDButton::DOMAIN_VTST)[1] == 0x07);
+	CHECK(back->resolve_command(InterDVDButton::DOMAIN_VTST)[7] == 2);
+	const uint32_t exit_first = (uint32_t(buf[pgc_off + cell_pb + 24 + 8]) << 24) | (uint32_t(buf[pgc_off + cell_pb + 24 + 9]) << 16) | (uint32_t(buf[pgc_off + cell_pb + 24 + 10]) << 8) | uint32_t(buf[pgc_off + cell_pb + 24 + 11]);
+	Ref<FileAccess> title_vob = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_1.VOB"), FileAccess::READ);
+	REQUIRE(title_vob.is_valid());
+	title_vob->seek(int64_t(exit_first) * InterDVDIfoWriter::SECTOR_SIZE);
+	const Vector<uint8_t> exit_nav = title_vob->get_buffer(InterDVDIfoWriter::SECTOR_SIZE);
+	REQUIRE(exit_nav.size() >= 158);
+	CHECK(exit_nav[157] == 0);
+}
+
+TEST_CASE("[Modules][InterDVD] sanitize_volume_id and ISO args") {
+	CHECK(InterDVDProject::sanitize_volume_id("My Disc!") == "MY_DISC");
+	CHECK(InterDVDProject::sanitize_volume_id("") == "BLAZIUM_DVD");
+	CHECK(InterDVDProject::language_be16("en") == 0x656E);
+	CHECK(InterDVDProject::language_be16("fr") == 0x6672);
+	const Vector<String> mkisofs = InterDVDIfoWriter::iso_tool_args("mkisofs", "My Disc!", "D:/work", "D:/out.iso");
+	CHECK(mkisofs.has("MY_DISC"));
+	CHECK(mkisofs.has("-V"));
+	const Vector<String> oscdimg = InterDVDIfoWriter::iso_tool_args("oscdimg.exe", "My Disc!", "D:/work", "D:/out.iso");
+	CHECK(oscdimg.has("-lMY_DISC"));
+}
+
+TEST_CASE("[Modules][InterDVD] IFO writer stores provider language and TXTDT") {
+	const String root = TestUtils::get_temp_path("inter_dvd_identity");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_provider_id("TEST PROVIDER");
+	project->set_disc_title("Hello Disc");
+	project->set_menu_language("fr");
+	project->set_audio_language("de");
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+	Ref<FileAccess> ifo = FileAccess::open(root.path_join("VIDEO_TS").path_join("VIDEO_TS.IFO"), FileAccess::READ);
+	REQUIRE(ifo.is_valid());
+	const Vector<uint8_t> vmg = ifo->get_buffer(int(ifo->get_length()));
+	REQUIRE(vmg.size() > 0x50);
+	CHECK(String::utf8((const char *)vmg.ptr() + 0x40, 13) == "TEST PROVIDER");
+	const uint32_t txtdt = (uint32_t(vmg[0xD4]) << 24) | (uint32_t(vmg[0xD5]) << 16) | (uint32_t(vmg[0xD6]) << 8) | uint32_t(vmg[0xD7]);
+	CHECK(txtdt != 0);
+	const int ut = 3 * 2048;
+	REQUIRE(vmg.size() > ut + 10);
+	CHECK(vmg[ut + 8] == 0x66);
+	CHECK(vmg[ut + 9] == 0x72);
+}
+
+TEST_CASE("[Modules][InterDVD] two muxed AC3 streams become two audio attrs") {
+	const String root = TestUtils::get_temp_path("inter_dvd_two_ac3");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+	const String encoded = TestUtils::get_temp_path("inter_dvd_two_ac3_src.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(encoded) == OK);
+	Ref<FileAccess> navf = FileAccess::open(encoded, FileAccess::READ);
+	REQUIRE(navf.is_valid());
+	const Vector<uint8_t> nav = navf->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	navf.unref();
+	auto private_pack = [](uint8_t p_id) {
+		Vector<uint8_t> sec;
+		sec.resize(InterDVDVobMux::SECTOR_SIZE);
+		sec.fill(0);
+		sec.write[0] = 0x00;
+		sec.write[1] = 0x00;
+		sec.write[2] = 0x01;
+		sec.write[3] = 0xBA;
+		sec.write[38] = 0x00;
+		sec.write[39] = 0x00;
+		sec.write[40] = 0x01;
+		sec.write[41] = 0xBD;
+		sec.write[46] = 0;
+		sec.write[47] = p_id;
+		return sec;
+	};
+	Ref<FileAccess> w = FileAccess::open(encoded, FileAccess::WRITE);
+	REQUIRE(w.is_valid());
+	w->store_buffer(nav.ptr(), nav.size());
+	const Vector<uint8_t> a0 = private_pack(0x80);
+	const Vector<uint8_t> a1 = private_pack(0x81);
+	w->store_buffer(a0.ptr(), a0.size());
+	w->store_buffer(a1.ptr(), a1.size());
+	w.unref();
+	CHECK(InterDVDVobMux::count_ac3_streams(encoded) == 2);
+	CHECK(InterDVDVobMux::count_spu_streams(encoded) == 0);
+
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	cell->set_encoded_path(encoded);
+	TypedArray<InterDVDCell> cells;
+	cells.push_back(cell);
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	title->set_cells(cells);
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	REQUIRE(vts.is_valid());
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	CHECK(vtsi[0x102] == 0);
+	CHECK(vtsi[0x103] == 2);
+	CHECK(vtsi[0x254] == 0);
+	CHECK(vtsi[0x255] == 0);
+	const int pgcit = 4096;
+	const uint32_t pgc_rel = (uint32_t(vtsi[pgcit + 12]) << 24) | (uint32_t(vtsi[pgcit + 13]) << 16) | (uint32_t(vtsi[pgcit + 14]) << 8) | uint32_t(vtsi[pgcit + 15]);
+	const int pgc_off = pgcit + int(pgc_rel);
+	CHECK(vtsi[pgc_off + 0x0C] == 0x80);
+	CHECK(vtsi[pgc_off + 0x0D] == 0x80);
+	CHECK(vtsi[pgc_off + 0x1C] == 0);
+}
+
+TEST_CASE("[Modules][InterDVD] SPU attr is written only when SPU PES exists") {
+	const String encoded = TestUtils::get_temp_path("inter_dvd_spu_src.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(encoded) == OK);
+	Ref<FileAccess> navf = FileAccess::open(encoded, FileAccess::READ);
+	const Vector<uint8_t> nav = navf->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	navf.unref();
+	Vector<uint8_t> spu;
+	spu.resize(InterDVDVobMux::SECTOR_SIZE);
+	spu.fill(0);
+	spu.write[0] = 0x00;
+	spu.write[1] = 0x00;
+	spu.write[2] = 0x01;
+	spu.write[3] = 0xBA;
+	spu.write[38] = 0x00;
+	spu.write[39] = 0x00;
+	spu.write[40] = 0x01;
+	spu.write[41] = 0xBD;
+	spu.write[46] = 0;
+	spu.write[47] = 0x20;
+	Ref<FileAccess> w = FileAccess::open(encoded, FileAccess::WRITE);
+	w->store_buffer(nav.ptr(), nav.size());
+	w->store_buffer(spu.ptr(), spu.size());
+	w.unref();
+	CHECK(InterDVDVobMux::contains_spu(encoded));
+	CHECK(InterDVDVobMux::count_spu_streams(encoded) == 1);
+
+	const String root = TestUtils::get_temp_path("inter_dvd_spu_ifo");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	cell->set_encoded_path(encoded);
+	TypedArray<InterDVDCell> cells;
+	cells.push_back(cell);
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	title->set_cells(cells);
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_titles(titles);
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	CHECK(vtsi[0x255] == 1);
+	const int pgcit = 4096;
+	const uint32_t pgc_rel = (uint32_t(vtsi[pgcit + 12]) << 24) | (uint32_t(vtsi[pgcit + 13]) << 16) | (uint32_t(vtsi[pgcit + 14]) << 8) | uint32_t(vtsi[pgcit + 15]);
+	const int pgc_off = pgcit + int(pgc_rel);
+	CHECK(vtsi[pgc_off + 0x1C] == 0x80);
+}
+
+TEST_CASE("[Modules][InterDVD] VTSM IFO has Root SRP when a Root menu is authored") {
+	const String root = TestUtils::get_temp_path("inter_dvd_vtsm_root");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+	Ref<InterDVDMenu> menu;
+	menu.instantiate();
+	menu->set_menu_type(InterDVDMenu::MENU_ROOT);
+	menu->set_buttons(buttons);
+	TypedArray<InterDVDMenu> menus;
+	menus.push_back(menu);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	project->set_menus(menus);
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err) == OK);
+	Ref<FileAccess> vts = FileAccess::open(root.path_join("VIDEO_TS").path_join("VTS_01_0.IFO"), FileAccess::READ);
+	const Vector<uint8_t> vtsi = vts->get_buffer(int(vts->get_length()));
+	const uint32_t vtsm_sec = (uint32_t(vtsi[0xD0]) << 24) | (uint32_t(vtsi[0xD1]) << 16) | (uint32_t(vtsi[0xD2]) << 8) | uint32_t(vtsi[0xD3]);
+	const int ut = int(vtsm_sec) * 2048;
+	REQUIRE(vtsi.size() > ut + 25);
+	CHECK(vtsi[ut + 24] == 0x83);
+}

--- a/modules/inter_dvd/tests/test_inter_dvd_instruction.h
+++ b/modules/inter_dvd/tests/test_inter_dvd_instruction.h
@@ -1,0 +1,131 @@
+/**************************************************************************/
+/*  test_inter_dvd_instruction.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/inter_dvd/machine/inter_dvd_instruction.h"
+#include "modules/inter_dvd/machine/inter_dvd_machine.h"
+#include "tests/test_macros.h"
+
+TEST_CASE("[Modules][InterDVD] groups 0-6 encode 8-byte commands") {
+	for (int g = 0; g <= 6; g++) {
+		String err;
+		const PackedByteArray bytes = InterDVDInstruction::encode(InterDVDInstruction::Group(g), InterDVDInstruction::SET_ASSIGN, InterDVDInstruction::CMP_EQ, 1, false, 4, false, false, InterDVDInstruction::LINK_NONE, InterDVDInstruction::DOMAIN_FPC, InterDVDInstruction::DOMAIN_FPC, 0, &err);
+		CHECK(bytes.size() == InterDVDMachine::INSTRUCTION_SIZE);
+		CHECK((bytes[0] >> 5) == g);
+		CHECK(((bytes[1] >> 5) & 0x07) == InterDVDInstruction::CMP_EQ);
+	}
+	CHECK(InterDVDInstruction::encode_nop().size() == 8);
+	CHECK(InterDVDInstruction::encode_nop()[0] == 0);
+}
+
+TEST_CASE("[Modules][InterDVD] set-ops and conditionals") {
+	const PackedByteArray set = InterDVDInstruction::encode_set(InterDVDInstruction::SET_ADD, 3, 10, false, false, nullptr);
+	CHECK(set.size() == 8);
+	CHECK((set[0] & 0x1F) == InterDVDInstruction::SET_ADD);
+	CHECK(set[3] == 3);
+	CHECK(set[5] == 10);
+
+	String err;
+	const PackedByteArray cmp = InterDVDInstruction::encode(InterDVDInstruction::GROUP_CMP_SET_LINK, InterDVDInstruction::SET_ASSIGN, InterDVDInstruction::CMP_GT, 0, false, InterDVDInstruction::SPRM_HL_BTNN, true, true, InterDVDInstruction::LINK_PGCN, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VMG, 2, &err);
+	CHECK(cmp.size() == 8);
+	CHECK(((cmp[1] >> 5) & 0x07) == InterDVDInstruction::CMP_GT);
+	CHECK((cmp[1] & 0x08) != 0);
+	CHECK((cmp[1] & 0x04) != 0);
+}
+
+TEST_CASE("[Modules][InterDVD] Link Jump Call RSM and illegal transfers") {
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::LINK_PGCN, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VMG, 1, nullptr).size() == 8);
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_TT, InterDVDInstruction::DOMAIN_FPC, InterDVDInstruction::DOMAIN_VTST, 1, nullptr).size() == 8);
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::CALL_SS, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VMG, 1, nullptr).size() == 8);
+	CHECK(InterDVDInstruction::encode_rsm(InterDVDInstruction::DOMAIN_VMG, nullptr).size() == 8);
+
+	String err;
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::LINK_PGCN, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VTST, 1, &err).is_empty());
+	CHECK(err.contains("Link"));
+	err = String();
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_VTS_TT, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, 2, &err).size() == 8);
+	err = String();
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_TT, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, 2, &err).is_empty());
+	CHECK(err.contains("JumpTT"));
+	err = String();
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::CALL_SS, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VTSM, 1, &err).is_empty());
+	CHECK(err.contains("VTST"));
+	err = String();
+	CHECK(InterDVDInstruction::encode_rsm(InterDVDInstruction::DOMAIN_VTST, &err).is_empty());
+	CHECK(err.contains("RSM"));
+	err = String();
+	CHECK(InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_SS, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VMG, 2, &err).is_empty());
+	CHECK(err.contains("JumpSS"));
+	const PackedByteArray jump_ss = InterDVDInstruction::encode_link(InterDVDInstruction::JUMP_SS, InterDVDInstruction::DOMAIN_VMG, InterDVDInstruction::DOMAIN_VMG, 5, nullptr);
+	REQUIRE(jump_ss.size() == 8);
+	CHECK(jump_ss[0] == 0x30);
+	CHECK(jump_ss[1] == 0x06);
+	CHECK(jump_ss[5] == 0x45);
+	const PackedByteArray link_ptt = InterDVDInstruction::encode_link(InterDVDInstruction::LINK_PTT, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, 2, nullptr);
+	REQUIRE(link_ptt.size() == 8);
+	CHECK(link_ptt[0] == 0x20);
+	CHECK(link_ptt[1] == 0x05);
+	CHECK(link_ptt[7] == 2);
+	const PackedByteArray link_cn = InterDVDInstruction::encode_link(InterDVDInstruction::LINK_CN, InterDVDInstruction::DOMAIN_VTST, InterDVDInstruction::DOMAIN_VTST, 3, nullptr);
+	CHECK(link_cn[0] == 0x20);
+	CHECK(link_cn[1] == 0x07);
+	CHECK(link_cn[7] == 3);
+}
+
+TEST_CASE("[Modules][InterDVD] SetSTN Exit Goto Break and SPRM helpers") {
+	const PackedByteArray stn = InterDVDInstruction::encode_set_stn(1, 2, true, 1, nullptr);
+	REQUIRE(stn.size() == 8);
+	CHECK(stn[0] == 0x51);
+	CHECK(stn[4] == 0x81);
+	CHECK(stn[5] == 0xC2);
+	CHECK(stn[6] == 0x81);
+	const PackedByteArray hl = InterDVDInstruction::encode_set_hl_btnn(4, nullptr);
+	CHECK(hl[0] == 0x46);
+	CHECK(hl[5] == 4);
+	CHECK(InterDVDInstruction::encode_set_hl_btnn(0, nullptr).is_empty());
+	const PackedByteArray exit_cmd = InterDVDInstruction::encode_exit();
+	CHECK(exit_cmd[0] == 0x30);
+	CHECK(exit_cmd[1] == 0x01);
+	const PackedByteArray go = InterDVDInstruction::encode_goto(3, nullptr);
+	CHECK(go[1] == 0x01);
+	CHECK(go[7] == 3);
+	CHECK(InterDVDInstruction::encode_break()[1] == 0x02);
+	const PackedByteArray timer = InterDVDInstruction::encode_set_nvtmr(12, 1, nullptr);
+	CHECK(timer[0] == 0x42);
+	CHECK(timer[5] == 12);
+	const PackedByteArray md = InterDVDInstruction::encode_set_gprmmd(2, 7, true, nullptr);
+	CHECK(md[0] == 0x47);
+	CHECK(md[4] == 1);
+	CHECK(md[5] == 2);
+	CHECK(int(InterDVDInstruction::SPRM_TT_N) == 4);
+	CHECK(int(InterDVDInstruction::SPRM_PTT_N) == 7);
+	CHECK(int(InterDVDInstruction::SPRM_NVTMR) == 9);
+	CHECK(int(InterDVDInstruction::SPRM_REGION) == 20);
+}

--- a/modules/inter_dvd/tests/test_inter_dvd_settings.h
+++ b/modules/inter_dvd/tests/test_inter_dvd_settings.h
@@ -1,0 +1,183 @@
+/**************************************************************************/
+/*  test_inter_dvd_settings.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
+#include "core/os/os.h"
+#include "modules/inter_dvd/author/inter_dvd_ifo_writer.h"
+#include "modules/inter_dvd/author/inter_dvd_project.h"
+#include "scene/2d/sprite_2d.h"
+#include "scene/gui/control.h"
+#include "scene/resources/packed_scene.h"
+#include "scene/resources/placeholder_textures.h"
+#include "tests/test_macros.h"
+#include "tests/test_utils.h"
+
+#ifdef TOOLS_ENABLED
+#include "modules/inter_dvd/editor/export/windows_inter_dvd_export_platform.h"
+#include "modules/inter_dvd/editor/inter_dvd_scene_baker.h"
+#endif
+
+TEST_CASE("[Modules][InterDVD] ProjectSettings defaults keep IFO region byte") {
+	CHECK(InterDVDSettings::setting_int("blazium/inter_dvd/default_region_mask", 1) == 1);
+	CHECK(InterDVDSettings::title_safe_bottom() == 432);
+	CHECK(InterDVDSettings::gop_size() == 15);
+	CHECK(InterDVDSettings::ac3_bitrate_k() == 192);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	CHECK(project->get_region_mask() == 1);
+	CHECK(project->get_parental_level() == 1);
+	CHECK(project->get_title_safe_bottom() == 432);
+}
+
+TEST_CASE("[Modules][InterDVD] progress reports total greater than zero") {
+	const String root = TestUtils::get_temp_path("inter_dvd_progress");
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	da->make_dir_recursive(root);
+	Ref<InterDVDProject> project;
+	project.instantiate();
+	Ref<InterDVDPGC> title;
+	title.instantiate();
+	TypedArray<InterDVDPGC> titles;
+	titles.push_back(title);
+	project->set_titles(titles);
+	Ref<InterDVDExportProgress> progress;
+	progress.instantiate();
+	String err;
+	CHECK(InterDVDIfoWriter::write_video_ts(root, project, true, "", &err, true, progress) == OK);
+	CHECK(progress->get_total() > 0);
+	CHECK(progress->get_step() >= 1);
+}
+
+TEST_CASE("[SceneTree][Modules][InterDVD] sync_highlight_from_scene uses Control and Sprite2D rects") {
+	Control *root = memnew(Control);
+	Control *play = memnew(Control);
+	play->set_name("Play");
+	play->set_position(Vector2(80, 200));
+	play->set_size(Vector2(240, 60));
+	root->add_child(play);
+
+	Ref<InterDVDButton> btn;
+	btn.instantiate();
+	btn->set_control_path(NodePath("Play"));
+	btn->sync_highlight_from_scene(root, Rect2(), 432);
+	CHECK(btn->get_highlight().position.x == 80);
+	CHECK(btn->get_highlight().position.y == 200);
+	CHECK(btn->get_highlight().size.x == 240);
+	CHECK(btn->get_highlight().size.y == 60);
+
+	Sprite2D *sprite = memnew(Sprite2D);
+	sprite->set_name("Icon");
+	sprite->set_centered(false);
+	sprite->set_offset(Vector2());
+	sprite->set_position(Vector2(10, 20));
+	Ref<PlaceholderTexture2D> tex;
+	tex.instantiate();
+	tex->set_size(Size2(32, 16));
+	sprite->set_texture(tex);
+	root->add_child(sprite);
+
+	Ref<InterDVDButton> spr_btn;
+	spr_btn.instantiate();
+	spr_btn->set_control_path(NodePath("Icon"));
+	spr_btn->sync_highlight_from_scene(root, Rect2(), 432);
+	CHECK(spr_btn->get_highlight().position.x == 10);
+	CHECK(spr_btn->get_highlight().position.y == 20);
+	CHECK(spr_btn->get_highlight().size.x == 32);
+	CHECK(spr_btn->get_highlight().size.y == 16);
+
+	Ref<InterDVDButton> missing;
+	missing.instantiate();
+	missing->set_control_path(NodePath("Gone"));
+	missing->sync_highlight_from_scene(root, Rect2(40, 50, 60, 20), 432);
+	CHECK(missing->get_highlight().position.x == 40);
+	CHECK(missing->get_highlight().size.x == 60);
+
+	Ref<InterDVDButton> unset;
+	unset.instantiate();
+	unset->set_control_path(NodePath("Gone"));
+	unset->sync_highlight_from_scene(root);
+	CHECK(unset->get_highlight().size.x == 0);
+	CHECK(unset->get_highlight().size.y == 0);
+
+	memdelete(root);
+}
+
+#ifdef TOOLS_ENABLED
+TEST_CASE("[Modules][InterDVD] export preset lists language and provider options") {
+	EditorExportPlatformWindowsInterDVD plat;
+	List<EditorExportPlatform::ExportOption> opts;
+	plat.get_export_options(&opts);
+	bool audio = false;
+	bool sub = false;
+	bool provider = false;
+	for (const EditorExportPlatform::ExportOption &opt : opts) {
+		if (opt.option.name == "inter_dvd/audio_language") {
+			audio = true;
+		} else if (opt.option.name == "inter_dvd/subtitle_language") {
+			sub = true;
+		} else if (opt.option.name == "inter_dvd/provider_id") {
+			provider = true;
+		}
+	}
+	CHECK(audio);
+	CHECK(sub);
+	CHECK(provider);
+}
+
+#ifndef _3D_DISABLED
+TEST_CASE("[Modules][InterDVD] dummy bake rejects packed Node3D without ffmpeg") {
+	const String path = TestUtils::get_temp_path("inter_dvd_node3d.tscn");
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+	REQUIRE(f.is_valid());
+	f->store_string("[gd_scene format=3]\n\n[node name=\"Root\" type=\"Node\"]\n\n[node name=\"Mesh\" type=\"MeshInstance3D\" parent=\".\"]\n");
+	f->close();
+
+	Ref<PackedScene> packed = ResourceLoader::load(path, "PackedScene");
+	REQUIRE(packed.is_valid());
+
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	cell->set_packed_scene(packed);
+	cell->set_duration_sec(1.0);
+	String err;
+	const Error code = InterDVDSceneBaker::bake_cell(cell, String(), false, &err);
+	if (OS::get_singleton()->get_current_rendering_method() == "dummy") {
+		CHECK(code == ERR_UNAVAILABLE);
+		CHECK(err.contains("3D"));
+	} else {
+		CHECK(code != OK);
+	}
+}
+#endif
+#endif

--- a/modules/inter_dvd/tests/test_inter_dvd_vob_mux.h
+++ b/modules/inter_dvd/tests/test_inter_dvd_vob_mux.h
@@ -1,0 +1,278 @@
+/**************************************************************************/
+/*  test_inter_dvd_vob_mux.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/file_access.h"
+#include "modules/inter_dvd/author/inter_dvd_project.h"
+#include "modules/inter_dvd/author/inter_dvd_vob_mux.h"
+#include "tests/test_macros.h"
+#include "tests/test_utils.h"
+
+TEST_CASE("[Modules][InterDVD] finalize rewrites empty ffmpeg NAV vobu_ea") {
+	const String path = TestUtils::get_temp_path("inter_dvd_rewrite_nav.vob");
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+	REQUIRE(f.is_valid());
+	Vector<uint8_t> nav;
+	nav.resize(InterDVDVobMux::SECTOR_SIZE);
+	nav.fill(0);
+	nav.write[0] = 0x00;
+	nav.write[1] = 0x00;
+	nav.write[2] = 0x01;
+	nav.write[3] = 0xBA;
+	nav.write[38] = 0x00;
+	nav.write[39] = 0x00;
+	nav.write[40] = 0x01;
+	nav.write[41] = 0xBF;
+	nav.write[57] = 0x00;
+	nav.write[58] = 0x01;
+	nav.write[59] = 0x5F;
+	nav.write[60] = 0x90;
+	nav.write[61] = 0x00;
+	nav.write[62] = 0x02;
+	nav.write[63] = 0xBF;
+	nav.write[64] = 0x20;
+	f->store_buffer(nav.ptr(), nav.size());
+	Vector<uint8_t> video;
+	video.resize(InterDVDVobMux::SECTOR_SIZE);
+	video.fill(0);
+	video.write[0] = 0x00;
+	video.write[1] = 0x00;
+	video.write[2] = 0x01;
+	video.write[3] = 0xBA;
+	video.write[38] = 0x00;
+	video.write[39] = 0x00;
+	video.write[40] = 0x01;
+	video.write[41] = 0xE0;
+	f->store_buffer(video.ptr(), video.size());
+	f.unref();
+
+	CHECK(InterDVDVobMux::finalize_title_vob(path) == OK);
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	const Vector<uint8_t> out = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(out.size() >= 1043);
+	CHECK(out[1039] == 0);
+	CHECK(out[1040] == 0);
+	CHECK(out[1041] == 0);
+	CHECK(out[1042] == 1);
+	CHECK(out[57] == 0);
+	CHECK(out[58] == 1);
+	CHECK(out[59] == 0x5F);
+	CHECK(out[60] == 0x90);
+	CHECK(out[69] == 0);
+	CHECK(out[70] == 0);
+	CHECK(out[71] == 1);
+	CHECK((out[72] & 0xC0) == 0xC0);
+	CHECK(out[4] == 0x44);
+
+	CHECK(out[1031 + 0xEA + 80] == 0x3F);
+	CHECK(out[1031 + 0xEA + 81] == 0xFF);
+	CHECK(out[1031 + 0xEA + 82] == 0xFF);
+	CHECK(out[1031 + 0xEA + 83] == 0xFF);
+	CHECK(out[1031 + 0xEA + 168] == 0x3F);
+	CHECK(out[1031 + 0xEA + 169] == 0xFF);
+}
+
+TEST_CASE("[Modules][InterDVD] finalize injects NAV with nonzero vobu_ea") {
+	const String path = TestUtils::get_temp_path("inter_dvd_inject_nav.vob");
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+	REQUIRE(f.is_valid());
+	Vector<uint8_t> sec;
+	sec.resize(InterDVDVobMux::SECTOR_SIZE);
+	sec.fill(0);
+	sec.write[0] = 0x00;
+	sec.write[1] = 0x00;
+	sec.write[2] = 0x01;
+	sec.write[3] = 0xBA;
+	sec.write[38] = 0x00;
+	sec.write[39] = 0x00;
+	sec.write[40] = 0x01;
+	sec.write[41] = 0xE0;
+	f->store_buffer(sec.ptr(), sec.size());
+	f.unref();
+
+	CHECK(InterDVDVobMux::finalize_title_vob(path) == OK);
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	CHECK(in->get_length() == InterDVDVobMux::SECTOR_SIZE * 2);
+	const Vector<uint8_t> nav = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 1043);
+	CHECK(nav[41] == 0xBF);
+	CHECK(nav[1039] == 0);
+	CHECK(nav[1040] == 0);
+	CHECK(nav[1041] == 0);
+	CHECK(nav[1042] == 1);
+}
+
+TEST_CASE("[Modules][InterDVD] apply_menu_buttons writes PCI HLI") {
+	const String path = TestUtils::get_temp_path("inter_dvd_menu_button.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(path) == OK);
+
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+	CHECK(InterDVDVobMux::apply_menu_buttons(path, buttons) == OK);
+
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	const Vector<uint8_t> nav = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 210);
+	CHECK(nav[142] == 1);
+	CHECK(nav[155] == 0x10);
+	CHECK(nav[156] == 0x00);
+	CHECK(nav[157] == 1);
+	CHECK(nav[158] == 1);
+	CHECK(nav[159] == 0);
+	CHECK(nav[160] == 0);
+	CHECK(nav[147] == 0);
+	CHECK(nav[148] == 1);
+	CHECK(nav[149] == 0x5F);
+	CHECK(nav[150] == 0x90);
+	CHECK(nav[197] == 0x30);
+	CHECK(nav[198] == 0x02);
+	CHECK(nav[202] == 1);
+}
+
+TEST_CASE("[Modules][InterDVD] apply_menu_buttons can hold HLI past cell end for infinite still") {
+	const String path = TestUtils::get_temp_path("inter_dvd_menu_hli_hold.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(path) == OK);
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+	CHECK(InterDVDVobMux::apply_menu_buttons(path, buttons, false, 0, 0, 0x1000, 0x3FFFFFFF) == OK);
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	const Vector<uint8_t> nav = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 151);
+	CHECK(nav[147] == 0x3F);
+	CHECK(nav[148] == 0xFF);
+	CHECK(nav[149] == 0xFF);
+	CHECK(nav[150] == 0xFF);
+}
+
+TEST_CASE("[Modules][InterDVD] apply_menu_buttons marks later NAV as same HLI") {
+	const String path = TestUtils::get_temp_path("inter_dvd_hli_same.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(path) == OK);
+	Ref<FileAccess> first = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(first.is_valid());
+	const Vector<uint8_t> nav0 = first->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	first.unref();
+	Ref<FileAccess> two = FileAccess::open(path, FileAccess::WRITE);
+	REQUIRE(two.is_valid());
+	two->store_buffer(nav0.ptr(), nav0.size());
+	two->store_buffer(nav0.ptr(), nav0.size());
+	two.unref();
+
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+	CHECK(InterDVDVobMux::apply_menu_buttons(path, buttons) == OK);
+
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	const Vector<uint8_t> a = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	const Vector<uint8_t> b = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(a.size() >= 143);
+	REQUIRE(b.size() >= 143);
+	CHECK(a[142] == 1);
+	CHECK(b[142] == 2);
+	CHECK(b[157] == 1);
+}
+
+TEST_CASE("[Modules][InterDVD] HLI auto-action and adjacent overrides") {
+	const String path = TestUtils::get_temp_path("inter_dvd_hli_chrome.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(path) == OK);
+
+	Ref<InterDVDButton> play;
+	play.instantiate();
+	play->set_highlight(Rect2(80, 200, 240, 60));
+	play->set_auto_action(true);
+	play->set_adjacent_up(3);
+	play->set_adjacent_down(4);
+	Ref<InterDVDButton> other;
+	other.instantiate();
+	other->set_highlight(Rect2(80, 300, 240, 60));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(play);
+	buttons.push_back(other);
+	CHECK(InterDVDVobMux::apply_menu_buttons(path, buttons) == OK);
+
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	const Vector<uint8_t> nav = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 200);
+	CHECK((nav[190] & 0x40) != 0);
+	CHECK((nav[193] & 0x3F) == 3);
+}
+
+TEST_CASE("[Modules][InterDVD] HLI packs per-button color groups") {
+	const String path = TestUtils::get_temp_path("inter_dvd_hli_color_group.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(path) == OK);
+	Ref<InterDVDButton> one;
+	one.instantiate();
+	one->set_highlight(Rect2(80, 200, 240, 60));
+	one->set_color_group(1);
+	one->set_select_color(Color(1, 0.92, 0.2));
+	Ref<InterDVDButton> two;
+	two.instantiate();
+	two->set_highlight(Rect2(80, 300, 240, 60));
+	two->set_color_group(2);
+	two->set_select_color(Color(1, 1, 1));
+	TypedArray<InterDVDButton> buttons;
+	buttons.push_back(one);
+	buttons.push_back(two);
+	CHECK(InterDVDVobMux::apply_menu_buttons(path, buttons) == OK);
+	Ref<FileAccess> in = FileAccess::open(path, FileAccess::READ);
+	REQUIRE(in.is_valid());
+	const Vector<uint8_t> nav = in->get_buffer(InterDVDVobMux::SECTOR_SIZE);
+	REQUIRE(nav.size() >= 220);
+	CHECK(nav[155] == 0x10);
+	CHECK((nav[187] >> 6) == 1);
+	CHECK((nav[205] >> 6) == 2);
+}
+
+TEST_CASE("[Modules][InterDVD] mux_cell rejects empty dummy when dummy disallowed") {
+	const String dummy = TestUtils::get_temp_path("inter_dvd_dummy_src.vob");
+	CHECK(InterDVDVobMux::write_dummy_vob(dummy) == OK);
+	CHECK_FALSE(InterDVDVobMux::contains_mpeg_video(dummy));
+	Ref<InterDVDCell> cell;
+	cell.instantiate();
+	cell->set_source_path(dummy);
+	const String out = TestUtils::get_temp_path("inter_dvd_reject_empty.vob");
+	String err;
+	CHECK(InterDVDVobMux::mux_cell(cell, out, String(), false, &err, false) != OK);
+	CHECK_FALSE(err.is_empty());
+}


### PR DESCRIPTION
## Summary
- Adds the InterDVD module: IFO/VOB writer, scene bake, PCI/HLI menus, and Windows Interactive DVD export.
- Documents `blazium/inter_dvd/*` ProjectSettings used by new projects and the exporter.
- Validated on the combined feature branch (editor build, `--doctool`, pre-commit, InterDVD tests) before this split.

## Test plan
- [x] `python -m SCons platform=windows target=editor tests=yes arch=x86_64 -j8`
- [x] `bin\blazium.windows.editor.tests.x86_64.console.exe --headless --test --test-case=*[InterDVD]*`
- [x] Export a small Interactive DVD project and confirm VIDEO_TS writes
- [x] Confirm no livewallpaper / screensaver / device_autorun files are in this PR