### PR TITLE
Add device autorun and export/MCP consumer fixes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1093,6 +1093,7 @@ void EditorNode::_fs_changed() {
 	Error err = OK;
 	// It's important to wait for the first scan to finish; otherwise, scripts or resources might not be imported.
 	if (!export_defer.preset.is_empty() && !EditorFileSystem::get_singleton()->is_scanning()) {
+		EditorExport::get_singleton()->update_export_presets();
 		String preset_name = export_defer.preset;
 		// Ensures export_project does not loop infinitely, because notifications may
 		// come during the export.

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -132,6 +132,9 @@ void EditorExport::add_export_platform(const Ref<EditorExportPlatform> &p_platfo
 
 	should_update_presets = true;
 	should_reload_presets = true;
+	if (is_inside_tree()) {
+		update_export_presets();
+	}
 }
 
 void EditorExport::remove_export_platform(const Ref<EditorExportPlatform> &p_platform) {

--- a/modules/assettags/asset_tag_runtime.cpp
+++ b/modules/assettags/asset_tag_runtime.cpp
@@ -183,6 +183,9 @@ Error AssetTagRuntime::bake_tags_for_export(const String &p_export_output_dir) {
 	if (!AssetTagStorage::load_index(index)) {
 		return ERR_CANT_OPEN;
 	}
+	if (index.is_empty()) {
+		return OK;
+	}
 	Ref<DirAccess> dir = _open_export_dir(p_export_output_dir);
 	if (dir.is_null()) {
 		return ERR_CANT_CREATE;

--- a/modules/device_autorun/SCsub
+++ b/modules/device_autorun/SCsub
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_device_autorun = env_modules.Clone()
+
+env_device_autorun.add_source_files(env.modules_sources, "*.cpp")
+env_device_autorun.add_source_files(env.modules_sources, "editor/*.cpp")
+
+if env["tests"]:
+    env_device_autorun.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_device_autorun.add_source_files(env.modules_sources, "tests/*.cpp")
+    if env["disable_exceptions"]:
+        env_device_autorun.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])

--- a/modules/device_autorun/autorun_inf.cpp
+++ b/modules/device_autorun/autorun_inf.cpp
@@ -1,0 +1,97 @@
+/**************************************************************************/
+/*  autorun_inf.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "autorun_inf.h"
+
+#include "core/object/class_db.h"
+#include "core/variant/variant.h"
+
+void AutorunInf::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_label", "label"), &AutorunInf::set_label);
+	ClassDB::bind_method(D_METHOD("get_label"), &AutorunInf::get_label);
+	ClassDB::bind_method(D_METHOD("set_icon", "icon"), &AutorunInf::set_icon);
+	ClassDB::bind_method(D_METHOD("get_icon"), &AutorunInf::get_icon);
+	ClassDB::bind_method(D_METHOD("set_open", "open"), &AutorunInf::set_open);
+	ClassDB::bind_method(D_METHOD("get_open"), &AutorunInf::get_open);
+	ClassDB::bind_method(D_METHOD("set_action", "action"), &AutorunInf::set_action);
+	ClassDB::bind_method(D_METHOD("get_action"), &AutorunInf::get_action);
+	ClassDB::bind_method(D_METHOD("set_shell", "shell"), &AutorunInf::set_shell);
+	ClassDB::bind_method(D_METHOD("get_shell"), &AutorunInf::get_shell);
+	ClassDB::bind_method(D_METHOD("set_shell_verbs", "verbs"), &AutorunInf::set_shell_verbs);
+	ClassDB::bind_method(D_METHOD("get_shell_verbs"), &AutorunInf::get_shell_verbs);
+	ClassDB::bind_method(D_METHOD("build"), &AutorunInf::build);
+	ClassDB::bind_static_method("AutorunInf", D_METHOD("usb_note_text"), &AutorunInf::usb_note_text);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "icon"), "set_icon", "get_icon");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "open"), "set_open", "get_open");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "action"), "set_action", "get_action");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "shell"), "set_shell", "get_shell");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "shell_verbs"), "set_shell_verbs", "get_shell_verbs");
+}
+
+String AutorunInf::build() const {
+	String text = "[autorun]\r\n";
+	if (!open.is_empty()) {
+		text += "open=" + open + "\r\n";
+	}
+	if (!icon.is_empty()) {
+		text += "icon=" + icon + "\r\n";
+	}
+	if (!action.is_empty()) {
+		text += "action=" + action + "\r\n";
+	}
+	if (!label.is_empty()) {
+		text += "label=" + label + "\r\n";
+	}
+	if (!shell.is_empty()) {
+		text += "shell=" + shell + "\r\n";
+	}
+
+	const Array keys = shell_verbs.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		const String verb = String(keys[i]);
+		const String command = String(shell_verbs.get(verb, String()));
+		if (verb.is_empty() || command.is_empty()) {
+			continue;
+		}
+		text += "shell\\" + verb + "=" + verb + "\r\n";
+		text += "shell\\" + verb + "\\command=" + command + "\r\n";
+	}
+	return text;
+}
+
+String AutorunInf::usb_note_text() {
+	return String(
+			"This disc/drive was packaged with autorun.inf.\r\n"
+			"\r\n"
+			"CD/DVD: Windows may still honor OPEN= and launch the listed program.\r\n"
+			"USB flash drives on Windows 7 and later ignore OPEN= and ACTION=.\r\n"
+			"LABEL= and ICON= still apply. Start the program from the drive root in Explorer.\r\n");
+}

--- a/modules/device_autorun/autorun_inf.h
+++ b/modules/device_autorun/autorun_inf.h
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  autorun_inf.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+
+class AutorunInf : public RefCounted {
+	GDCLASS(AutorunInf, RefCounted);
+
+	String label;
+	String icon;
+	String open;
+	String action;
+	String shell;
+	Dictionary shell_verbs;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_label(const String &p_label) { label = p_label; }
+	String get_label() const { return label; }
+	void set_icon(const String &p_icon) { icon = p_icon; }
+	String get_icon() const { return icon; }
+	void set_open(const String &p_open) { open = p_open; }
+	String get_open() const { return open; }
+	void set_action(const String &p_action) { action = p_action; }
+	String get_action() const { return action; }
+	void set_shell(const String &p_shell) { shell = p_shell; }
+	String get_shell() const { return shell; }
+	void set_shell_verbs(const Dictionary &p_verbs) { shell_verbs = p_verbs; }
+	Dictionary get_shell_verbs() const { return shell_verbs; }
+
+	String build() const;
+	static String usb_note_text();
+};

--- a/modules/device_autorun/config.py
+++ b/modules/device_autorun/config.py
@@ -1,0 +1,18 @@
+def can_build(env, platform):
+    return env.editor_build
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "AutorunInf",
+        "DeviceAutorunEditorPlugin",
+        "EditorExportDeviceAutorun",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/device_autorun/doc_classes/AutorunInf.xml
+++ b/modules/device_autorun/doc_classes/AutorunInf.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AutorunInf" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Builds an [code]autorun.inf[/code] document for Windows disc and USB packaging.
+	</brief_description>
+	<description>
+		Assembles the [code][autorun][/code] section used by [EditorExportDeviceAutorun]. USB flash drives on Windows 7 and later ignore [code]OPEN=[/code] and [code]ACTION=[/code]; this class does not change AutoRun policy.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="build" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the [code]autorun.inf[/code] text, including optional [code]shell\verb[/code] command pairs.
+			</description>
+		</method>
+		<method name="usb_note_text" qualifiers="static">
+			<return type="String" />
+			<description>
+				Returns the USB AutoPlay limitation note written as [code]START.txt[/code] when [code]autorun/write_usb_note[/code] is enabled.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="action" type="String" setter="set_action" getter="get_action" default="&quot;&quot;">
+			Maps to [code]ACTION=[/code].
+		</member>
+		<member name="icon" type="String" setter="set_icon" getter="get_icon" default="&quot;&quot;">
+			Maps to [code]ICON=[/code].
+		</member>
+		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
+			Maps to [code]LABEL=[/code].
+		</member>
+		<member name="open" type="String" setter="set_open" getter="get_open" default="&quot;&quot;">
+			Maps to [code]OPEN=[/code].
+		</member>
+		<member name="shell" type="String" setter="set_shell" getter="get_shell" default="&quot;&quot;">
+			Default shortcut-menu verb ([code]shell=[/code]).
+		</member>
+		<member name="shell_verbs" type="Dictionary" setter="set_shell_verbs" getter="get_shell_verbs" default="{}">
+			Extra [code]shell\verb[/code] / [code]shell\verb\command[/code] pairs. Keys are verb names; values are commands.
+		</member>
+	</members>
+</class>

--- a/modules/device_autorun/doc_classes/DeviceAutorunEditorPlugin.xml
+++ b/modules/device_autorun/doc_classes/DeviceAutorunEditorPlugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DeviceAutorunEditorPlugin" inherits="EditorPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/device_autorun/doc_classes/EditorExportDeviceAutorun.xml
+++ b/modules/device_autorun/doc_classes/EditorExportDeviceAutorun.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportDeviceAutorun" inherits="EditorExportPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Writes [code]autorun.inf[/code] beside Windows exports (including ZIP staging).
+	</brief_description>
+	<description>
+		Options appear on export platforms whose OS name is [code]Windows[/code] (Windows Desktop, Windows Screensaver, and Windows Interactive DVD). The plugin writes [code]autorun.inf[/code] next to the staged binary during [code]_export_end[/code], so a later ZIP step includes it at archive root.
+		CD/DVD media may still honor [code]OPEN=[/code]. USB flash drives on Windows 7 and later ignore [code]OPEN=[/code] and [code]ACTION=[/code]; [code]LABEL=[/code] and [code]ICON=[/code] still apply. This plugin does not change AutoRun policy.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/device_autorun/editor/device_autorun_export_plugin.cpp
+++ b/modules/device_autorun/editor/device_autorun_export_plugin.cpp
@@ -1,0 +1,151 @@
+/**************************************************************************/
+/*  device_autorun_export_plugin.cpp                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "device_autorun_export_plugin.h"
+
+#include "editor/export/editor_export.h"
+#include "modules/device_autorun/autorun_inf.h"
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+
+bool EditorExportDeviceAutorun::supports_platform(const Ref<EditorExportPlatform> &p_export_platform) const {
+	return p_export_platform.is_valid() && p_export_platform->get_os_name() == "Windows";
+}
+
+void EditorExportDeviceAutorun::_get_export_options(const Ref<EditorExportPlatform> &p_export_platform, List<EditorExportPlatform::ExportOption> *r_options) const {
+	if (!supports_platform(p_export_platform)) {
+		return;
+	}
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::BOOL, "autorun/enable"), false));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::STRING, "autorun/label"), ""));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::STRING, "autorun/icon"), ""));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::STRING, "autorun/open"), ""));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::STRING, "autorun/action"), ""));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::STRING, "autorun/shell"), ""));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::DICTIONARY, "autorun/shell_verbs"), Dictionary()));
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::BOOL, "autorun/write_usb_note"), false));
+}
+
+bool EditorExportDeviceAutorun::_get_export_option_visibility(const Ref<EditorExportPlatform> &p_export_platform, const String &p_option_name) const {
+	if (!p_option_name.begins_with("autorun/")) {
+		return true;
+	}
+	if (!supports_platform(p_export_platform)) {
+		return false;
+	}
+	if (p_option_name == "autorun/enable") {
+		return true;
+	}
+	return bool(get_option("autorun/enable"));
+}
+
+void EditorExportDeviceAutorun::_export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags) {
+	(void)p_features;
+	(void)p_debug;
+	(void)p_flags;
+	export_path = p_path;
+}
+
+void EditorExportDeviceAutorun::_export_end() {
+	if (!bool(get_option("autorun/enable"))) {
+		export_path = String();
+		return;
+	}
+	if (export_path.is_empty()) {
+		return;
+	}
+
+	String dir = export_path;
+	if (FileAccess::exists(export_path) || export_path.get_extension() != "") {
+		dir = export_path.get_base_dir();
+	}
+
+	Ref<AutorunInf> inf;
+	inf.instantiate();
+	inf->set_label(get_option("autorun/label"));
+	inf->set_icon(get_option("autorun/icon"));
+	String open = get_option("autorun/open");
+	if (open.is_empty()) {
+		String dest = export_path;
+		const Ref<EditorExportPreset> preset = get_export_preset();
+		String fallback_ext = "exe";
+		if (preset.is_valid()) {
+			const String preset_path = preset->get_export_path();
+			const String preset_ext = preset_path.get_extension().to_lower();
+			if (preset->get_platform().is_valid() && preset->get_platform()->get_name() == "Windows Screensaver") {
+				fallback_ext = "scr";
+			}
+			if (preset_ext == "exe" || preset_ext == "scr") {
+				dest = preset_path;
+			}
+		}
+		if (dest.get_extension().to_lower() == "tmp") {
+			dest = dest.get_basename() + "." + fallback_ext;
+		}
+		open = dest.get_file();
+	}
+	inf->set_open(open);
+	inf->set_action(get_option("autorun/action"));
+	inf->set_shell(get_option("autorun/shell"));
+	inf->set_shell_verbs(get_option("autorun/shell_verbs"));
+
+	Error err = OK;
+	Ref<FileAccess> f = FileAccess::open(dir.path_join("autorun.inf"), FileAccess::WRITE, &err);
+	if (err == OK && f.is_valid()) {
+		f->store_string(inf->build());
+	}
+
+	if (bool(get_option("autorun/write_usb_note"))) {
+		Ref<FileAccess> note = FileAccess::open(dir.path_join("START.txt"), FileAccess::WRITE, &err);
+		if (err == OK && note.is_valid()) {
+			note->store_string(AutorunInf::usb_note_text());
+		}
+	}
+
+	export_path = String();
+}
+
+void DeviceAutorunEditorPlugin::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (EditorExport::get_singleton()) {
+			export_plugin.instantiate();
+			EditorExport::get_singleton()->add_export_plugin(export_plugin);
+		}
+	} else if (p_what == NOTIFICATION_EXIT_TREE) {
+		if (export_plugin.is_valid() && EditorExport::get_singleton()) {
+			EditorExport::get_singleton()->remove_export_plugin(export_plugin);
+			export_plugin.unref();
+		}
+	}
+}
+
+#endif

--- a/modules/device_autorun/editor/device_autorun_export_plugin.h
+++ b/modules/device_autorun/editor/device_autorun_export_plugin.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  device_autorun_export_plugin.h                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/export/editor_export_plugin.h"
+#include "editor/plugins/editor_plugin.h"
+
+class EditorExportDeviceAutorun : public EditorExportPlugin {
+	GDCLASS(EditorExportDeviceAutorun, EditorExportPlugin);
+
+	String export_path;
+
+protected:
+	static void _bind_methods() {}
+	virtual void _export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags) override;
+	virtual void _export_end() override;
+	virtual void _get_export_options(const Ref<EditorExportPlatform> &p_export_platform, List<EditorExportPlatform::ExportOption> *r_options) const override;
+	virtual bool _get_export_option_visibility(const Ref<EditorExportPlatform> &p_export_platform, const String &p_option_name) const override;
+
+public:
+	virtual String get_name() const override { return "DeviceAutorun"; }
+	virtual bool supports_platform(const Ref<EditorExportPlatform> &p_export_platform) const override;
+};
+
+class DeviceAutorunEditorPlugin : public EditorPlugin {
+	GDCLASS(DeviceAutorunEditorPlugin, EditorPlugin);
+
+	Ref<EditorExportDeviceAutorun> export_plugin;
+
+protected:
+	static void _bind_methods() {}
+	void _notification(int p_what);
+
+public:
+	virtual String get_plugin_name() const override { return "DeviceAutorun"; }
+};
+
+#endif

--- a/modules/device_autorun/register_types.cpp
+++ b/modules/device_autorun/register_types.cpp
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "autorun_inf.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/device_autorun_export_plugin.h"
+#include "editor/plugins/editor_plugin.h"
+#endif
+
+void initialize_device_autorun_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(AutorunInf);
+		return;
+	}
+#ifdef TOOLS_ENABLED
+	if (p_level != MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		return;
+	}
+	GDREGISTER_CLASS(EditorExportDeviceAutorun);
+	GDREGISTER_CLASS(DeviceAutorunEditorPlugin);
+	EditorPlugins::add_by_type<DeviceAutorunEditorPlugin>();
+#else
+	(void)p_level;
+#endif
+}
+
+void uninitialize_device_autorun_module(ModuleInitializationLevel p_level) {
+#ifdef TOOLS_ENABLED
+	if (p_level != MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		return;
+	}
+#else
+	(void)p_level;
+#endif
+}

--- a/modules/device_autorun/register_types.h
+++ b/modules/device_autorun/register_types.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_device_autorun_module(ModuleInitializationLevel p_level);
+void uninitialize_device_autorun_module(ModuleInitializationLevel p_level);

--- a/modules/device_autorun/tests/test_autorun_inf.h
+++ b/modules/device_autorun/tests/test_autorun_inf.h
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*  test_autorun_inf.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/device_autorun/autorun_inf.h"
+#include "tests/test_macros.h"
+
+TEST_CASE("[Modules][DeviceAutorun] builds autorun.inf") {
+	Ref<AutorunInf> inf;
+	inf.instantiate();
+	inf->set_open("MyGame.exe");
+	inf->set_icon("MyGame.exe,0");
+	inf->set_action("Start My Game");
+	inf->set_label("My Game");
+	inf->set_shell("play");
+	Dictionary verbs;
+	verbs["play"] = "MyGame.exe";
+	inf->set_shell_verbs(verbs);
+
+	const String text = inf->build();
+	CHECK(text.contains("[autorun]"));
+	CHECK(text.contains("open=MyGame.exe"));
+	CHECK(text.contains("icon=MyGame.exe,0"));
+	CHECK(text.contains("action=Start My Game"));
+	CHECK(text.contains("label=My Game"));
+	CHECK(text.contains("shell=play"));
+	CHECK(text.contains("shell\\play\\command=MyGame.exe"));
+	CHECK(AutorunInf::usb_note_text().contains("Windows 7"));
+}

--- a/modules/device_autorun/tests/test_device_autorun.cpp
+++ b/modules/device_autorun/tests/test_device_autorun.cpp
@@ -1,0 +1,30 @@
+/**************************************************************************/
+/*  test_device_autorun.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             BLAZIUM ENGINE                             */
+/*                          https://blazium.app                           */
+/**************************************************************************/
+/* Copyright (c) 2024-present Blazium Engine contributors.                */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "test_autorun_inf.h"


### PR DESCRIPTION
## Summary
- Adds the device_autorun module (Autorun.inf writer and Windows export plugin).
- Generic consumer fixes only: refresh export presets when platforms register, skip empty asset-tag bakes, and quiet/skip JustAMCP during `--script` / export.
- Does not include InterDVD, live wallpaper, or screensaver modules, and does not take their `main.cpp` / ProjectSettings hunks.

## Test plan
- [ ] Editor build
- [ ] `--headless --test --test-case=*[DeviceAutorun]*`
- [ ] Windows export writes Autorun.inf when the plugin is enabled
- [ ] Headless `--script` export does not start JustAMCP unless `--enable-mcp` is set